### PR TITLE
fix(disc): spin the drive up and re-check before "no disc" on Launch Disc (#73)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -455,9 +455,12 @@ int sysLaunchDisc(void)
         LOG("[DISC] drive reports NODISC -- spinning up and re-checking (#73)\n");
         sceCdStandby();
         sceCdSync(0);
-        for (spin = 0; spin < 20; spin++) {          // ~4 s budget for a cold spin-up + re-detect
-            while (sceCdGetDiskType() == SCECdDETCT) // let it finish identifying after the spin-up
-                ;
+        for (spin = 0; spin < 20; spin++) { // ~4 s budget for a cold spin-up + re-detect
+            // Let it finish identifying after the spin-up, but bounded + yielding: a dirty laser or
+            // damaged disc can stick in DETCT, and a bare spin would hang Launch Disc and peg the CPU.
+            int detecting = 0;
+            while (sceCdGetDiskType() == SCECdDETCT && detecting++ < 50)
+                DelayThread(20 * 1000); // ~1 s cap, yields to other threads
             type = sceCdGetDiskType();
             if (type != SCECdNODISC)
                 break;

--- a/src/system.c
+++ b/src/system.c
@@ -40,6 +40,7 @@
 
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioInit, fileXioExit, fileXioDevctl
+#include <delaythread.h> // DelayThread() -- inter-poll gap in the Launch Disc spin-up retry (#73)
 
 typedef struct
 {
@@ -443,6 +444,28 @@ int sysLaunchDisc(void)
         ;
 
     type = sceCdGetDiskType();
+    // Issue #73 (SCPH-77001 + FMCB): an idle drive spins the disc DOWN and then reports NODISC
+    // even with a game disc loaded, so Launch Disc bailed to the "no disc" message before it could
+    // wake. A tray open/close "fixed" it only because that forces a spin-up + re-detect -- so do the
+    // same in software: on NODISC, kick the drive to standby (spins the disc up; the same call
+    // sysGetDiscID uses before it reads the key) and re-poll the type for a few seconds. A genuinely
+    // empty drive still ends at the -2 bail below, just ~4 s later.
+    if (type == SCECdNODISC) {
+        int spin;
+        LOG("[DISC] drive reports NODISC -- spinning up and re-checking (#73)\n");
+        sceCdStandby();
+        sceCdSync(0);
+        for (spin = 0; spin < 20; spin++) {          // ~4 s budget for a cold spin-up + re-detect
+            while (sceCdGetDiskType() == SCECdDETCT) // let it finish identifying after the spin-up
+                ;
+            type = sceCdGetDiskType();
+            if (type != SCECdNODISC)
+                break;
+            DelayThread(200 * 1000); // 200 ms between polls
+        }
+        LOG("[DISC] after spin-up: type=%d (%d re-polls)\n", type, spin);
+    }
+
     if (type != SCECdPS2DVD && type != SCECdPS2CD) // no disc / not a PS2 game disc
         return -2;
 


### PR DESCRIPTION
Fixes the residual on [#73](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/73) that AndrewBento root-caused after the PR #75 BOOT2 fix landed.

### The cause (Andrew's own diagnosis)
> the disc launch function... only works while the disc is spinning inside the PS2. If the disc isn't spinning, it... gives the message that there's no disc.

On some consoles (his: SCPH-77001 + FMCB) an idle drive spins the disc **down** and then reports `SCECdNODISC` even with a game disc loaded. `sysLaunchDisc` read the disc type once and bailed straight to "No PS2 disc." Opening and closing the tray "fixed" it only because that forces a hardware spin-up + re-detect.

### The fix
When the first `sceCdGetDiskType()` is `SCECdNODISC`, do the spin-up in software before giving up:

```c
sceCdStandby();   // spins the disc up -- the same call sysGetDiscID uses before reading the key
sceCdSync(0);
// then re-poll sceCdGetDiskType() for ~4 s (20 x 200 ms), letting each SCECdDETCT settle
```

`sceCdStandby()` is exactly what the existing `sysGetDiscID` (system.c:353-354) already uses to bring the drive to a spinning/ready state before reading the disc key, so this is a known-good call on this hardware — not a new API. A genuinely empty drive still lands on the same `-2` "no disc" message, just ~4 s later; a spun-down-but-loaded drive now wakes and boots. Two LOG lines record the spin-up + resolved type.

### Validation
- Build-green both containers; clang-format clean.
- HW: with a disc that has spun down (leave the console idle at the menu), Launch Disc should now wake it and boot instead of saying "no disc"; an empty drive still reports "no disc" (after a short spin-up attempt); a spinning disc is unaffected (NODISC branch is skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)