### PR TITLE
docs(credits): add bodvenomz and nuno6573 to tester credits

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -61,4 +61,4 @@ BDMA-ATA (exFAT internal-HDD block-device support), plus fixes, feedback and ove
 by saildot4k
 
 Testing, bug reports and real-hardware feedback
-by eliminator1403, lucaslmgv, AndrewBento and AcidReach
+by eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573


### PR DESCRIPTION
Tester credits entry now reads: eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573 (eliminator1403 and nuno6573 verified — eliminator was already present; nuno6573 was not and is now added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)