### PR TITLE
perf(cheats): lazily allocate the ~1 MB cheat table (was permanent BSS)

### DIFF
--- a/include/cheatman.h
+++ b/include/cheatman.h
@@ -68,7 +68,9 @@ typedef struct
     int enabled;
 } cheat_entry_t;
 
-extern cheat_entry_t gCheats[MAX_CODES];
+// Lazily allocated (~1.03 MB) on the first cheat-file load of the session -- NULL until then.
+// It used to be permanent BSS, held even with cheats off (the default). See load_cheats().
+extern cheat_entry_t *gCheats;
 
 void InitCheatsConfig(config_set_t *configSet);
 int GetCheatsEnabled(void);

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -30,7 +30,7 @@ static int gEnableCheat; // Enables PS2RD Cheat Engine - 0 for Off, 1 for On
 static int gCheatMode;   // Cheat Mode - 0 Enable all cheats, 1 Cheats selected by user
 
 static u32 gCheatList[MAX_CHEATLIST]; // Store hooks/codes addr+val pairs
-cheat_entry_t gCheats[MAX_CODES];
+cheat_entry_t *gCheats = NULL;        // lazily allocated in load_cheats (~1.03 MB); reclaims the old permanent BSS
 
 static int gEnableImage;           // Prebuilt PS2RD cheat image (.img) - 0 Off, 1 On
 static u32 gImage[MAX_IMAGEWORDS]; // The loaded .img patch words (zeroed when none/failed)
@@ -412,7 +412,19 @@ int load_cheats(const char *cheatfile)
     char *buf = NULL;
     int ret;
 
-    memset(gCheats, 0, sizeof(gCheats));
+    // Lazy cheat table: MAX_CODES x sizeof(cheat_entry_t) (~1.03 MB) that used to sit in BSS
+    // permanently, held even with cheats off (the default). Allocated on the first cheat-file
+    // load and kept for the session (a successful launch hands off to ExecPS2 anyway; a failed
+    // one reuses the buffer on retry). An allocation failure degrades exactly like an unreadable
+    // cheat file -- the launch legs already toast _STR_ERR_CHEATS_LOAD_FAILED for ret < 0.
+    if (gCheats == NULL) {
+        gCheats = (cheat_entry_t *)malloc(MAX_CODES * sizeof(cheat_entry_t));
+        if (gCheats == NULL) {
+            LOG("%s: cheat table allocation failed (%d bytes)\n", __FUNCTION__, (int)(MAX_CODES * sizeof(cheat_entry_t)));
+            return -1;
+        }
+    }
+    memset(gCheats, 0, MAX_CODES * sizeof(cheat_entry_t));
 
     LOG("%s: Reading cheat file '%s'...\n", __FUNCTION__, cheatfile);
     buf = read_text_file(cheatfile, 0);
@@ -436,8 +448,9 @@ void set_cheats_list(void)
 
     memset((void *)gCheatList, 0, sizeof(gCheatList));
 
-    // Populate the cheat list
-    for (int i = 0; i < MAX_CODES; ++i) {
+    // Populate the cheat list (gCheats == NULL means no cheat file was ever loaded this
+    // session -- fall through so gCheatList still gets its blank terminator below)
+    for (int i = 0; gCheats != NULL && i < MAX_CODES; ++i) {
         if (gCheats[i].enabled) {
             for (int j = 0; j < MAX_CHEATLIST && gCheats[i].codes[j].addr != 0; ++j) {
                 if (cheatCount + 2 <= MAX_CHEATLIST) {

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -448,9 +448,14 @@ void set_cheats_list(void)
 
     memset((void *)gCheatList, 0, sizeof(gCheatList));
 
-    // Populate the cheat list (gCheats == NULL means no cheat file was ever loaded this
-    // session -- fall through so gCheatList still gets its blank terminator below)
-    for (int i = 0; gCheats != NULL && i < MAX_CODES; ++i) {
+    // No cheat file was ever loaded this session: the zeroed list above ALREADY carries its
+    // addr=0 terminator, so return instead of re-testing the pointer every loop iteration
+    // (PR #101 review -- LOG in the body forces a reload of the global each pass).
+    if (gCheats == NULL)
+        return;
+
+    // Populate the cheat list
+    for (int i = 0; i < MAX_CODES; ++i) {
         if (gCheats[i].enabled) {
             for (int j = 0; j < MAX_CHEATLIST && gCheats[i].codes[j].addr != 0; ++j) {
                 if (cheatCount + 2 <= MAX_CHEATLIST) {

--- a/src/gui.c
+++ b/src/gui.c
@@ -2549,6 +2549,9 @@ void guiManageCheats(void)
     int selectedCheat = 0;
     int visibleCheats = 10; // Maximum number of cheats visible on screen
 
+    if (gCheats == NULL) // defensive: the menu is only reachable after load_cheats, but never deref NULL
+        return;
+
     while (cheatCount < MAX_CODES && strlen(gCheats[cheatCount].name) > 0)
         cheatCount++;
 


### PR DESCRIPTION
[Parity-audit](docs/PARITY-AUDIT-2026-07-06.md) queue item #4 — the largest single memory lever found by the audit.

### The problem
`gCheats[250]` × ~4.2 KB per entry ≈ **1.03 MB of always-resident BSS** — held even with cheats **off** (the default), on a console with 32 MB total. It was the single largest static allocation in the ELF.

### The change
`gCheats` is only ever populated by `load_cheats` (launch path) and read by the launch-time cheat menu + `set_cheats_list` — it never needs to exist while browsing. It's now a pointer, allocated on the **first cheat-file load of the session** and kept for reuse (a successful launch hands off to `ExecPS2` anyway; a failed one reuses the buffer on retry). Allocation failure degrades exactly like an unreadable cheat file (`load_cheats` → -1 → the legs' existing `ERR_CHEATS_LOAD_FAILED` toast).

NULL-guards: `set_cheats_list` falls through so `gCheatList` still gets its blank terminator; `guiManageCheats` returns defensively.

**Net: ~1 MB of EE RAM reclaimed for every cheats-off session** — headroom for large game lists, big themes, coverflow art.

### Validation
- Build-green both containers; clang-format clean.
- HW/PCSX2: cheats off → everything unchanged (table never allocates); cheats on + .cht present → loads/applies exactly as before, launch-time cheat select menu works, "Disable All" works; cheats on + missing .cht → same toast as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)