### PR TITLE
fix(gui): network/device tab hidden after re-enabling a protocol

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -541,6 +541,16 @@ void initSupport(item_list_t *itemList, int mode, int force_reinit)
             mod->support = itemList;
             mod->support->owner = mod;
             initMenuForListSupport(mod);
+        } else {
+            // Re-enable after a prior disable: the support + its menu item already exist (registered on
+            // an earlier enable), so the !mod->support branch above -- the ONLY place that sets
+            // menuItem.visible = 1 -- is skipped. Disabling a mode (else branch below) set visible = 0
+            // but LEFT mod->support non-NULL, so without restoring it here a tab that was ever toggled
+            // off stays hidden for the rest of the session even when re-selected. This is why picking a
+            // network protocol after having switched away from it showed no tab. BDM device tabs escape
+            // this via bdmNeedsUpdate's per-refresh visibility (and bdmInitDevicesData overrides it on
+            // its own path); ETH/UDPFS/MMCE/APP/FAV/HDD have no such hook, so restore it here.
+            mod->menuItem.visible = 1;
         }
 
         if (((force_reinit) && (mod->support->enabled)) || (startMode == START_MODE_AUTO && !mod->support->enabled)) {


### PR DESCRIPTION
**Root cause of "I pick a network protocol and the tab still doesn't show."** Confirmed by a 12-agent trace, adversarially verified against the code.

### The bug
`initSupport()` sets `menuItem.visible = 1` **only** inside the `if (!mod->support)` first-registration branch (via `initMenuForListSupport` — the only place in opl.c that sets `visible = 1`). Turning a mode **off** takes the outer else branch: it sets `visible = 0` but **leaves `mod->support` non-NULL**. So on **re-enable**, `!mod->support` is false, the visibility restore is skipped, and the tab stays hidden for the rest of the session even when you re-select the protocol.

The first enable from a clean Off boot works (support is NULL then), so it only bites *after* a mode has been toggled off once — which is why it read as "still doesn't show" after switching protocols and coming back.

### Why only network tabs
BDM device tabs (USB/MX4SIO/HDD/UDPBD) re-evaluate visibility every refresh (`bdmNeedsUpdate` + `bdmInitDevicesData`), so they self-heal. **SMB (ETH_MODE)** and **UDPFS Files (UDPFS_MODE)** have no per-refresh visibility hook, so once hidden they never came back. MMCE/APP/FAV/HDD shared the same latent flaw on any Off→on toggle.

### The fix
When `startMode` is truthy and the support is already registered, set `menuItem.visible = 1` (the else of the first-registration branch). The existing menu node is reused — no duplicate `GUI_OP_ADD_MENU`, and the carousel reaches the re-shown tab immediately. Safe for BDM modes (their own path overrides this).

Build-green ps2dev:latest; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)