### PR TITLE
docs: reconcile CREDITS and README acknowledgements (everyone in both)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -56,9 +56,50 @@ by fjtrujy
 -----------------------------------------------------------------------------
 
 RiptOPL fork
+by NathanNeurotic (Ripto)
+
+RiptOPL stands entirely on the shoulders of the PS2 homebrew community. None of it
+would exist without the ps2homebrew team (https://github.com/ps2homebrew) and their
+many years of open-source work on Open PS2 Loader and the PS2SDK, kept free, open,
+and readable so that people like us can study it, learn from it, and build on it.
+Every feature in this fork began as their code and their ideas.
+
+RiptOPL is a direct agglomeration of the wider OPL family, bringing together
+features, code, and ideas from:
+
+  - rickgaiser's OPL                https://github.com/rickgaiser/Open-PS2-Loader
+  - neutrino                        https://github.com/rickgaiser/neutrino
+  - sOPL (mystyq)                   https://github.com/mystyq/Stable-Open-PS2-Loader
+  - uOPL (Wolf3s)                   https://github.com/Wolf3s/uOPL
+  - wOPL (KrahJohlito)              https://github.com/KrahJohlito/wOPL
+  - OPL DB (Jay-Jay-OPL)            https://github.com/Jay-Jay-OPL/OPL-Daily-Builds
+  - POPSLoader                      https://github.com/NathanNeurotic/POPSLoader
+  - OPL RetroGEM ID (CosmicScale)   https://github.com/CosmicScale/Open-PS2-Loader-Retro-GEM
+  - nhddl (pcm720)                  https://github.com/pcm720/nhddl
+  - official OPL                    https://github.com/ps2homebrew/Open-PS2-Loader
+
+Special and sincere thanks to:
+
+  - Wolf3s and KrahJohlito - the driving force behind uOPL / wOPL, where much of
+    this fork's modern functionality originated. The Neutrino external-core loader
+    and the Coverflow and Favourites interfaces are all reimplementations of
+    features they designed and pioneered together. This fork is as much a tribute
+    to their work as anything else.
+  - bbsan2k - for the MMCE (Memory Card Mass Storage) protocol that makes SD-via-
+    memory-card loading through the PS2's memory-card slot possible.
+  - saildot4k - for BDMA-ATA (exFAT internal-HDD block-device support), and the
+    fixes, feedback, and oversight that shaped this fork's block-device work.
+  - Berion - for the artwork and theme design that has shaped how OPL looks.
+  - Ifcaro and jimmikaelkael - the original Open PS2 Loader authors - and every
+    contributor across OPL's long history, all named above in this file.
 
 BDMA-ATA (exFAT internal-HDD block-device support), plus fixes, feedback and oversight
 by saildot4k
 
 Testing, bug reports and real-hardware feedback
 by eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573
+
+If you want the canonical, actively-maintained project, it lives at
+https://github.com/ps2homebrew/Open-PS2-Loader - please support it. This fork is a
+downstream labor of love, not a replacement, and it exists only because that
+upstream work is open for everyone to learn from.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,31 @@ With special and sincere thanks to:
 - **Ifcaro** and **jimmikaelkael** — the original Open PS2 Loader authors — and every
   contributor across OPL's long history.
 
+### The wider Open PS2 Loader team
+
+RiptOPL inherits the work of everyone who built Open PS2 Loader over the years. They are
+credited in full in [CREDITS](CREDITS), and named here so this fork never obscures whose
+work it is built on:
+
+- **Core developers** — Ifcaro, volca, jimmikaelkael, polo35, izdubar, hominem.te.esse and
+  SP193, with the original main code based on **Polo**'s HD Project.
+- **Contributing developers** — BatRastard, crazyc, dlanor, doctorxyz, reprep, belek666,
+  Maximus32 and misfire.
+- **Module authors** — **Eugene Plotnikov** (SMSUTILS / SMSMAP / SMSTCPIP), **Marcus R. Brown**
+  (DEV9 / ATAD and the derived cdvdman code), **bbsan2k** (MMCE), **icyson55** (OPL-CL /
+  network update), **Eric Young** (the DES algorithm in the SMB code), and the **ps2dev** team
+  (USB / Network / PS2HDD modules from the PS2SDK).
+- **CI/CD** — **fjtrujy** (Docker + GitHub Actions).
+- **UI & artwork** — **Berion**.
+- **Quality assurance** — RandQalan, yoshi314, EP, LocalH, lee4, El_Patas, ShaolinAssassin,
+  algol, gledson999, jolek and zero35.
+
+### Real-hardware testing (this fork)
+
+Enormous thanks to the testers who run every rolling build on real consoles and file the
+reports that shape the fixes — **eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz
+and nuno6573**.
+
 If you want the canonical, actively-maintained project, it lives at
 **[ps2homebrew/Open-PS2-Loader](https://github.com/ps2homebrew/Open-PS2-Loader)** — please
 support it. This fork is a downstream labor of love, not a replacement, and it exists only


### PR DESCRIPTION
Makes `CREDITS` and the README **Acknowledgements** section mutually complete.

**CREDITS** gains the README's level of detail — the ps2homebrew tribute, the full OPL-family agglomeration list (rickgaiser OPL, neutrino, sOPL, uOPL, wOPL, OPL DB, POPSLoader, RetroGEM, nhddl, official OPL, with links), and the special-thanks context for Wolf3s/KrahJohlito, bbsan2k, saildot4k and Berion — while keeping all its detailed original-author copyright attributions.

**README acknowledgements** gains a complete roll-call so everyone named in `CREDITS` appears there too: core + contributing developers, all module authors (Eugene Plotnikov, Marcus R. Brown, icyson55, Eric Young, ps2dev), fjtrujy (CI/CD), the full QA team, and all six real-hardware testers (previously only eliminator1403 was named).

Verified both directions programmatically: every `CREDITS` name is present in the README, and every README family/project is present in `CREDITS`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)