### PR TITLE
fix(gui): guidance toast when a network protocol is switched on (UDPFS silent-enable)

### DIFF
--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -917,3 +917,7 @@ gui_strings:
   string: UDPFS Access
 - label: MMCE_GAMEID_NEUTRINO_SKIP
   string: MMCE GameID not applied -- neutrino.elf is on this card (switching it would unload Neutrino).
+- label: NET_UDPFS_TAB_HINT
+  string: UDPFS on -- open the new UDPFS tab and press Confirm to connect. PC side runs udpfsd -d <games folder>.
+- label: NET_UDPBD_TAB_HINT
+  string: Network block device on -- its tab appears once the PC server answers (udpfsd -b for UDPFS Image, udpbd-server for UDPBD).

--- a/src/gui.c
+++ b/src/gui.c
@@ -1125,6 +1125,17 @@ void guiShowDeviceConfig(void)
         if (gNetworkProtocol != netProtocolWas && (bdmIsUDPBDLoaded() || ethGetModulesLoaded() || udpfsGetModulesLoaded()))
             guiMsgBox(_l(_STR_NETBOOT_RESTART), 0, NULL);
 
+        // "Nothing happens" guard (hardware report on Beta-2937): enabling a network protocol gave NO
+        // feedback -- the UDPFS tab joins the ring silently and then waits for a Confirm-press inside
+        // it (Manual start), and the block transports show a tab only once the PC server answers.
+        // Tell the user what to expect + which PC server to run, right at the moment they turn it on.
+        if (gNetworkProtocol != netProtocolWas) {
+            if (gNetworkProtocol == NET_PROTO_UDPFS)
+                guiMsgBox(_l(_STR_NET_UDPFS_TAB_HINT), 0, NULL);
+            else if (gNetworkProtocol == NET_PROTO_UDPFSBD || gNetworkProtocol == NET_PROTO_UDPBD)
+                guiMsgBox(_l(_STR_NET_UDPBD_TAB_HINT), 0, NULL);
+        }
+
         // A BDM tab can be latched hidden (bdmNeedsUpdate force-hides it when its enable flag reads 0,
         // then short-circuits until the device generation bumps). Re-evaluate device visibility now so
         // re-enabling a device here brings its tab back without a physical replug.

--- a/src/gui.c
+++ b/src/gui.c
@@ -1119,22 +1119,26 @@ void guiShowDeviceConfig(void)
         if (nowUdp && !wasUdp && ps2_ip_use_dhcp)
             guiMsgBox(_l(_STR_UDPBD_NEEDS_STATIC_IP), 0, NULL);
 
-        // Each network transport loads its IOP module chain once per boot (the load latch is not cleared
-        // live). If any network stack is already up and the user changed protocol, the switch takes effect
-        // only after a restart -- say so instead of silently doing nothing.
-        if (gNetworkProtocol != netProtocolWas && (bdmIsUDPBDLoaded() || ethGetModulesLoaded() || udpfsGetModulesLoaded()))
-            guiMsgBox(_l(_STR_NETBOOT_RESTART), 0, NULL);
-
         // "Nothing happens" guard (hardware report on Beta-2937): enabling a network protocol gave NO
         // feedback -- the UDPFS tab joins the ring silently and then waits for a Confirm-press inside
         // it (Manual start), and the block transports show a tab only once the PC server answers.
         // Tell the user what to expect + which PC server to run, right at the moment they turn it on.
+        // Shown BEFORE the restart notice below (PR #78 review): when a restart is pending, the restart
+        // message must be the LAST word so the guidance reads as "after that". Suppressing the hint in
+        // the restart case instead would lose it forever -- no protocol-CHANGE event fires on the next
+        // boot, which is exactly the silent-enable hole this guards against.
         if (gNetworkProtocol != netProtocolWas) {
             if (gNetworkProtocol == NET_PROTO_UDPFS)
                 guiMsgBox(_l(_STR_NET_UDPFS_TAB_HINT), 0, NULL);
             else if (gNetworkProtocol == NET_PROTO_UDPFSBD || gNetworkProtocol == NET_PROTO_UDPBD)
                 guiMsgBox(_l(_STR_NET_UDPBD_TAB_HINT), 0, NULL);
         }
+
+        // Each network transport loads its IOP module chain once per boot (the load latch is not cleared
+        // live). If any network stack is already up and the user changed protocol, the switch takes effect
+        // only after a restart -- say so instead of silently doing nothing.
+        if (gNetworkProtocol != netProtocolWas && (bdmIsUDPBDLoaded() || ethGetModulesLoaded() || udpfsGetModulesLoaded()))
+            guiMsgBox(_l(_STR_NETBOOT_RESTART), 0, NULL);
 
         // A BDM tab can be latched hidden (bdmNeedsUpdate force-hides it when its enable flag reads 0,
         // then short-circuits until the device generation bumps). Re-evaluate device visibility now so


### PR DESCRIPTION
Addresses eliminator1403's report: *"after turning on udpfs nothing happens, like it don't even refresh or give any message."*

### What the trace found
The mechanics already work: `applyConfig` re-registers the UDPFS tab in-session and Manual-start tabs init on a Confirm press inside them. But the enable moment is **completely silent** — the DHCP warning and restart notice are both conditional, the new tab joins the ring without announcement, it then waits for a Confirm press the user has no reason to know about, and the block transports (UDPBD / UDPFS Image) only show a tab once the PC server answers. From the user's chair: nothing happened.

### Fix
A per-family guidance toast at the exact moment the protocol changes:
- **UDPFS (Files)**: "UDPFS on — open the new UDPFS tab and press Confirm to connect. PC side runs udpfsd -d \<games folder\>."
- **UDPBD / UDPFS (Image)**: "Network block device on — its tab appears once the PC server answers (udpfsd -b for UDPFS Image, udpbd-server for UDPBD)."

Two new lang labels appended at the **end** of `lng_tmpl/_base.yml` (append-only rule — no positional-ID shift for stale language packs; English-only until the lng_fork overlay rerun).

Build-green on both containers; clang-format clean.

HW test: Device Settings → Network Protocol Off→UDPFS → expect the toast, then the UDPFS tab; Confirm inside it with udpfsd -d running → list appears. Off→UDPBD → block-device toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)