### PR TITLE
fix(neutrino): lean launch sub-path on the bdm + hdd legs (Δ8)

### DIFF
--- a/docs/NEUTRINO-PARITY-2026-07-05.md
+++ b/docs/NEUTRINO-PARITY-2026-07-05.md
@@ -117,4 +117,6 @@ RiptOPL post-#79 already matches 1, 2 (mostly), and the handoff mechanics. The r
 | 9 | Δ9 64-frag budget pre-count (bd-backend devices, ISO+VMCs) | M | new count-only helper reusing `bdmsupport.c` fraglist code, called from Δ8's sub-path | HW: fragmented VMC → toast; clean device boots |
 | 10 | Δ10 optional `-elf=cdrom0:\<startup>;1` (shape-guarded, flagged) | M | `src/system.c` `sysLaunchNeutrino` | HW: per-GameID compat entry with file deps applies pre-reset (udptty log); broad regression boots |
 
+**Status (2026-07-05):** Δ1–Δ7 shipped via PRs #81/#84/#86 (rolling Beta-2965). Δ8 implemented as PR #87 (`bdmTryNeutrinoLaunch`/`hddTryNeutrinoLaunch` early gates; hdd keeps a single-sector ZSO probe → native fallback; udp abort paths owned by the bdm helper). Δ9/Δ10 not started.
+
 **Bottom line:** NHDDL's reliability is not magic — it is (1) one IOP lifetime, (2) a nearly-empty launch path, (3) one VMC mechanism, (4) a validated, user-visible Neutrino pick. RiptOPL already owns (1) post-#79 and has a *better* failure UX and loader than NHDDL. The remaining convergence is: validate what you resolve (Δ1/Δ2/Δ5), stop doing native-core work and risky mutations after the point where the GUI can't report them (Δ6/Δ8), and de-conflict the two VMC mechanisms NHDDL never had to reconcile (Δ3/Δ9).

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -669,6 +669,101 @@ static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     sysLaunchPopstarter(vcdElf, vcdSelector, "");
 }
 
+// Δ8 (NHDDL parity): the LEAN Neutrino launch path. Everything bdmLaunchGame's native flow
+// prepares -- VMC superblock prompts + mcemu patching, sbPrepare's cdvdman patch, per-part
+// fragment lists (with a hard abort past 64 frags), layer-1 probing, cheats (with dialogs),
+// PS2RD images, ATA DMA setup -- exists for the EMBEDDED cdvdman core; Neutrino re-derives all
+// of it from -bsd/-dvd after its own IOP reset. Paying for that work meant a Neutrino launch
+// could DIE on native-only failures (the fragmented-ISO abort, an interactive cheats dialog
+// mid-launch, a VMC-superblock cancel whose result the launch then ignored). NHDDL's whole
+// pre-handoff is ~3 file operations; this is ours.
+// Returns 1 = handled (handed off, or aborted with the user informed -- caller returns);
+// 0 = proceed with the native launch (core is OPL, or Neutrino unavailable on a non-udp device).
+static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, bdm_device_data_t *pDeviceData, config_set_t *configSet)
+{
+    int coreLoader = 0;
+    configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+    // UDPBD/UDPFS have no embedded cdvdman backend -- the "udp" BDM device can ONLY boot via
+    // Neutrino, so force the core and treat every Neutrino failure below as a clean abort
+    // (falling through to the native path would deinit into a no-op = black screen).
+    int isUdp = bdmDriverIsUDPBD(pDeviceData->bdmDriver);
+    if (isUdp)
+        coreLoader = 1;
+    if (!coreLoader)
+        return 0;
+
+    // Abort helper contract: on udp the launch is unbootable without Neutrino -- consume the
+    // launch (autolaunch mirrors its normal teardown); on local devices fall back to native.
+    int failResult = isUdp ? 1 : 0;
+
+    if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
+        // isValidIsoName() admits .zso case-insensitively and game->extension is stored verbatim,
+        // so an upper/mixed-case ".ZSO" must reject here too (Neutrino can't run it).
+        guiWarning(_l(isUdp ? _STR_NET_NEEDS_NEUTRINO : _STR_NEUTRINO_BAD_FORMAT), 6);
+        goto fail;
+    }
+
+    const char *neutrinoPath = sbResolveNeutrinoPath(pDeviceData->bdmPrefix); // #300: AUTO probes this device for a co-located install
+    if (neutrinoPath == NULL) {
+        guiWarning(_l(isUdp ? _STR_NET_NEEDS_NEUTRINO : _STR_NEUTRINO_NOT_FOUND), 6);
+        goto fail;
+    }
+
+    // Everything Neutrino actually needs from the config/device, copied to THIS stack frame
+    // (deinit below frees configSet's owner + pDeviceData).
+    int compatmask = 0, neutrinoVideo = 0;
+    char neutrinoExtraArgs[256] = "";
+    neutrino_vmc_args_t neutrinoVmc = {0};
+    char partname[256], bdmCurrentDriver[32];
+    configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatmask); // same source sbPrepare reads; no IRX patch needed
+    configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
+    sbBuildVmcNeutrinoArgs(configSet, pDeviceData->bdmPrefix, &neutrinoVmc); // Δ2-validated -mc args
+    sbCreatePath(game, partname, pDeviceData->bdmPrefix, "/", 0);            // -dvd target (multi-part was rejected above)
+    snprintf(bdmCurrentDriver, sizeof(bdmCurrentDriver), "%s", pDeviceData->bdmDriver);
+
+    if (gRememberLastPlayed) {
+        configSetStr(configGetByType(CONFIG_LAST), "last_played", game->startup);
+        saveConfig(CONFIG_LAST, 0);
+    }
+
+    // Δ6 preflight (driver token + network toml sync) -- abort stays in a live menu.
+    if (sysNeutrinoPreflight(bdmCurrentDriver, neutrinoPath) < 0)
+        goto fail;
+
+    // MMCE cross-device game-id (#261) with the Δ3 -mc-covered-slot guard. Before deinit (uses game).
+    mmceSendGameID(game->startup, neutrinoPath,
+                   (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0));
+
+    if (gAutoLaunchBDMGame == NULL) {
+        // Keep-IOP handoff: keep BOTH the game device and the neutrino.elf device mounted
+        // (Neutrino reads its -cwd config/modules and the ISO through our mounts pre-reset).
+        int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+        deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp frees bdmGames/game
+    } else {
+        miniDeinit(configSet);
+        free(gAutoLaunchBDMGame);
+        gAutoLaunchBDMGame = NULL;
+        free(gAutoLaunchDeviceData);
+        gAutoLaunchDeviceData = NULL;
+    }
+
+    // gPS2Logo passes the user's preference straight through: Neutrino performs its own logo
+    // read/validation for -logo, so the native path's CheckPS2Logo disc pass is not needed here.
+    sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, &neutrinoVmc);
+    return 1;
+
+fail:
+    if (failResult && gAutoLaunchBDMGame != NULL) {
+        miniDeinit(configSet); // mirror the normal autolaunch teardown (ioEnd/configEnd + frees configSet)
+        free(gAutoLaunchBDMGame);
+        gAutoLaunchBDMGame = NULL;
+        free(gAutoLaunchDeviceData);
+        gAutoLaunchDeviceData = NULL;
+    }
+    return failResult;
+}
+
 void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 {
     int i, fd, iop_fd, index, compatmask = 0;
@@ -700,6 +795,11 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         bdmLaunchVcd(itemList, game->name, configSet);
         return;
     }
+
+    // Δ8: Neutrino core gets its own lean path FIRST -- everything below is native-core prep it
+    // neither needs nor should be able to die on (see bdmTryNeutrinoLaunch).
+    if (bdmTryNeutrinoLaunch(itemList, game, pDeviceData, configSet))
+        return;
 
     char vmc_name[32], vmc_path[256], have_error = 0;
     int vmc_id, size_mcemu_irx = 0;
@@ -927,80 +1027,17 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         settings->hddIsLBA48 = pDeviceData->bdmHddIsLBA48;
     }
 
-    // Per-game Neutrino core: resolve the external ELF + reject unsupported
-    // formats here, while `game` is still valid (deinit below frees it).
-    int coreLoader = 0;
-    configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
-    // UDPBD/UDPFS have no embedded cdvdman backend -- the "udp" BDM device (either transport) can ONLY
-    // boot via the external Neutrino core. Force it on here (while the GUI is up); if Neutrino is missing
-    // the block below warns + clears it.
-    if (bdmDriverIsUDPBD(bdmCurrentDriver))
-        coreLoader = 1;
-    const char *neutrinoPath = NULL;
-    char neutrinoExtraArgs[256] = "";      // per-game Neutrino flags; copied before deinit frees configSet's owner
-    int neutrinoVideo = 0;                 // per-game Neutrino -gsm video mode; copied before deinit
-    neutrino_vmc_args_t neutrinoVmc = {0}; // per-game VMC -mc args; resolved before deinit, lives on this stack frame across the launch (#47)
-    if (coreLoader) {
-        configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
-        configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
-        neutrinoPath = sbResolveNeutrinoPath(pDeviceData->bdmPrefix); // #300: AUTO also probes this USB/mass device for a co-located neutrino.elf
-        // The udp (UDPBD/UDPFS) device has no embedded cdvdman backend, so the _STR_NEUTRINO_* warnings'
-        // "...launching with <OPL> core" tail is a false promise there (the launch just aborts below).
-        // Show the network-specific message instead so the user understands the abort.
-        int isUdp = bdmDriverIsUDPBD(bdmCurrentDriver);
-        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
-            // isValidIsoName() admits .zso case-insensitively and game->extension is stored
-            // verbatim, so an upper/mixed-case ".ZSO" must reject here too (Neutrino can't run it).
-            guiWarning(_l(isUdp ? _STR_NET_NEEDS_NEUTRINO : _STR_NEUTRINO_BAD_FORMAT), 6);
-            coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
-            guiWarning(_l(isUdp ? _STR_NET_NEEDS_NEUTRINO : _STR_NEUTRINO_NOT_FOUND), 6);
-            coreLoader = 0;
-        }
-
-        // VMC -> neutrino (#47): resolve any per-game VMC into discrete -mc0/-mc1 argv entries
-        // (NOT the whitespace-tokenized extra-args buffer, which would split a spaced VMC name),
-        // before deinit frees configSet / pDeviceData.
-        if (coreLoader)
-            sbBuildVmcNeutrinoArgs(configSet, pDeviceData->bdmPrefix, &neutrinoVmc);
-    }
-
-    // UDPBD has no embedded cdvdman fallback: every BDM_*_MODE below is local-storage only, so a
-    // udp game with coreLoader cleared (Neutrino missing/bad-format -- already warned above) would
-    // otherwise deinit into a no-op launch (black screen). Abort cleanly here while the GUI is up.
-    if (!coreLoader && bdmDriverIsUDPBD(bdmCurrentDriver)) {
-        if (gAutoLaunchBDMGame != NULL) {
-            miniDeinit(configSet); // mirror the normal autolaunch teardown (ioEnd/configEnd + frees configSet)
-            free(gAutoLaunchBDMGame);
-            gAutoLaunchBDMGame = NULL;
-            free(gAutoLaunchDeviceData);
-            gAutoLaunchDeviceData = NULL;
-        }
-        return;
-    }
+    // Δ8: Neutrino never reaches this point (bdmTryNeutrinoLaunch handled it at the top), so
+    // everything from here on is the NATIVE (embedded cdvdman) launch only -- including the udp
+    // impossibility: the udp device is Neutrino-only and its aborts happen inside the helper.
 
     // MMCE cross-device game-id (#261): push the disc id to a present SD2PSX/MemCard PRO2 (either slot)
     // so it switches its per-game folder, even though this game is not on the MMCE. Self-probes +
     // no-ops if no card answers / feature off. Must run BEFORE deinit frees `game`.
-    mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL,
-                   (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
+    mmceSendGameID(game->startup, NULL, 0);
 
     if (gAutoLaunchBDMGame == NULL) {
-        // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino reads its config/modules from the
-        // neutrino.elf device (-cwd) AND opens the game ISO through OUR mass mount before doing its
-        // own IOP reset -- keep BOTH mounted across the teardown. An MC-hosted neutrino needs no
-        // exception of its own (-1 second slot). ee_core launches keep the full teardown: everything
-        // they need is embedded before deinit.
-        if (coreLoader) {
-            // D6: everything that can fail the launch and is checkable NOW runs pre-teardown --
-            // driver-token validation + (udp transports) the bsd toml ip= sync. Abort = stay in menu.
-            if (sysNeutrinoPreflight(bdmCurrentDriver, neutrinoPath) < 0)
-                return;
-            int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-            deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees bdmGames/game
-        } else {
-            deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
-        }
+        deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
     } else {
         miniDeinit(configSet);
 
@@ -1009,13 +1046,6 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
         free(gAutoLaunchDeviceData);
         gAutoLaunchDeviceData = NULL;
-    }
-
-    // Neutrino core: hand off with the stack-resident partname + driver token
-    // (both survive the deinit above; `game` does not and is not used here).
-    if (coreLoader) {
-        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, &neutrinoVmc);
-        return;
     }
 
     LOG("bdm pre sysLaunchLoaderElf\n");

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -665,6 +665,73 @@ static void hddLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     hddDoLaunchVcd(itemList, hddVcdGames[idx].name, hddVcdParts[idx]);
 }
 
+// Δ8 (NHDDL parity): the LEAN Neutrino launch path for HDL games -- see bdmTryNeutrinoLaunch's
+// rationale in bdmsupport.c. The native flow's VMC block-chain prompts + mcemu patching, DMA
+// setup, sbPrepare, cheats (with dialogs), PS2RD images and CheckPS2Logo all exist for the
+// embedded cdvdman core; Neutrino re-derives everything from -bsd=ata -bsdfs=hdl -dvd=hdl:<part>
+// after its own IOP reset. The one probe Neutrino DOES need is the ZSO header check (its hdl
+// backend can't run ZSO) -- a single sector read, kept here.
+// Returns 1 = handled (caller returns); 0 = proceed with the native launch.
+static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
+{
+    int coreLoader = 0;
+    configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+    if (!coreLoader)
+        return 0;
+
+    // ZSO probe (one sector): Neutrino's hdl backend can't run ZSO -- fall back to the native
+    // core, which can. Same read the native path performs for its layer-1 setup.
+    hddReadSectors(game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET, 1, IOBuffer);
+    if (*(u32 *)IOBuffer == ZSO_MAGIC) {
+        guiWarning(_l(_STR_NEUTRINO_BAD_FORMAT), 6);
+        return 0;
+    }
+
+    const char *neutrinoPath = sbResolveNeutrinoPath(NULL); // #300: HDD keeps custom-path + mc0/mc1 + Device-picker resolution (raw APA isn't POSIX-reachable; pfs0 probe = shared-slot risk)
+    if (neutrinoPath == NULL) {
+        guiWarning(_l(_STR_NEUTRINO_NOT_FOUND), 6);
+        return 0;
+    }
+
+    // Everything Neutrino needs, copied to THIS frame (deinit below frees `game`).
+    int compatMode = 0, neutrinoVideo = 0;
+    char neutrinoExtraArgs[256] = "";
+    char apaPart[APA_IDMAX + 1];
+    configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatMode);
+    configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
+    snprintf(apaPart, sizeof(apaPart), "%s", game->partition_name);
+
+    if (gRememberLastPlayed) {
+        configSetStr(configGetByType(CONFIG_LAST), "last_played", game->startup);
+        saveConfig(CONFIG_LAST, 0);
+    }
+
+    if (sysNeutrinoPreflight("apa", neutrinoPath) < 0) // Δ6 pre-teardown validation
+        return 1;
+
+    // MMCE cross-device game-id (#261); HDD emits no -mc args (VMC->neutrino deferred), mask 0.
+    mmceSendGameID(game->startup, neutrinoPath, 0);
+
+    if (gAutoLaunchGame == NULL) {
+        // Keep-IOP handoff: keep the HDD stack up (NHDDL hands off with its full ATA stack
+        // resident) AND the neutrino.elf device (-cwd config/module reads).
+        int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+        deinitEx(UNMOUNT_EXCEPTION, HDD_MODE, neutrinoDevMode); // CAREFUL: itemCleanUp frees hddGames/game
+    } else {
+        miniDeinit(configSet);
+        free(gAutoLaunchGame);
+        gAutoLaunchGame = NULL;
+        fileXioUmount("pfs0:");
+        fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
+    }
+
+    LOG("[NEUTRINO] apa partition_name=[%s]\n", apaPart);
+    // gPS2Logo passes the preference straight through (Neutrino does its own logo work).
+    sysLaunchNeutrino("apa", apaPart, compatMode, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, NULL /* HDD VMC->neutrino deferred (APA/pfs) */);
+    return 1;
+}
+
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 {
     int i, size_irx = 0;
@@ -690,6 +757,11 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         game = &hddGames.games[id];
     else
         game = gAutoLaunchGame;
+
+    // D8: Neutrino core gets its own lean path FIRST -- everything below is native-core prep it
+    // neither needs nor should be able to die on (see hddTryNeutrinoLaunch).
+    if (hddTryNeutrinoLaunch(game, configSet))
+        return;
 
     apa_sub_t parts[APA_MAXSUB + 1];
     char vmc_name[2][32];
@@ -785,10 +857,6 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     int dmaType = 0, dmaMode = 7, compatMode = 0;
     configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatMode);
     configGetInt(configSet, CONFIG_ITEM_DMA, &dmaMode);
-    int coreLoader = 0;
-    int isZSO = 0;
-    char apaPart[APA_IDMAX + 1];
-    configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
     if (dmaMode < 3)
         dmaType = 0x20;
     else {
@@ -841,7 +909,6 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     settings->common.layer1_start = 0; // cdvdman will read it from APA header
     hddReadSectors(game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET, 1, IOBuffer);
     if (*(u32 *)IOBuffer == ZSO_MAGIC) {
-        isZSO = 1;
         probed_fd = 0;
         probed_lba = game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET;
         ziso_init((ZISO_header *)IOBuffer, *(u32 *)((u8 *)IOBuffer + sizeof(ZISO_header)));
@@ -852,42 +919,15 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         }
     }
 
-    // Per-game Neutrino core: copy partition_name into a local BEFORE deinit —
-    // deinit / free(gAutoLaunchGame) below free `game`; reading it after is UAF.
-    const char *neutrinoPath = NULL;
-    char neutrinoExtraArgs[256] = ""; // per-game Neutrino flags; copied before deinit frees `game`
-    int neutrinoVideo = 0;            // per-game Neutrino -gsm video mode; copied before deinit
-    if (coreLoader) {
-        configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
-        configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
-        snprintf(apaPart, sizeof(apaPart), "%s", game->partition_name);
-        neutrinoPath = sbResolveNeutrinoPath(NULL); // #300: HDD passes NULL -- the raw APA root isn't POSIX-open-reachable and a pfs0: co-location probe is a single-shared-slot risk (L3-freeze saga), so HDD keeps the custom-path + mc0/mc1 + Device-picker resolution only
-        if (isZSO) {
-            guiWarning(_l(_STR_NEUTRINO_BAD_FORMAT), 6);
-            coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
-            guiWarning(_l(_STR_NEUTRINO_NOT_FOUND), 6);
-            coreLoader = 0;
-        }
-    }
+    // D8: Neutrino never reaches this point (hddTryNeutrinoLaunch handled it at the top) --
+    // everything from here on is the NATIVE (embedded cdvdman) launch only.
 
     // MMCE cross-device game-id (#261): push the HDL disc id to a present MMCE card before the HDD
     // teardown (self-probes mmce0/mmce1; no-ops if no card / feature off). Read `game` before deinit.
-    mmceSendGameID(game->startup, coreLoader ? neutrinoPath : NULL, 0); // HDD leg emits no -mc args (VMC->neutrino deferred)
+    mmceSendGameID(game->startup, NULL, 0);
 
     if (gAutoLaunchGame == NULL) {
-        // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): keep the HDD stack up (NHDDL hands off with
-        // its full ATA stack resident) AND the neutrino.elf device (-cwd config/module reads) across
-        // the teardown. An MC-hosted neutrino needs no exception (-1 second slot). ee_core launches
-        // keep the full teardown: everything they need is embedded before deinit.
-        if (coreLoader) {
-            if (sysNeutrinoPreflight("apa", neutrinoPath) < 0) // D6 pre-teardown validation
-                return;
-            int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-            deinitEx(UNMOUNT_EXCEPTION, HDD_MODE, neutrinoDevMode); // CAREFUL: itemCleanUp still frees hddGames/game
-        } else {
-            deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
-        }
+        deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
     } else {
         miniDeinit(configSet);
 
@@ -896,13 +936,6 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
         fileXioUmount("pfs0:");
         fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
-    }
-
-    // Neutrino core: hand off using the apaPart copy (game is freed above).
-    if (coreLoader) {
-        LOG("[NEUTRINO] apa partition_name=[%s]\n", apaPart);
-        sysLaunchNeutrino("apa", apaPart, compatMode, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, NULL /* HDD VMC->neutrino deferred (APA/pfs) */);
-        return;
     }
 
     settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -671,7 +671,8 @@ static void hddLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
 // embedded cdvdman core; Neutrino re-derives everything from -bsd=ata -bsdfs=hdl -dvd=hdl:<part>
 // after its own IOP reset. The one probe Neutrino DOES need is the ZSO header check (its hdl
 // backend can't run ZSO) -- a single sector read, kept here.
-// Returns 1 = handled (caller returns); 0 = proceed with the native launch.
+// Returns 1 = handled (handed off; caller returns); 0 = proceed with the native launch (core is
+// OPL, or any Neutrino-side failure -- ZSO, no install, preflight -- since HDL always boots natively).
 static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
 {
     int coreLoader = 0;
@@ -707,8 +708,11 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
         saveConfig(CONFIG_LAST, 0);
     }
 
-    if (sysNeutrinoPreflight("apa", neutrinoPath) < 0) // Δ6 pre-teardown validation
-        return 1;
+    // Δ6 pre-teardown validation. On failure fall back to the native core (same contract as
+    // bdmTryNeutrinoLaunch's non-udp legs): HDL always boots natively, and the native path owns
+    // the autolaunch teardown -- aborting here instead would leak gAutoLaunchGame/configSet.
+    if (sysNeutrinoPreflight("apa", neutrinoPath) < 0)
+        return 0;
 
     // MMCE cross-device game-id (#261); HDD emits no -mc args (VMC->neutrino deferred), mask 0.
     mmceSendGameID(game->startup, neutrinoPath, 0);


### PR DESCRIPTION
Batch 4 — the biggest structural item of the [parity analysis](docs/NEUTRINO-PARITY-2026-07-05.md), in its own PR for careful review.

### The problem
On bdm/hdd the coreLoader gate sat **after** the full native-launch preparation, so a Neutrino launch still paid for — and could die on — work only the embedded cdvdman core needs:
- the per-part **fragment-list build with its hard abort past 64 fragments** (Neutrino re-derives fragments itself; its mmce/udpfs backends have no limit at all)
- an **interactive cheats dialog mid-launch** (Neutrino ignores OPL cheats)
- **VMC-superblock continue/cancel prompts** + mcemu IRX patching (Neutrino VMCs use the Δ2-validated `-mc` args)
- sbPrepare's cdvdman patch, layer-1 probing, PS2RD images, ATA DMA setup, CheckPS2Logo passes

### The fix
`bdmTryNeutrinoLaunch` / `hddTryNeutrinoLaunch` run **first** and do only what Neutrino needs: config reads (compat = the same `$Compatibility` key sbPrepare reads — no IRX patch), Δ2-validated VMC args, last-played save, Δ6 preflight, Δ3-guarded gameID, `deinitEx`, handoff. The hdd helper keeps the one probe Neutrino *does* need — a single-sector ZSO header check (its hdl backend can't run ZSO → falls back to native, which can). All udp abort paths (incl. the autolaunch mini-teardown) moved into the bdm helper; the native path can no longer be reached with a udp driver. NHDDL's whole pre-handoff is ~3 file ops; this is ours.

### Behavior notes
- `-logo` now passes the user's `gPS2Logo` preference directly — Neutrino performs its own logo read/validation; the native CheckPS2Logo pass served the embedded core.
- **Native (OPL-core) launches are unchanged**: the gate returns 0 and the old flow runs, minus its now-dead Neutrino branches.
- A **fragmented ISO now boots via Neutrino** instead of hard-aborting (Neutrino's own 64-frag check still applies on bd devices — the Δ9 pre-count is the planned follow-up for a friendly message there).

### Validation
- Build-green both containers; clang-format clean.
- HW matrix: per device (USB/MX4SIO/exFAT/APA/UDP) — Neutrino launch of a normal ISO (boots), a deliberately fragmented ISO (now boots or fails inside Neutrino rather than aborting in OPL), a game with a cheats file present (no dialog on the Neutrino path; dialog still on OPL-core), VMC configured (works via -mc); OPL-core launches on the same games (unchanged). UDP: game with no neutrino installed → clean abort to menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)