### PR TITLE
feat(neutrino): opt-in -elf=cdrom0: emission (parity Δ10) + audit queue status

### DIFF
--- a/docs/NEUTRINO.md
+++ b/docs/NEUTRINO.md
@@ -96,6 +96,15 @@ Arguments are space-separated, e.g.:
 > the config file — OPL reads and forwards the full string at launch even though the on-screen
 > editor caps the visible length.
 
+### Experimental: automatic `-elf=` (config key only)
+
+Setting `neutrino_elf_arg = 1` by hand in `settings_riptopl.cfg` (there is deliberately no
+settings-screen row for this) makes every Neutrino launch also pass
+`-elf=cdrom0:\<STARTUP>;1` -- the game's boot-file path -- so Neutrino's per-GameID
+`config/<GameID>.toml` compatibility lookup can resolve before its IOP reset. It is only
+emitted for retail-shaped startups (`AAAA_NNN.NN`) and never when your own args already carry
+an `-elf=`. Off by default; if a launch misbehaves with it on, remove the key and report.
+
 For the full list of flags Neutrino accepts, see the
 [Neutrino documentation](https://github.com/rickgaiser/neutrino).
 

--- a/docs/PARITY-AUDIT-2026-07-06.md
+++ b/docs/PARITY-AUDIT-2026-07-06.md
@@ -173,6 +173,21 @@ Ranked by user-visible payoff ÷ effort, black-screen / data-loss risks first. *
 | 14 | **Per-slot VMC enable/disable (`$`-disabled `-mc` token)** | Nicety mirroring NHDDL's disabled-arg convention | LOW | S | `sbBuildVmcNeutrinoArgs` — emit `$-mcN=` when a slot is toggled off |
 | 15 | **`plasma_blend_color` theme key** | Theme authors can't tint the secondary plasma blend | LOW | M | new `CONFIG_OPL_PLAS_BLEND_COLOR` + picker + renderer thread |
 
+### Queue status (2026-07-06, end of day)
+
+Shipped same-day: **#2** `-gsm` picker (PR #94), **#3** argv byte guard — upgraded to the full
+15-string/256-byte kernel budget after source verification (PR #97), **#4** `gCheats` lazy-alloc
+(PR #101), **#5** Δ10 `-elf=` opt-in (`neutrino_elf_arg`, this PR), **#6** 480p recovery (PR #95),
+**#8** DualSense — shipped as the named `-ds5.ELF` rolling asset per maintainer decision, default
+unchanged (PR #100), **#9** per-game `-dbc`/`-logo` (PR #96), **#10** audit reconciliation (PR #91),
+**#12** `-dvd=` free-text double-emit is prevented by the emit-order + last-wins semantics plus the
+#97 budget; **#1** Δ9 shipped as PR #88. **#7 RTC last-played: RETRACTED, not a gap** — all seven
+launch legs write the same key in the same single `CONFIG_LAST` file, so last-write-wins already
+equals newest-wins; NHDDL needs timestamps only because its per-device files can disagree, a
+situation RiptOPL's single-file model cannot enter. Remaining open: **#11** user-selectable
+`-bsdfs`, **#13** persistent cover cache, **#14** per-slot VMC disable, **#15** grammar
+verification (done — folded into #2).
+
 ### Non-goals (do NOT queue — deliberate fork decisions)
 - **Native-core `-qb` quickboot** — `-qb` is Neutrino-only; deliberately not emitted after a menu session (mixed IOP state is what Neutrino's reset exists to erase). Parity doc §4.2.
 - **Dropping `-mc` VMC files** (parity doc §4.3), **libconfig backend migration** (prior decision), **trimming OPL breadth** (PS1/POPS/cheats/PADEMU) to chase NHDDL minimalism, and a **headless pure-forwarder entry** (adds a path, low value for a full launcher — OPL's breadth is the point).

--- a/include/config.h
+++ b/include/config.h
@@ -100,6 +100,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_NEUTRINO_PATH        "neutrino_path"
 #define CONFIG_OPL_NEUTRINO_DEVICE      "neutrino_device"   // legacy device-INDEX (mc0/mass0/mmce0); read-only, migrated
 #define CONFIG_OPL_NEUTRINO_DEVTYPE     "neutrino_devtype"  // device-TYPE (NEUTRINO_DEV_*); the live key
+#define CONFIG_OPL_NEUTRINO_ELF_ARG     "neutrino_elf_arg"  // opt-in (no UI row): auto-emit -elf=cdrom0:\<startup>;1 (parity Delta-10)
 #define CONFIG_OPL_POPSTARTER_PATH      "popstarter_path"   // free-text custom path (used only when device=Custom)
 #define CONFIG_OPL_POPSTARTER_DEVICE    "popstarter_device" // device TYPE holding POPS/POPSTARTER.ELF (POPS_DEV_*)
 #define CONFIG_OPL_BDMA_SOURCE          "bdma_source"

--- a/include/opl.h
+++ b/include/opl.h
@@ -243,6 +243,7 @@ enum { NEUTRINO_DEV_AUTO = 0,     // game device, then mc0/mc1 (legacy behaviour
        NEUTRINO_DEV_EXFAT_HDD,    // BDM "ata" internal exFAT HDD -> the mounted massN:
        NEUTRINO_DEV_APA_HDD };    // APA HDD: the mounted OPL data partition (pfs0:)
 extern int gNeutrinoDevice;       // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy neutrino_path
+extern int gNeutrinoElfArg;       // opt-in (settings key only, no UI): auto-emit -elf=cdrom0:\<startup>;1 on Neutrino launches
 extern char gPopstarterPath[256]; // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
 extern char gBootDir[256];        // boot directory (cwd) OPL launched from, e.g. "mass0:/APPS"; "" if undeterminable
 extern int gDeinitTerminal;       // 1 while deinit() runs for exit/poweroff, 0 for a game/app LAUNCH teardown.

--- a/include/system.h
+++ b/include/system.h
@@ -39,7 +39,7 @@ typedef struct neutrino_vmc_args
     char arg[NEUTRINO_VMC_SLOTS][160];
 } neutrino_vmc_args_t;
 
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, int neutrinoGsmComp, const neutrino_vmc_args_t *vmcArgs);
+void sysLaunchNeutrino(const char *driver, const char *path, const char *startup, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, int neutrinoGsmComp, const neutrino_vmc_args_t *vmcArgs);
 
 // D6 pre-deinit launch pre-flight: validates the driver token and (network transports) syncs the
 // bsd toml ip= while every mount is up and the GUI can still toast. Call BEFORE deinitEx in every

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -804,7 +804,7 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
 
     // gPS2Logo passes the user's preference straight through: Neutrino performs its own logo
     // read/validation for -logo, so the native path's CheckPS2Logo disc pass is not needed here.
-    sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, &neutrinoVmc);
+    sysLaunchNeutrino(bdmCurrentDriver, partname, game->startup, compatmask, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, &neutrinoVmc);
     return 1;
 
 fail:

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -733,7 +733,7 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
 
     LOG("[NEUTRINO] apa partition_name=[%s]\n", apaPart);
     // gPS2Logo passes the preference straight through (Neutrino does its own logo work).
-    sysLaunchNeutrino("apa", apaPart, compatMode, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, NULL /* HDD VMC->neutrino deferred (APA/pfs) */);
+    sysLaunchNeutrino("apa", apaPart, game->startup, compatMode, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, NULL /* HDD VMC->neutrino deferred (APA/pfs) */);
     return 1;
 }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -690,7 +690,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
             return;
         int neutrinoDevMode = oplPath2Mode(neutrinoPath);
         deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode);
-        sysLaunchNeutrino("mmce", mmcePartname, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, &neutrinoVmc);
+        sysLaunchNeutrino("mmce", mmcePartname, game->startup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, &neutrinoVmc);
         return;
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -194,6 +194,7 @@ char gExitPath[256];
 char gNeutrinoArgs[256];   // extra command-line flags appended to every Neutrino launch
 char gNeutrinoPath[256];   // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
 int gNeutrinoDevice;       // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy gNeutrinoPath
+int gNeutrinoElfArg;       // opt-in (settings key only, no UI): auto-emit -elf=cdrom0: on Neutrino launches (parity Delta-10)
 char gPopstarterPath[256]; // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
 int gPopstarterDevice;     // POPSTARTER.ELF device (POPS_DEV_*); Default = cwd then VCD device; legacy path -> Custom
 int gBdmaSource;           // BDMA SOURCE device family (VCD_BDMA_SRC_*) to read exFAT driver variants from
@@ -1488,6 +1489,7 @@ static void _loadConfig()
             // Neutrino Device: prefer the new device-TYPE key; if absent (config predates the picker
             // change), migrate the legacy device-INDEX value -- 0=Auto, 1/2=mc0/mc1 -> MC, 11/12=
             // mmce0/mmce1 -> MMCE, 3-10=mass* -> Auto (a bare massN index can't name a driver type).
+            configGetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, &gNeutrinoElfArg);
             if (!configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, &gNeutrinoDevice)) {
                 int legacyDev = 0;
                 if (configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVICE, &legacyDev)) {
@@ -1770,6 +1772,7 @@ static void _saveConfig()
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs);
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath);
         configSetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, gNeutrinoDevice); // device-TYPE (NEUTRINO_DEV_*); the legacy neutrino_device key is left as-is
+        configSetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, gNeutrinoElfArg);
         configSetStr(configOPL, CONFIG_OPL_POPSTARTER_PATH, gPopstarterPath);
         configSetInt(configOPL, CONFIG_OPL_POPSTARTER_DEVICE, gPopstarterDevice);
         configSetInt(configOPL, CONFIG_OPL_BDMA_SOURCE, gBdmaSource);
@@ -2450,6 +2453,7 @@ static void setDefaults(void)
     gNeutrinoArgs[0] = '\0';
     gNeutrinoPath[0] = '\0';
     gNeutrinoDevice = NEUTRINO_DEV_AUTO;
+    gNeutrinoElfArg = 0; // experimental Delta-10 -elf emission stays opt-in
     gPopstarterPath[0] = '\0';
     gPopstarterDevice = POPS_DEV_DEFAULT;
     gBdmaSource = VCD_BDMA_SRC_USB;

--- a/src/system.c
+++ b/src/system.c
@@ -1187,7 +1187,26 @@ int sysNeutrinoPreflight(const char *driver, const char *neutrinoPath)
     return 0;
 }
 
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, int neutrinoGsmComp, const neutrino_vmc_args_t *vmcArgs)
+// Does `s` look like a retail boot-file name (AAAA_NNN.NN, e.g. SLUS_123.45)? Gates the opt-in
+// -elf=cdrom0: emission below to startups neutrino can actually resolve a GameID from.
+static int sysStartupShapeOk(const char *s)
+{
+    int i;
+    if (s == NULL || strlen(s) != 11 || s[4] != '_' || s[8] != '.')
+        return 0;
+    for (i = 0; i < 4; i++)
+        if (!((s[i] >= 'A' && s[i] <= 'Z') || (s[i] >= '0' && s[i] <= '9')))
+            return 0;
+    for (i = 5; i <= 10; i++) {
+        if (i == 8)
+            continue;
+        if (s[i] < '0' || s[i] > '9')
+            return 0;
+    }
+    return 1;
+}
+
+void sysLaunchNeutrino(const char *driver, const char *path, const char *startup, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, int neutrinoGsmComp, const neutrino_vmc_args_t *vmcArgs)
 {
     if (neutrinoPath == NULL || driver == NULL || path == NULL) {
         LOG("[NEUTRINO] null arg, abort\n");
@@ -1290,6 +1309,19 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
         else
             snprintf(gsmArg, sizeof(gsmArg), "-gsm=%s", gsmVideoTokens[neutrinoVideo]);
         argv[argc++] = gsmArg;
+    }
+
+    // Parity Delta-10, OPT-IN via settings_riptopl.cfg "neutrino_elf_arg"=1 (deliberately no UI
+    // row -- experimental): hand neutrino the boot ELF path directly so its per-GameID
+    // config/<GameID>.toml compat lookup can resolve pre-reset. Shape-guarded to AAAA_NNN.NN
+    // startups and skipped when the user already forwards an -elf= (structured field or free
+    // text) -- neutrino must see exactly one.
+    static char elfArg[40]; // outlives argv[] until the ExecPS2 handoff
+    if (gNeutrinoElfArg && sysStartupShapeOk(startup) && argc < argvMax &&
+        !neutrinoArgHasActiveFlag(gNeutrinoArgs, "-elf=") && !neutrinoArgHasActiveFlag(extraArgs, "-elf=")) {
+        snprintf(elfArg, sizeof(elfArg), "-elf=cdrom0:\\%s;1", startup);
+        argv[argc++] = elfArg;
+        LOG("[NEUTRINO] neutrino_elf_arg=1: emitting %s\n", elfArg);
     }
 
     // VMC slots (#47): emit each configured "-mcN=...bin" as its OWN argv entry. These come from

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -329,7 +329,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
 
     // Hand off to Neutrino with the udpfs driver token. `partname` (the filesystem game path) + the token
     // survive the deinit above; `game` does not and is not used past this point.
-    sysLaunchNeutrino("udpfs", partname, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, &neutrinoVmc);
+    sysLaunchNeutrino("udpfs", partname, game->startup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, &neutrinoVmc);
 }
 
 static config_set_t *udpfsGetConfig(item_list_t *itemList, int id)


### PR DESCRIPTION
**Δ10 — the last unstarted item of the [Neutrino parity plan](docs/NEUTRINO-PARITY-2026-07-05.md).** Hands Neutrino the boot ELF path (`-elf=cdrom0:\<STARTUP>;1`) so its per-GameID `config/<GameID>.toml` compat lookup can resolve **before** its IOP reset — today that lookup fails hard with only a printf.

### Deliberately conservative shape
- **Opt-in** via the `settings_riptopl.cfg` key `neutrino_elf_arg = 1` — deliberately **no settings-screen row** (experimental; the key is the "LOG-visible flag" the parity doc called for, and every emission is LOGged).
- **Shape-guarded**: only for retail-shaped startups (`AAAA_NNN.NN`).
- **Never double-emits**: skipped whenever the user's args already carry an `-elf=` (structured field or free text).
- `sysLaunchNeutrino` gains the `startup` param, threaded from all four legs; documented in `docs/NEUTRINO.md`.

### Also in this PR: audit queue status + one retraction
`docs/PARITY-AUDIT-2026-07-06.md` gains an end-of-day status section — **10 of 15 queue items shipped same-day** (#88, #94–#97, #100, #101, this one) — and **item #7 (RTC cross-device last-played) is retracted as not-a-gap**: all seven launch legs write the same key in the same single `CONFIG_LAST` file, so last-write-wins already *is* newest-wins. NHDDL needs timestamps only because its per-device files can disagree — a state our single-file model can't enter. Verified against all 7 write sites + the consumer before retracting.

### Validation
- Build-green both containers; clang-format clean.
- HW (opt-in testers only): add `neutrino_elf_arg = 1` to the cfg → debug argv LOG shows `-elf=cdrom0:\SLUS_xxx.xx;1` on retail games, absent on homebrew-named ISOs; per-GameID toml applies pre-reset (udptty); key absent → zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)