### PR TITLE
ci(diag): ship the unpacked primary ELF as an issue-#102 boot-regression probe

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -257,6 +257,11 @@ jobs:
             exit 1
           fi
           cp -f "$MAIN_ELF" rolling/RIPTOPL.ELF
+          # Issue #102 diagnostic: opl_stripped.elf is the exact UNPACKED input to ps2-packer
+          # (already built as an intermediate of RIPTOPL.ELF). Shipping it lets a tester A/B the
+          # ps2-packer self-decompression stub against the packed ELF: if the unpacked one boots
+          # on a console where the packed default does not, the packer stage is the culprit.
+          [ -f opl_stripped.elf ] && cp -f opl_stripped.elf rolling/RIPTOPL-latest-unpacked.ELF || echo "WARN: opl_stripped.elf missing for the #102 diagnostic"
           [ -f DETAILED_CHANGELOG ] && cp -f DETAILED_CHANGELOG rolling/ || true
           # IRX provenance manifest for the primary container's SDK prebuilts (see the pinned job).
           sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST.txt 2>/dev/null || true
@@ -336,6 +341,9 @@ jobs:
           echo "VERSIONED_BASE=RIPTOPL-${VER}" >> "$GITHUB_ENV"
           if [ -f rolling/RIPTOPL.ELF ]; then
             mv -f rolling/RIPTOPL.ELF "rolling/RIPTOPL-${VER}.ELF"
+          fi
+          if [ -f rolling/RIPTOPL-latest-unpacked.ELF ]; then
+            mv -f rolling/RIPTOPL-latest-unpacked.ELF "rolling/RIPTOPL-${VER}-latest-unpacked.ELF"
           fi
           if [ -f rolling/RIPTOPL-oldsdk.ELF ]; then
             mv -f rolling/RIPTOPL-oldsdk.ELF "rolling/RIPTOPL-${VER}-oldsdk.ELF"
@@ -579,6 +587,9 @@ jobs:
               printf -- '- RIPTOPL-DEBUG-*.zip: debug builds (iopcore/ingame/eesio/ppctty/DTL_T10000), both SDKs -- diagnostics\n'
             fi
             printf -- '- %s.ELF: bare loader, ps2dev:latest toolchain (primary)\n' "$VERSIONED_BASE"
+            if [ -f "rolling/${VERSIONED_BASE}-latest-unpacked.ELF" ]; then
+              printf -- '- %s-latest-unpacked.ELF: UNPACKED primary (no ps2-packer) -- issue #102 boot-regression diagnostic, try if the primary black-screens\n' "$VERSIONED_BASE"
+            fi
             if [ "$HAS_WOPLSDK" = yes ]; then
               printf -- '- %s-woplsdk.ELF: bare loader, wOPL'"'"'s digest-pinned ghcr.io/ps2homebrew container, stock SDK MMCE drivers\n' "$VERSIONED_BASE"
             else


### PR DESCRIPTION
Diagnostic-only CI change to root-cause [#102](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/102) (the packed primary ELF black-screens at boot on hardware; oldsdk/woplsdk boot fine).

### What a 3-agent investigation established
- **Not an SDK change** — the `ps2dev/ps2dev:latest` container digest is byte-identical between the working Beta-2991 and broken Beta-3001 runs (`sha256:12d99e28…`).
- **Not the coherent-mmce swap** — pinned source, identical container → identical binary.
- **Not a source logic bug** — every #96–#99 change is launch/settings-path, none is boot-reached; the added `LOG` calls compile to nothing in release; the enum insert is pin-protected (`COMPAT_DMA = 100`), the struct is a stack-only string intermediary, the arrays are terminator-walked.
- **Not binary size** — the −1 MB `gCheats` test (#101/Beta-3004) didn't help, and the packed ELF has a *measured* 21.5 MB margin to any fixed address.

What remains is a **latest-toolchain codegen/layout effect** that either trips the **ps2-packer self-decompression stub** (which runs *before* any OPL C — matching a pre-menu black screen) or exposes a latent fault only on the latest gcc's output.

### The decisive test this PR enables
Does an **unpacked** primary ELF boot? `opl_stripped.elf` is the exact pre-ps2-packer input and is already built as an intermediate, so this stages it as **`RIPTOPL-<ver>-latest-unpacked.ELF`** (+ versioned rename + release-notes line). **Zero extra build time.**

- Unpacked boots where packed doesn't → **ps2-packer is the culprit** (fix: ship the primary unpacked, or pin a known-good packer stub).
- Unpacked still black-screens → a genuine **latest-gcc miscompile**; bisect #96–#99 and diff `opl.map`.

No compiled-code change; workflow YAML validated. **Recommend rolling this so AndrewBento can A/B the unpacked ELF.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)