### PR TITLE
feat(qol): forced-480p recovery combo + right-justified theme text

### DIFF
--- a/src/fntsys.c
+++ b/src/fntsys.c
@@ -521,20 +521,19 @@ int fntRenderString(int id, int x, int y, short aligned, size_t width, size_t he
     width = rmScaleX(width);
     height = rmScaleY(height);
 
-    if (aligned & ALIGN_HCENTER) {
-        if (width) {
-            x -= min(fntCalcDimensions(id, string), width) >> 1;
+    if (aligned & (ALIGN_HCENTER | ALIGN_RIGHT)) {
+        // Measure ONCE: fntCalcDimensions decodes UTF-8 + touches the glyph cache, and the min()
+        // macro double-evaluates its arguments (PR #95 review; the old HCENTER branch paid this too).
+        int strWidth = fntCalcDimensions(id, string);
+        if (width)
+            strWidth = min(strWidth, width);
+        if (aligned & ALIGN_HCENTER) {
+            x -= strWidth >> 1;
         } else {
-            x -= fntCalcDimensions(id, string) >> 1;
-        }
-    } else if (aligned & ALIGN_RIGHT) {
-        // Right-justify: x is the RIGHT edge (theme aligned=2), same width clamp as HCENTER.
-        // renderman.c already right-aligns pixmaps; TEXT lacked the branch, so aligned=2
-        // themes silently rendered left-aligned (wOPL/uOPL theme parity).
-        if (width) {
-            x -= min(fntCalcDimensions(id, string), width);
-        } else {
-            x -= fntCalcDimensions(id, string);
+            // Right-justify: x is the RIGHT edge (theme aligned=2). renderman.c already
+            // right-aligns pixmaps; TEXT lacked the branch, so aligned=2 themes silently
+            // rendered left-aligned (wOPL/uOPL theme parity).
+            x -= strWidth;
         }
     }
 
@@ -652,20 +651,19 @@ int fntRenderString(int id, int x, int y, short aligned, size_t width, size_t he
     width = rmScaleX(width);
     height = rmScaleY(height);
 
-    if (aligned & ALIGN_HCENTER) {
-        if (width) {
-            x -= min(fntCalcDimensions(id, string), width) >> 1;
+    if (aligned & (ALIGN_HCENTER | ALIGN_RIGHT)) {
+        // Measure ONCE: fntCalcDimensions decodes UTF-8 + touches the glyph cache, and the min()
+        // macro double-evaluates its arguments (PR #95 review; the old HCENTER branch paid this too).
+        int strWidth = fntCalcDimensions(id, string);
+        if (width)
+            strWidth = min(strWidth, width);
+        if (aligned & ALIGN_HCENTER) {
+            x -= strWidth >> 1;
         } else {
-            x -= fntCalcDimensions(id, string) >> 1;
-        }
-    } else if (aligned & ALIGN_RIGHT) {
-        // Right-justify: x is the RIGHT edge (theme aligned=2), same width clamp as HCENTER.
-        // renderman.c already right-aligns pixmaps; TEXT lacked the branch, so aligned=2
-        // themes silently rendered left-aligned (wOPL/uOPL theme parity).
-        if (width) {
-            x -= min(fntCalcDimensions(id, string), width);
-        } else {
-            x -= fntCalcDimensions(id, string);
+            // Right-justify: x is the RIGHT edge (theme aligned=2). renderman.c already
+            // right-aligns pixmaps; TEXT lacked the branch, so aligned=2 themes silently
+            // rendered left-aligned (wOPL/uOPL theme parity).
+            x -= strWidth;
         }
     }
 

--- a/src/fntsys.c
+++ b/src/fntsys.c
@@ -527,6 +527,15 @@ int fntRenderString(int id, int x, int y, short aligned, size_t width, size_t he
         } else {
             x -= fntCalcDimensions(id, string) >> 1;
         }
+    } else if (aligned & ALIGN_RIGHT) {
+        // Right-justify: x is the RIGHT edge (theme aligned=2), same width clamp as HCENTER.
+        // renderman.c already right-aligns pixmaps; TEXT lacked the branch, so aligned=2
+        // themes silently rendered left-aligned (wOPL/uOPL theme parity).
+        if (width) {
+            x -= min(fntCalcDimensions(id, string), width);
+        } else {
+            x -= fntCalcDimensions(id, string);
+        }
     }
 
     if (aligned & ALIGN_VCENTER) {
@@ -648,6 +657,15 @@ int fntRenderString(int id, int x, int y, short aligned, size_t width, size_t he
             x -= min(fntCalcDimensions(id, string), width) >> 1;
         } else {
             x -= fntCalcDimensions(id, string) >> 1;
+        }
+    } else if (aligned & ALIGN_RIGHT) {
+        // Right-justify: x is the RIGHT edge (theme aligned=2), same width clamp as HCENTER.
+        // renderman.c already right-aligns pixmaps; TEXT lacked the branch, so aligned=2
+        // themes silently rendered left-aligned (wOPL/uOPL theme parity).
+        if (width) {
+            x -= min(fntCalcDimensions(id, string), width);
+        } else {
+            x -= fntCalcDimensions(id, string);
         }
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1369,8 +1369,12 @@ static void _loadConfig()
             if (!(getKeyPressed(KEY_TRIANGLE) && getKeyPressed(KEY_CROSS))) {
                 configGetInt(configOPL, CONFIG_OPL_VMODE, &gVMode);
             } else {
-                LOG("--- Triangle + Cross held at boot - setting Video Mode to Auto ---\n");
-                gVMode = 0;
+                // Recovery combo: force 480p PROGRESSIVE (EDTV 640x448p@60, vmode index 3), not
+                // Auto -- Auto resolves to region-default interlaced 480i/576i, which is exactly
+                // what some modern displays/upscalers fail to sync, leaving the user still blind
+                // (upstream OPL PR #1332 uses the same fixed-480p escape hatch).
+                LOG("--- Triangle + Cross held at boot - forcing Video Mode to 480p (recovery) ---\n");
+                gVMode = 3;
                 configSetInt(configOPL, CONFIG_OPL_VMODE, gVMode);
             }
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -1139,9 +1139,16 @@ static theme_element_t *initBasic(const char *themePath, config_set_t *themeConf
         elem->height = h;
 
     snprintf(elemProp, sizeof(elemProp), "%s_aligned", name);
-    if (configGetInt(themeConfig, elemProp, &intValue))
-        elem->aligned = (intValue == 0) ? ALIGN_NONE : ALIGN_CENTER;
-    else
+    if (configGetInt(themeConfig, elemProp, &intValue)) {
+        // 0 = none/left, 2 = right-justified (wOPL/uOPL theme key; used to silently center),
+        // anything else = centered (the long-standing non-zero behavior).
+        if (intValue == 0)
+            elem->aligned = ALIGN_NONE;
+        else if (intValue == 2)
+            elem->aligned = (ALIGN_VCENTER | ALIGN_RIGHT);
+        else
+            elem->aligned = ALIGN_CENTER;
+    } else
         elem->aligned = aligned;
 
     snprintf(elemProp, sizeof(elemProp), "%s_scaled", name);


### PR DESCRIPTION
Two small [parity-audit](docs/PARITY-AUDIT-2026-07-06.md) queue items (#6, #10):

### 1. Boot-video recovery → forced 480p progressive
The Triangle+Cross held-at-boot combo set Video Mode to **Auto** — which resolves to region-default *interlaced* 480i/576i, exactly the signal class some modern displays/upscalers/OSSC fail to sync. A user whose TV can't show interlaced was still blind after the recovery combo. Now it forces **EDTV 640x448p @60Hz** (a universally-safe progressive mode), matching upstream OPL PR #1332's fixed-480p escape hatch.

### 2. Theme `aligned=2` → right-justified text (wOPL/uOPL theme parity)
The theme parser collapsed any non-zero `<elem>_aligned` to CENTER — and it turns out the audit's "renderer already supports it" claim was **only true for pixmaps**: `fntsys.c`'s text renderer had no right-align branch at all (verified: both text sites check only `ALIGN_HCENTER`). This adds:
- parser: `aligned=2` → `ALIGN_VCENTER | ALIGN_RIGHT` (0 = left, other non-zero = center, unchanged),
- `fntsys.c`: a right-edge branch at both text-render sites with the same width clamp HCENTER uses.

wOPL/uOPL themes using `aligned=2` now render as their authors intended instead of silently centering.

### Validation
- Build-green both containers; clang-format clean; no config/lang changes.
- HW/PCSX2: hold Triangle+Cross at boot → GUI comes up 480p and the setting persists; a theme with `SomeText_aligned=2` right-aligns; `aligned=0/1` themes unchanged; default themes (no key) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)