### PR TITLE
fix(neutrino): no-IOP-reset handoff to neutrino.elf (vendored NHDDL-style loader)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ ifneq ($(GIT_TAG),latest)
 endif
 endif
 
-FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o lang.o lang_internal.o config.o hdd.o dialogs.o \
+FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o elfldr_noreset.o elfldr.o lang.o lang_internal.o config.o hdd.o dialogs.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o udpfssupport.o hddsupport.o zso.o lz4.o \
 		appsupport.o mmcesupport.o favsupport.o vcdsupport.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
 
@@ -305,6 +305,8 @@ clean:	download_lwNBD
 	rm -fr $(MAPFILE) $(EE_BIN) $(EE_BIN_PACKED) $(EE_BIN_STRIPPED) $(EE_VPKD).* $(EE_OBJS_DIR) $(EE_ASM_DIR)
 	echo "-EE core"
 	$(MAKE) -C ee_core clean
+	echo "-ELF loader"
+	$(MAKE) -C elfldr clean
 	echo "-IOP core"
 	echo " -imgdrv"
 	$(MAKE) -C modules/iopcore/imgdrv clean
@@ -434,6 +436,13 @@ ee_core/ee_core.elf: ee_core
 
 $(EE_ASM_DIR)ee_core.c: ee_core/ee_core.elf | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ eecore_elf
+
+elfldr/elfldr.elf: elfldr
+	echo "-ELF loader (no-IOP-reset handoff)"
+	$(MAKE) -C $<
+
+$(EE_ASM_DIR)elfldr.c: elfldr/elfldr.elf | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ elfldr_elf
 
 $(EE_ASM_DIR)udnl.c: $(UDNL_OUT) | $(EE_ASM_DIR)
 	$(BIN2C) $(UDNL_OUT) $@ udnl_irx

--- a/docs/RECOVERY-2026-07-03.md
+++ b/docs/RECOVERY-2026-07-03.md
@@ -21,6 +21,32 @@
 > EE-side hardening of the *menu* MMCE read (unbounded `read()` with no timeout — a genuinely dead
 > card can still hang; mirror the in-game bounded-wait). **The other symptoms remain HARDWARE-PENDING** — run the §8 matrix.
 
+> **UPDATE 2026-07-04 (verification round against primary sources):**
+> 1. **VCD/POPSTARTER selector ([PR #66](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/66)) — VERIFIED CORRECT, ready to roll.** The maintainer
+>    hardware-confirmed both selector forms: `mass:/POPS/XX.<name>.ELF` for every BDMA source
+>    (**including MMCE** — POPSTARTER reads MMCE via a BDMA driver variant that remounts the card
+>    as `mass:`) and `smb:/POPS/SB.<name>.ELF` for SMB. Cross-checked against POPSLoader
+>    (`BuildPopstarterSelectorPath` emits the same strings; `TranslateMMCEPathForPopStarter`
+>    rewrites `mmce<N>:/` → `mass:/`; the BDMAssault variants all register device name `"mass"`).
+>    POPSTARTER receives the selector as argv[0] with argc=1.
+> 2. **Neutrino USB black-screen → OSDSYS — ROOT CAUSE CONFIRMED + FIX BUILT** (branch
+>    `claude/neutrino-noreset-handoff`): ps2sdk's `LoadELFFromFileWithPartition` child loader
+>    SifLoadElf()s neutrino.elf through the live mounts but then `SifIopReset`s and reloads ONLY
+>    `rom0:SIO2MAN/MCMAN/MCSERV` (ee/elf-loader/src/loader/src/loader.c:131-146) — Neutrino then
+>    cannot read its `-cwd` config/modules or open the `-dvd` ISO (it does all of that through the
+>    LAUNCHER's mounts before its own IOP reset, neutrino main.c:294/477/728). NHDDL avoids this
+>    with a vendored no-reset loader ("Modified to not reset IOP for use with NHDDL"). OPL's args
+>    were verified byte-correct — only the handoff changes. Fix: vendored `elfldr/` no-reset child
+>    loader (`sysLoadELFKeepIOP`) + `deinitEx` keeps BOTH the game device and the neutrino.elf
+>    device mounted. NOTE: ps2sdk gained `LoadELFFromFileWithPartitionNoReset` upstream (8890d8b5,
+>    2026-06-30) but NEITHER container ships it yet (latest carries a 2026-06-21 SDK) — hence the
+>    vendored loader, which also fixes the OLDSDK ELF.
+> 3. **MMCE in-game freeze — RETEST BEFORE ANY VERDICT.** No in-game freeze report exists on a
+>    build containing the coherent driver: issue #56's last comment is 2026-07-02, the first
+>    #64-fixed zip published 2026-07-03. A report only counts if the on-screen version is
+>    **Beta-2921 or later** (2827a2a4 = merge of #64; current rolling = 2925). The "upstream
+>    mmcedrv limitation" hypothesis stays UNVERIFIED until a ≥2921 freeze is reproduced.
+
 Hardware validation (2026-07-02/03) came back negative on four fronts. A six-track
 investigation (each finding adversarially re-verified against the code where noted)
 traced every reported symptom to concrete root causes. This document records the

--- a/elfldr/Makefile
+++ b/elfldr/Makefile
@@ -1,0 +1,23 @@
+# RiptOPL no-IOP-reset child loader (see loader.c). Built like NHDDL's loader:
+# a tiny ELF linked into BIOS-unused memory (0x84000) so it can overwrite user
+# memory with the target ELF while OPL's IOP state stays untouched.
+
+EE_LINKFILE := linkfile
+EE_CFLAGS = -D_EE -Os -G0 -Wall
+EE_CFLAGS += -fdata-sections -ffunction-sections
+EE_LDFLAGS = -Wl,-zmax-page-size=128
+EE_LDFLAGS += -s -Wl,--gc-sections
+
+EE_BIN = elfldr.elf
+
+EE_OBJS = loader.o
+
+EE_LIBS =
+
+all: $(EE_BIN)
+
+clean:
+	rm -f -r $(EE_OBJS) $(EE_BIN)
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal

--- a/elfldr/linkfile
+++ b/elfldr/linkfile
@@ -1,0 +1,69 @@
+ENTRY(__start);
+
+MEMORY {
+	bios	: ORIGIN = 0x00000000, LENGTH = 528K /* 0x00000000 - 0x00084000: BIOS memory */
+	bram	: ORIGIN = 0x00084000, LENGTH = 496K /* 0x00084000 - 0x00100000: BIOS unused memory */
+	gram	: ORIGIN = 0x00100000, LENGTH =  31M /* 0x00100000 - 0x02000000: GAME memory */
+}
+
+REGION_ALIAS("MAIN_REGION", bram);
+
+PHDRS {
+  text PT_LOAD;
+}
+
+SECTIONS {
+	.text : {
+		*(.text)
+	} >MAIN_REGION :text
+
+	.reginfo : { *(.reginfo) } >MAIN_REGION
+
+	.ctors ALIGN(16): {
+		KEEP(*crtbegin*.o(.ctors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
+		KEEP(*(SORT(.ctors.*)))
+		KEEP(*(.ctors))
+	} >MAIN_REGION
+
+	.dtors ALIGN(16): {
+		KEEP(*crtbegin*.o(.dtors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
+		KEEP(*(SORT(.dtors.*)))
+		KEEP(*(.dtors))
+	} >MAIN_REGION
+
+	.rodata ALIGN(128): {
+		*(.rodata)
+	} >MAIN_REGION
+
+	.data ALIGN(128): {
+		_fdata = . ;
+		*(.data)
+		SORT(CONSTRUCTORS)
+	} >MAIN_REGION
+
+	_gp = ALIGN(128) + 0x7ff0;
+	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
+	.lit8 ALIGN(128): { *(.lit8) } >MAIN_REGION
+
+	.sdata ALIGN(128): {
+		*(.sdata)
+	} >MAIN_REGION
+
+	.sbss ALIGN(128) : {
+		_fbss = . ;
+		*(.sbss)
+	} >MAIN_REGION
+
+	.bss ALIGN(128) : {
+		*(.bss)
+	} >MAIN_REGION
+
+	/* Symbols needed by crt0.s.  */
+	PROVIDE(_end = .);
+	PROVIDE(_heap_size = -1);
+
+	PROVIDE(_stack = .);
+	PROVIDE(_stack_size = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION) - _stack);
+}

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -1,0 +1,84 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Modified for RiptOPL: NO IOP reset (same approach as NHDDL's neutrino
+# handoff). This child loader runs from BIOS-unused memory (0x84000), loads
+# the target ELF through the STILL-LIVE IOP -- OPL's drivers and mounts stay
+# up -- and jumps into it. The target (Neutrino) reads its config/modules and
+# the game ISO through those mounts, then performs its own IOP reset. The
+# ps2sdk loader's SifIopReset + rom0:SIO2MAN/MCMAN/MCSERV reload is exactly
+# what broke every launch whose files lived on a BDM device.
+*/
+
+#include <kernel.h>
+#include <loadfile.h>
+#include <ps2sdkapi.h>
+#include <sifrpc.h>
+#include <errno.h>
+
+//--------------------------------------------------------------
+// Redefinition of init/deinit libc:
+//--------------------------------------------------------------
+// DON'T REMOVE is for reducing binary size.
+// These functions are defined as weak in /libc/src/init.c
+//--------------------------------------------------------------
+void _libcglue_init() {}
+void _libcglue_deinit() {}
+void _libcglue_args_parse(int argc, char **argv) {}
+
+DISABLE_PATCHED_FUNCTIONS();
+DISABLE_EXTRA_TIMERS_FUNCTIONS();
+PS2_DISABLE_AUTOSTART_PTHREAD();
+
+//--------------------------------------------------------------
+// Clear user memory
+// PS2Link (C) 2003 Tord Lindstrom (pukko@home.se)
+//         (C) 2003 adresd (adresd_ps2dev@yahoo.com)
+//--------------------------------------------------------------
+static void wipeUserMem(void)
+{
+    int i;
+    for (i = 0x100000; i < GetMemorySize(); i += 64) {
+        __asm__ __volatile__(
+            "\tsq $0, 0(%0) \n"
+            "\tsq $0, 16(%0) \n"
+            "\tsq $0, 32(%0) \n"
+            "\tsq $0, 48(%0) \n" ::"r"(i));
+    }
+}
+
+// argv[0] = path to the target ELF; the full argv is forwarded to it verbatim
+// (the ExecPS2 syscall marshals the strings, so wiping user memory is safe).
+int main(int argc, char *argv[])
+{
+    static t_ExecData elfdata;
+    int ret;
+
+    elfdata.epc = 0;
+
+    if (argc < 1)
+        return -EINVAL;
+
+    SifInitRpc(0);
+    wipeUserMem();
+
+    // Writeback data cache before loading ELF.
+    FlushCache(0);
+    SifLoadFileInit();
+    ret = SifLoadElf(argv[0], &elfdata);
+    SifLoadFileExit();
+    if (ret == 0 && elfdata.epc != 0) {
+        FlushCache(0);
+        FlushCache(2);
+        return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
+    } else {
+        SifExitRpc();
+        return -ENOENT;
+    }
+}

--- a/include/opl.h
+++ b/include/opl.h
@@ -79,6 +79,10 @@ void menuDeferredUpdate(void *data);
 void moduleUpdateMenu(int mode, int themeChanged, int langChanged);
 void handleLwnbdSrv();
 void deinit(int exception, int modeSelected);
+// deinit with a SECOND kept mode (-1 = none): the Neutrino no-reset handoff needs BOTH the game's
+// device and the neutrino.elf-hosting device mounted, since Neutrino reads its config/modules and
+// the game ISO through our live mounts before doing its own IOP reset.
+void deinitEx(int exception, int modeSelected, int modeSelected2);
 
 // Shutdown minimal services initiated for auto loading.
 void miniDeinit(config_set_t *configSet);

--- a/include/system.h
+++ b/include/system.h
@@ -45,6 +45,13 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
 // token; partition = "" for non-HDD. Caller deinit()s with UNMOUNT_EXCEPTION first (see system.c).
 void sysLaunchPopstarter(const char *popstarterElf, const char *selector, const char *partition);
 
+// ELF handoff that KEEPS the IOP (drivers + mounts) alive -- NHDDL parity for the Neutrino
+// launch: the vendored elfldr/ child loader SifLoadElf()s the target through OPL's live mounts
+// and never SifIopReset()s (the target resets the IOP itself). Container-independent: works the
+// same on ps2dev:latest and the OLDSDK pin. Returns only on failure (bad path/ELF), like
+// LoadELFFromFileWithPartition. Implemented in elfldr_noreset.c.
+int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, char *argv[]);
+
 int sysExecElf(const char *path);
 int sysLoadModuleBuffer(void *buffer, int size, int argc, char *argv);
 int sysCheckMC(void);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -985,15 +985,17 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL);
 
     if (gAutoLaunchBDMGame == NULL) {
-        // Neutrino: keep the device that holds neutrino.elf MOUNTED across the teardown
-        // (UNMOUNT_EXCEPTION) so sysLaunchNeutrino's LoadELFFromFile can still read it -- apps launch
-        // the same way. A memory-card-hosted neutrino (oplPath2Mode == -1) survives any deinit, so keep
-        // NO_EXCEPTION there. Without this a mass/MMCE-hosted neutrino.elf is unreachable post-deinit.
-        int neutrinoDevMode = coreLoader ? oplPath2Mode(neutrinoPath) : -1;
-        if (neutrinoDevMode >= 0)
-            deinit(UNMOUNT_EXCEPTION, neutrinoDevMode);
-        else
+        // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino reads its config/modules from the
+        // neutrino.elf device (-cwd) AND opens the game ISO through OUR mass mount before doing its
+        // own IOP reset -- keep BOTH mounted across the teardown. An MC-hosted neutrino needs no
+        // exception of its own (-1 second slot). ee_core launches keep the full teardown: everything
+        // they need is embedded before deinit.
+        if (coreLoader) {
+            int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+            deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees bdmGames/game
+        } else {
             deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
+        }
     } else {
         miniDeinit(configSet);
 

--- a/src/elfldr_noreset.c
+++ b/src/elfldr_noreset.c
@@ -1,0 +1,118 @@
+/*
+  No-IOP-reset ELF handoff (NHDDL parity) for the Neutrino launch path.
+
+  ps2sdk's LoadELFFromFileWithPartition SifLoadElf()s the target through the live IOP but then
+  SifIopReset()s and reloads ONLY rom0:SIO2MAN/MCMAN/MCSERV before jumping in
+  (ee/elf-loader/src/loader/src/loader.c). Neutrino must read its config/modules (-cwd) and open
+  the game ISO through the LAUNCHER's mounts before doing its own IOP reset, so that handoff
+  black-screens every setup whose neutrino/ folder or game lives on a BDM device.
+
+  ps2sdk gained a NoReset entry point in 8890d8b5 (2026-06-30), but neither build container ships
+  it yet (ps2dev:latest probed 2026-07-04 carries a 2026-06-21 SDK; the OLDSDK pin is 2025-07-25),
+  so we vendor the child loader instead (elfldr/loader.c, the NHDDL approach): copy it into
+  BIOS-unused memory at 0x84000, ExecPS2 into it with argv[0] = target path, and it SifLoadElf()s
+  the target through OPL's still-live mounts -- no IOP reset. Works identically on both SDKs.
+*/
+
+#include <kernel.h>
+#include <sifrpc.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+extern unsigned char elfldr_elf[];
+extern unsigned int size_elfldr_elf;
+
+#define ELFLDR_ELF_MAGIC 0x464c457f
+#define ELFLDR_PT_LOAD   1
+
+typedef struct
+{
+    u8 ident[16];
+    u16 type;
+    u16 machine;
+    u32 version;
+    u32 entry;
+    u32 phoff;
+    u32 shoff;
+    u32 flags;
+    u16 ehsize;
+    u16 phentsize;
+    u16 phnum;
+    u16 shentsize;
+    u16 shnum;
+    u16 shstrndx;
+} elfldr_header_t;
+
+typedef struct
+{
+    u32 type;
+    u32 offset;
+    void *vaddr;
+    u32 paddr;
+    u32 filesz;
+    u32 memsz;
+    u32 flags;
+    u32 align;
+} elfldr_pheader_t;
+
+// Wipe the BIOS-unused region the child loader is linked into (0x84000 - 0x100000,
+// below OPL itself -- see elfldr/linkfile).
+static void wipeBramMem(void)
+{
+    int i;
+    for (i = 0x00084000; i < 0x100000; i += 64) {
+        __asm__ __volatile__(
+            "\tsq $0, 0(%0) \n"
+            "\tsq $0, 16(%0) \n"
+            "\tsq $0, 32(%0) \n"
+            "\tsq $0, 48(%0) \n" ::"r"(i));
+    }
+}
+
+int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, char *argv[])
+{
+    elfldr_header_t *eh;
+    elfldr_pheader_t *eph;
+    void *pdata;
+    int i, fd;
+
+    (void)partition; // the Neutrino handoff always passes "" -- no APA-partition context needed
+
+    // Probe the target through our still-live mounts so a bad path fails fast in OPL
+    // instead of inside the child loader (which can only fall through to OSDSYS).
+    if (filename == NULL || (fd = open(filename, O_RDONLY)) < 0)
+        return -1;
+    close(fd);
+
+    // argv[0] must be the target path (the child SifLoadElf()s argv[0] and forwards
+    // the whole vector); the ExecPS2 syscall marshals the strings across the jump.
+    char *new_argv[argc + 1];
+    new_argv[0] = (char *)filename;
+    for (i = 0; i < argc; i++)
+        new_argv[i + 1] = argv[i];
+
+    wipeBramMem();
+
+    eh = (elfldr_header_t *)elfldr_elf;
+    if (_lw((u32)&eh->ident) != ELFLDR_ELF_MAGIC)
+        return -1;
+
+    eph = (elfldr_pheader_t *)(elfldr_elf + eh->phoff);
+    for (i = 0; i < eh->phnum; i++) {
+        if (eph[i].type != ELFLDR_PT_LOAD)
+            continue;
+
+        pdata = (void *)(elfldr_elf + eph[i].offset);
+        memcpy(eph[i].vaddr, pdata, eph[i].filesz);
+
+        if (eph[i].memsz > eph[i].filesz)
+            memset((void *)((u8 *)(eph[i].vaddr) + eph[i].filesz), 0, eph[i].memsz - eph[i].filesz);
+    }
+
+    sceSifExitRpc();
+    FlushCache(0);
+    FlushCache(2);
+
+    return ExecPS2((void *)eh->entry, NULL, argc + 1, new_argv);
+}

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -876,14 +876,16 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL);
 
     if (gAutoLaunchGame == NULL) {
-        // Neutrino: keep the device that holds neutrino.elf mounted across the teardown
-        // (UNMOUNT_EXCEPTION) so sysLaunchNeutrino's LoadELFFromFile can read it -- apps do the same.
-        // mc-hosted neutrino (oplPath2Mode == -1) survives any deinit, so keep NO_EXCEPTION there.
-        int neutrinoDevMode = coreLoader ? oplPath2Mode(neutrinoPath) : -1;
-        if (neutrinoDevMode >= 0)
-            deinit(UNMOUNT_EXCEPTION, neutrinoDevMode);
-        else
+        // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): keep the HDD stack up (NHDDL hands off with
+        // its full ATA stack resident) AND the neutrino.elf device (-cwd config/module reads) across
+        // the teardown. An MC-hosted neutrino needs no exception (-1 second slot). ee_core launches
+        // keep the full teardown: everything they need is embedded before deinit.
+        if (coreLoader) {
+            int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+            deinitEx(UNMOUNT_EXCEPTION, HDD_MODE, neutrinoDevMode); // CAREFUL: itemCleanUp still frees hddGames/game
+        } else {
             deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
+        }
     } else {
         miniDeinit(configSet);
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -592,13 +592,11 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
             fileXioClose(vmc_fds[0]);
         if (vmc_fds[1] >= 0)
             fileXioClose(vmc_fds[1]);
-        // Keep the device that holds neutrino.elf mounted (UNMOUNT_EXCEPTION) so LoadELFFromFile can
-        // read it post-teardown -- apps do the same. mc-hosted neutrino (mode -1) survives any deinit.
+        // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino opens the mmce-hosted game through
+        // OUR mmceman mount and its config/modules from the neutrino.elf device (-cwd) before its own
+        // IOP reset -- keep BOTH mounted. An MC-hosted neutrino needs no exception (-1 second slot).
         int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-        if (neutrinoDevMode >= 0)
-            deinit(UNMOUNT_EXCEPTION, neutrinoDevMode);
-        else
-            deinit(NO_EXCEPTION, MMCE_MODE);
+        deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode);
         sysLaunchNeutrino("mmce", mmcePartname, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, &neutrinoVmc);
         return;
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -106,7 +106,7 @@ static void clearIOModuleT(opl_io_module_t *mod)
 
 // forward decl
 static void clearMenuGameList(opl_io_module_t *mdl);
-static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected);
+static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected, int modeSelected2);
 static void reset(void);
 static void deferredAudioInit(void);
 
@@ -592,11 +592,11 @@ static void initAllSupport(int force_reinit)
     initSupport(favGetObject(0), FAV_MODE, force_reinit);
 }
 
-static void deinitAllSupport(int exception, int modeSelected)
+static void deinitAllSupport(int exception, int modeSelected, int modeSelected2)
 {
     for (int i = 0; i < MODE_COUNT; i++) {
         if (list_support[i].support != NULL)
-            moduleCleanup(&list_support[i], exception, modeSelected);
+            moduleCleanup(&list_support[i], exception, modeSelected, modeSelected2);
     }
 }
 
@@ -2189,7 +2189,7 @@ static int loadLwnbdSvr(void)
     guiExecDeferredOps();
 
     // Deinitialize all support without shutting down the HDD unit.
-    deinitAllSupport(NO_EXCEPTION, IO_MODE_SELECTED_ALL);
+    deinitAllSupport(NO_EXCEPTION, IO_MODE_SELECTED_ALL, -1);
     clearErrorMessage(); /* At this point, an error might have been displayed (since background tasks were completed).
                             Clear it, otherwise it will get displayed after the server is closed. */
 
@@ -2283,13 +2283,13 @@ static void reset(void)
     mcInit(MC_TYPE_XMC);
 }
 
-static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected)
+static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected, int modeSelected2)
 {
     if (!mod->support)
         return;
 
     // Shutdown if not required anymore.
-    if ((mod->support->mode != modeSelected) && (modeSelected != IO_MODE_SELECTED_ALL)) {
+    if ((mod->support->mode != modeSelected) && (mod->support->mode != modeSelected2) && (modeSelected != IO_MODE_SELECTED_ALL)) {
         if (mod->support->itemShutdown)
             mod->support->itemShutdown(mod->support);
     } else {
@@ -2311,6 +2311,11 @@ static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected)
 int gDeinitTerminal = 0;
 
 void deinit(int exception, int modeSelected)
+{
+    deinitEx(exception, modeSelected, -1);
+}
+
+void deinitEx(int exception, int modeSelected, int modeSelected2)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
 
@@ -2340,7 +2345,7 @@ void deinit(int exception, int modeSelected)
 #endif
     unloadPads();
 
-    deinitAllSupport(exception, modeSelected);
+    deinitAllSupport(exception, modeSelected, modeSelected2);
 
     audioEnd();
     ioEnd();

--- a/src/system.c
+++ b/src/system.c
@@ -1164,7 +1164,13 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
             LOG("[NEUTRINO]   argv[%d]=%s\n", i, argv[i]);
     }
 
-    LoadELFFromFileWithPartition(neutrinoPath, "", argc, argv);
+    // Hand off WITHOUT the elf-loader IOP reset (NHDDL parity, vendored elfldr/): Neutrino reads
+    // its config/modules (-cwd) and opens the game ISO through OUR still-mounted devices, and only
+    // then does its own IOP reset -- the old resetting handoff left it a bare SIO2MAN/MCMAN/MCSERV
+    // IOP, so any USB/BDM-hosted neutrino.elf setup black-screened to OSDSYS. The callers keep both
+    // the game device and the neutrino.elf device mounted (deinitEx).
+    if (sysLoadELFKeepIOP(neutrinoPath, "", argc, argv) < 0)
+        LOG("[NEUTRINO] keep-IOP handoff failed for %s\n", neutrinoPath);
 }
 
 // Hand off to an external POPSTARTER.ELF to boot a PS1 VCD. The caller resolves the per-device

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -315,14 +315,11 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     // `game`. Neutrino path forwarded so a Neutrino launch protects the MMCE hand-off timing.
     mmceSendGameID(game->startup, neutrinoPath);
 
-    // Keep the device that holds neutrino.elf MOUNTED across teardown (UNMOUNT_EXCEPTION) so
-    // sysLaunchNeutrino's LoadELFFromFile can still read it; an MC-hosted neutrino (mode -1) survives any
-    // deinit, so NO_EXCEPTION there. Mirrors bdmsupport's Neutrino deinit contract.
+    // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino reads the game through OUR udpfs
+    // filesystem and its config/modules from the neutrino.elf device (-cwd) before its own IOP
+    // reset -- keep BOTH mounted across the teardown. Mirrors bdmsupport's Neutrino deinit contract.
     int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-    if (neutrinoDevMode >= 0)
-        deinit(UNMOUNT_EXCEPTION, neutrinoDevMode);
-    else
-        deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit calls udpfsCleanUp -> udpfsGames/game freed
+    deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees udpfsGames/game
 
     // Hand off to Neutrino with the udpfs driver token. `partname` (the filesystem game path) + the token
     // survive the deinit above; `game` does not and is not used past this point.


### PR DESCRIPTION
**Fixes Neutrino USB launches black-screening to OSDSYS** — root cause verified against primary sources before building.

### Root cause (confirmed, file:line)
- ps2sdk's `LoadELFFromFileWithPartition` child loader `SifLoadElf()`s neutrino.elf through the live mounts, **then `SifIopReset`s and reloads only `rom0:SIO2MAN/MCMAN/MCSERV`** (`ee/elf-loader/src/loader/src/loader.c:131-146`).
- Neutrino reads its `-cwd` config/modules and opens the `-dvd` ISO **through the launcher's mounts** and only then does its own IOP reset (`neutrino ee/loader/src/main.c:294/477/728`). After our reset it found a bare IOP → open() fails → OSDSYS.
- NHDDL hands off with a loader whose header literally says *"Modified to not reset IOP for use with NHDDL"* (`nhddl/loader/loader.c`) — that's the parity this PR adopts.
- OPL's `-bsd`/`-dvd`/`-cwd` args were verified byte-correct against NHDDL/neutrino and are untouched.

### The fix
1. **`elfldr/`** — vendored NHDDL-style child loader (linked at 0x84000): `SifLoadElf` via the **live** IOP, `ExecPS2`, no reset. Vendored rather than using ps2sdk's new `LoadELFFromFileWithPartitionNoReset` because neither container ships it yet (added upstream 2026-06-30; ps2dev:latest carries a 2026-06-21 SDK) — and vendoring fixes the **OLDSDK ELF too**.
2. **`sysLoadELFKeepIOP()`** — stages the embedded loader with argv[0]=neutrino path; probes the path first so a bad setup fails inside OPL instead of falling to OSDSYS. Only `sysLaunchNeutrino` uses it — POPSTARTER (#66 semantics) and APPS keep the classic resetting loader.
3. **`deinitEx()`** — deinit with a second kept mode: all four Neutrino callers (bdm/hdd/mmce/udpfs) now keep **both** the game device and the neutrino.elf device mounted. Previously an MC-hosted neutrino got `NO_EXCEPTION` (full teardown incl. the game's device) — harmless under the old reset, load-bearing now.

### Validation
- Build-green on **ps2dev:latest** and **ps2max/dev:v20250725-2** (both ELFs produced; only pre-existing warnings).
- clang-format 12 clean.
- HW test matrix: USB-hosted neutrino + USB game (the failing case), MC-hosted neutrino + USB game, MMCE game via Neutrino, UDPBD/UDPFS launch (Neutrino-locked path), APA/HDL launch. ee_core ISO launches are untouched by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)