### PR TITLE
fix(elfldr): load target ELFs via fileXio (iomanX) — fixes neutrino-on-MMCE

### DIFF
--- a/docs/RECOVERY-2026-07-03.md
+++ b/docs/RECOVERY-2026-07-03.md
@@ -21,6 +21,17 @@
 > EE-side hardening of the *menu* MMCE read (unbounded `read()` with no timeout — a genuinely dead
 > card can still hang; mirror the in-game bounded-wait). **The other symptoms remain HARDWARE-PENDING** — run the §8 matrix.
 
+> **UPDATE 2026-07-05b (last recovery residual root-caused + fixed):** neutrino-hosted-on-MMCE
+> launches failed in BOTH loader generations (boot.elf-revert pre-#67, black screen post-#67)
+> because of a probe/load API split: OPL resolves `mmce0:/neutrino/neutrino.elf` via
+> fileXio→**iomanX** (succeeds), but the child loader loaded it via SifLoadElf→rom0:LOADFILE→
+> plain **ioman** — and `mmceman` registers its device with iomanX ONLY (binary import tables:
+> mmceman imports `iomanx`, bdmfs_fatfs imports `ioman`, which is why USB-hosted worked). Also
+> explains "worked once then never": a leftover neutrino/ folder on the card makes Auto prefer
+> the unloadable card copy for MMCE-hosted games. FIX: the elfldr child now loads the target ELF
+> **via fileXio (iomanX-aware) first**, SifLoadElf fallback — one load path covering
+> mass/mc/mmce/pfs/smb, finally consistent with the probe.
+
 > **UPDATE 2026-07-04 (verification round against primary sources):**
 > 1. **VCD/POPSTARTER selector ([PR #66](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/66)) — VERIFIED CORRECT, ready to roll.** The maintainer
 >    hardware-confirmed both selector forms: `mass:/POPS/XX.<name>.ELF` for every BDMA source

--- a/elfldr/Makefile
+++ b/elfldr/Makefile
@@ -3,7 +3,9 @@
 # memory with the target ELF while OPL's IOP state stays untouched.
 
 EE_LINKFILE := linkfile
-EE_CFLAGS = -D_EE -Os -G0 -Wall
+# NEWLIB_PORT_AWARE: this loader calls the raw fileXio client on purpose (no newlib fds exist
+# here); the SDK headers #error on direct fio/fileXio use unless the caller declares awareness.
+EE_CFLAGS = -D_EE -DNEWLIB_PORT_AWARE -Os -G0 -Wall
 EE_CFLAGS += -fdata-sections -ffunction-sections
 EE_LDFLAGS = -Wl,-zmax-page-size=128
 EE_LDFLAGS += -s -Wl,--gc-sections
@@ -12,7 +14,9 @@ EE_BIN = elfldr.elf
 
 EE_OBJS = loader.o
 
-EE_LIBS =
+# fileXio EE client: the child loads the target ELF through the resident fileXio server
+# (iomanX-aware -- reaches mmceN:/pfs/smb paths the ROM LOADFILE's plain-ioman lookup cannot).
+EE_LIBS = -lfileXio
 
 all: $(EE_BIN)
 

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -10,17 +10,29 @@
 # Modified for RiptOPL: NO IOP reset (same approach as NHDDL's neutrino
 # handoff). This child loader runs from BIOS-unused memory (0x84000), loads
 # the target ELF through the STILL-LIVE IOP -- OPL's drivers and mounts stay
-# up -- and jumps into it. The target (Neutrino) reads its config/modules and
-# the game ISO through those mounts, then performs its own IOP reset. The
-# ps2sdk loader's SifIopReset + rom0:SIO2MAN/MCMAN/MCSERV reload is exactly
-# what broke every launch whose files lived on a BDM device.
+# up -- and jumps into it. The target (Neutrino/POPSTARTER) reads its
+# config/modules and the game through those mounts, then performs its own
+# IOP reset.
+#
+# The target is read via fileXio (iomanX) FIRST, falling back to SifLoadElf
+# (rom0:LOADFILE, plain ioman) only if that fails. The ROM LOADFILE cannot
+# see iomanX-ONLY filesystems: mmceman registers its mmceN: device with
+# iomanX and never with ioman (binary import tables: mmceman imports iomanx,
+# while bdmfs_fatfs imports ioman) -- so an MMCE-hosted neutrino.elf probed
+# fine from OPL (fileXio) but SifLoadElf() returned -ENOENT here, black-
+# screening every neutrino-on-MMCE launch. fileXio reaches ioman devices
+# too, so one load path now covers mass/mc/mmce/pfs/smb uniformly -- and it
+# matches how OPL resolved the path in the first place.
 */
 
 #include <kernel.h>
 #include <loadfile.h>
 #include <ps2sdkapi.h>
 #include <sifrpc.h>
+#include <fileXio_rpc.h>
+#include <fileio.h>
 #include <errno.h>
+#include <string.h>
 
 //--------------------------------------------------------------
 // Redefinition of init/deinit libc:
@@ -35,6 +47,39 @@ void _libcglue_args_parse(int argc, char **argv) {}
 DISABLE_PATCHED_FUNCTIONS();
 DISABLE_EXTRA_TIMERS_FUNCTIONS();
 PS2_DISABLE_AUTOSTART_PTHREAD();
+
+#define ELF_MAGIC   0x464c457f
+#define ELF_PT_LOAD 1
+
+typedef struct
+{
+    u8 ident[16];
+    u16 type;
+    u16 machine;
+    u32 version;
+    u32 entry;
+    u32 phoff;
+    u32 shoff;
+    u32 flags;
+    u16 ehsize;
+    u16 phentsize;
+    u16 phnum;
+    u16 shentsize;
+    u16 shnum;
+    u16 shstrndx;
+} elf_header_t;
+
+typedef struct
+{
+    u32 type;
+    u32 offset;
+    void *vaddr;
+    u32 paddr;
+    u32 filesz;
+    u32 memsz;
+    u32 flags;
+    u32 align;
+} elf_pheader_t;
 
 //--------------------------------------------------------------
 // Clear user memory
@@ -53,6 +98,66 @@ static void wipeUserMem(void)
     }
 }
 
+static int readAll(int fd, void *buf, int size)
+{
+    u8 *p = (u8 *)buf;
+    while (size > 0) {
+        int got = fileXioRead(fd, p, size);
+        if (got <= 0)
+            return -1;
+        p += got;
+        size -= got;
+    }
+    return 0;
+}
+
+// Manual ELF load through the resident fileXio server (iomanX-aware). The program segments load
+// into user memory (>= 0x100000, already wiped) well above this loader's bram home, so reading
+// straight to each vaddr is safe. Returns 0 and sets *entry on success. gp stays 0 at ExecPS2:
+// standard PS2 crt0s load $gp themselves (POPSLoader's embedded loader ships the same way).
+static int loadElfViaFileXio(const char *path, u32 *entry)
+{
+    elf_header_t eh;
+    elf_pheader_t ph;
+    int fd, i, loaded = 0;
+
+    if (fileXioInit() < 0)
+        return -1;
+    fd = fileXioOpen(path, FIO_O_RDONLY);
+    if (fd < 0)
+        return -1;
+
+    if (readAll(fd, &eh, sizeof(eh)) != 0 || _lw((u32)&eh.ident) != ELF_MAGIC || eh.phnum == 0) {
+        fileXioClose(fd);
+        return -1;
+    }
+
+    for (i = 0; i < eh.phnum; i++) {
+        if (fileXioLseek(fd, eh.phoff + i * sizeof(elf_pheader_t), SEEK_SET) < 0 ||
+            readAll(fd, &ph, sizeof(ph)) != 0) {
+            fileXioClose(fd);
+            return -1;
+        }
+        if (ph.type != ELF_PT_LOAD || ph.memsz == 0)
+            continue;
+        if (ph.filesz > 0) {
+            if (fileXioLseek(fd, ph.offset, SEEK_SET) < 0 || readAll(fd, ph.vaddr, ph.filesz) != 0) {
+                fileXioClose(fd);
+                return -1;
+            }
+        }
+        if (ph.memsz > ph.filesz)
+            memset((u8 *)ph.vaddr + ph.filesz, 0, ph.memsz - ph.filesz);
+        loaded++;
+    }
+    fileXioClose(fd);
+
+    if (!loaded)
+        return -1;
+    *entry = eh.entry;
+    return 0;
+}
+
 // argv[0] = path of the ELF to LOAD; argv[1..] = the target's FULL argv, forwarded verbatim
 // (argv[1] becomes the target's argv[0]). The caller CONTROLS the target's argv[0]: Neutrino
 // gets its own path (NHDDL convention), POPSTARTER gets the "XX./SB." selector it string-parses
@@ -62,9 +167,8 @@ static void wipeUserMem(void)
 int main(int argc, char *argv[])
 {
     static t_ExecData elfdata;
+    u32 entry;
     int ret;
-
-    elfdata.epc = 0;
 
     if (argc < 2)
         return -EINVAL;
@@ -74,6 +178,15 @@ int main(int argc, char *argv[])
 
     // Writeback data cache before loading ELF.
     FlushCache(0);
+
+    if (loadElfViaFileXio(argv[0], &entry) == 0) {
+        FlushCache(0);
+        FlushCache(2);
+        return ExecPS2((void *)entry, NULL, argc - 1, &argv[1]);
+    }
+
+    // Fallback: the classic LOADFILE path (covers an environment without a resident fileXio).
+    elfdata.epc = 0;
     SifLoadFileInit();
     ret = SifLoadElf(argv[0], &elfdata);
     SifLoadFileExit();


### PR DESCRIPTION
**The last recovery residual, root-caused and fixed:** neutrino.elf hosted ON the MMCE card failed in both loader generations (revert-to-boot.elf pre-#67, black screen post-#67) while USB-hosted worked.

### Root cause — a probe/load API split, proven from binary import tables
- OPL resolves `mmce0:/neutrino/neutrino.elf` via `open()` → fileXio → **iomanX** → succeeds → commits to the path.
- The child loader loaded it via `SifLoadElf` → rom0:LOADFILE → **plain ioman** — and `mmceman` registers its device with **iomanX only**: `mmceman.irx` imports `iomanx` (both driver generations), while `bdmfs_fatfs.irx` imports `ioman` (which is exactly why USB-hosted worked).

This also explains AndrewBento's "worked once, then never again": test runs left a `neutrino/` folder on the card, and the AUTO resolver prefers the game device — MMCE-hosted games silently resolved to the unloadable card copy while USB games fell through to the loadable mc0 copy.

### Fix
The `elfldr` child now loads the target through the **resident fileXio server first** (iomanX-aware — one load path covering mass/mc/mmce/pfs/smb, finally consistent with the probe), with classic `SifLoadElf` as fallback. Manual segment loading + `ExecPS2(entry, 0, …)` is POPSLoader-proven. `NEWLIB_PORT_AWARE` is defined for the child only (it deliberately talks raw fileXio — no newlib fds exist in a bare loader).

### Validation
- Build-green on **ps2dev:latest** and **ps2max/dev:v20250725-2**; child is 75 KB (bram window is 496 KB); clang-format clean.
- HW matrix: neutrino folder on **MMCE** + game on MMCE and on USB (the failing cases), neutrino on USB + game on USB (regression), neutrino on MC (regression), PS1 VCD launches (same child — regression), and cleanup tip for testers: a stale `neutrino/` folder on the card is now *loadable*, but if it's an old/partial copy, Auto will still prefer it — keep one good copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)