### PR TITLE
feat(release): named DualSense (DS5) loader for all three SDK flavours (supersedes #100)

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -90,6 +90,26 @@ jobs:
           echo "Staged pinned rolling assets:"
           ls -la rolling
 
+      - name: Build + stage DualSense (DS5) loader (PS2MAXSDK)
+        # DualSense (DS5 USB) is HW-validated (maintainer, 2026-07-06) but kept OFF in the default
+        # build by choice. Ship a ready-made DUALSENSE=1 loader for THIS SDK flavour as a named
+        # top-level asset so DS5 owners can pick their preferred (recommended) flavour without
+        # digging in the VARIANTS zip. Best-effort: a DS5 build hiccup must not sink the main flavour.
+        # LOCALVERSION carries "-PS2MAXSDK-ds5" so hardware reports self-identify.
+        run: |
+          make --trace clean
+          rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the DS5 output is unambiguous
+          if make --trace LOCALVERSION=PS2MAXSDK-ds5 DUALSENSE=1 release; then
+            DS5_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+            if [ -n "${DS5_ELF:-}" ] && [ -f "$DS5_ELF" ]; then
+              cp -f "$DS5_ELF" rolling/RIPTOPL-PS2MAXSDK-ds5.ELF
+            else
+              echo "WARN: PS2MAXSDK DUALSENSE=1 build produced no ELF; skipping DS5 asset this run" >&2
+            fi
+          else
+            echo "WARN: PS2MAXSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
+          fi
+
       - name: Build variant + debug extras (pinned = PS2MAXSDK)
         # Runs AFTER staging so the per-build `make clean` can't wipe the saved main ELF.
         run: sh ./.github/scripts/build_rolling_extras.sh "-PS2MAXSDK" "PS2MAXSDK"
@@ -168,6 +188,24 @@ jobs:
           sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST-WOPLSDK.txt 2>/dev/null || true
           echo "Staged wOPL-sdk rolling assets:"
           ls -la rolling
+
+      - name: Build + stage DualSense (DS5) loader (WOPLSDK)
+        # Named DUALSENSE=1 loader on the recommended #1 (pinned) toolchain -- the reliable DS5
+        # build. Best-effort so a DS5 hiccup can't sink the main WOPLSDK flavour. LOCALVERSION
+        # carries "-WOPLSDK-ds5" so hardware reports self-identify.
+        run: |
+          make --trace clean
+          rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the DS5 output is unambiguous
+          if make --trace LOCALVERSION=WOPLSDK-ds5 DUALSENSE=1 release; then
+            DS5_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+            if [ -n "${DS5_ELF:-}" ] && [ -f "$DS5_ELF" ]; then
+              cp -f "$DS5_ELF" rolling/RIPTOPL-WOPLSDK-ds5.ELF
+            else
+              echo "WARN: WOPLSDK DUALSENSE=1 build produced no ELF; skipping DS5 asset this run" >&2
+            fi
+          else
+            echo "WARN: WOPLSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
+          fi
 
       - name: Build variant + debug extras (wOPL-sdk)
         # Runs AFTER staging so the per-build `make clean` can't wipe the saved main ELF.
@@ -275,6 +313,25 @@ jobs:
           echo "Staged ps2dev-latest rolling assets:"
           ls -la rolling
 
+      - name: Build + stage DualSense (DS5) loader (PS2DEVLATESTSDK)
+        # Named DUALSENSE=1 loader on the ps2dev:latest toolchain. Like the plain PS2DEVLATESTSDK
+        # build this rides the moving SDK tag (may not boot -- issue #102); DS5 owners who want a
+        # reliable build should prefer the -WOPLSDK-ds5 / -PS2MAXSDK-ds5 assets. Best-effort so a
+        # DS5 hiccup can't sink the required primary flavour. LOCALVERSION carries "-PS2DEVLATESTSDK-ds5".
+        run: |
+          make --trace clean
+          rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the DS5 output is unambiguous
+          if make --trace LOCALVERSION=PS2DEVLATESTSDK-ds5 DUALSENSE=1 release; then
+            DS5_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+            if [ -n "${DS5_ELF:-}" ] && [ -f "$DS5_ELF" ]; then
+              cp -f "$DS5_ELF" rolling/RIPTOPL-PS2DEVLATESTSDK-ds5.ELF
+            else
+              echo "WARN: PS2DEVLATESTSDK DUALSENSE=1 build produced no ELF; skipping DS5 asset this run" >&2
+            fi
+          else
+            echo "WARN: PS2DEVLATESTSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
+          fi
+
       - name: Build variant + debug extras (ps2dev:latest = standard)
         # Runs after staging the main ELF so the per-build `make clean` can't wipe it.
         run: sh ./.github/scripts/build_rolling_extras.sh "-PS2DEVLATESTSDK" "PS2DEVLATESTSDK"
@@ -346,6 +403,12 @@ jobs:
           if [ -f rolling/RIPTOPL-WOPLSDK.ELF ]; then
             mv -f rolling/RIPTOPL-WOPLSDK.ELF "rolling/RIPTOPL-${VER}-WOPLSDK.ELF"
           fi
+          # DualSense (DS5) named loaders, one per SDK flavour (best-effort -- any may be absent).
+          for sdk in WOPLSDK PS2MAXSDK PS2DEVLATESTSDK; do
+            if [ -f "rolling/RIPTOPL-${sdk}-ds5.ELF" ]; then
+              mv -f "rolling/RIPTOPL-${sdk}-ds5.ELF" "rolling/RIPTOPL-${VER}-${sdk}-ds5.ELF"
+            fi
+          done
           echo "Renamed assets:"
           ls -la rolling
 
@@ -543,6 +606,10 @@ jobs:
             printf 'When something misbehaves on hardware, please say WHICH flavour you ran (the in-app version\n'
             printf 'string suffix tells you). A PS2DEVLATESTSDK-only failure points at an SDK regression; an\n'
             printf 'all-three failure points at RiptOPL code. Those bits triple the value of a report.\n'
+            printf '\n'
+            printf '**DualSense / DS5 (USB) owners:** each flavour also ships a ready-made DUALSENSE=1 loader as\n'
+            printf 'a named `RIPTOPL-<version>-<SDK>-ds5.ELF` asset (see "Other downloads"). Same reliability order\n'
+            printf 'applies -- prefer `-WOPLSDK-ds5` or `-PS2MAXSDK-ds5`. The default builds keep DualSense OFF.\n'
             printf '\n## Bundled Neutrino core\n'
             printf 'Required for the per-game Neutrino launch mode. From the official repo:\n'
             printf '  https://github.com/rickgaiser/neutrino\n'
@@ -597,6 +664,11 @@ jobs:
               printf -- '- (pinned %s PS2MAXSDK build FAILED this run)\n' "$SDK_VER"
             fi
             printf -- '- %s-PS2DEVLATESTSDK.ELF: bare loader, ps2dev:latest toolchain (bleeding-edge -- moving SDK tag, may not boot on all consoles; see "Get started")\n' "$VERSIONED_BASE"
+            for sdk in WOPLSDK PS2MAXSDK PS2DEVLATESTSDK; do
+              if [ -f "rolling/${VERSIONED_BASE}-${sdk}-ds5.ELF" ]; then
+                printf -- '- %s-%s-ds5.ELF: %s toolchain WITH DualSense (DS5 USB) pad support (same reliability as the %s bare loader above)\n' "$VERSIONED_BASE" "$sdk" "$sdk" "$sdk"
+              fi
+            done
             printf -- '- IRX-MANIFEST*.txt: SHA256 of every SDK-prebuilt IOP module each toolchain consumed\n'
             printf -- '- %s-src.zip: source snapshot to rebuild this exact commit\n' "$VERSIONED_BASE"
             if ls rolling/RIPTOPL-LANGS-*.zip >/dev/null 2>&1; then

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,10 @@ IGS ?= $(EXTRA_FEATURES)
 #Enables/disables pad emulator
 PADEMU ?= 1
 
-#Enables/disables experimental PS5 DualSense (USB) support in the pad emulator. UNVALIDATED --
-#needs real DS5 hardware to test, so it is OFF by default and never affects the default build.
+#Enables/disables PS5 DualSense (USB) support in the pad emulator. HW-VALIDATED on a real DS5
+#(maintainer, 2026-07-06) but kept OFF in the default build by deliberate choice -- the rolling
+#release ships ready-made DUALSENSE=1 builds as named RIPTOPL-<version>-<SDK>-ds5.ELF assets,
+#one per SDK flavour (WOPLSDK / PS2MAXSDK / PS2DEVLATESTSDK).
 DUALSENSE ?= 0
 
 #Enables/disables building of an edition of OPL that will support the DTL-T10000 (SDK v2.3+)

--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ This build layers several features on top of upstream OPL:
   **Device Settings** page consolidates the per-device options, cache sizes, Block-Devices
   (BDM) settings, all MMCE settings, the network-boot controls (the UDPBD/UDPFS toggle + the
   **Net Boot Protocol** picker, interlocked with SMB), and the Favourites tab toggle in one place.
-- **DualSense / DualShock 5 (USB):** optional controller support, compiled in with
-  `make DUALSENSE=1`.
+- **DualSense / DualShock 5 (USB):** optional controller support — grab a ready-made
+  `RIPTOPL-<version>-<SDK>-ds5.ELF` (one per SDK flavour) from the rolling release, or build
+  with `make DUALSENSE=1`.
 - **Ready-to-use defaults:** a fresh install boots with sensible options already enabled —
   widescreen, cover art, notifications, sound effects + boot sound, USB, delete/rename, and
   the PS2 logo, with the device tabs in **Manual** mode. Video mode stays **Auto**. Change
@@ -226,8 +227,9 @@ because that upstream work is open for everyone to learn from.
 RiptOPL ships **one full-feature build** — GSM video-mode handling, in-game
 screenshots (IGS), DS3/DS4 pad emulation (PADEMU), VMC, PS2RD cheats and parental
 controls are all included in the standard ELF (no upstream-style per-feature variants).
-DualSense / DualShock 5 (USB) support is the one optional extra, compiled in with
-`make DUALSENSE=1`.
+DualSense / DualShock 5 (USB) support is the one optional extra: the rolling release ships it
+prebuilt as named `RIPTOPL-<version>-<SDK>-ds5.ELF` assets (one per SDK flavour), or build your
+own with `make DUALSENSE=1`.
 
 There are two release channels:
 

--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -17,6 +17,7 @@ ELFs and supporting files are published alongside it:
 | `RIPTOPL-<version>-WOPLSDK.ELF` | Bare loader, wOPL's digest-pinned `ghcr.io/ps2homebrew` container (**recommended #1**; in-app version ends `-WOPLSDK`). |
 | `RIPTOPL-<version>-PS2MAXSDK.ELF` | Bare loader, `ps2max/dev` (pinned) toolchain (**recommended #2**; in-app version ends `-PS2MAXSDK`). |
 | `RIPTOPL-<version>-PS2DEVLATESTSDK.ELF` | Bare loader, `ps2dev/ps2dev:latest` toolchain (bleeding-edge; in-app version ends `-PS2DEVLATESTSDK`; may not boot on all consoles). |
+| `RIPTOPL-<version>-<SDK>-ds5.ELF` | Same as the bare loader for each SDK flavour, **with DualSense (DS5 USB) pad support** compiled in (`DUALSENSE=1`). One per flavour (`-WOPLSDK-ds5` / `-PS2MAXSDK-ds5` / `-PS2DEVLATESTSDK-ds5`); same reliability order applies. The default builds keep DualSense OFF. Best-effort — a flavour's DS5 build may be absent if it failed that run. |
 | `RIPTOPL-<version>-src.zip` | Source snapshot to rebuild this exact commit. |
 | `SHA256SUMS.txt` | SHA256 of every published binary + the source snapshot. |
 | `IRX-MANIFEST*.txt` | SHA256 of every SDK-prebuilt IOP module each toolchain consumed (provenance for silent SDK-side driver swaps). |


### PR DESCRIPTION
Supersedes #100. Ships a ready-made DualSense (DS5 USB) loader as a **named top-level asset for every SDK flavour**, per maintainer direction ("it should be building to all 3 — that's the whole point"). DualSense is HW-validated (maintainer, 2026-07-06) but the default builds keep it OFF by choice.

## New assets (one per flavour, same reliability order as the bare loaders)

| Asset | Toolchain |
|---|---|
| `RIPTOPL-<version>-WOPLSDK-ds5.ELF` | recommended #1 (pinned, boots reliably) |
| `RIPTOPL-<version>-PS2MAXSDK-ds5.ELF` | recommended #2 (pinned, boots reliably) |
| `RIPTOPL-<version>-PS2DEVLATESTSDK-ds5.ELF` | bleeding-edge (moving tag; may not boot — #102) |

## How

- Each of the three build jobs gains a **best-effort** `Build + stage DualSense (DS5) loader` step (`LOCALVERSION=<SDK>-ds5 DUALSENSE=1`) staging `RIPTOPL-<SDK>-ds5.ELF`. A DS5 build hiccup skips only that one bonus asset — never the main flavour (tolerant, no `exit 1`).
- Publish job's version-rename loop, release notes ("Get started" pointer + "Other downloads" listing), and the `*.ELF` SHA256SUMS glob pick them up automatically.
- **Robustness fix over #100:** clear the main build's leftover root ELF before the DS5 build, so `ls RIPTOPL-*.ELF | head` is unambiguous (clean's glob doesn't remove the SDK-suffixed name — #100 relied on sort order).
- Makefile + README + ROLLING_RELEASE.md updated to point DS5 owners at the per-flavour assets.

Built on top of the #105 relabel (WOPLSDK/PS2MAXSDK/PS2DEVLATESTSDK) and #103. Workflow YAML validated; no source-code change (Makefile edit is comment-only).