### PR TITLE
fix(net): toml ip= sync on UDPBD launches; correct udpfsd flags everywhere

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -543,9 +543,9 @@ jobs:
               printf '  config/bsd-udpfsbd.toml (for UDPFS); otherwise the official build. Just copy the\n'
               printf '  whole neutrino/ folder to mc?:/ (it already holds neutrino.elf + config/ + modules/).\n'
               printf '  Network games (UDPFS, both Files and Image): run pcm720/udpfsd on the PC\n'
-              printf '  (https://github.com/pcm720/udpfsd -- a single binary, -d for Files, -b for Image).\n'
+              printf '  (https://github.com/pcm720/udpfsd -- a single binary: -fsroot <dir> for Files, -bdpath <image> for Image).\n'
               printf '  UDPBD is retired: old UDPBD configs auto-migrate to UDPFS (Image) and the old\n'
-              printf '  udpbd-server no longer applies -- switch the PC side to udpfsd -b.\n'
+              printf '  udpbd-server no longer applies -- switch the PC side to udpfsd -bdpath <image>.\n'
             else
               printf '  (Could not bundle Neutrino this run -- please grab the latest build from the link above.)\n'
             fi

--- a/docs/NEUTRINO.md
+++ b/docs/NEUTRINO.md
@@ -137,7 +137,7 @@ FILESYSTEM (`udpfs:`), Image is the `udpfs_bd` BLOCK device (`massN:`).
 |---|---|---|
 | IOP driver | `udpfs_ioman.irx` → `udpfs:` (filesystem) | `udpfs_bd.irx` → `massN:` (block device) |
 | PC serves | a folder containing **`CD/` and `DVD/` subfolders** of ISOs (the standard OPL layout — OPL lists from `<served>/CD` + `<served>/DVD`, NOT from the folder root) | a **FAT/exFAT disk image** |
-| Server command | `udpfsd -d <dir>` | `udpfsd -b <image>` |
+| Server command | `udpfsd -fsroot <dir>` | `udpfsd -bdpath <image>` |
 | Launch | by name (`-dvd=udpfs:<name>`, stock `-bsd=udpfs`) — no `massN:`, no fragment list | mounted like a USB drive (`massN:`, fragment-list launch) |
 | Add a game | drop it into the served `CD/` or `DVD/` folder | mount the image, copy, unmount |
 | Compression | transparent `.zso`/`.cso`/`.chd` | — (raw sectors only) |

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -918,8 +918,8 @@ gui_strings:
 - label: MMCE_GAMEID_NEUTRINO_SKIP
   string: MMCE GameID not applied -- neutrino.elf is on this card (switching it would unload Neutrino).
 - label: NET_UDPFS_TAB_HINT
-  string: UDPFS on -- open the new UDPFS tab and press Confirm to connect. PC side runs udpfsd -d <games folder>.
+  string: UDPFS on -- open the new UDPFS tab and press Confirm to connect. PC side runs udpfsd -fsroot <games folder>.
 - label: NET_UDPBD_TAB_HINT
-  string: Network block device on -- its tab appears once the PC server answers (udpfsd -b for UDPFS Image, udpbd-server for UDPBD).
+  string: Network block device on -- its tab appears once the PC server answers (udpfsd -bdpath for UDPFS Image, udpbd-server for UDPBD).
 - label: NEUTRINO_VMC_MISSING
   string: Per-game VMC file not found -- launching without it (game uses its real card).

--- a/src/system.c
+++ b/src/system.c
@@ -1215,9 +1215,13 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
         }
     }
 
-    // UDPFS launches: Neutrino's ministack reads its IP from the bsd toml, not from OPL's network
-    // config -- sync it so the games that just LISTED over the network also BOOT over it.
-    if (!strcmp(deviceName, "udpfs") || !strcmp(deviceName, "udpfsbd"))
+    // Network launches: Neutrino's ministack reads its IP from the bsd toml, not from OPL's network
+    // config -- sync it so the games that just LISTED over the network also BOOT over it. This MUST
+    // cover udpbd too: the stock bsd-udpbd.toml hardcodes ip=192.168.1.10 with the same args=["ip=...]
+    // quoting the helper anchors on, and Neutrino has NO other IP channel (no CLI/env option; -cfg
+    // loads BEFORE the bsd toml and module re-declaration is last-wins) -- without the sync, UDPBD
+    // games list fine (browse uses ps2_ip) then black-screen on boot for any subnet but 192.168.1.x.
+    if (!strcmp(deviceName, "udpfs") || !strcmp(deviceName, "udpfsbd") || !strcmp(deviceName, "udpbd"))
         sysSyncNeutrinoUdpfsToml(neutrinoPath, deviceName);
 
     // Append user-supplied Neutrino flags: global defaults first, then the per-game


### PR DESCRIPTION
Two concrete catches from the NHDDL/udpfsd investigation (full findings below in the session doc trail):

### 1. UDPBD launches never got the ip= toml sync — list-then-black-screen off 192.168.1.x
`sysSyncNeutrinoUdpfsToml` ran only for `udpfs`/`udpfsbd`; a `-bsd=udpbd` launch booted against the stock `bsd-udpbd.toml`'s hardcoded `ip=192.168.1.10`. Verified against the neutrino source that **no other IP channel exists** (no CLI/env; `-cfg` loads *before* the bsd toml and module re-declaration is last-wins), so the rewrite is the only mechanism — one added condition, no helper change (stock toml uses the identical `args=["ip=…"]` quoting).

### 2. Our documented `udpfsd` commands don't work
`-d`/`-b` are the old Python server's flags; the Go `udpfsd` defines **`-fsroot <dir>` / `-bdpath <image>`** and hard-exits on unknown flags. Fixed in `docs/NEUTRINO.md`, the rolling release-notes heredoc, and the two #78 guidance-toast strings (text-only, same labels — no positional-ID shift).

### Also from the investigation (no code needed)
- NHDDL supports **UDPBD only** — no udpfs exists in it; its smap_udpbd is the same module we vendor (ours adds a reconnect watchdog + DMA-overflow guard); its IP "solution" is a README telling users to hand-edit the toml. Our stack verified as a hardened superset; Δ6's pre-deinit hoist re-validated as the only viable design.
- wOPL's shared-prefix-parsing branch: nothing structural to adopt — our PR-A/#60 resolver is a superset; their `massN:`==USB assumption would break MX4SIO/iLink/exFAT mass-path launchers and the #60 fix.
- Queued for batch 2: NHDDL's structural MX4SIO↔mmceman SIO2 exclusion (we have no such interlock).

Build-green on both containers; clang-format clean.

HW test: UDPBD protocol + PC on a non-192.168.1.x subnet → game boots (was: lists then black screen); UDPFS toast now prints working server commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)