### PR TITLE
fix(vcd): POPSTARTER gets the bare device label (mass:/smb:), fixing VCD launch on every device

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -639,8 +639,8 @@ static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
         return;
     }
-    // POPSTARTER only parses the ELF-NAME prefix of argv[0] (the "XX." BDMA token) to pick the source --
-    // the device portion of the path is ignored -- so the live mass<N>: root is fine here.
+    // vcdBuildSelector emits the BARE POPSTARTER label ("mass:/POPS/XX.<name>.ELF"), NOT this live
+    // unit-numbered mount -- POPSTARTER remounts under "mass:" after its own IOP reset (see the function).
     vcdBuildSelector(vcdPrefix, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
 
     // POPSTARTER reloads its block-device driver from the MC after its OWN IOP reset, so equip the

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -221,8 +221,19 @@ void vcdBuildSelector(const char *devPrefix, const char *prefix, const char *nam
 {
     if (out == NULL || outSize <= 0)
         return;
-    const char *dp = devPrefix ? devPrefix : "";
-    snprintf(out, outSize, "%s%s%c%s%s.ELF", dp, POPS_FOLDER, vcdSep(dp), prefix ? prefix : "", name ? name : "");
+    // POPSTARTER does its OWN SifIopReset + BDMAssault remount BEFORE it reads argv[0], so it resolves
+    // the selector against its post-reset namespace -- the BARE device kind-label (mass:/smb:), NOT
+    // OPL's live unit-numbered mount (mass0:/mmce0:/smb0:) or the SMB share path. Handing it a
+    // unit-numbered path (or backslash-separated SMB path) leaves the sibling <name>.VCD unresolvable
+    // and it black-screens after being reached. Match the maintainer's proven POPSLoader format
+    // (bin/POPSLDR/system.lua): <bare-label>:/POPS/<XX.|SB.><name>.ELF, forward slashes throughout.
+    // RiptOPL mounts every block VCD source (USB/MX4SIO/iLink/exFAT-HDD) through the BDMAssault
+    // usbhdfsd variant, which POPSTARTER re-registers as "mass:" -- and MMCE is translated to mass:
+    // too -- so the ONLY distinction is SMB (SB. prefix, "smb:") vs everything else ("mass:"). The
+    // incoming devPrefix (a live unit-numbered mount) is intentionally NOT used for the string body.
+    (void)devPrefix;
+    const char *root = (prefix != NULL && !strcmp(prefix, VCD_PREFIX_SMB)) ? "smb:" : "mass:";
+    snprintf(out, outSize, "%s/%s/%s%s.ELF", root, POPS_FOLDER, prefix ? prefix : "", name ? name : "");
 }
 
 // ---- per-device VCD view state ------------------------------------------------


### PR DESCRIPTION
**Fixes VCD (PS1) launch failing on every device** — POPSTARTER.ELF is reached but black-screens.

### Root cause (cross-referenced against your POPSLoader)
POPSTARTER does its **own** `SifIopReset` + BDMAssault remount **before** it parses `argv[0]`, so it resolves the selector against its post-reset namespace — the **bare** device kind-label (`mass:`/`smb:`), never OPL's live unit-numbered mount. OPL was emitting:
- `mass0:/POPS/XX.<name>.ELF` (USB / MX4SIO / iLink / exFAT-HDD)
- `mmce0:/POPS/XX.<name>.ELF` (MMCE)
- `smb0:<share>\POPS\SB.<name>.ELF` (SMB — with backslashes)

After POPSTARTER's remount none of those tokens name a mounted volume, so the sibling `<name>.VCD` is unresolvable → black screen. Confirmed against `NathanNeurotic/POPSLoader` `bin/POPSLDR/system.lua`, which emits bare `mass:/POPS/XX.` and `smb:/POPS/SB.` with forward slashes.

### Fix
`vcdBuildSelector` now emits the proven bare label:
- **`mass:/POPS/XX.<name>.ELF`** for every block source — RiptOPL mounts them all through the BDMAssault `usbhdfsd` variant, which POPSTARTER re-registers as `mass:`; MMCE is translated to `mass:` as well.
- **`smb:/POPS/SB.<name>.ELF`** (forward slashes) for SMB.

The `.VCD`-stripped name and the `XX.`/`SB.` prefixes were already correct — only the device token + separators change. Example (USB, 'Crash Bandicoot'): `mass0:/POPS/XX.Crash Bandicoot.ELF` → `mass:/POPS/XX.Crash Bandicoot.ELF`.

Build-green ps2dev:latest; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)