### PR TITLE
fix(neutrino): suppress the global -logo on the mmce backend (#56 root cause)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1184,6 +1184,17 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
         return;
     }
 
+    // HW-confirmed (issue #56, AndrewBento, PSXMemCard Gen2): Neutrino's -logo on the mmce backend
+    // black-screens GAME-DEPENDENTLY ("depends a bit on luck which game") -- and the identical
+    // failure reproduces on NHDDL, so it is a Neutrino/mmce interaction, not this launcher. Every
+    // affected game boots with the logo off, so the GLOBAL PS2-Logo toggle is suppressed for
+    // mmce-hosted games until that is fixed upstream. Deliberate escape hatch: a user-supplied
+    // "-logo" in the global/per-game Neutrino args still passes through the tokenizer untouched.
+    if (EnablePS2Logo && !strcmp(driver, "mmce")) {
+        LOG("[NEUTRINO] -logo suppressed on mmce (issue #56: game-dependent black screens, repro'd on NHDDL)\n");
+        EnablePS2Logo = 0;
+    }
+
     char bsd[16];
     char bsdfs[16];
     char filePath[288];        // "-dvd=hdl:" (9) + up to a 255-char path + NUL — avoid truncation (B2)


### PR DESCRIPTION
**AndrewBento root-caused the game-dependent Neutrino-MMCE black screens on hardware** ([#56](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/56), comment of 2026-07-06): it's the **PS2 Logo** option. With `-logo` ON, certain mmce-hosted games black-screen ("depends a bit on luck which game you're starting"); with it OFF, **every previously-failing game boots** (Devil May Cry, GTA San Andreas, Fatal Frame — the whole flip-flopping set). He then reproduced the **identical failure on NHDDL** — so this is a Neutrino/mmce-backend interaction, exactly where [#89](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/89)'s scope note said the trail led if the settle didn't cure it. Not our launcher.

### The change (one conditional)
Until it's fixed upstream, the **global** PS2-Logo toggle no longer emits `-logo` for mmce-hosted games (`driver == "mmce"`), with a LOG line when suppressed. Escape hatch preserved: a user-supplied `-logo` in the global/per-game Neutrino args still passes through the tokenizer untouched — so a title that tolerates the logo can still get it per-game (the structured toggle for that lands with [#96](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/96)).

Other drivers unchanged; OPL core unchanged (its logo path is `CheckPS2Logo` + embedded cdvdman, unrelated to `-logo`).

### Suggested upstream follow-up
Andrew's cross-launcher repro (RiptOPL + NHDDL, PSXMemCard Gen2, per-title list) is a ready-made bug report for `rickgaiser/neutrino` — worth filing so the suppression can eventually be removed.

### Validation
- Build-green both containers; clang-format clean.
- HW: PS2 Logo ON + DMC/GTA-SA from MMCE via Neutrino → now boots (no `-logo` in the argv LOG, suppression LOG present); same games from USB via Neutrino → `-logo` still emitted; OPL-core MMCE launches unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)