### PR TITLE
fix(mmce): send GameID for Neutrino-core launches of MMCE-hosted games (issue #68)

### DIFF
--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -586,6 +586,17 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     if (coreLoader) {
         char mmcePartname[256];
         snprintf(mmcePartname, sizeof(mmcePartname), "%s", partname); // defensive copy across the deinit teardown (partname is a stack buffer, not freed by deinit)
+        // GameID for the NEUTRINO core (issue #68): the native OPL-core launch deliberately does
+        // NOT push a launcher GameID (see the issue-#50 note below -- in OPL core the in-game
+        // card is OPL's mcemu, and a mid-launch re-switch froze early-MC-probing games). That
+        // reasoning does NOT extend to Neutrino: it has no mcemu -- the game talks to the card's
+        // REAL emulated-MC surface -- and nothing else ever tells the card which game is
+        // starting, so its per-game folder never engaged (USB-hosted games via Neutrino DID work:
+        // the cross-device paths all send it). NHDDL does exactly this before launching neutrino
+        // (mmceMountVMC). mmceSendGameID waits out the card's busy bit (bounded ~3 s), so the
+        // #50 mid-launch-switch race does not apply; the MC-hosted-neutrino protect guard is
+        // inside the helper (skips + warns when neutrinoPath sits on this slot's mcN:).
+        mmceSendGameID(game->startup, neutrinoPath);
         // Neutrino bypasses OPL's mcemu, so the VMC fds opened above go unused on
         // this path — close them instead of leaking until the IOP reset (B3).
         if (vmc_fds[0] >= 0)


### PR DESCRIPTION
Fixes the surviving item in [#68](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/68) (post-rectification): per-game GameID cards never engage when an **MMCE-hosted game launches via the Neutrino core**, while OPL-core launches work.

### Root cause — a skip inherited without its reasoning
The native MMCE launch deliberately skips the launcher-side GameID push (the issue-#50 note in `mmcesupport.c`: in OPL core the in-game card is OPL's **mcemu**, and a mid-launch re-switch froze early-MC-probing games). The Neutrino branch inherited that skip — but Neutrino has **no mcemu**: the game talks to the card's real emulated-MC surface, and nothing else ever tells the card which game is starting. USB-hosted games via Neutrino always worked because every cross-device path (bdm/hdd/eth/udpfs) already calls `mmceSendGameID`. NHDDL pushes the per-game mount before launching neutrino on MMCE devices (`mmceMountVMC`) — this is that parity, one call.

### Why the #50 freeze concern doesn't apply here
`mmceSendGameID` polls the card's busy bit (bounded ~3 s) before the launch proceeds, and the Neutrino handoff has further work after it — the mid-launch-switch race #50 described was OPL-core's instant boot path. The MC-hosted-neutrino protect guard inside the helper still skips + warns when neutrino.elf lives on the same slot's `mcN:`.

### Explains every #68 data point
- MMCE game + Neutrino core → no GameID card ✅ (this fix)
- MMCE game + OPL core → works (card handled in-game, unchanged)
- USB game + Neutrino → works (cross-device path already sends)
- neutrino.elf on MC → GameID skipped with warning (protect guard, by design)
- neutrino.elf on MMCE root → freeze — separate bug, already fixed in #72

Build-green on both containers; clang-format clean.

HW test: MMCE-hosted game via Neutrino core → per-game card should now engage (MGS2 Substance / GTA VC per the report); regression: same game via OPL core, and a USB game via Neutrino.

🤖 Generated with [Claude Code](https://claude.com/claude-code)