### PR TITLE
themes: only enqueue MMCE decorator art on selection transitions

### DIFF
--- a/include/themes.h
+++ b/include/themes.h
@@ -64,6 +64,9 @@ typedef struct
 
     const char *decorator;
     mutable_image_t *decoratorImage;
+
+    int lastSelectedItemId;
+    char lastSelectedStartup[256];
 } items_list_t;
 
 typedef struct theme_element

--- a/src/themes.c
+++ b/src/themes.c
@@ -908,6 +908,20 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
     if (item) {
         items_list_t *itemsList = (items_list_t *)elem->extended;
         item_list_t *list = menu->item->userdata;
+        int mmceSelectionChanged = 0;
+        char *selectedStartup = NULL;
+
+        if (list != NULL && list->mode == MMCE_MODE && itemsList->decoratorImage != NULL && itemsList->decoratorImage->cache != NULL) {
+            selectedStartup = list->itemGetStartup(list, item->item.id);
+            if (selectedStartup == NULL)
+                selectedStartup = "";
+
+            if (itemsList->lastSelectedItemId != item->item.id || strcmp(itemsList->lastSelectedStartup, selectedStartup) != 0) {
+                mmceSelectionChanged = 1;
+                itemsList->lastSelectedItemId = item->item.id;
+                snprintf(itemsList->lastSelectedStartup, sizeof(itemsList->lastSelectedStartup), "%s", selectedStartup);
+            }
+        }
 
         int posX = elem->posX, posY = elem->posY;
         if (elem->aligned) {
@@ -927,10 +941,13 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
             if (itemsList->decoratorImage) {
                 GSTEXTURE *itemIconTex;
 
-                /* MMCE main-page row art must never queue fresh IO; only use already-ready textures. */
                 if (list != NULL && list->mode == MMCE_MODE && itemsList->decoratorImage->cache != NULL) {
                     image_cache_t *cache = itemsList->decoratorImage->cache;
-                    itemIconTex = cacheGetTextureIfReady(cache, &ps->item.cache_id[cache->userId], &ps->item.cache_uid[cache->userId]);
+
+                    if (mmceSelectionChanged && ps == item)
+                        itemIconTex = getGameImageTexture(cache, menu->item->userdata, &ps->item);
+                    else
+                        itemIconTex = cacheGetTextureIfReady(cache, &ps->item.cache_id[cache->userId], &ps->item.cache_uid[cache->userId]);
                 } else
                     itemIconTex = getGameImageTexture(itemsList->decoratorImage->cache, menu->item->userdata, &ps->item);
 
@@ -972,6 +989,8 @@ static void initItemsList(const char *themePath, config_set_t *themeConfig, them
         itemsList->decorator = decorator; // Will be used later (thmValidate)
 
     itemsList->decoratorImage = NULL;
+    itemsList->lastSelectedItemId = -1;
+    itemsList->lastSelectedStartup[0] = '\0';
 
     elem->extended = itemsList;
     // elem->endElem = &endBasic; does the job


### PR DESCRIPTION
### Motivation
- Prevent draw-loop driven MMCE cover request side-effects by separating request initiation from display-time retrieval so IO enqueueing only happens on real selection transitions.
- Keep existing behavior for non-MMCE modes (USB/HDD/SMB/MX4SIO/Apps/iLink) and avoid changing art naming/path logic.

### Description
- Add lightweight per-items-list selection state to `items_list_t` in `include/themes.h` as `lastSelectedItemId` and `lastSelectedStartup[256]` to detect selection transitions.
- In `src/themes.c` `drawItemsList` compute `mmceSelectionChanged` when `list->mode == MMCE_MODE` and the decorator has a cache by comparing `item->item.id` and the startup string from `list->itemGetStartup(list, item->item.id)`.
- For MMCE mode only, call the enqueue-capable path (`getGameImageTexture` / `cacheGetTexture`) only when the selection actually changed for the selected row, and otherwise use `cacheGetTextureIfReady` for display-only retrieval to avoid queuing IO from the draw path.
- Initialize the new tracking fields in `initItemsList` so `lastSelectedItemId` starts as `-1` and `lastSelectedStartup` is empty, and leave non-MMCE retrieval logic unchanged.

### Testing
- Ran `make -j2` (project build) which failed in this environment because required language YAML files are missing (`lng_src/English.yml`, `lng_src/Albanian.yml`), so a full build verification could not complete.
- Attempted to build the object with `make obj/themes.o` which failed due to no matching Makefile rule in this environment, so further compile validation was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4037476e48321b3db615e2ab29e0b)