### PR TITLE
feat(release): ship a named DualSense (DS5) loader in the rolling release

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -271,6 +271,22 @@ jobs:
           echo "Staged ps2dev-latest rolling assets:"
           ls -la rolling
 
+      - name: Build + stage DualSense (DS5) loader (ps2dev:latest)
+        # HW-validated on a real DualSense (maintainer, 2026-07-06). The DEFAULT ELF stays
+        # DUALSENSE=0 by deliberate choice; DS5 owners grab this named top-level build instead
+        # of digging it out of the VARIANTS zip. LOCALVERSION carries "-latest-ds5" so hardware
+        # reports self-identify.
+        run: |
+          set -eu
+          make --trace clean
+          make --trace LOCALVERSION=latest-ds5 DUALSENSE=1 release
+          DS5_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+          if [ -z "${DS5_ELF:-}" ] || [ ! -f "$DS5_ELF" ]; then
+            echo "No RIPTOPL ELF produced by the DUALSENSE=1 build" >&2
+            exit 1
+          fi
+          cp -f "$DS5_ELF" rolling/RIPTOPL-ds5.ELF
+
       - name: Build variant + debug extras (ps2dev:latest = standard)
         # Runs after staging the main ELF so the per-build `make clean` can't wipe it.
         run: sh ./.github/scripts/build_rolling_extras.sh "" "latest"
@@ -342,6 +358,9 @@ jobs:
           fi
           if [ -f rolling/RIPTOPL-woplsdk.ELF ]; then
             mv -f rolling/RIPTOPL-woplsdk.ELF "rolling/RIPTOPL-${VER}-woplsdk.ELF"
+          fi
+          if [ -f rolling/RIPTOPL-ds5.ELF ]; then
+            mv -f rolling/RIPTOPL-ds5.ELF "rolling/RIPTOPL-${VER}-ds5.ELF"
           fi
           echo "Renamed assets:"
           ls -la rolling
@@ -579,6 +598,9 @@ jobs:
               printf -- '- RIPTOPL-DEBUG-*.zip: debug builds (iopcore/ingame/eesio/ppctty/DTL_T10000), both SDKs -- diagnostics\n'
             fi
             printf -- '- %s.ELF: bare loader, ps2dev:latest toolchain (primary)\n' "$VERSIONED_BASE"
+            if [ -f "rolling/${VERSIONED_BASE}-ds5.ELF" ]; then
+              printf -- '- %s-ds5.ELF: bare loader WITH DualSense (DS5 USB) pad support, ps2dev:latest toolchain\n' "$VERSIONED_BASE"
+            fi
             if [ "$HAS_WOPLSDK" = yes ]; then
               printf -- '- %s-woplsdk.ELF: bare loader, wOPL'"'"'s digest-pinned ghcr.io/ps2homebrew container, stock SDK MMCE drivers\n' "$VERSIONED_BASE"
             else

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ IGS ?= $(EXTRA_FEATURES)
 #Enables/disables pad emulator
 PADEMU ?= 1
 
-#Enables/disables experimental PS5 DualSense (USB) support in the pad emulator. UNVALIDATED --
-#needs real DS5 hardware to test, so it is OFF by default and never affects the default build.
+#Enables/disables PS5 DualSense (USB) support in the pad emulator. HW-VALIDATED on a real DS5
+#(maintainer, 2026-07-06) but kept OFF in the default build by deliberate choice -- the rolling
+#release ships a ready-made DUALSENSE=1 build as the named RIPTOPL-<version>-ds5.ELF asset.
 DUALSENSE ?= 0
 
 #Enables/disables building of an edition of OPL that will support the DTL-T10000 (SDK v2.3+)

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ This build layers several features on top of upstream OPL:
   **Device Settings** page consolidates the per-device options, cache sizes, Block-Devices
   (BDM) settings, all MMCE settings, the network-boot controls (the UDPBD/UDPFS toggle + the
   **Net Boot Protocol** picker, interlocked with SMB), and the Favourites tab toggle in one place.
-- **DualSense / DualShock 5 (USB):** optional controller support, compiled in with
-  `make DUALSENSE=1`.
+- **DualSense / DualShock 5 (USB):** optional controller support -- grab the ready-made
+  `RIPTOPL-<version>-ds5.ELF` from the rolling release, or build with `make DUALSENSE=1`.
 - **Ready-to-use defaults:** a fresh install boots with sensible options already enabled —
   widescreen, cover art, notifications, sound effects + boot sound, USB, delete/rename, and
   the PS2 logo, with the device tabs in **Manual** mode. Video mode stays **Auto**. Change
@@ -226,8 +226,9 @@ because that upstream work is open for everyone to learn from.
 RiptOPL ships **one full-feature build** — GSM video-mode handling, in-game
 screenshots (IGS), DS3/DS4 pad emulation (PADEMU), VMC, PS2RD cheats and parental
 controls are all included in the standard ELF (no upstream-style per-feature variants).
-DualSense / DualShock 5 (USB) support is the one optional extra, compiled in with
-`make DUALSENSE=1`.
+DualSense / DualShock 5 (USB) support is the one optional extra: the rolling release
+ships it prebuilt as the named `RIPTOPL-<version>-ds5.ELF` asset (or build your own
+with `make DUALSENSE=1`).
 
 There are two release channels:
 


### PR DESCRIPTION
DualSense support is **HW-validated on a real DS5** (maintainer, 2026-07-06). Per the maintainer's call, the **default ELF stays `DUALSENSE=0`** — instead the rolling release gains a first-class named asset: **`RIPTOPL-<version>-ds5.ELF`**, built in the primary (ps2dev:latest) job with `LOCALVERSION=latest-ds5` so hardware reports self-identify. Previously the only prebuilt DS5 ELFs were buried inside the VARIANTS zip.

- **rolling-release.yml**: DS5 build+stage step after the primary staging (its own `make clean`, so it can't wipe the staged primary ELF), versioned-rename wiring, and a release-notes line for the new asset.
- **Makefile**: comment updated (validated, deliberately opt-in) — the `DUALSENSE ?= 0` default is unchanged.
- **README**: points DS5 users at the ready-made asset.

No compiled-code change (docs/CI only); workflow YAML validated. *(Note: the branch name predates the design decision — the content ships the named-artifact approach, not a default flip.)*

Validation: next rolling run should publish `RIPTOPL-<ver>-ds5.ELF` alongside the primary ELF and list it in the release notes; a DS5 owner grabs it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)