### PR TITLE
fix(mmce): serialize the DeviceReadSectors re-probe under mmce_io_sema (PR #62 review follow-up)

### DIFF
--- a/modules/iopcore/cdvdman/device-mmce.c
+++ b/modules/iopcore/cdvdman/device-mmce.c
@@ -127,17 +127,26 @@ int DeviceReadSectors(u64 lsn, void *buffer, unsigned int sectors)
 
     DPRINTF("%s(%u, 0x%p, %u)\n", __func__, (unsigned int)lsn, buffer, sectors);
 
+    // Hold mmce_io_sema across the WHOLE function. Every mmcedrv call in this file is serialized through
+    // it -- the VMC path (mmce_read_offset/write_offset) runs on a different IOP thread and drives the
+    // same non-reentrant SIO2 link -- and the late-recovery re-probe below is an mmcedrv call too, so it
+    // must be inside the lock (not before it, which raced a concurrent VMC transaction). Taking it here
+    // also makes the mmce_dev_ready check-and-set atomic. (DeviceLock, the only other taker, is the
+    // shutdown-only barrier in oplShutdown -- never held by a caller of this function, so no deadlock.)
+    WaitSema(mmce_io_sema);
+
     if (!mmce_dev_ready) {
         // Init never saw the device. One cheap re-probe per read: a card that came back late (slow SD
         // re-enumeration across the IOP reboot) recovers here; otherwise fail fast instead of driving
         // a dead transport. Guard the pointer: DeviceFSInit leaves it NULL when mmcedrv wasn't resident
         // (it bails before resolving the exports), and these are zero-init statics on first boot.
-        if (fp_mmcedrv_get_size == NULL || fp_mmcedrv_get_size(cdvdman_settings.iso_fd) <= 0)
+        if (fp_mmcedrv_get_size == NULL || fp_mmcedrv_get_size(cdvdman_settings.iso_fd) <= 0) {
+            SignalSema(mmce_io_sema);
             return SCECdErREAD;
+        }
         mmce_dev_ready = 1;
     }
 
-    WaitSema(mmce_io_sema);
     do {
         res = fp_mmcedrv_read_sector(cdvdman_settings.iso_fd, (u32)lsn, sectors, buffer);
         retries++;


### PR DESCRIPTION
Follow-up to the [Gemini review on #62](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/62). **Verified real, not dismissed** — I traced it because it contradicted an earlier internal review that had refuted a similar claim.

**The race:** the late-recovery re-probe added in #62 called `fp_mmcedrv_get_size()` *before* `WaitSema(mmce_io_sema)` — the only mmcedrv call in the file outside the lock. `mmce_io_sema` serializes all mmcedrv access because the VMC path (`mmce_read_offset`/`mmce_write_offset`) runs on a **separate IOP thread** — confirmed live in [`modules/mcemu/device-mmce.c`](modules/mcemu/device-mmce.c) — and drives the same non-reentrant SIO2 link. When `mmce_dev_ready == 0` (flaky/late card) and a VMC transaction is in flight, the unlocked re-probe collided with it: the SIO2 state-corruption class this file exists to avoid.

**Fix:** take the sema at the top of `DeviceReadSectors`. The re-probe runs inside the lock, the `mmce_dev_ready` check-and-set becomes atomic, and both the early-return and normal paths release it.

**Deadlock-safe:** the only other `mmce_io_sema` taker is `DeviceLock()`, the shutdown-only barrier in `oplShutdown()` (cdvdman.c:100) — never held by a caller of `DeviceReadSectors`. This is the same acquisition the original code always made, just moved earlier in the same function.

Note this corrects an inconsistency *I* introduced in #62 (the re-probe was the one call breaking the file's locking discipline), not a pre-existing bug.

Build-green ps2dev:latest; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)