### PR TITLE
fix(mmce): settle the switched card after any GameID push (Neutrino MMCE freezes)

### DIFF
--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -640,23 +640,38 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // (mmceMountVMC). mmceSendGameID waits out the card's busy bit (bounded ~3 s); the
         // MC-hosted-neutrino protect guard is inside the helper (skips + warns when neutrinoPath
         // sits on this slot's mcN:).
-        mmceSendGameID(game->startup, neutrinoPath,
-                       (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
-        // NHDDL-parity caveat: NHDDL's neutrino.elf never lives on the MMCE, so it has no reads
-        // left after the switch. Ours can (Auto prefers the game device), and the busy bit can
-        // clear before the card's FILESYSTEM surface is back (Gen2 remounts slowly) -- so when
-        // the loader's next read is from the switched card, wait for its fs to answer a directory
-        // probe (bounded ~5 s; poll-first so a fast card costs ~0 ms).
-        if (neutrinoPath != NULL && !strncmp(neutrinoPath, "mmce", 4)) {
-            char mmceRoot[8];
-            snprintf(mmceRoot, sizeof(mmceRoot), "%.5s:/", neutrinoPath); // "mmceN" + ":/"
-            for (int settle = 0; settle < 25; settle++) {
-                int dfd = fileXioDopen(mmceRoot);
-                if (dfd >= 0) {
-                    fileXioDclose(dfd);
-                    break;
+        int gameIdSwitched = mmceSendGameID(game->startup, neutrinoPath,
+                                            (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
+        // Fs-settle after a card switch. The 0x8 devctl physically re-mounts the card, and on Gen2
+        // the busy bit (mmceSendGameID's own wait) can clear before the FILESYSTEM surface is back.
+        // The game on this leg is ALWAYS mmce-hosted, so after any actual switch (gameIdSwitched)
+        // both our own reads below (neutrino.elf load, ISO open for the keep-IOP handoff) AND
+        // Neutrino's own post-reset mmceman read hit the just-switched card. Wait for the SWITCHED
+        // slot's fs to answer a directory probe first. Prior code gated this on an mmce-hosted
+        // neutrino.elf, which MISSED the game-on-MMCE / neutrino-on-USB case entirely: the card
+        // still switched (for the game's per-game folder) but nothing waited (issue #56/#68, lucas:
+        // "neutrino on USB, game from MMCE" froze on some titles). Probe the game's own slot (the
+        // one mmceSendGameID switched) -- covers both-on-MMCE (same slot) too. Poll-first so a fast
+        // card costs ~0 ms; bounded (~5 s) so a dead card can't hang; LOG each outcome so a debug
+        // ELF can distinguish "settling" from "hung" and localise a black screen to OPL vs Neutrino.
+        if (gameIdSwitched) {
+            char mmceRoot[sizeof(mmcePrefix)];
+            mmceGetDeviceRoot(mmceRoot, sizeof(mmceRoot)); // the game's slot ("mmceN:/")
+            if (mmceRoot[0] != '\0') {
+                int settled = 0, settle;
+                for (settle = 0; settle < 25; settle++) {
+                    int dfd = fileXioDopen(mmceRoot);
+                    if (dfd >= 0) {
+                        fileXioDclose(dfd);
+                        settled = 1;
+                        break;
+                    }
+                    DelayThread(200 * 1000);
                 }
-                DelayThread(200 * 1000);
+                if (settled)
+                    LOG("MMCE settle: %s fs surface up after ~%d ms\n", mmceRoot, settle * 200);
+                else
+                    LOG("MMCE settle: %s fs surface not back within ~5000 ms; launching anyway\n", mmceRoot);
             }
         }
         // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino opens the mmce-hosted game through

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -657,6 +657,14 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         if (gameIdSwitched) {
             char mmceRoot[sizeof(mmcePrefix)];
             mmceGetDeviceRoot(mmceRoot, sizeof(mmceRoot)); // the game's slot ("mmceN:/")
+            // The game is mmce-hosted here, so its own slot is normally the one mmceSendGameID
+            // switched. But the helper falls back to the OTHER slot when the game's slot has no
+            // card (or is -mc-covered), so stay consistent: if the game's slot isn't present, settle
+            // the other slot instead -- otherwise we'd probe an empty slot for the full ~5 s
+            // (PR #89 review). Same 0x1 presence devctl mmceSendGameID itself uses.
+            if (mmceRoot[0] != '\0' && strlen(mmceRoot) >= 5 &&
+                fileXioDevctl(mmceRoot, 0x1, NULL, 0, NULL, 0) == -1)
+                mmceRoot[4] = (mmceRoot[4] == '0') ? '1' : '0'; // mmce0:/ <-> mmce1:/
             if (mmceRoot[0] != '\0') {
                 int settled = 0, settle;
                 for (settle = 0; settle < 25; settle++) {


### PR DESCRIPTION
Addresses the MMCE + Neutrino-core freezes in [#56](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/56) / [#68](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/68) (AndrewBento, lucaslmgv — PSXMemCard Gen2).

### The gap
The Neutrino-core MMCE launch pushes the per-game GameID (`devctl 0x8`) whenever the game is MMCE-hosted, which **physically re-mounts the card**. The fs-settle wait that follows only ran when *neutrino.elf itself* was mmce-hosted:

```c
if (neutrinoPath != NULL && !strncmp(neutrinoPath, "mmce", 4)) { ... settle ... }
```

So a **game-on-MMCE / neutrino-on-USB** launch switched the card and then handed off with **no wait at all**. On a Gen2 card the busy bit clears before the filesystem surface returns, so our own post-switch reads (neutrino.elf load + ISO open for the keep-IOP handoff) *and* Neutrino's own post-reset mmceman read could hit a still-remounting card and freeze on some titles — exactly lucas's "neutrino on USB, game from MMCE froze on Crash/Psychonauts but not Tony Hawk's Underground."

### The change
Gate the settle on whether `mmceSendGameID` **actually switched a card** (its return value, previously discarded) and probe the **game's own slot** — the one that switched — instead of the neutrino.elf slot:
- Covers both-on-MMCE (same slot → unchanged timing) **and** the previously-unwaited game-on-MMCE/neutrino-on-USB case.
- Poll-first (fast card ≈ 0 ms), bounded ~5 s so a dead card can't hang.
- **LOGs the outcome** (`fs surface up after ~N ms` / `not back within ~5000 ms`) so a debug ELF can distinguish "settling" from "hung."

### Honest scope
This does **not** change the both-on-MMCE path's timing (it already settled). So if Andrew's game-dependent black screens in *that* config survive, they point **past the handoff into Neutrino's own post-IOP-reset mmceman re-init**, which OPL can't influence after `ExecPS2`. The new LOG breadcrumbs — plus the `[NEUTRINO] argv[]` lines already printed before `ExecPS2` — are what will confirm OPL vs Neutrino as the death site, so we know whether to keep digging here or escalate upstream with a known-good/known-bad title list.

### Validation
- Build-green both containers; clang-format clean; no lang/string changes.
- HW matrix (debug ELF preferred, to capture the settle LOG): game-on-MMCE + neutrino-on-USB launch of a title that previously froze (Crash Twinsanity / Psychonauts) — expect it to wait then boot; both-on-MMCE unchanged; USB-game + MMCE-card cross-device gameID unaffected; OPL-core MMCE launch (no gameID) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)