### PR TITLE
fix(pops,mmce): preserve POPSTARTER's argv[0] selector; keep STOCK in-game mmcedrv

### DIFF
--- a/.github/scripts/install_coherent_mmce.sh
+++ b/.github/scripts/install_coherent_mmce.sh
@@ -1,21 +1,27 @@
 #!/bin/sh
-# Install a COHERENT MMCE driver trio (mmceman/mmcedrv/mmceigr) into the container's
-# $(PS2SDK)/iop/irx, replacing the SDK-provided prebuilts, for the ps2dev/ps2dev:latest build.
+# Install a MENU-coherent mmceman into the container's $(PS2SDK)/iop/irx, replacing the
+# SDK-provided prebuilt, for the ps2dev/ps2dev:latest build. mmcedrv/mmceigr (the IN-GAME
+# modules) are deliberately LEFT AS THE CONTAINER'S STOCK PREBUILTS.
 #
-# WHY: the ps2dev:latest container gets its mmceman/mmcedrv/mmceigr via ps2sdk-ports, pinned to
+# WHY (menu / mmceman): the ps2dev:latest container gets its mmce trio via ps2sdk-ports, pinned to
 # ps2-mmce v2.1.1 (979dd77e, 2026-03-07) -- which PREDATES the 2026-06-14 "Changes to mmceman for
 # ps2sdk sio2man updates" fix (cccc366). The same container's sio2man is the post-May-2026 refactor,
-# so the pinned v2.1.1 driver's sio2man hook is DESYNCED from the runtime sio2man. That mismatch
-# hangs MMCE both in the menu (cover-art reads freeze after the list populates) and in-game (freeze
-# after the PS2 logo): short SIO2 exchanges (dir enumeration) happen to work, sustained transfers
-# (a PNG read, ISO streaming) hit the broken arbitration. The pinned ps2max/dev build is unaffected
-# (its SDK ships a July-2025 mmceman coherent with its July-2025 sio2man), so this is latest-only.
+# so the pinned v2.1.1 mmceman's sio2man hook is DESYNCED from the runtime sio2man: short SIO2
+# exchanges (dir enumeration) happen to work, sustained transfers (cover-art PNG reads) freeze the
+# menu. Rebuilding mmceman from MMCE_PIN (includes cccc366) fixed this -- hardware-confirmed.
 #
-# FIX: build the trio from ps2-mmce @ MMCE_PIN (the "latest" tag db3e93f0, which INCLUDES the
-# sio2man-compat fix) against THIS container's SDK, so the hook matches the container's sio2man,
-# then drop the IRX into $(PS2SDK)/iop/irx. The OPL Makefile's MMCE_ASSETS_DIR already points there,
-# so every subsequent make (ELF, cdvdman/mcemu USE_MMCE modules, variants, debug) embeds the
-# coherent driver with no further changes. Idempotent: safe to run once per job before building.
+# WHY NOT mmcedrv/mmceigr (in-game): mmcedrv drives SIO2 directly (its import table has NO sio2man
+# dependency -- verified by binary import-table parse), and its SOURCE is UNCHANGED between the
+# v2.1.1 pin and MMCE_PIN (`git diff v2.1.1..db3e93f0 -- mmcedrv` is empty). Our repo-Makefile
+# rebuild on the new toolchain produced a DIFFERENT binary (10009 vs 11337 bytes) that FAILED
+# in-game on hardware (issue #56/#68 reports, 2026-07-05: OPL-core MMCE games broken on the
+# "latest" flavour but fine on the "woplsdk" flavour, whose only relevant delta is stock-vs-rebuilt
+# mmcedrv). The stock ports-built binary is field-proven in-game (wOPL ships the byte-identical
+# file). Same source, proven binary: keep stock.
+#
+# The OPL Makefile's MMCE_ASSETS_DIR points at $(PS2SDK)/iop/irx, so every subsequent make (ELF,
+# cdvdman/mcemu USE_MMCE modules, variants, debug) picks this mix up with no further changes.
+# Idempotent: safe to run once per job before building.
 #
 # Pin is an immutable SHA (the "latest" tag is force-moved upstream). Bump deliberately.
 set -eu
@@ -30,26 +36,28 @@ WORK="$(mktemp -d)"
 # Clean up on normal exit AND on the signals a CI cancel/timeout sends -- some ash/dash builds don't
 # run the EXIT trap on signal termination, so name them explicitly (harmless where EXIT already covers it).
 trap 'rm -rf "$WORK"' EXIT TERM INT HUP
-echo "== Building coherent MMCE driver from ps2-mmce @ ${MMCE_PIN} =="
+echo "== Building menu-coherent mmceman from ps2-mmce @ ${MMCE_PIN} =="
 git clone --quiet "$MMCE_REPO" "$WORK/mmceman"
 git -C "$WORK/mmceman" checkout --quiet "$MMCE_PIN"
 
 # Older-SDK make quirk: the per-module obj dir isn't auto-created by every Makefile.iopglobal
-# vintage -- pre-create them so the first compile step doesn't fail on a missing directory.
-mkdir -p "$WORK/mmceman/mmceman/obj" "$WORK/mmceman/mmcedrv/obj" "$WORK/mmceman/mmceigr/obj"
+# vintage -- pre-create it so the first compile step doesn't fail on a missing directory.
+mkdir -p "$WORK/mmceman/mmceman/obj"
 
-make -C "$WORK/mmceman"
+make -C "$WORK/mmceman/mmceman"
 
-installed=0
-for m in mmceman mmcedrv mmceigr; do
-    src="$WORK/mmceman/$m/irx/$m.irx"
-    if [ ! -f "$src" ]; then
-        echo "ERROR: $m.irx was not produced by the ps2-mmce build" >&2
+src="$WORK/mmceman/mmceman/irx/mmceman.irx"
+if [ ! -f "$src" ]; then
+    echo "ERROR: mmceman.irx was not produced by the ps2-mmce build" >&2
+    exit 1
+fi
+cp -f "$src" "$DEST/mmceman.irx"
+echo "  installed mmceman.irx ($(wc -c < "$src") bytes) -> $DEST/"
+for m in mmcedrv mmceigr; do
+    if [ ! -f "$DEST/$m.irx" ]; then
+        echo "ERROR: stock $m.irx missing from the SDK prebuilts" >&2
         exit 1
     fi
-    cp -f "$src" "$DEST/$m.irx"
-    echo "  installed $m.irx ($(wc -c < "$src") bytes) -> $DEST/"
-    installed=$((installed + 1))
+    echo "  keeping STOCK $m.irx ($(wc -c < "$DEST/$m.irx") bytes) in $DEST/ (in-game, field-proven)"
 done
-[ "$installed" -eq 3 ] || { echo "ERROR: expected 3 MMCE IRX, installed $installed" >&2; exit 1; }
-echo "== Coherent MMCE driver installed over the SDK prebuilts =="
+echo "== Menu-coherent mmceman installed; in-game mmcedrv/mmceigr remain the SDK stock prebuilts =="

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -94,10 +94,11 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow || true
 
-      - name: Install coherent MMCE driver (latest-only)
-        # Rebuild mmceman/mmcedrv/mmceigr from ps2-mmce (with the 2026-06-14 sio2man-compat fix)
-        # over the container SDK prebuilts (pinned to the desynced v2.1.1) so the driver matches
-        # the container post-refactor sio2man -- fixes the MMCE menu + in-game freezes. See script.
+      - name: Install menu-coherent mmceman (latest-only)
+        # Rebuild mmceman ONLY from ps2-mmce (with the 2026-06-14 sio2man-compat fix) over the
+        # container SDK prebuilt (pinned to the desynced v2.1.1) -- fixes the MMCE MENU freeze.
+        # The in-game mmcedrv/mmceigr stay the SDK stock prebuilts: same source as the pin, and
+        # the stock binaries are field-proven in-game where our rebuild was not. See script header.
         run: sh ./.github/scripts/install_coherent_mmce.sh
 
       - name: Compile -> make clean release
@@ -215,10 +216,11 @@ jobs:
         run: |
           echo "OPL_VERSION=$(make oplversion)" >> "$GITHUB_ENV"
 
-      - name: Install coherent MMCE driver (latest-only)
-        # Rebuild mmceman/mmcedrv/mmceigr from ps2-mmce (with the 2026-06-14 sio2man-compat fix)
-        # over the container SDK prebuilts (pinned to the desynced v2.1.1) so the driver matches
-        # the container post-refactor sio2man -- fixes the MMCE menu + in-game freezes. See script.
+      - name: Install menu-coherent mmceman (latest-only)
+        # Rebuild mmceman ONLY from ps2-mmce (with the 2026-06-14 sio2man-compat fix) over the
+        # container SDK prebuilt (pinned to the desynced v2.1.1) -- fixes the MMCE MENU freeze.
+        # The in-game mmcedrv/mmceigr stay the SDK stock prebuilts: same source as the pin, and
+        # the stock binaries are field-proven in-game where our rebuild was not. See script header.
         run: sh ./.github/scripts/install_coherent_mmce.sh
 
       - name: Compile -> make ${{ matrix.extra }} ${{ matrix.pademu }} ${{ matrix.extra }} NOT_PACKED=1
@@ -465,10 +467,11 @@ jobs:
         run: |
           echo "OPL_VERSION=$(make oplversion)" >> "$GITHUB_ENV"
 
-      - name: Install coherent MMCE driver (latest-only)
-        # Rebuild mmceman/mmcedrv/mmceigr from ps2-mmce (with the 2026-06-14 sio2man-compat fix)
-        # over the container SDK prebuilts (pinned to the desynced v2.1.1) so the driver matches
-        # the container post-refactor sio2man -- fixes the MMCE menu + in-game freezes. See script.
+      - name: Install menu-coherent mmceman (latest-only)
+        # Rebuild mmceman ONLY from ps2-mmce (with the 2026-06-14 sio2man-compat fix) over the
+        # container SDK prebuilt (pinned to the desynced v2.1.1) -- fixes the MMCE MENU freeze.
+        # The in-game mmcedrv/mmceigr stay the SDK stock prebuilts: same source as the pin, and
+        # the stock binaries are field-proven in-game where our rebuild was not. See script header.
         run: sh ./.github/scripts/install_coherent_mmce.sh
 
       - name: Compile -> make debug

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -230,12 +230,12 @@ jobs:
         id: ver
         run: echo "version=$(make oplversion)" >> "$GITHUB_OUTPUT"
 
-      - name: Install coherent MMCE driver (latest-only)
+      - name: Install menu-coherent mmceman (latest-only)
         # This container's SDK ships mmceman pinned to ps2-mmce v2.1.1, which predates the
         # 2026-06-14 sio2man-compat fix and is desynced from the container's post-refactor
-        # sio2man -- freezing MMCE both in-menu (cover-art reads) and in-game. Rebuild the trio
-        # from ps2-mmce with the fix and install over the SDK prebuilts BEFORE the OPL build
-        # embeds them. See docs/RECOVERY-2026-07-03.md and the script header.
+        # sio2man -- freezing the MENU (cover-art reads). Rebuild mmceman ONLY; the in-game
+        # mmcedrv/mmceigr stay the SDK stock prebuilts (same source as the pin, and the stock
+        # binaries are field-proven in-game where our rebuild was not -- see the script header).
         run: sh ./.github/scripts/install_coherent_mmce.sh
 
       - name: Build (make clean release)

--- a/docs/RECOVERY-2026-07-03.md
+++ b/docs/RECOVERY-2026-07-03.md
@@ -56,6 +56,27 @@
 >    **Beta-2921 or later** (2827a2a4 = merge of #64; current rolling = 2925). The "upstream
 >    mmcedrv limitation" hypothesis stays UNVERIFIED until a ≥2921 freeze is reproduced.
 
+> **UPDATE 2026-07-05 (first HW reports on the 3-flavour zip → two root causes closed):**
+> - **PS1/VCD "__common" on every non-HDD device — REAL ROOT CAUSE FOUND (PR #66 was necessary
+>   but not sufficient):** the stock SDK elf-loader's child CLOBBERS the target's argv[0] with
+>   `<partition><filename>` and shifts the selector to argv[1]
+>   (ps2sdk loader.c: `new_argv[0] = fullPath`), so POPSTARTER never saw the `XX./SB.` prefix and
+>   always took its HDD route ("__common"). POPSLoader's vendored loader explicitly "preserves
+>   caller args" — that's the divergence. FIX: the elfldr/ child contract is now
+>   argv[0]=load-path, argv[1..]=the target's FULL argv (caller controls the target's argv[0]);
+>   `sysLaunchPopstarter` hands non-HDD launches through it (selector stays argv[0], no OPL-side
+>   IOP reset — POPSLoader REBOOT_IOP=0 parity); HDD/APA keeps the classic partition-context
+>   loader (its HDD route is correct there).
+> - **MMCE in-game (OPL core) on the latest flavour — OWNED BY OUR DRIVER REBUILD, not upstream:**
+>   testers report OPL-core MMCE games broken on `-latest` but working on `-woplsdk` (same code).
+>   Binary analysis: mmcedrv imports NO sio2man (drives SIO2 directly) and its SOURCE is unchanged
+>   v2.1.1→db3e93f0 — our repo-Makefile rebuild (10009b vs stock 11337b) is the only in-game
+>   delta, and the stock ports-built binary is field-proven (wOPL ships the byte-identical file).
+>   FIX: `install_coherent_mmce.sh` now installs ONLY the rebuilt mmceman (menu pairing fix,
+>   HW-confirmed) and keeps STOCK mmcedrv/mmceigr in-game.
+> - **Neutrino handoff (PR #67) HW-CONFIRMED on USB** (+ gameID/per-game VMC switching restored
+>   as a side effect). Residual under watch: neutrino-hosted-on-MMCE black screen (one report).
+
 Hardware validation (2026-07-02/03) came back negative on four fronts. A six-track
 investigation (each finding adversarially re-verified against the code where noted)
 traced every reported symptom to concrete root causes. This document records the

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -53,8 +53,12 @@ static void wipeUserMem(void)
     }
 }
 
-// argv[0] = path to the target ELF; the full argv is forwarded to it verbatim
-// (the ExecPS2 syscall marshals the strings, so wiping user memory is safe).
+// argv[0] = path of the ELF to LOAD; argv[1..] = the target's FULL argv, forwarded verbatim
+// (argv[1] becomes the target's argv[0]). The caller CONTROLS the target's argv[0]: Neutrino
+// gets its own path (NHDDL convention), POPSTARTER gets the "XX./SB." selector it string-parses
+// to pick its backend -- the stock SDK loader clobbers argv[0] with the load path, which is
+// exactly what sent POPSTARTER down its HDD "__common" route on every non-HDD VCD launch.
+// The ExecPS2 syscall marshals the strings, so wiping user memory is safe.
 int main(int argc, char *argv[])
 {
     static t_ExecData elfdata;
@@ -62,7 +66,7 @@ int main(int argc, char *argv[])
 
     elfdata.epc = 0;
 
-    if (argc < 1)
+    if (argc < 2)
         return -EINVAL;
 
     SifInitRpc(0);
@@ -76,7 +80,7 @@ int main(int argc, char *argv[])
     if (ret == 0 && elfdata.epc != 0) {
         FlushCache(0);
         FlushCache(2);
-        return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
+        return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, &argv[1]);
     } else {
         SifExitRpc();
         return -ENOENT;

--- a/include/system.h
+++ b/include/system.h
@@ -45,11 +45,13 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
 // token; partition = "" for non-HDD. Caller deinit()s with UNMOUNT_EXCEPTION first (see system.c).
 void sysLaunchPopstarter(const char *popstarterElf, const char *selector, const char *partition);
 
-// ELF handoff that KEEPS the IOP (drivers + mounts) alive -- NHDDL parity for the Neutrino
-// launch: the vendored elfldr/ child loader SifLoadElf()s the target through OPL's live mounts
-// and never SifIopReset()s (the target resets the IOP itself). Container-independent: works the
-// same on ps2dev:latest and the OLDSDK pin. Returns only on failure (bad path/ELF), like
-// LoadELFFromFileWithPartition. Implemented in elfldr_noreset.c.
+// ELF handoff that KEEPS the IOP (drivers + mounts) alive -- NHDDL parity: the vendored elfldr/
+// child loader SifLoadElf()s the target through OPL's live mounts and never SifIopReset()s (the
+// target resets the IOP itself). argv is the target's FULL argv, argv[0] INCLUDED and
+// caller-controlled -- unlike LoadELFFromFileWithPartition, which clobbers the target's argv[0]
+// with "<partition><filename>" (that clobber is what broke POPSTARTER's XX./SB. selector).
+// Container-independent: works the same on ps2dev:latest and the OLDSDK pin. Returns only on
+// failure (bad path/ELF). Implemented in elfldr_noreset.c.
 int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, char *argv[]);
 
 int sysExecElf(const char *path);

--- a/src/elfldr_noreset.c
+++ b/src/elfldr_noreset.c
@@ -77,7 +77,13 @@ int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, cha
     void *pdata;
     int i, fd;
 
-    (void)partition; // the Neutrino handoff always passes "" -- no APA-partition context needed
+    (void)partition; // callers pass "" -- no APA-partition context needed on this path
+
+    // argv here is the target's FULL argv -- argv[0] INCLUDED and caller-controlled (Neutrino:
+    // its own path; POPSTARTER: the XX./SB. selector it string-parses). At least argv[0] must
+    // be supplied: the child forwards &argv[1] verbatim, never synthesizing a replacement.
+    if (argc < 1 || argv == NULL || argv[0] == NULL)
+        return -1;
 
     // Probe the target through our still-live mounts so a bad path fails fast in OPL
     // instead of inside the child loader (which can only fall through to OSDSYS).
@@ -85,8 +91,8 @@ int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, cha
         return -1;
     close(fd);
 
-    // argv[0] must be the target path (the child SifLoadElf()s argv[0] and forwards
-    // the whole vector); the ExecPS2 syscall marshals the strings across the jump.
+    // Child contract: argv[0] = load path (SifLoadElf'd), argv[1..] = the target's full argv;
+    // the ExecPS2 syscall marshals the strings across the jump.
     char *new_argv[argc + 1];
     new_argv[0] = (char *)filename;
     for (i = 0; i < argc; i++)

--- a/src/system.c
+++ b/src/system.c
@@ -1067,9 +1067,15 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
     char compatModes[32] = ""; // stays empty when no compat modes are forwarded (B1)
     char globalArgsBuf[256];   // mutable copy of gNeutrinoArgs for tokenizing (tokens point in)
     char extraArgsBuf[256];    // mutable copy of the per-game extraArgs for tokenizing
-    char *argv[32];            // auto args (max ~6) + tokenized user flags
+    char *argv[32];            // target argv[0] + auto args (max ~6) + tokenized user flags
     int argc = 0;
     const int argvMax = (int)(sizeof(argv) / sizeof(argv[0]));
+
+    // Target argv[0] = neutrino.elf's own path (NHDDL convention). sysLoadELFKeepIOP forwards
+    // argv verbatim -- argv[0] included -- so this must be supplied explicitly here (POPSTARTER
+    // launches use the same loader with a selector as argv[0] instead).
+    if (argc < argvMax)
+        argv[argc++] = (char *)neutrinoPath;
 
     if (!strcmp(deviceName, "apa")) {
         snprintf(bsd, sizeof(bsd), "-bsd=ata");
@@ -1188,7 +1194,24 @@ void sysLaunchPopstarter(const char *popstarterElf, const char *selector, const 
     char *argv[1];
     argv[0] = (char *)selector;
     LOG("[POPS] elf=%s argv0=%s part=%s\n", popstarterElf, selector, partition ? partition : "");
-    LoadELFFromFileWithPartition(popstarterElf, partition ? partition : "", 1, argv);
+
+    if (partition != NULL && partition[0] != '\0') {
+        // HDD/APA launches keep the classic resetting loader: the partition-context handoff is
+        // the hardware-proven PP. path, and POPSTARTER's HDD route is the CORRECT one there.
+        LoadELFFromFileWithPartition(popstarterElf, partition, 1, argv);
+        return;
+    }
+
+    // BDMA/SMB: POPSTARTER string-parses ARGV[0] for the XX./SB. selector prefix to pick its
+    // backend. The stock SDK loader CLOBBERS the target's argv[0] with "<partition><filename>"
+    // and shifts the selector to argv[1] -- POPSTARTER then saw a prefixless "POPSTARTER.ELF"
+    // basename, took its HDD route, and died on "__common" (issues #56/#69: PS1 launch failing
+    // on every non-HDD device, regardless of the selector STRING, which PR #66 already fixed).
+    // Hand off via the argv-preserving no-reset loader instead -- POPSLoader parity: its loader
+    // "preserves caller args" and defaults REBOOT_IOP_WHILE_LOADING_POPSTARTER=0; POPSTARTER
+    // does its own IOP reset and reloads its drivers from the MC regardless.
+    if (sysLoadELFKeepIOP(popstarterElf, "", 1, argv) < 0)
+        LOG("[POPS] keep-IOP handoff failed for %s\n", popstarterElf);
 }
 
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags)


### PR DESCRIPTION
Two hardware-confirmed root causes from the first 3-flavour rolling reports (#56/#68/#69):

### 1. PS1/VCD `__common` — you called it: the `XX.` never reached argv[0]
The stock SDK elf-loader's child **clobbers the target's argv[0]** with `<partition><filename>` and shifts the selector to argv[1] (`ps2sdk loader.c: new_argv[0] = fullPath`). POPSTARTER string-parses ARGV[0], saw a prefixless `POPSTARTER.ELF`, took its HDD route → `__common` → boot.elf, on every non-HDD device. #66's selector *string* was right; the slot was wrong. POPSLoader's own loader "preserves caller args" — that's the divergence.

**Fix:** the `elfldr/` child contract is now `argv[0]=load path, argv[1..]=target's FULL argv` (caller controls target argv[0]). `sysLaunchPopstarter` routes non-HDD launches through it — selector stays argv[0], no OPL-side IOP reset (POPSLoader `REBOOT_IOP=0` parity; POPSTARTER resets and re-equips from MC itself). Neutrino behaviour unchanged (it supplies its own path as argv[0]). HDD/APA keeps the classic partition-context loader — the HDD route is *correct* there.

### 2. MMCE OPL-core: our mmcedrv rebuild owned it, not upstream
Testers: OPL-core MMCE games broken on `-latest`, fine on `-woplsdk` — same code. Binary analysis: mmcedrv **imports no sio2man** (drives SIO2 directly) and its **source is unchanged v2.1.1→db3e93f0** — our repo-Makefile rebuild (10009 vs stock 11337 bytes) was pure toolchain delta, and the stock ports-built binary is field-proven (wOPL ships the byte-identical file).

**Fix:** `install_coherent_mmce.sh` installs ONLY the rebuilt mmceman (menu cover-art pairing fix, HW-confirmed) and keeps **stock mmcedrv/mmceigr** in-game. Verified in-container: mmceman `e6f3695d` installed, mmcedrv/mmceigr kept at stock `d9e0d476`/`981323e1`.

### Validation
- Build-green **ps2dev:latest** (new script exercised end-to-end) and **ps2max/dev:v20250725-2**; clang-format clean.
- HW matrix: PS1 VCD from USB / MMCE / SMB (expect XX./SB. route, no `__common`), PS1 from HDD-APA (regression check), OPL-core MMCE game on the default ELF (expect woplsdk-equivalent behaviour now), Neutrino USB launch (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)