### PR TITLE
fix(neutrino): enforce the real ExecPS2 argv budget (15 strings / 256 bytes per hop)

### DIFF
--- a/src/elfldr_noreset.c
+++ b/src/elfldr_noreset.c
@@ -100,8 +100,11 @@ int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, cha
     {
         int pool = (int)strlen(filename) + 1;
         int j;
-        for (j = 0; j < argc; j++)
+        for (j = 0; j < argc; j++) {
+            if (argv[j] == NULL)
+                return -1; // a NULL mid-argv would crash SetArg's copy inside ExecPS2 -- refuse here
             pool += (int)strlen(argv[j]) + 1;
+        }
         if (argc + 1 > 15 || pool > 256) {
             LOG("[ELFLDR] argv over the kernel budget (args=%d/15, pool=%d/256) -- refusing handoff\n", argc + 1, pool);
             return -1;

--- a/src/elfldr_noreset.c
+++ b/src/elfldr_noreset.c
@@ -15,6 +15,7 @@
 */
 
 #include <kernel.h>
+#include "include/ioman.h" // LOG (kernel argv-budget refusal trace)
 #include <sifrpc.h>
 #include <string.h>
 #include <fcntl.h>
@@ -90,6 +91,22 @@ int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, cha
     if (filename == NULL || (fd = open(filename, O_RDONLY)) < 0)
         return -1;
     close(fd);
+
+    // Kernel args-area budget, the last line of defense for EVERY keep-IOP handoff (Neutrino and
+    // POPSTARTER): SetArg copies at most 15 strings into ONE 256-byte pool (NULs included) and
+    // ExecPS2 forwards the UNCLAMPED count -- exceeding either limit corrupts rather than
+    // truncates. Callers are expected to fit (sysLaunchNeutrino budgets itself); refuse loudly
+    // here rather than hand the kernel a mangled argv.
+    {
+        int pool = (int)strlen(filename) + 1;
+        int j;
+        for (j = 0; j < argc; j++)
+            pool += (int)strlen(argv[j]) + 1;
+        if (argc + 1 > 15 || pool > 256) {
+            LOG("[ELFLDR] argv over the kernel budget (args=%d/15, pool=%d/256) -- refusing handoff\n", argc + 1, pool);
+            return -1;
+        }
+    }
 
     // Child contract: argv[0] = load path (SifLoadElf'd), argv[1..] = the target's full argv;
     // the ExecPS2 syscall marshals the strings across the jump.

--- a/src/system.c
+++ b/src/system.c
@@ -1191,9 +1191,13 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
     char compatModes[32] = ""; // stays empty when no compat modes are forwarded (B1)
     char globalArgsBuf[256];   // mutable copy of gNeutrinoArgs for tokenizing (tokens point in)
     char extraArgsBuf[256];    // mutable copy of the per-game extraArgs for tokenizing
-    char *argv[32];            // target argv[0] + auto args (max ~6) + tokenized user flags
+    char *argv[16];            // target argv[0] + auto args + tokenized user flags (kernel-budgeted)
     int argc = 0;
-    const int argvMax = (int)(sizeof(argv) / sizeof(argv[0]));
+    // 14, NOT sizeof(argv): the kernel args area holds at most 15 strings per ExecPS2 hop (ps2sdk
+    // exit.c SetArg, SETARG_MAX_ARGS 15 -- and ExecPS2 forwards the UNCLAMPED count, so overflowing
+    // makes the kernel read string bytes as argv pointers). Hop 1 prepends the elfldr child's load
+    // path, spending one slot, so the target argv must stay <= 14 entries.
+    const int argvMax = 14;
 
     // Target argv[0] = neutrino.elf's own path (NHDDL convention). sysLoadELFKeepIOP forwards
     // argv verbatim -- argv[0] included -- so this must be supplied explicitly here (POPSTARTER
@@ -1293,6 +1297,28 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
     // string (so a game can extend the global set). Both are tokenized on whitespace.
     argc = appendArgTokens(argv, argc, argvMax, globalArgsBuf, sizeof(globalArgsBuf), gNeutrinoArgs);
     argc = appendArgTokens(argv, argc, argvMax, extraArgsBuf, sizeof(extraArgsBuf), extraArgs);
+
+    // ExecPS2 argv BYTE budget (verified vs ps2sdk exit.c SetArg + the crt0 args struct): each hop
+    // carries its strings in ONE 256-byte pool, every NUL included. Hop 1 packs the child's load
+    // path PLUS this argv -- neutrinoPath is counted TWICE (loadpath and target argv[0]). SetArg's
+    // copy is UNbounded, so exceeding the pool corrupts rather than truncates. Fit by dropping tail
+    // args (user extras sit last; each drop LOGged); the argv[0]/-bsd/-dvd floor must survive or
+    // nothing can boot anyway -- past that, refuse and let the LOG name the overage.
+    {
+        int pool = (int)strlen(neutrinoPath) + 1; // hop-1 child argv[0] = the load path
+        int i;
+        for (i = 0; i < argc; i++)
+            pool += (int)strlen(argv[i]) + 1;
+        while (pool > 256 && argc > 3) {
+            argc--;
+            pool -= (int)strlen(argv[argc]) + 1;
+            LOG("[NEUTRINO] argv pool over 256 bytes -- dropping tail arg: %s\n", argv[argc]);
+        }
+        if (pool > 256) {
+            LOG("[NEUTRINO] argv pool %d bytes even at the core-args floor (256 max) -- refusing handoff\n", pool);
+            return;
+        }
+    }
 
     // Log the FULL argv (not just bsd/dvd/compat) so the VMC -mc args are verifiable on hardware (#47).
     LOG("[NEUTRINO] elf=%s argc=%d\n", neutrinoPath, argc);


### PR DESCRIPTION
The deferred [parity-audit](docs/PARITY-AUDIT-2026-07-06.md) item, shipped only after verifying the actual kernel mechanism — and the verification found it's **worse than the audit's "truncation" framing: it's latent memory corruption.**

### Verified mechanism (ps2sdk source + libkernel disasm, cross-checked against ps2-packer's crt0 and wOPL's own 16-slot guard)
Every `ExecPS2` hop passes argv through a kernel args area of **15 strings max + one 256-byte string pool** (every NUL counted). Two hazards:
1. `SetArg` clamps the *copied* strings to 15, but `ExecPS2` forwards the **unclamped** argc to syscall 7 — >15 args make the kernel dereference string-payload bytes as argv pointers.
2. `SetArg`'s copy loop has **no byte bound** — a >256-byte pool **corrupts rather than truncates**.

Our keep-IOP chain makes **hop 1 (OPL → elfldr child) the binding constraint**: the child's load path is prepended (so target argc ≤ 14), and `neutrinoPath` is counted **twice** in the pool (loadpath + target argv[0]). The old `argvMax = 32` guarded an illusion — a maxed launch (long `-dvd` path + two 160-byte `-mc` args + user extras) walks into both hazards.

### The fix
- **`sysLaunchNeutrino`**: `argvMax` 32 → **14**; after assembly, the 256-byte pool is fitted by dropping tail args (user extras sit last; every drop LOGged); below the `argv[0]/-bsd/-dvd` floor it refuses with a LOG naming the overage.
- **`sysLoadELFKeepIOP`**: belt-and-braces check covering *every* keep-IOP handoff (POPSTARTER included): args > 15 or pool > 256 → LOG + refuse.

### Impact
Normal launches (~6–9 args, ~120 bytes) are far under both limits — zero behavior change. Only pathological configurations (which previously mangled the kernel args area silently) now degrade gracefully with a LOG trail. NHDDL documents the same ~255-char ceiling; wOPL caps at 16 slots.

### Validation
- Build-green both containers; clang-format clean.
- HW (debug ELF): normal Neutrino + VMC launch → argv LOG identical to before; stuff the per-game args box with junk flags → `dropping tail arg:` LOG lines and the launch still boots with core args intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)