### PR TITLE
fix(neutrino): pre-deinit launch preflight + bounded launch IO drain (Δ6/Δ7)

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -41,6 +41,11 @@ typedef struct neutrino_vmc_args
 
 void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, const neutrino_vmc_args_t *vmcArgs);
 
+// D6 pre-deinit launch pre-flight: validates the driver token and (network transports) syncs the
+// bsd toml ip= while every mount is up and the GUI can still toast. Call BEFORE deinitEx in every
+// Neutrino leg. Returns 0 = proceed; <0 = abort the launch (a toast has already been shown).
+int sysNeutrinoPreflight(const char *driver, const char *neutrinoPath);
+
 // Launch an external POPSTARTER.ELF for a PS1 VCD. selector = the argv[0] "<POPS>/<prefix><name>.ELF"
 // token; partition = "" for non-HDD. Caller deinit()s with UNMOUNT_EXCEPTION first (see system.c).
 void sysLaunchPopstarter(const char *popstarterElf, const char *selector, const char *partition);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -923,3 +923,7 @@ gui_strings:
   string: Network block device on -- its tab appears once the PC server answers (udpfsd -bdpath for UDPFS Image, udpbd-server for UDPBD).
 - label: NEUTRINO_VMC_MISSING
   string: Per-game VMC file not found -- launching without it (game uses its real card).
+- label: NEUTRINO_DEV_UNSUPPORTED
+  string: Neutrino cannot launch from this device -- launch aborted.
+- label: NEUTRINO_TOML_SYNC_FAILED
+  string: Neutrino network config (bsd toml) missing or unwritable -- launch aborted, check the neutrino folder.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -992,6 +992,10 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // exception of its own (-1 second slot). ee_core launches keep the full teardown: everything
         // they need is embedded before deinit.
         if (coreLoader) {
+            // D6: everything that can fail the launch and is checkable NOW runs pre-teardown --
+            // driver-token validation + (udp transports) the bsd toml ip= sync. Abort = stay in menu.
+            if (sysNeutrinoPreflight(bdmCurrentDriver, neutrinoPath) < 0)
+                return;
             int neutrinoDevMode = oplPath2Mode(neutrinoPath);
             deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees bdmGames/game
         } else {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -881,6 +881,8 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // the teardown. An MC-hosted neutrino needs no exception (-1 second slot). ee_core launches
         // keep the full teardown: everything they need is embedded before deinit.
         if (coreLoader) {
+            if (sysNeutrinoPreflight("apa", neutrinoPath) < 0) // D6 pre-teardown validation
+                return;
             int neutrinoDevMode = oplPath2Mode(neutrinoPath);
             deinitEx(UNMOUNT_EXCEPTION, HDD_MODE, neutrinoDevMode); // CAREFUL: itemCleanUp still frees hddGames/game
         } else {

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -663,6 +663,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino opens the mmce-hosted game through
         // OUR mmceman mount and its config/modules from the neutrino.elf device (-cwd) before its own
         // IOP reset -- keep BOTH mounted. An MC-hosted neutrino needs no exception (-1 second slot).
+        if (sysNeutrinoPreflight("mmce", neutrinoPath) < 0) // D6 pre-teardown validation
+            return;
         int neutrinoDevMode = oplPath2Mode(neutrinoPath);
         deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode);
         sysLaunchNeutrino("mmce", mmcePartname, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, &neutrinoVmc);

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -48,7 +48,7 @@ static base_game_info_t *mmceGames;
 // forward declaration
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
-static int mmceModLoaded; // defined next to mmceLoadModules below; read by mmceSendGameID's arm check
+static int mmceModLoaded = 0; // latched by mmceLoadModules; read by mmceSendGameID's arm check
 
 int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask)
 {
@@ -234,7 +234,6 @@ void mmceSetPrefix(void)
     mmceRefreshArtRoots();
 }
 
-static int mmceModLoaded = 0;
 void mmceLoadModules(void)
 {
     // mmceman is a singleton -- loading the IRX buffer twice creates a 2nd instance. Guard so this is

--- a/src/opl.c
+++ b/src/opl.c
@@ -2309,7 +2309,11 @@ static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected,
 
 // Max delay(1) ticks (~ms) to drain the IO worker during exit/poweroff teardown
 // before proceeding anyway; bounded because the IOP is reset/powered off right after.
-#define EXIT_IO_DRAIN_TICKS 1000
+#define EXIT_IO_DRAIN_TICKS   1000
+// Δ7: launch-path drain bound (~10 s of delay(1) ticks). Generous -- a healthy slow device drains in
+// well under this -- but finite, so one wedged art read on a dying device can no longer freeze the
+// loading screen forever (the handoff targets IOP-reset themselves; a straggler cannot outlive that).
+#define LAUNCH_IO_DRAIN_TICKS 10000
 
 // 1 while deinit() tears down for exit/poweroff, 0 for a game/app launch. Consumed by device shutdowns
 // that must behave differently on the launch path (hddShutdown keeps DEV9 powered so the post-deinit
@@ -2336,13 +2340,21 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
     // For the terminal teardown modes (exit = IO_MODE_SELECTED_ALL,
     // poweroff = IO_MODE_SELECTED_NONE) cap the drain: those paths reset the IOP
     // (LoadExecPS2) or power the machine off immediately afterward, so a request
-    // stuck on a removed/slow device must not hang teardown forever. The launch
-    // path (a specific mode) keeps the unbounded wait so its IOP state stays clean.
+    // stuck on a removed/slow device must not hang teardown forever.
+    // Δ7 (NHDDL parity): the LAUNCH path is now bounded too (longer budget). The old unbounded
+    // wait "so its IOP state stays clean" predates the keep-IOP handoff work: post-#79 the two
+    // excepted mounts stay alive regardless, and Neutrino/POPSTARTER perform their OWN IOP reset
+    // after reading their files -- a straggler request cannot corrupt what gets rebuilt fresh.
+    // Unbounded, it turned one wedged cover read on a dying device into a permanently frozen
+    // loading screen BEFORE the handoff even started. NHDDL has no IO worker to drain at all.
     int terminalTeardown = gDeinitTerminal;
-    if (terminalTeardown)
+    if (terminalTeardown) {
         ioBlockOpsTimed(1, EXIT_IO_DRAIN_TICKS);
-    else
-        ioBlockOps(1);
+    } else {
+        ioBlockOpsTimed(1, LAUNCH_IO_DRAIN_TICKS); // always returns IO_OK -- timeout shows as leftover requests
+        if (ioHasPendingRequests())
+            LOG("deinit: launch IO drain timed out after %d ticks -- proceeding (straggler cannot survive the target's IOP reset)\n", LAUNCH_IO_DRAIN_TICKS);
+    }
     guiExecDeferredOps();
     cacheEnd(terminalTeardown);
 

--- a/src/system.c
+++ b/src/system.c
@@ -10,6 +10,7 @@
 
 #include "include/opl.h"
 #include "include/gui.h"
+#include "include/lang.h" // _l(_STR_...) -- sysNeutrinoPreflight abort toasts
 #include "include/ethsupport.h"
 #include "include/hddsupport.h"
 #include "include/util.h"
@@ -1042,39 +1043,45 @@ static int neutrinoArgHasActiveFlag(const char *args, const char *flag)
 // Rewrite the "ip=A.B.C.D" token inside <neutrino dir>/config/bsd-<device>.toml to the PS2's configured
 // static IP. Neutrino's ministack takes its IP from that toml -- hardcoded 192.168.1.10 in the stock and
 // bundled files -- NOT from anything OPL used while browsing, so any mismatch means the UDPFS server's
-// discovery reply never routes back and the game black-screens after a perfectly healthy list. POSIX IO;
-// runs post-deinit (mc/mmce/the game's own device stay mounted; a neutrino.elf on some OTHER stopped BDM
-// device just fails the open). Best-effort: a missing or hand-restructured toml is logged + left alone,
-// so behavior degrades to exactly the old hand-edit contract. Anchored to the stock `"ip=` quoting so a
-// comment mentioning ip= can never be clobbered.
-static void sysSyncNeutrinoUdpfsToml(const char *neutrinoPath, const char *deviceName)
+// discovery reply never routes back and the game black-screens after a perfectly healthy list. Δ6: now
+// runs PRE-deinit via sysNeutrinoPreflight (every mount is up, the GUI is alive), so a hard failure can
+// abort to the menu with a toast instead of dying invisibly post-teardown. Anchored to the stock `"ip=`
+// quoting so a comment mentioning ip= can never be clobbered.
+// Returns 0 = OK to launch (synced / already-in-sync / benign leave-alone), <0 = abort the launch:
+// the toml is MISSING (neutrino cannot load its bsd config at all) or was mangled-then-restored (the
+// old ip survives, so the boot would black-screen on any other subnet).
+static int sysSyncNeutrinoUdpfsToml(const char *neutrinoPath, const char *deviceName)
 {
-    static char toml[2048];
-    static char updated[2048 + 20];
+    static char toml[4096]; // Δ6: raised from 2048 -- an annotated toml no longer gets skipped
+    static char updated[4096 + 20];
     char tomlPath[288];
     char newIp[20];
     int fd, len;
 
     const char *slash = strrchr(neutrinoPath, '/');
     if (slash == NULL)
-        return;
+        return 0; // custom flat path -- no dir to anchor on; old hand-edit contract
     snprintf(tomlPath, sizeof(tomlPath), "%.*sconfig/bsd-%s.toml", (int)(slash - neutrinoPath) + 1, neutrinoPath, deviceName);
 
     fd = open(tomlPath, O_RDONLY);
     if (fd < 0) {
-        LOG("[NEUTRINO] no %s to sync ip= into (%d)\n", tomlPath, fd);
-        return;
+        LOG("[NEUTRINO] no %s -- neutrino cannot boot this transport without it\n", tomlPath);
+        return -1; // missing bsd toml = guaranteed post-teardown failure -> abort while GUI is alive
     }
     len = read(fd, toml, sizeof(toml) - 1);
     close(fd);
-    if (len <= 0 || len >= (int)sizeof(toml) - 1)
-        return; // empty, unreadable, or larger than any real bsd toml -- leave it alone
+    if (len <= 0)
+        return -1; // unreadable/empty bsd toml -> same guaranteed failure
+    if (len >= (int)sizeof(toml) - 1) {
+        LOG("[NEUTRINO] %s larger than %d -- ip= left as-is\n", tomlPath, (int)sizeof(toml));
+        return 0; // exotic hand-built toml: proceed on the old hand-edit contract
+    }
     toml[len] = '\0';
 
     char *tok = strstr(toml, "\"ip=");
     if (tok == NULL) {
         LOG("[NEUTRINO] %s has no \"ip= token -- left as-is\n", tomlPath);
-        return;
+        return 0; // hand-restructured toml: the user owns the ip; proceed
     }
     char *valStart = tok + 4;
     char *valEnd = valStart;
@@ -1083,14 +1090,14 @@ static void sysSyncNeutrinoUdpfsToml(const char *neutrinoPath, const char *devic
 
     snprintf(newIp, sizeof(newIp), "%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
     if ((int)strlen(newIp) == (int)(valEnd - valStart) && !strncmp(valStart, newIp, strlen(newIp)))
-        return; // already in sync -- don't touch the file
+        return 0; // already in sync -- don't touch the file
 
     snprintf(updated, sizeof(updated), "%.*s%s%s", (int)(valStart - toml), toml, newIp, valEnd);
 
     fd = open(tomlPath, O_WRONLY | O_TRUNC);
     if (fd < 0) {
         LOG("[NEUTRINO] cannot rewrite %s (%d) -- ip= left as-is\n", tomlPath, fd);
-        return;
+        return 0; // write-protected media: proceed on the old hand-edit contract
     }
     int expected = (int)strlen(updated);
     int written = write(fd, updated, expected);
@@ -1105,9 +1112,37 @@ static void sysSyncNeutrinoUdpfsToml(const char *neutrinoPath, const char *devic
             write(fd, toml, len);
             close(fd);
         }
-        return;
+        return -1; // the OLD ip survives -> the boot would black-screen; abort while GUI is alive
     }
     LOG("[NEUTRINO] synced %s ip= -> %s\n", tomlPath, newIp);
+    return 0;
+}
+
+// Δ6 (NHDDL parity): everything that can FAIL a Neutrino launch and is checkable pre-teardown runs
+// HERE, called by every device leg BEFORE deinitEx -- the GUI is alive for a toast and nothing has
+// been torn down, so a failure is "stay in the menu", not a post-teardown black screen. Returns
+// 0 = proceed; <0 = abort (a toast was shown).
+int sysNeutrinoPreflight(const char *driver, const char *neutrinoPath)
+{
+    if (driver == NULL || neutrinoPath == NULL)
+        return -1;
+
+    const char *deviceName = getDeviceName(driver);
+    if (!strcmp(deviceName, "unsupported")) {
+        LOG("[NEUTRINO] preflight: unsupported device '%s'\n", driver);
+        guiWarning(_l(_STR_NEUTRINO_DEV_UNSUPPORTED), 6);
+        return -1;
+    }
+
+    // Network transports: sync the bsd toml ip= NOW, while the toml's device is mounted and a
+    // failure can still be reported (see sysSyncNeutrinoUdpfsToml for the abort conditions).
+    if (!strcmp(deviceName, "udpfs") || !strcmp(deviceName, "udpfsbd") || !strcmp(deviceName, "udpbd")) {
+        if (sysSyncNeutrinoUdpfsToml(neutrinoPath, deviceName) < 0) {
+            guiWarning(_l(_STR_NEUTRINO_TOML_SYNC_FAILED), 6);
+            return -1;
+        }
+    }
+    return 0;
 }
 
 void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, const neutrino_vmc_args_t *vmcArgs)
@@ -1215,14 +1250,9 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
         }
     }
 
-    // Network launches: Neutrino's ministack reads its IP from the bsd toml, not from OPL's network
-    // config -- sync it so the games that just LISTED over the network also BOOT over it. This MUST
-    // cover udpbd too: the stock bsd-udpbd.toml hardcodes ip=192.168.1.10 with the same args=["ip=...]
-    // quoting the helper anchors on, and Neutrino has NO other IP channel (no CLI/env option; -cfg
-    // loads BEFORE the bsd toml and module re-declaration is last-wins) -- without the sync, UDPBD
-    // games list fine (browse uses ps2_ip) then black-screen on boot for any subnet but 192.168.1.x.
-    if (!strcmp(deviceName, "udpfs") || !strcmp(deviceName, "udpfsbd") || !strcmp(deviceName, "udpbd"))
-        sysSyncNeutrinoUdpfsToml(neutrinoPath, deviceName);
+    // Δ6: the bsd toml ip= sync (network transports) now runs PRE-deinit inside sysNeutrinoPreflight
+    // -- called by every device leg before deinitEx -- so a failure aborts to a live menu with a
+    // toast instead of dying invisibly here, post-teardown. Nothing to do at this point.
 
     // Append user-supplied Neutrino flags: global defaults first, then the per-game
     // string (so a game can extend the global set). Both are tokenized on whitespace.

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -319,6 +319,10 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino reads the game through OUR udpfs
     // filesystem and its config/modules from the neutrino.elf device (-cwd) before its own IOP
     // reset -- keep BOTH mounted across the teardown. Mirrors bdmsupport's Neutrino deinit contract.
+    // D6: pre-teardown validation -- for UDPFS this is where the bsd toml ip= sync now happens
+    // (was post-deinit inside sysLaunchNeutrino); a failure toasts and stays in the menu.
+    if (sysNeutrinoPreflight("udpfs", neutrinoPath) < 0)
+        return;
     int neutrinoDevMode = oplPath2Mode(neutrinoPath);
     deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees udpfsGames/game
 


### PR DESCRIPTION
Batch 3 of the [parity analysis](docs/NEUTRINO-PARITY-2026-07-05.md): the last failure-capable work moves off the post-teardown blind window.

### Δ6 — `sysNeutrinoPreflight()`, called by every Neutrino leg *before* `deinitEx`
- **Driver-token validation**: an unsupported token used to abort *inside* `sysLaunchNeutrino`, post-deinit, into a dead GUI. Now: toast + stay in the menu.
- **Network transports**: the bsd toml `ip=` sync (udpfs/udpfsbd/udpbd) runs while the toml's device is mounted and the GUI is alive. Hard-aborts with a toast only where the boot is *guaranteed* to die anyway: toml missing/unreadable (neutrino can't load its bsd config at all) or mangled-then-restored (old ip survives → off-subnet black screen). Benign cases keep the old hand-edit contract: no `ip=` token, write-protected media, oversize (cap raised 2048→4096 so annotated tomls aren't skipped).

### Δ7 — bounded launch IO drain
The launch path's `deinitEx` drain was unbounded — one wedged cover read on a dying device froze the loading screen forever *before the handoff even started*. The "keeps IOP state clean" rationale predates the keep-IOP handoff work: the excepted mounts stay alive regardless, and Neutrino/POPSTARTER IOP-reset themselves after reading their files, so a straggler cannot corrupt what gets rebuilt fresh. Bounded ~10 s, LOG + proceed; exit/poweroff keep their existing shorter bound. NHDDL has no IO worker to drain at all.

### Validation
- Build-green both containers; clang-format clean. Two lang labels appended at END of `_base.yml`.
- HW: UDPFS/UDPBD launch with the toml deleted → toast + stay in menu (was: black screen); normal launches on every device (regression); yank a USB mid-cover-load then immediately launch from another device → proceeds ≤10 s later instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)