### PR TITLE
docs: add concise per-game settings note in How to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ USB modes:
 | `CHT`  | for cheats files                                     | all         |
 | `APPS`  | for ELF files                                       | all         |
 
+Per-game settings are stored per title in the `CFG` context. Typical use cases include compatibility toggles, video options (GSM), cheat toggles, and VMC assignment.
+
 OPL will automatically create the above directory structure the first time you launch it and enable your favorite device.
 
 For HDDs formatted with the APA partition scheme, OPL will read `hdd0:__common/OPL/conf_hdd.cfg` for the config entry `hdd_partition` to use as your OPL partition.


### PR DESCRIPTION
### Motivation
- Make users aware that per-game settings are stored per title in the `CFG` context and what they are typically used for without adding a full manual section.

### Description
- Inserted a single-line note in the README `How to use` section (`README.md`) stating that per-game settings are stored per title in `CFG` and listing typical uses: compatibility toggles, GSM video options, cheat toggles, and VMC assignment.

### Testing
- Documentation-only change; verified the insertion with `git status --short`, `git diff -- README.md`, and `nl -ba README.md | sed -n '112,130p'`, and committed the update successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f45b446483218a05b0a87761ed47)