### PR TITLE
Add forward declaration for cacheDropQueuedRequestLocked

### DIFF
--- a/src/texcache.c
+++ b/src/texcache.c
@@ -87,6 +87,7 @@ static void cacheClearItem(cache_entry_t *item, int freeTxt);
 static void cacheResetTextureState(GSTEXTURE *texture);
 static void cacheResetRequestTrackingLocked(void);
 static void cacheWakeWorker(void);
+static void cacheDropQueuedRequestLocked(load_image_request_t *req);
 
 static void cacheReleaseTexture(GSTEXTURE *texture)
 {


### PR DESCRIPTION
### Motivation

- Declare the `cacheDropQueuedRequestLocked` helper to ensure the function is known before use and to prevent implicit-declaration warnings or build issues.

### Description

- Add a static prototype `static void cacheDropQueuedRequestLocked(load_image_request_t *req);` to `src/texcache.c` alongside the other internal helper declarations.

### Testing

- Built the project with `make` and compilation completed successfully with no new warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f84c97648321a623800266aafc36)