### PR TITLE
fix(config): resolve a BDM launch-identity boot dir to its massN: mount

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -75,6 +75,11 @@ int bdmGetDeviceSlotsByType(int bdmType, int *slots, int maxSlots);
 // for a device of that type to mount, so the BDMA equip can read a source device that isn't enabled for
 // games. Returns 1 if a device is present afterwards, 0 otherwise. Idempotent + instant when already up.
 int bdmEnsureSourceModules(int bdmType, u32 timeoutMs);
+// If bootPath starts with a BDM launch-binding identity (usb0:/ilink0:/sd0:/mx4sio0:/sdc0:/ata0:) that
+// fileXio can't open, return its BDM_TYPE_* so the caller can resolve the device's writable massN: root
+// (bdmGetDeviceRootByType). Returns BDM_TYPE_UNKNOWN for readable type-A prefixes (mass/mc/mmce/pfs/hdd/
+// host/cdrom) and the UDPBD network type -- those must be left untouched. Anchored to the leading token.
+int bdmBootIdentityType(const char *bootPath);
 
 int bdmFindPartition(char *target, const char *name, int write);
 int bdmIsUDPBDLoaded(void);                  // 1 if the UDPBD NIC stack is loaded (the SMB stack must not load on top)

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -84,6 +84,41 @@ static int bdmDetermineDeviceType(const char *driverName)
     return BDM_TYPE_UNKNOWN;
 }
 
+// If bootPath begins with a BDM launch-binding block-device IDENTITY (usb0:/ilink0:/sd0:/mx4sio0:/
+// sdc0:/ata0:) return its BDM_TYPE_* -- these prefixes name a device but have NO readable filesystem
+// (fileXioDopen on the typed root always fails, see bdmProbeTypedDeviceRoot); the device is reachable
+// only via its massN: mount, resolvable with bdmGetDeviceRootByType(type). Returns BDM_TYPE_UNKNOWN for
+// everything that must be left ALONE: type-A readable prefixes (mass/mc/mmce/pfs/hdd/host/cdrom) and the
+// UDPBD network type (no local massN: mount, never a boot source). The test is anchored to the leading
+// "<driver><unit>:" segment and strips the trailing unit digits ("ata0" -> "ata"), so it can never
+// substring-match a folder name deeper in the path. Used by opl.c to turn a boot dir that arrived as a
+// launch identity into the device's writable massN: root.
+int bdmBootIdentityType(const char *bootPath)
+{
+    if (bootPath == NULL)
+        return BDM_TYPE_UNKNOWN;
+
+    const char *colon = strchr(bootPath, ':');
+    if (colon == NULL || colon == bootPath)
+        return BDM_TYPE_UNKNOWN; // no "<device>:" segment
+
+    char stem[16];
+    size_t n = (size_t)(colon - bootPath);
+    if (n >= sizeof(stem))
+        return BDM_TYPE_UNKNOWN;
+    memcpy(stem, bootPath, n);
+    stem[n] = '\0';
+    while (n > 0 && stem[n - 1] >= '0' && stem[n - 1] <= '9') // "ata0" -> "ata", "mx4sio0" -> "mx4sio"
+        stem[--n] = '\0';
+
+    int type = bdmDetermineDeviceType(stem);
+    // Only the local block-device identities are resolvable to a massN: mount. UDPBD is network (no
+    // massN:), UNKNOWN covers every readable type-A prefix -- neither must be remapped.
+    if (type == BDM_TYPE_USB || type == BDM_TYPE_ILINK || type == BDM_TYPE_SDC || type == BDM_TYPE_ATA)
+        return type;
+    return BDM_TYPE_UNKNOWN;
+}
+
 static const char *bdmGetTypedPathForDriver(const char *driverName)
 {
     if (bdmDriverIsUSB(driverName))

--- a/src/opl.c
+++ b/src/opl.c
@@ -1205,10 +1205,59 @@ static int tryAlternateDevice(int types)
     return 0;
 }
 
+// The launcher can hand OPL a boot path that is a BDM launch-binding IDENTITY (ata0:/usb0:/mx4sio0:/
+// ilink0:/sd0:) -- e.g. booting from an internal exFAT HDD, whose cwd may come through as ata0:. fileXio
+// cannot open such a prefix, so settings both READ back empty (defaults silently loaded) and fail to SAVE
+// ("Error saving settings"). The device's ONLY readable+writable path is its massN: mount, which is not
+// up at setBootDir/main time (BDM transports load after init(), and the semaphore that guards module
+// loading is created there too) -- so we resolve HERE, in the deferred config load, the first point at
+// which massN: is guaranteed mounted. Rewrite the identity to the SAME device's massN: root IN PLACE,
+// preserving the boot folder (ata0:/APPS -> mass0:/APPS): gBootDir stays non-empty and readable, so the
+// read below and every later save target the boot device with NO cross-device (MC) fallback. Type-A
+// prefixes (mass/mc/mmce/pfs/hdd/host) and APA HDD (pfs0:/hdd0:, a different device family) return early,
+// untouched.
+static void resolveBootDirToMass(void)
+{
+    int bt = bdmBootIdentityType(gBootDir);
+    if (bt == BDM_TYPE_UNKNOWN)
+        return; // readable/non-BDM boot dir (or empty) -> nothing to remap
+
+    char root[BDM_DEVICE_ROOT_MAX + 2]; // "massN:/"
+    bdmEnsureSourceModules(bt, 2000);   // load the transport + bounded-wait for the device (instant if already up)
+    if (!bdmGetDeviceRootByType(bt, root, sizeof(root))) {
+        // The boot device did not mount in time. Drop the dead identity so the existing empty-gBootDir
+        // discovery/alternate-save can still find a home for the config, rather than every read/save
+        // silently failing against an unopenable prefix.
+        gBootDir[0] = '\0';
+        configEnd();
+        configInit(NULL);
+        return;
+    }
+
+    size_t rlen = strlen(root);
+    if (rlen > 0 && root[rlen - 1] == '/')
+        root[rlen - 1] = '\0';                    // "massN:/" -> "massN:"
+    const char *tail = strchr(gBootDir, ':') + 1; // bdmBootIdentityType guaranteed a ':' -> "/APPS" | "APPS" | ""
+    char resolved[sizeof(gBootDir)];
+    if (tail[0] == '\0' || tail[0] == '/')
+        snprintf(resolved, sizeof(resolved), "%s%s", root, tail); // "massN:" + "/APPS" or ""
+    else
+        snprintf(resolved, sizeof(resolved), "%s/%s", root, tail); // "massN:" + "/" + "APPS"
+    size_t dl = strlen(resolved);
+    if (dl > 1 && resolved[dl - 1] == '/')
+        resolved[dl - 1] = '\0'; // match setBootDir's no-trailing-slash contract
+
+    LOG("BOOT resolved launch identity %s -> %s\n", gBootDir, resolved);
+    snprintf(gBootDir, sizeof(gBootDir), "%s", resolved);
+    configEnd();
+    configInit(gBootDir); // re-point the config sets from the dead identity to the massN: path
+}
+
 static void _loadConfig()
 {
     int value, themeID = -1, langID = -1;
     const char *temp;
+    resolveBootDirToMass(); // ata0:/APPS -> mass0:/APPS (boot-device massN:) before the first read
     int result = configReadMulti(lscstatus);
     // Settings come from the boot dir (cwd). Only when the boot path was undeterminable (gBootDir
     // empty -> configInit fell back to the MC default) do we re-enable the legacy multi-device


### PR DESCRIPTION
## Problem (eliminator1403)

Booting RiptOPL from an **internal exFAT HDD**, the launcher can hand `argv[0]` / `getcwd()` as a **BDM launch-binding identity** — `ata0:` / `usb0:` / `mx4sio0:` / `ilink0:` / `sd0:` — which `fileXio` **cannot open** (only the device's `massN:` mount is readable/writable). `setBootDir` stored that prefix into `gBootDir` verbatim, so:

- **Config READ silently failed** → defaults loaded, the user's saved settings ignored.
- **Config SAVE failed** → *"Error saving settings"*.
- Because `gBootDir` was non-empty, **neither** the empty-`gBootDir` read-discovery **nor** the alternate-save fallback fired — so nothing caught it.

This is the "settings don't save to device" report.

## Why it can't be fixed early

The device's only readable path is its `massN:` mount, and that is **not up** at `setBootDir` / `main()` time — BDM transports load *after* `init()`, which is also where `bdmLoadModuleLock` is created. Resolving early would hit an unmounted device (and an uninitialized semaphore). Verified in code: `configInit` runs at `opl.c` init before `bdmInitSemaphore()`, and `autoLaunchBDMGame` literally `delay()`+polls `mass0:..mass4:` waiting for the mount.

## Fix

Resolve in the **deferred config load** (`_loadConfig`) — the first point `massN:` is proven mounted (it's where the existing BDM config discovery already runs, and it's after `bdmInitSemaphore()`).

`resolveBootDirToMass()` rewrites the launch identity to the **same device's** `massN:` root **in place, preserving the boot folder** (`ata0:/APPS` → `mass0:/APPS`). `gBootDir` stays non-empty and readable, so the read below and every later save target the **boot device** — with **no cross-device (memory-card) fallback**. (The minimal "leave it empty and ride the existing discovery" alternative would, with an MC inserted, migrate config *to the MC*, since both the read and save discovery try MC first — exactly the fallback we don't want.)

New `bdmBootIdentityType()` classifies the leading device token (digit-stripped, anchored, reusing `bdmDetermineDeviceType`). **Type-A prefixes** (`mass`/`mc`/`mmce`/`pfs`/`hdd`/`host`) and the **UDPBD** network type return `UNKNOWN` and are left untouched — in particular the **APA HDD** (`pfs0:`/`hdd0:`) is a different device family and is **never** remapped to `massN:`. If the device fails to mount in time, the dead identity is dropped to empty so the existing discovery/alternate-save can still find a home for the config.

## Scope / testing

- 3 files, +89 lines; the common (type-A) boot path returns early with **zero behaviour change**.
- Build-green on `ps2max/dev:v20250725-2`; `clang-format` clean.
- **HW-pending**: PCSX2 boots via `host:` (the untouched type-A path), so the `ata0:`→`massN:` path is only exercisable on a real internal-exFAT-HDD boot.
- Note: this makes the save *target* the correct `massN:` root; the separate exFAT-HDD BDM write reliability caveat is unchanged (do not add a refuse-exFAT guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)