### PR TITLE
fix(mmce): guard mmcedrv export lookup against a failed/absent module (PR #61 review follow-up)

### DIFF
--- a/modules/iopcore/cdvdman/device-mmce.c
+++ b/modules/iopcore/cdvdman/device-mmce.c
@@ -53,9 +53,18 @@ void DeviceFSInit(void)
 {
     int64_t iso_size = 0;
 
-    // get modload export table
+    // get modload export table. getModInfo returns 0 AND leaves info.exports UNINITIALIZED when the
+    // module isn't resident (ioplib_util.c:94), so reading info.exports[4..9] after a failed lookup
+    // dereferences stack garbage -- a straight IOP crash, indistinguishable from the freezes this file
+    // exists to make diagnosable. If mmcedrv somehow isn't loaded, bail with the fail-fast state so
+    // reads return SCECdErREAD instead. (A NULL check on the resulting pointers would miss this: the
+    // garbage is not necessarily NULL.)
     modinfo_t info;
-    getModInfo("mmcedrv\0", &info);
+    if (!getModInfo("mmcedrv\0", &info)) {
+        mmce_dev_ready = 0;
+        DPRINTF("DeviceFSInit: mmcedrv not resident -- reads will fail fast\n");
+        return;
+    }
 
     //Get func ptrs
     fp_mmcedrv_get_size = (void *)info.exports[4];
@@ -121,11 +130,11 @@ int DeviceReadSectors(u64 lsn, void *buffer, unsigned int sectors)
     if (!mmce_dev_ready) {
         // Init never saw the device. One cheap re-probe per read: a card that came back late (slow SD
         // re-enumeration across the IOP reboot) recovers here; otherwise fail fast instead of driving
-        // a dead transport.
-        if (fp_mmcedrv_get_size(cdvdman_settings.iso_fd) > 0)
-            mmce_dev_ready = 1;
-        else
+        // a dead transport. Guard the pointer: DeviceFSInit leaves it NULL when mmcedrv wasn't resident
+        // (it bails before resolving the exports), and these are zero-init statics on first boot.
+        if (fp_mmcedrv_get_size == NULL || fp_mmcedrv_get_size(cdvdman_settings.iso_fd) <= 0)
             return SCECdErREAD;
+        mmce_dev_ready = 1;
     }
 
     WaitSema(mmce_io_sema);

--- a/src/opl.c
+++ b/src/opl.c
@@ -1662,8 +1662,11 @@ static int configWriteChecked(int types)
     int result = configWriteMulti(types);
     if (result > 0) {
         for (int bit = 1; bit < (1 << CONFIG_INDEX_COUNT); bit <<= 1) {
-            if ((types & bit) && configGetByType(bit)->modified)
-                return 0;
+            if (types & bit) {
+                config_set_t *cfg = configGetByType(bit); // NULL only if a requested set was never allocated
+                if (cfg != NULL && cfg->modified)
+                    return 0;
+            }
         }
     }
     return result;


### PR DESCRIPTION
Follow-up to the [Gemini review on #61](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/61). Three potential null-deref flags, assessed against the code:

**Real (and worse than flagged):** `DeviceFSInit` reads `info.exports[4..9]` after `getModInfo("mmcedrv")` without checking its return. `getModInfo` returns 0 **and leaves `info.exports` uninitialized** when the module isn't resident ([ioplib_util.c:94](modules/iopcore/cdvdman/ioplib_util.c)) — so a failed lookup dereferences stack **garbage** (an IOP crash, the exact undiagnosable-freeze class this file exists to prevent). Gemini's suggested NULL-check on the function pointers would miss it because the garbage need not be NULL. Fixed by checking `getModInfo`'s return and bailing to the fail-fast state.

**Complements the above:** `DeviceReadSectors`' re-probe now guards `fp_mmcedrv_get_size` for NULL (with FSInit bailing on failure, the pointer stays NULL — a zero-init static — on first boot).

**Defensive/unreachable but free:** `configWriteChecked` guards `configGetByType()` for NULL (can't happen in this post-init call path, but the contract allows it).

Out of scope but noted: `device-smb.c` has the same unchecked `getModInfo` pattern — left for a separate change to keep this focused.

Build-green ps2dev:latest; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)