### PR TITLE
fix(vcd): the BDMA equip never gates the POPSTARTER handoff (#56)

### DIFF
--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -105,12 +105,13 @@ enum {
 int vcdEquipBdma(int source, int mode, char *diag, int diagSize);
 // Read the equipped variant from mc?:/POPSTARTER/bdma_config.txt (VCD_BDMA_FAT32 if absent).
 int vcdReadBdmaMode(void);
-// Auto-equip the BDMA variant matching the game's device (source/mode) on the VCD launch path, so the
-// driver POPSTARTER reloads from the MC after its own IOP reset can mount the drive (else OSDSYS). No-op
-// when already equipped. Returns 1 = launch may proceed (equipped, or clean-FAT32 best-effort), 0 =
-// ABORT: a different family's working pair is equipped and couldn't be replaced -- the user was shown
-// the equip diagnostic, and the pair is deliberately NOT wiped as collateral. See vcdsupport.c.
-int vcdEnsureBdmaForLaunch(int source, int mode);
+// Best-effort auto-equip of the BDMA variant matching the game's device (source/mode) before a VCD
+// launch, so the driver pair POPSTARTER reloads from the MC after its own IOP reset fits the drive.
+// No-op when already equipped. CARD PREP ONLY -- it never blocks the handoff: on any equip failure it
+// keeps the card's current pair (never wiped as collateral), toasts the diagnostic in passing, and the
+// launch proceeds (the VCD launch is a plain POPSTARTER.ELF + argv[0]-selector handoff; POPSTARTER
+// owns everything after the exec). See vcdsupport.c.
+void vcdEnsureBdmaForLaunch(int source, int mode);
 
 // Are POPSTARTER's SMB network modules (smbman/ps2ip/ps2smap/ps2dev9) present on a card? 1 = yes.
 // Gate SMB/ETH VCD launches on this -- we don't install these from the ELF.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -643,23 +643,19 @@ static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     // unit-numbered mount -- POPSTARTER remounts under "mass:" after its own IOP reset (see the function).
     vcdBuildSelector(vcdPrefix, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
 
-    // POPSTARTER reloads its block-device driver from the MC after its OWN IOP reset, so equip the
-    // device-matching BDMAssault variant first -- otherwise it can't mount this exFAT drive and drops to
-    // OSDSYS (the reported MX4SIO failure). iLink/UDPBD/unknown have no BDMA variant and are left as-is.
-    // An equip ABORT (0) means a different family's working pair is on the card and couldn't be
-    // replaced; the user was shown the diagnostic, and launching would only end in OSDSYS anyway.
+    // Best-effort card prep: POPSTARTER reloads its block-device driver pair from the MC after its OWN
+    // IOP reset, so try to equip the device-matching BDMAssault variant first. NEVER a launch gate --
+    // the handoff below always proceeds (POPSTARTER owns everything past the exec); a failed equip just
+    // toasts its diagnostic in passing. iLink/UDPBD/unknown have no BDMA variant and are left as-is.
     switch (pDeviceData->bdmDeviceType) {
         case BDM_TYPE_USB:
-            if (!vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_USB, VCD_BDMA_USBEXFAT))
-                return;
+            vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_USB, VCD_BDMA_USBEXFAT);
             break;
         case BDM_TYPE_SDC:
-            if (!vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MX4SIO, VCD_BDMA_MX4SIO))
-                return;
+            vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MX4SIO, VCD_BDMA_MX4SIO);
             break;
         case BDM_TYPE_ATA:
-            if (!vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_HDD, VCD_BDMA_ATA))
-                return;
+            vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_HDD, VCD_BDMA_ATA);
             break;
         default:
             break;

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -419,11 +419,10 @@ static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set
         return;
     }
     vcdBuildSelector(mmcePrefix, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
-    // POPSTARTER reloads its driver from the MC after its own IOP reset -> ensure the .mmce BDMAssault
-    // variant is equipped first, or it can't mount the MMCE drive (-> OSDSYS). An abort means a
-    // different family's working pair is on the card and couldn't be replaced (user was shown why).
-    if (!vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MMCE, VCD_BDMA_MMCE))
-        return;
+    // Best-effort card prep: try to equip the .mmce BDMAssault variant so the driver pair POPSTARTER
+    // reloads from the MC fits this drive. NEVER a launch gate -- the handoff below always proceeds
+    // (POPSTARTER owns everything past the exec); a failed equip just toasts its diagnostic in passing.
+    vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MMCE, VCD_BDMA_MMCE);
     deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the MMCE device mounted across the IOP reset
     sysLaunchPopstarter(vcdElf, vcdSelector, "");
 }

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -21,7 +21,7 @@
 #include "include/ioman.h"       // LOG (BDMA equip probe trace)
 #include "include/bdmsupport.h"  // BDM_TYPE_* + bdmGetDeviceRootByType (BDMA source differentiation)
 #include "include/mmcesupport.h" // mmceLoadModules (ensure mmceman for the MMCE BDMA source)
-#include "include/gui.h"         // guiMsgBox (launch-path BDMA equip diagnostics)
+#include "include/gui.h"         // guiWarning (passing toast on a failed launch-path BDMA equip)
 #include "include/lang.h"        // _l + _STR_BDMA_ERR_* (same texts the Settings-screen equip shows)
 #include "include/vcdsupport.h"
 
@@ -667,52 +667,43 @@ int vcdEquipBdma(int source, int mode, char *diag, int diagSize)
     return (mr != 0) ? mr : 0;
 }
 
-// Auto-equip the device-matching BDMA driver on the VCD launch path (POPSLoader's ApplyBdmaMode parity).
-// POPSTARTER does its OWN SifIopReset, then reloads its block-device drivers from the FIXED memory-card
-// files mc?:/POPSTARTER/usbd.irx + usbhdfsd.irx -- RiptOPL's live mx4sio_bd/ata_bd modules die at that
-// reset. For an exFAT game those two files MUST be the device-matching BDMAssault variant or POPSTARTER
-// can't mount the drive and drops to OSDSYS (the reported MX4SIO failure). `source`/`mode` are the game
-// device's BDMA family. Idempotent: skips the copy when the matching variant is already equipped.
-// Returns 1 when the launch may proceed, 0 when it must be ABORTED: a DIFFERENT family's pair is
-// equipped and could not be replaced. The old fallback silently downgraded the card to FAT32 here,
-// which unlink()s the working pair (collateral: the other device family's VCDs break too) and still
-// boots this game with the wrong driver -> a mystery OSDSYS drop with no message. Keep the pair,
-// surface the same diagnostics the Settings-screen equip shows, and let the user fix the source files.
-int vcdEnsureBdmaForLaunch(int source, int mode)
+// Best-effort auto-equip of the device-matching BDMA driver before a VCD launch (POPSLoader's
+// ApplyBdmaMode parity). POPSTARTER does its OWN SifIopReset, then reloads its block-device drivers
+// from the FIXED memory-card files mc?:/POPSTARTER/usbd.irx + usbhdfsd.irx; equipping copies the
+// device-matching BDMAssault variant pair there so those files fit the game's device. `source`/`mode`
+// are the game device's BDMA family. Idempotent: skips the copy when the matching variant is already
+// equipped.
+//
+// This is CARD PREP, not launch policy. The VCD launch itself is a simple handoff -- resolve
+// POPSTARTER.ELF, hand it the argv[0] selector (XX. / SB. / bare), exec -- and POPSTARTER owns
+// everything after that (maintainer contract, issues #56 review). So this helper NEVER blocks the
+// launch: on any equip failure it keeps whatever pair is on the card (never unlink a working pair as
+// collateral), shows a passing toast with the same diagnostic family the Settings-screen equip uses
+// (so a failed prep is no longer a silent mystery), and the handoff proceeds regardless.
+void vcdEnsureBdmaForLaunch(int source, int mode)
 {
     char diag[160];
 
     if (!gBdmaApplyOnLaunch)
-        return 1; // user opted to manage the BDMA driver manually (General Settings -> BDMA Source/Mode)
+        return; // user opted to manage the BDMA driver manually (General Settings -> BDMA Source/Mode)
     if (mode <= VCD_BDMA_FAT32 || mode >= VCD_BDMA_MODE_COUNT)
-        return 1; // FAT32 / invalid -> POPSTARTER's built-in driver, nothing to equip
+        return; // FAT32 / invalid -> POPSTARTER's built-in driver, nothing to equip
     if (vcdReadBdmaMode() == mode)
-        return 1; // the matching variant is already on the card
+        return; // the matching variant is already on the card
 
     int er = vcdEquipBdma(source, mode, diag, sizeof(diag));
     if (er == 0)
-        return 1;
+        return;
 
-    if (vcdReadBdmaMode() == VCD_BDMA_FAT32) {
-        // Nothing is equipped: POPSTARTER's built-in driver still handles FAT32-formatted media, so the
-        // launch stays best-effort exactly as before (exFAT media surfaces in POPSTARTER, as always).
-        LOG("VCD BDMA equip failed (%d: %s) with clean FAT32 state -- launching with POPSTARTER's built-in driver\n", er, diag);
-        return 1;
-    }
-
-    // A different family's pair is on the card and the replacement failed (-4 source files absent,
-    // -2 card full, -3 IO error). Mirror the Settings-screen equip diagnostics instead of silence.
-    // Every abort MUST say something: an unmapped code (-1 = source open/seek failed mid-copy, or a
-    // future value) falls through to the IO-error text rather than a mute launch that "does nothing".
-    if (er == -4) {
-        char msg[256];
-        snprintf(msg, sizeof(msg), "%s\n%s", _l(_STR_BDMA_ERR_SRC), diag);
-        guiMsgBox(msg, 0, NULL);
-    } else if (er == -2)
-        guiMsgBox(_l(_STR_BDMA_ERR_SPACE), 0, NULL);
+    // Equip failed (-4 source files absent, -2 card full, -3 IO error, -1/other mid-copy). Inform in
+    // passing -- toast the Settings-screen diagnostic family + LOG the full detail -- and launch anyway.
+    LOG("VCD BDMA equip failed (%d: %s) -- launching as-is (card keeps its current driver pair)\n", er, diag);
+    if (er == -4)
+        guiWarning(_l(_STR_BDMA_ERR_SRC), 6);
+    else if (er == -2)
+        guiWarning(_l(_STR_BDMA_ERR_SPACE), 6);
     else
-        guiMsgBox(_l(_STR_BDMA_ERR_IO), 0, NULL);
-    return 0;
+        guiWarning(_l(_STR_BDMA_ERR_IO), 6);
 }
 
 // ---- SMB requirements guard ---------------------------------------------------------


### PR DESCRIPTION
Per the maintainer's contract (restated in review): **the VCD launch is a simple handoff** — resolve `POPSTARTER.ELF`, hand it the argv[0] selector (`XX.` / `SB.` / bare), exec. POPSTARTER does the rest on its side. OPL must not referee it.

### What was wrong
`vcdEnsureBdmaForLaunch` had grown launch-policy powers:
- **Blocked the launch** with a modal dialog when a different family's driver pair was equipped and the replacement failed.
- **Proceeded silently** when nothing was equipped and the equip failed — [#56](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/56)'s MMCE-VCD boot.elf with no clue why.

### The change (a net deletion)
The equip is now **best-effort card prep, nothing more**: attempt to copy the device-matching BDMAssault pair (still never unlinking a working pair as collateral), on failure LOG the full diagnostic + show a **passing toast** (same `_STR_BDMA_ERR_*` texts the Settings screen uses), and **always fall through to the handoff**. Return type is `void`; the abort plumbing at all four call sites (bdm USB/MX4SIO/ATA + mmce) is deleted.

Andrew's scenario now: equip fails → toast says why → launch proceeds anyway → POPSTARTER reports its own state. No silent mystery, no refused launch, no OPL guessing.

### Validation
- Build-green both containers; clang-format clean; no lang/string changes (reuses existing BDMA error texts as toasts).
- HW: MMCE-tab VCD with an unequipped card + missing variant files → toast + launch attempt (POPSTARTER side reports); with variant files present → auto-equip then boots as before; USB FAT32 VCD unchanged; Settings-screen equip unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)