### PR TITLE
fix(mmce): no mmce fs traffic across the GameID switch (Neutrino-MMCE UI freeze)

### DIFF
--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -586,6 +586,16 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     if (coreLoader) {
         char mmcePartname[256];
         snprintf(mmcePartname, sizeof(mmcePartname), "%s", partname); // defensive copy across the deinit teardown (partname is a stack buffer, not freed by deinit)
+        // Neutrino bypasses OPL's mcemu, so the VMC fds opened above go unused on this path --
+        // close them instead of leaking until the IOP reset (B3). Closed BEFORE the GameID push
+        // below (Beta-2947 hardware report): the 0x8 switch physically re-mounts the card, and
+        // closing a handle opened against the PRE-switch filesystem afterwards wedged mmceman --
+        // the GUI froze the instant the GameID appeared on the card. NHDDL's ordering has ZERO
+        // mmce filesystem traffic after its mmceMountVMC; match it as closely as we can.
+        if (vmc_fds[0] >= 0)
+            fileXioClose(vmc_fds[0]);
+        if (vmc_fds[1] >= 0)
+            fileXioClose(vmc_fds[1]);
         // GameID for the NEUTRINO core (issue #68): the native OPL-core launch deliberately does
         // NOT push a launcher GameID (see the issue-#50 note below -- in OPL core the in-game
         // card is OPL's mcemu, and a mid-launch re-switch froze early-MC-probing games). That
@@ -593,16 +603,27 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // REAL emulated-MC surface -- and nothing else ever tells the card which game is
         // starting, so its per-game folder never engaged (USB-hosted games via Neutrino DID work:
         // the cross-device paths all send it). NHDDL does exactly this before launching neutrino
-        // (mmceMountVMC). mmceSendGameID waits out the card's busy bit (bounded ~3 s), so the
-        // #50 mid-launch-switch race does not apply; the MC-hosted-neutrino protect guard is
-        // inside the helper (skips + warns when neutrinoPath sits on this slot's mcN:).
+        // (mmceMountVMC). mmceSendGameID waits out the card's busy bit (bounded ~3 s); the
+        // MC-hosted-neutrino protect guard is inside the helper (skips + warns when neutrinoPath
+        // sits on this slot's mcN:).
         mmceSendGameID(game->startup, neutrinoPath);
-        // Neutrino bypasses OPL's mcemu, so the VMC fds opened above go unused on
-        // this path — close them instead of leaking until the IOP reset (B3).
-        if (vmc_fds[0] >= 0)
-            fileXioClose(vmc_fds[0]);
-        if (vmc_fds[1] >= 0)
-            fileXioClose(vmc_fds[1]);
+        // NHDDL-parity caveat: NHDDL's neutrino.elf never lives on the MMCE, so it has no reads
+        // left after the switch. Ours can (Auto prefers the game device), and the busy bit can
+        // clear before the card's FILESYSTEM surface is back (Gen2 remounts slowly) -- so when
+        // the loader's next read is from the switched card, wait for its fs to answer a directory
+        // probe (bounded ~5 s; poll-first so a fast card costs ~0 ms).
+        if (neutrinoPath != NULL && !strncmp(neutrinoPath, "mmce", 4)) {
+            char mmceRoot[8];
+            snprintf(mmceRoot, sizeof(mmceRoot), "%.5s:/", neutrinoPath); // "mmceN" + ":/"
+            for (int settle = 0; settle < 25; settle++) {
+                int dfd = fileXioDopen(mmceRoot);
+                if (dfd >= 0) {
+                    fileXioDclose(dfd);
+                    break;
+                }
+                DelayThread(200 * 1000);
+            }
+        }
         // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino opens the mmce-hosted game through
         // OUR mmceman mount and its config/modules from the neutrino.elf device (-cwd) before its own
         // IOP reset -- keep BOTH mounted. An MC-hosted neutrino needs no exception (-1 second slot).


### PR DESCRIPTION
Fixes AndrewBento's Beta-2947 report on [#56](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/56): MMCE-hosted game via Neutrino core → GameID appears on the Gen2 card (#76 working) → **GUI freezes instantly**, no black screen.

### Root cause — NHDDL's ordering, which #76 cited, wasn't fully copied
NHDDL's `mmceMountVMC` is the **last** act before handoff, with **zero** mmce filesystem operations afterwards (its neutrino.elf never lives on the card; the game's reads go through neutrino's own freshly-loaded driver post-IOP-reset). Our #76 flow switched the card and then immediately `fileXioClose`d two VMC handles opened against the **pre-switch** filesystem — a stale-handle close into a re-mounting card wedges mmceman. Gen1 remounts fast enough to race through (lucaslmgv unaffected); Gen2 doesn't (Andrew frozen).

### Fix
1. Close the (Neutrino-unused) VMC fds **before** the GameID push — zero stale handles across the switch.
2. When neutrino.elf itself lives on the switched card (Auto prefers the game device), bounded-poll a directory open on the card root (~5 s, poll-first = ~0 ms on fast cards) before the loader's next read — the busy bit can clear before the fs surface is back.

### Also noted from the report (separate follow-ups, not in this PR)
- Neutrino-on-emulated-MC + MMCE game → black screen: gameID correctly skipped (guard + warning working as designed); the residual is neutrino's own `-bsd=mmce` behavior on Gen2 — needs a known-good title cross-check (Vice City worked on Gen1) before pointing upstream.
- VCD BDMA source/mode needing manual alignment with the PopStarter device — usability defect, separate fix planned.
- Launch Disc transient "no disc" after tray close — retry polish planned.

Build-green on both containers; clang-format clean.

HW test: MMCE game via Neutrino with neutrino folder on MMCE and on USB (freeze gone, gameID still arrives), Gen1 regression check, USB game via Neutrino (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)