### PR TITLE
docs(credits): add lucaslmgv and AndrewBento (relentless real-hardware testing)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -61,4 +61,4 @@ BDMA-ATA (exFAT internal-HDD block-device support), plus fixes, feedback and ove
 by saildot4k
 
 Testing, bug reports and real-hardware feedback
-by eliminator1403
+by eliminator1403, lucaslmgv, AndrewBento and AcidReach


### PR DESCRIPTION
Their Beta-2931..2949 reports on #56/#68/#69/#73 root-caused five shipped fixes: the POPSTARTER argv[0] clobber, the mmcedrv rebuild regression, the Gen2 GameID-switch freeze, the woplsdk fileXio-client regression, and the Launch Disc spin-state behavior. CREDITS entry extended alongside eliminator1403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)