### PR TITLE
fix(mmce): de-conflict GameID vs -mc VMC args; arm transport at menu time (Δ3/Δ4)

### DIFF
--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -24,6 +24,10 @@ void mmceLaunchGame(item_list_t *itemList, int fd, config_set_t *configSet);
 // protectMcPath: on a Neutrino launch, the resolved neutrino.elf path. If it lives on the emulated
 // memory card (mcN:) of the slot we would switch, the switch is skipped so it can't yank the loader
 // out from under sysLaunchNeutrino (NHDDL parity, issue #51). Pass NULL when nothing needs protecting.
-int mmceSendGameID(const char *startup, const char *protectMcPath);
+// vmcSlotMask bit N = "a -mcN Neutrino VMC arg is set for this launch": that slot's MC comes from
+// the VMC FILE, so its physical card is NOT switched (pass 0 on OPL-core paths -- mcemu, unchanged).
+int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask);
+// Arm the GameID transport at menu/settings time (idempotent; no-op when the feature is off).
+void mmceArmGameIDTransport(void);
 
 #endif

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -982,7 +982,8 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // MMCE cross-device game-id (#261): push the disc id to a present SD2PSX/MemCard PRO2 (either slot)
     // so it switches its per-game folder, even though this game is not on the MMCE. Self-probes +
     // no-ops if no card answers / feature off. Must run BEFORE deinit frees `game`.
-    mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL);
+    mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL,
+                   (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
 
     if (gAutoLaunchBDMGame == NULL) {
         // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino reads its config/modules from the

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -780,8 +780,8 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
         strcpy(filename, game->startup);
     // MMCE cross-device game-id (#261): push the disc id to a present MMCE card before the SMB teardown
     // (self-probes mmce0/mmce1; no-ops if no card / feature off). Read `game` before deinit frees it.
-    mmceSendGameID(game->startup, NULL); // SMB has no Neutrino branch -> nothing to protect
-    deinit(NO_EXCEPTION, ETH_MODE);      // CAREFUL: deinit will call ethCleanUp, so ethGames/game will be freed
+    mmceSendGameID(game->startup, NULL, 0); // SMB has no Neutrino branch -> nothing to protect, no -mc args
+    deinit(NO_EXCEPTION, ETH_MODE);         // CAREFUL: deinit will call ethCleanUp, so ethGames/game will be freed
 
     settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;
     settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_SMAP;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -873,7 +873,7 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
     // MMCE cross-device game-id (#261): push the HDL disc id to a present MMCE card before the HDD
     // teardown (self-probes mmce0/mmce1; no-ops if no card / feature off). Read `game` before deinit.
-    mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL);
+    mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL, 0); // HDD leg emits no -mc args (VMC->neutrino deferred)
 
     if (gAutoLaunchGame == NULL) {
         // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): keep the HDD stack up (NHDDL hands off with

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -48,33 +48,57 @@ static base_game_info_t *mmceGames;
 // forward declaration
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
+static int mmceModLoaded; // defined next to mmceLoadModules below; read by mmceSendGameID's arm check
 
-int mmceSendGameID(const char *startup, const char *protectMcPath)
+int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask)
 {
     char mmceDevice[sizeof(mmcePrefix)];
 
     if (!gMMCEEnableGameID || startup == NULL || startup[0] == '\0')
         return 0;
 
-    // #261 cross-device launches (a USB/HDD/SMB game with the MMCE holding the card) can reach here on a
-    // cold boot where the MMCE tab was never opened, so its Start Mode (default Manual) never loaded
-    // mmceman. Without mmceman resident the mmce0:/mmce1: devctl probes below all fail and the game-id is
-    // silently dropped -> the card never switches to the per-game folder (issue #51). Self-arm the
-    // transport here; mmceLoadModules() is idempotent (guarded by mmceModLoaded).
-    mmceLoadModules();
+    // Δ4 (NHDDL parity): do NOT self-arm the transport here. Loading an IRX inside the launch
+    // sequence puts a module load/start at the launch's most fragile moment; the arming now happens
+    // at menu/settings time (mmceArmGameIDTransport, called from initAllSupport whenever the GameID
+    // feature is on), where a failure is a harmless LOG. Preserves the #51 intent -- GameID works
+    // without the MMCE page ever being enabled -- with the risk moved off the launch path. If the
+    // module is not resident by launch time (arm failed / raced), skip gracefully like no-card.
+    if (!mmceModLoaded) {
+        LOG("MMCE GameID: transport not armed -- skipping (menu-time arm failed or pending)\n");
+        return 0;
+    }
 
+    // Candidate order: the configured/resolved slot first, then both slots as fallback -- a card in
+    // EITHER slot still gets the game-id on a cross-device launch (#261). Same 0x1 presence devctl
+    // as mmceDetectSlot. Δ3 (NHDDL parity): a slot whose -mc<slot> Neutrino arg is set gets its MC
+    // from the VMC FILE, not the card's per-game folder -- switching the physical card for it is
+    // moot and only adds the busy/re-mount window, so covered slots are skipped; a card in the
+    // OTHER, uncovered slot still gets the push. vmcSlotMask bit N = "-mcN arg present" (0 = the
+    // OPL-core paths, which use mcemu and keep today's behavior).
     mmceGetDeviceRoot(mmceDevice, sizeof(mmceDevice));
-    // Use the resolved slot only if a card is actually present there; otherwise -- no slot resolved
-    // (MMCE tab off, the common cross-device case), OR a configured/stale gMMCESlot that is now empty
-    // -- probe both slots so a card in EITHER slot still gets the game-id for per-game folder switching
-    // on a cross-device (USB/HDD/SMB) launch (#261). The same 0x1 device-present devctl mmceDetectSlot uses.
-    if (mmceDevice[0] == '\0' || fileXioDevctl(mmceDevice, 0x1, NULL, 0, NULL, 0) == -1) {
-        if (fileXioDevctl("mmce0:/", 0x1, NULL, 0, NULL, 0) != -1)
-            snprintf(mmceDevice, sizeof(mmceDevice), "mmce0:/");
-        else if (fileXioDevctl("mmce1:/", 0x1, NULL, 0, NULL, 0) != -1)
-            snprintf(mmceDevice, sizeof(mmceDevice), "mmce1:/");
-        else
-            return 0; // no MMCE card present -> graceful no-op
+    {
+        const char *cands[3] = {mmceDevice[0] != '\0' ? mmceDevice : NULL, "mmce0:/", "mmce1:/"};
+        int tried[2] = {0, 0};
+        int found = 0;
+        for (int c = 0; c < 3 && !found; c++) {
+            if (cands[c] == NULL || strlen(cands[c]) < 5)
+                continue;
+            int slot = cands[c][4] - '0';
+            if (slot < 0 || slot > 1 || tried[slot])
+                continue;
+            tried[slot] = 1;
+            if ((vmcSlotMask >> slot) & 1) {
+                LOG("MMCE GameID: slot %d covered by a -mc%d VMC arg -- not switching that card\n", slot, slot);
+                continue;
+            }
+            if (fileXioDevctl(cands[c], 0x1, NULL, 0, NULL, 0) != -1) {
+                if (cands[c] != mmceDevice)
+                    snprintf(mmceDevice, sizeof(mmceDevice), "%s", cands[c]);
+                found = 1;
+            }
+        }
+        if (!found)
+            return 0; // no eligible MMCE card present -> graceful no-op
     }
 
     // NHDDL-parity guard (#51): never switch the per-game card on a slot whose EMULATED memory card
@@ -222,6 +246,17 @@ void mmceLoadModules(void)
     LOG("MMCESUPPORT LoadModules\n");
     LOG("[MMCEMAN]:\n");
     sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
+}
+
+// Δ4 (NHDDL parity): arm the GameID transport OUTSIDE the launch path. NHDDL loads mmceman once at
+// boot; RiptOPL used to self-arm inside mmceSendGameID -- an IRX load/start at the launch's most
+// fragile moment (issue #51's fix, right intent, wrong timing). Called from initAllSupport (boot +
+// every settings apply) via the IO worker, so a wedged load is a harmless LOG at menu time instead
+// of a dead launch. Idempotent (mmceLoadModules latches); no-op when the GameID feature is off.
+void mmceArmGameIDTransport(void)
+{
+    if (gMMCEEnableGameID)
+        mmceLoadModules();
 }
 
 void mmceInit(item_list_t *itemList)
@@ -606,7 +641,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // (mmceMountVMC). mmceSendGameID waits out the card's busy bit (bounded ~3 s); the
         // MC-hosted-neutrino protect guard is inside the helper (skips + warns when neutrinoPath
         // sits on this slot's mcN:).
-        mmceSendGameID(game->startup, neutrinoPath);
+        mmceSendGameID(game->startup, neutrinoPath,
+                       (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
         // NHDDL-parity caveat: NHDDL's neutrino.elf never lives on the MMCE, so it has no reads
         // left after the switch. Ours can (Auto prefers the game device), and the busy bit can
         // clear before the card's FILESYSTEM surface is back (Gen2 remounts slowly) -- so when

--- a/src/opl.c
+++ b/src/opl.c
@@ -590,6 +590,13 @@ static void initAllSupport(int force_reinit)
     initSupport(hddGetObject(0), HDD_MODE, force_reinit);
     initSupport(appGetObject(0), APP_MODE, force_reinit);
     initSupport(favGetObject(0), FAV_MODE, force_reinit);
+
+    // Δ4 (NHDDL parity): arm the MMCE GameID transport HERE -- at boot and on every settings apply --
+    // instead of self-arming inside mmceSendGameID during a launch (an IRX load at the launch's most
+    // fragile moment; issue #51's fix with the timing corrected). Deferred to the IO worker like
+    // udpfsInit's module load; idempotent, and a failure is a harmless LOG at menu time.
+    if (gMMCEEnableGameID)
+        ioPutRequest(IO_CUSTOM_SIMPLEACTION, &mmceArmGameIDTransport);
 }
 
 static void deinitAllSupport(int exception, int modeSelected, int modeSelected2)

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -313,7 +313,8 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
 
     // MMCE cross-device game-id (#261): push the disc id to a present MMCE card before teardown frees
     // `game`. Neutrino path forwarded so a Neutrino launch protects the MMCE hand-off timing.
-    mmceSendGameID(game->startup, neutrinoPath);
+    mmceSendGameID(game->startup, neutrinoPath,
+                   (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
 
     // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino reads the game through OUR udpfs
     // filesystem and its config/modules from the neutrino.elf device (-cwd) before its own IOP


### PR DESCRIPTION
Batch 2 of the [parity analysis](docs/NEUTRINO-PARITY-2026-07-05.md) — the two behavioral deltas deliberately held out of #81 for clean HW bisection.

### Δ3 — one VMC mechanism per slot
A Neutrino launch with a `$VMC_N` file arg **and** an MMCE card applied both mechanisms: Neutrino's fhi points the game's slot-N MC at the `.bin`, while the launcher also switched the physical card's per-game folder — a moot switch that only adds the busy/re-mount window (the same window behind the Gen2 freeze class). `mmceSendGameID` now takes a `vmcSlotMask`: covered slots are skipped; a card in the *other*, uncovered slot still gets the push. OPL-core paths pass 0 — mcemu behavior unchanged. This is also the structural answer to lucas's "two save surfaces" observation: with a VMC configured, the card's folder is deliberately left alone.

### Δ4 — no IRX loads inside the launch path
`mmceSendGameID` self-armed mmceman at launch time (#51's fix — right intent, most fragile possible timing; wOPL never self-arms, NHDDL arms once at boot). Arming now happens in `initAllSupport` (boot + every settings apply) via the IO worker — idempotent, failure is a harmless menu-time LOG — and the launch path skips gracefully if the transport isn't resident. #51's intent preserved: GameID works with the MMCE page never enabled, so long as the feature flag is on.

### Validation
- Build-green both containers; clang-format clean.
- HW: (Δ3) USB game + `$VMC_0` + MMCE in slot 1 → card does NOT switch, game sees the .bin; same with card in slot 2 & no `$VMC_1` → card DOES switch. (Δ4) MMCE page disabled + GameID on → LOG shows menu-time arm; USB launch still switches the card; launch path does no IRX load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)