### PR TITLE
docs: clarify VMC as core per-game save capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ USB modes:
 | ------ | ---------------------------------------------------- | ----------- |
 | `CD`   | for games on CD media - i.e. blue-bottom discs       | USB and SMB |
 | `DVD`  | for DVD5 and DVD9 images (if filesystem supports +4gb files) | USB and SMB |
-| `VMC`  | for Virtual Memory Card images - from 8MB up to 64MB | all         |
+| `VMC`  | Virtual Memory Card images (headline save feature): stored in `VMC/`, typically 8MB to 64MB, then assigned per game via **Game Settings** | all         |
 | `CFG`  | for saving per-game configuration files              | all         |
 | `ART`  | for game art images                                  | all         |
 | `THM`  | for themes support                                   | all         |
@@ -119,7 +119,7 @@ USB modes:
 | `CHT`  | for cheats files                                     | all         |
 | `APPS`  | for ELF files                                       | all         |
 
-Per-game settings are stored per title in the `CFG` context. Typical use cases include compatibility toggles, video options (GSM), cheat toggles, and VMC assignment.
+Per-game settings are stored per title in the `CFG` context. Typical use cases include compatibility toggles, video options (GSM), cheat toggles, and assigning a VMC file from the `VMC` folder to that game.
 
 OPL will automatically create the above directory structure the first time you launch it and enable your favorite device.
 


### PR DESCRIPTION
### Motivation
- Surface VMC as a headline capability in the "How to use" docs by documenting where VMC files live, their typical sizes (8MB–64MB), and that VMC images are assigned per-game via Game Settings while keeping warnings minimal and factual.

### Description
- Updated `README.md` to replace the `VMC` table row with a concise headline-style description that states VMC files are stored in `VMC/`, typically 8MB–64MB, and are assigned via `Game Settings`, and adjusted the nearby per-game settings paragraph to reference assigning a VMC from the `VMC` folder.

### Testing
- No automated tests exist for these documentation changes; I verified the edit locally by inspecting `README.md` (`nl -ba`), ran `git status --short`, and committed with the message `docs: clarify VMC as core per-game save capability`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f4de21588321a30134a0d20bab68)