### PR TITLE
fix(config): fall back to a writable device when the boot-dir save fails

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1635,10 +1635,14 @@ static void _saveConfig()
     }
 
     lscret = configWriteMulti(lscstatus);
-    // The boot dir (cwd) is the only save target. The alternate-device save + the cwd redirect
-    // pointer are legacy-discovery aids, kept only for the boot-path-undeterminable sanity case
-    // (gBootDir empty); with a known boot dir, settings save there and nowhere else.
-    if (gBootDir[0] == '\0') {
+    // The boot dir (cwd) is the preferred save target, but fall back to a writable device
+    // (trySaveAlternateDevice: MC -> MMCE -> BDM -> BDM-HDD -> HDD) plus a redirect pointer when the
+    // boot dir is undeterminable (gBootDir empty) OR the write to it FAILS. A boot device can be
+    // unwritable: a launch-binding identity (ata0:/usb0:, which fileXio can't open) or a
+    // read-only/flaky exFAT HDD. Without this fallback its settings are silently lost -- "Error saving
+    // settings" when RiptOPL is booted from an internal exFAT HDD (reported by eliminator1403). On
+    // success the redirect makes the next boot load the config from wherever it actually landed.
+    if (gBootDir[0] == '\0' || lscret <= 0) {
         if (lscret <= 0)
             lscret = trySaveAlternateDevice(lscstatus);
         if (lscret > 0)


### PR DESCRIPTION
## The bug (reported by eliminator1403)
Booting RiptOPL from an **internal exFAT HDD** → **"Error saving settings"**; settings don't persist.

## Root cause
`8d6232f2` made settings save to the **boot dir (cwd)**, derived from `argv[0]`. But the alternate-device fallback + redirect (`opl.c`) only ran when `gBootDir` was **empty** — *not* when the write **failed**. A boot device can be unwritable:
- a **launch-binding identity** (`ata0:`/`usb0:`) — `fileXio` can't open these; only `massN:` is readable/writable (per the BDMA notes)
- a **read-only / flaky exFAT HDD**

So the boot-dir write fails, nothing catches it, and settings are silently lost.

## Fix
Trigger the **existing** fallback (`trySaveAlternateDevice`: MC → MMCE → BDM → BDM-HDD → HDD, then `writeConfigPathRedirect`) on **write-failure** too, not just when `gBootDir` is empty. Settings then land on a writable device and the next boot's redirect loads them from there. When the boot-dir write **succeeds**, the path is unchanged — settings stay in the boot dir as designed.

One-line condition change (`gBootDir[0] == '\0'` → `gBootDir[0] == '\0' || lscret <= 0`) + comment.

Built green on `v20250725`, clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)