### PR TITLE
feat(fav): allow Favourites as the startup page (issue #54)

### DIFF
--- a/modules/ds34usb/iop/ds34usb.c
+++ b/modules/ds34usb/iop/ds34usb.c
@@ -498,8 +498,8 @@ static void readReport(u8 *data, int pad)
             ds34pad[pad].data[17] = report->PressureR2; // R2
 
             // FIXED: Properly extract 4-bit battery and power fields
-            battery_level = report->Battery & 0x0F;  // Battery is 4 bits (0-15)
-            power_state = report->Power & 0x0F;      // Power is 4 bits (0-15)
+            battery_level = report->Battery & 0x0F; // Battery is 4 bits (0-15)
+            power_state = report->Power & 0x0F;     // Power is 4 bits (0-15)
 
             if (report->PSButton) { // display battery level
                 // Scale 4-bit battery (0-15) to 8-bit (0-255)

--- a/src/gui.c
+++ b/src/gui.c
@@ -486,8 +486,10 @@ int guiDeviceTypeToIoMode(int deviceType)
         return HDD_MODE;
     else if (deviceType == 3)
         return APP_MODE;
-    else
+    else if (deviceType == 4)
         return MMCE_MODE;
+    else
+        return FAV_MODE;
 }
 
 int guiIoModeToDeviceType(int ioMode)
@@ -502,6 +504,8 @@ int guiIoModeToDeviceType(int ioMode)
         return 3;
     if (ioMode == MMCE_MODE)
         return 4;
+    if (ioMode == FAV_MODE)
+        return 5;
 
     return 0;
 }
@@ -971,7 +975,7 @@ static int guiDeviceUpdater(int modified)
 
 void guiShowDeviceConfig(void)
 {
-    const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), NULL};
+    const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), _l(_STR_FAV), NULL};
     const char *deviceModes[] = {_l(_STR_OFF), _l(_STR_MANUAL), _l(_STR_AUTO), NULL};
     const char *deviceSlots[] = {"0", "1", _l(_STR_AUTO), NULL};
     const char *deviceAckWaitCycles[] = {"0", "1", "2", "3", "4", "5", NULL};

--- a/src/gui.c
+++ b/src/gui.c
@@ -488,8 +488,10 @@ int guiDeviceTypeToIoMode(int deviceType)
         return APP_MODE;
     else if (deviceType == 4)
         return MMCE_MODE;
-    else
+    else if (deviceType == 5)
         return FAV_MODE;
+    else
+        return APP_MODE; // safe fallback for unexpected indices: Apps is always present, FAV may be disabled
 }
 
 int guiIoModeToDeviceType(int ioMode)

--- a/src/opl.c
+++ b/src/opl.c
@@ -1649,7 +1649,11 @@ static void _saveConfig()
 
 void applyConfig(int themeID, int langID, int skipDeviceRefresh)
 {
-    if (gDefaultDevice < 0 || gDefaultDevice > MMCE_MODE)
+    if (gDefaultDevice < 0 || gDefaultDevice > FAV_MODE)
+        gDefaultDevice = MMCE_MODE;
+    // Favourites (issue #54) is a valid startup page only while the FAV tab is enabled; otherwise fall
+    // back so a stale "start on Favourites" choice can't boot into a hidden/empty tab.
+    if (gDefaultDevice == FAV_MODE && !gFAVStartMode)
         gDefaultDevice = MMCE_MODE;
 
     guiUpdateScrollSpeed();


### PR DESCRIPTION
Implements the "Favourites as the startup screen" request from #54.

- Adds **Favourites** to the Default-device picker (`CFG_DEFDEVICE`) so it can be chosen as the boot page.
- Wires it through `guiDeviceTypeToIoMode` / `guiIoModeToDeviceType` (index 5 ↔ `FAV_MODE`).
- Widens the boot-device clamp to `FAV_MODE`, and **falls back to MMCE if Favourites is selected but the FAV tab is disabled** (`gFAVStartMode`), so a stale choice can't boot into a hidden/empty tab.

Verified: compiles + links clean on the `v20250725` release toolchain.

Note: the other #54 items are separate —
- `.tar` cover art is **already implemented** (toggle "Enable .tar art" in GFX settings, build 2814 `191fc8ee`) — the reporter just needs to enable it.
- Favourites info-parity (resolution/aspect) and cfg/cht.tar are follow-ups (info-parity needs a repro to pin the exact missing field; cfg/cht.tar is wiring into the shared config/cheat load paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)