### PR TITLE
fix(disc): tray-close re-detect instead of standby for the spun-down drive (#73)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -445,15 +445,19 @@ int sysLaunchDisc(void)
 
     type = sceCdGetDiskType();
     // Issue #73 (SCPH-77001 + FMCB): an idle drive spins the disc DOWN and then reports NODISC
-    // even with a game disc loaded, so Launch Disc bailed to the "no disc" message before it could
-    // wake. A tray open/close "fixed" it only because that forces a spin-up + re-detect -- so do the
-    // same in software: on NODISC, kick the drive to standby (spins the disc up; the same call
-    // sysGetDiscID uses before it reads the key) and re-poll the type for a few seconds. A genuinely
-    // empty drive still ends at the -2 bail below, just ~4 s later.
+    // even with a game disc loaded, so Launch Disc bailed to the "no disc" message. A physical
+    // tray open/close revives it because that forces a full mech re-detect. The first software
+    // attempt used sceCdStandby() -- WRONG STATE: standby is what sysGetDiscID issues AFTER a
+    // disc is detected; on a mech that already decided NODISC it never spins the disc up
+    // (HW-confirmed by the reporter: "the disc doesn't start spinning"). The software equivalent
+    // of the tray cycle is a TRAY-CLOSE REQUEST on the already-closed tray, which re-runs the
+    // detect cycle. A genuinely empty drive still ends at the -2 bail below, just ~4 s later.
     if (type == SCECdNODISC) {
         int spin;
-        LOG("[DISC] drive reports NODISC -- spinning up and re-checking (#73)\n");
-        sceCdStandby();
+        u32 traychk = 0;
+        int tr = sceCdTrayReq(SCECdTrayClose, &traychk);
+        (void)tr; // only read by LOG (a no-op in release builds)
+        LOG("[DISC] drive reports NODISC -- tray-close re-detect (#73): req=%d traychk=%lu\n", tr, (unsigned long)traychk);
         sceCdSync(0);
         for (spin = 0; spin < 20; spin++) { // ~4 s budget for a cold spin-up + re-detect
             // Let it finish identifying after the spin-up, but bounded + yielding: a dirty laser or
@@ -466,7 +470,7 @@ int sysLaunchDisc(void)
                 break;
             DelayThread(200 * 1000); // 200 ms between polls
         }
-        LOG("[DISC] after spin-up: type=%d (%d re-polls)\n", type, spin);
+        LOG("[DISC] after tray-close re-detect: type=%d (%d re-polls)\n", type, spin);
     }
 
     if (type != SCECdPS2DVD && type != SCECdPS2CD) // no disc / not a PS2 game disc


### PR DESCRIPTION
Follow-up to [#90](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/90), driven by AndrewBento's hardware retest on [#73](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/73): the standby-based fix **did not revive his drive** — *"the disc doesn't start spinning; it just shows the no disc message."*

### Why #90's approach failed
`sceCdStandby()` was ported from `sysGetDiscID` — but that function issues it **after** a disc is already detected. On a mech that has already decided NODISC, standby never engages, so the re-poll loop just watched a parked drive for 4 seconds.

### The corrected mechanism
The physical tray open/close that *does* revive the drive forces a full mech **re-detect**. The software equivalent is `sceCdTrayReq(SCECdTrayClose)` on the already-closed tray, which re-runs the detect cycle (constants + prototype verified against ps2sdk `libcdvd-common.h`). The bounded re-poll loop from #90 is kept unchanged; the LOG now records the TrayReq result + `traychk` so the next hardware report tells us exactly what the mech did.

Empty drive → same graceful `-2` "no disc" ~4s later. Spinning disc → this branch never runs.

### Validation
- Build-green both containers (including the `(void)tr` release-build warning fix); clang-format clean.
- HW (Andrew's exact scenario): let the disc spin down at the menu → Launch PS2 Disc → the drive should now audibly spin up and boot; if it still fails, the new LOG line (`req=… traychk=…`) tells us whether the mech even accepted the tray request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)