### PR TITLE
feat(vcd): optional display-only hide of the PS1 game-ID prefix in the VCD list

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -108,6 +108,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_POPSTARTER_DEVICE    "popstarter_device" // device TYPE holding POPS/POPSTARTER.ELF (POPS_DEV_*)
 #define CONFIG_OPL_BDMA_SOURCE          "bdma_source"
 #define CONFIG_OPL_BDMA_APPLY           "bdma_apply_launch"
+#define CONFIG_OPL_VCD_HIDE_GAMEID      "vcd_hide_gameid" // display-only: hide a leading PS1 game-ID prefix from the VCD list
 #define CONFIG_OPL_WRITE_POPS_NET       "write_popstarter_net"
 #define CONFIG_OPL_HDD_GAME_LIST_CACHE  "hdd_game_list_cache"
 #define CONFIG_OPL_EXIT_PATH            "exit_path"

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -88,6 +88,7 @@ enum UI_ITEMS {
     CFG_BDMASOURCE,
     CFG_LBL_BDMAMODE,
     CFG_BDMAMODE,
+    CFG_VCD_HIDE_GAMEID, // display-only: hide a leading PS1 game-ID prefix from the VCD list
 
     CFG_XSENSITIVITY,
     CFG_YSENSITIVITY,

--- a/include/opl.h
+++ b/include/opl.h
@@ -264,6 +264,7 @@ extern int gPopstarterDevice;   // POPSTARTER.ELF device (POPS_DEV_*); legacy no
 extern int gBdmaSource;         // BDMA SOURCE device family (VCD_BDMA_SRC_*); persisted in conf
 extern int gBdmaMode;           // BDMA MODE mirrored from the mc?:/POPSTARTER/ marker (VCD_BDMA_*)
 extern int gBdmaApplyOnLaunch;  // auto-equip the launched VCD's matching exFAT driver before boot (1=on)
+extern int gVcdHideGameId;      // display-only: hide a leading PS1 game-ID prefix from the VCD list (1=on, default off)
 extern int gWritePopstarterNet; // mirror network settings into POPSTARTER's IPCONFIG/SMBCONFIG on save
 // Enable Debug Colors
 extern int gEnableDebug;

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -49,6 +49,10 @@ void vcdBuildSelector(const char *devPrefix, const char *prefix, const char *nam
 int vcdModeSupported(int mode);
 // Is the given device mode currently showing its VCD list (vs its disc list)?
 int vcdViewActive(int mode);
+// Display-only: strip a leading PS1 game-ID prefix from a VCD list name when the gVcdHideGameId
+// setting is on and `mode` is a VCD view; returns `text` unchanged otherwise. COSMETIC -- the
+// result is for on-screen text only, never for launch/art/favourites/config lookups.
+const char *vcdDisplayName(int mode, const char *text);
 // Flip the VCD view for a mode + mark it dirty so the owning support's NeedsUpdate forces a rescan.
 void vcdToggleView(int mode);
 // Returns 1 exactly once after a toggle (and clears the flag) -- call from the support's NeedsUpdate.

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -951,3 +951,7 @@ gui_strings:
   string: Force Neutrino's block-device filesystem (-bsdfs). Auto = per-device default. hdl/bd are expert options; pair them with a matching -dvd= in the launch args if the auto path shape doesn't fit.
 - label: PLASCOLOR
   string: Plasma Blend Color
+- label: VCD_HIDE_GAMEID
+  string: Hide PS1 Game ID (VCD list)
+- label: HINT_VCD_HIDE_GAMEID
+  string: Cosmetic only -- hide a leading game-ID prefix (e.g. SLUS_005.51.) from PS1/VCD list names. Names without an ID are shown as-is. Does not change launch, cover art, or favourites.

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -193,6 +193,11 @@ struct UIItem diaConfig[] = {
     {UI_ENUM, CFG_BDMAMODE, 1, 1, _STR_HINT_BDMA_MODE, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_HIDE_GAMEID}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_VCD_HIDE_GAMEID, 1, 1, _STR_HINT_VCD_HIDE_GAMEID, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_WRITE}}},
     {UI_SPACER},
     {UI_BOOL, CFG_ENWRITEOP, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},

--- a/src/gui.c
+++ b/src/gui.c
@@ -552,6 +552,7 @@ void guiShowConfig()
     // "VCD BDMA Apply on Launch": when ON the launch auto-equips the matching driver, so the manual
     // SOURCE/MODE pickers are hidden; flipping it OFF (live, via guiUpdater) reveals them.
     diaSetInt(diaConfig, CFG_BDMA_APPLY, gBdmaApplyOnLaunch);
+    diaSetInt(diaConfig, CFG_VCD_HIDE_GAMEID, gVcdHideGameId);
     diaSetVisible(diaConfig, CFG_LBL_BDMASOURCE, !gBdmaApplyOnLaunch);
     diaSetVisible(diaConfig, CFG_BDMASOURCE, !gBdmaApplyOnLaunch);
     diaSetVisible(diaConfig, CFG_LBL_BDMAMODE, !gBdmaApplyOnLaunch);
@@ -589,6 +590,7 @@ reshow_config:
                 snprintf(gPopstarterPath, sizeof(gPopstarterPath), "%s", tmpPop);
         }
         diaGetInt(diaConfig, CFG_BDMA_APPLY, &gBdmaApplyOnLaunch);
+        diaGetInt(diaConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId); // display-only; next list draw reflects it, no rebuild needed
         {
             // Equip BDMA modules only when SOURCE or MODE actually changed (the equip copies
             // files to the memory card). vcdEquipBdma is free-space-gated + truncation-safe, so a

--- a/src/opl.c
+++ b/src/opl.c
@@ -200,6 +200,7 @@ int gPopstarterDevice;     // POPSTARTER.ELF device (POPS_DEV_*); Default = cwd 
 int gBdmaSource;           // BDMA SOURCE device family (VCD_BDMA_SRC_*) to read exFAT driver variants from
 int gBdmaMode;             // BDMA MODE last reflected from the mc?:/POPSTARTER/ marker (VCD_BDMA_*); not persisted
 int gBdmaApplyOnLaunch;    // auto-equip the launched VCD's matching exFAT driver before boot (1=on, default)
+int gVcdHideGameId;        // display-only: hide a leading PS1 game-ID prefix from the VCD list (1=on, default off)
 int gWritePopstarterNet;   // mirror the network settings into POPSTARTER's IPCONFIG/SMBCONFIG on save
 int gEnableDebug;
 int gPS2Logo;
@@ -1510,6 +1511,7 @@ static void _loadConfig()
                 gPopstarterDevice = (gPopstarterPath[0] != '\0') ? POPS_DEV_CUSTOM : POPS_DEV_DEFAULT;
             configGetInt(configOPL, CONFIG_OPL_BDMA_SOURCE, &gBdmaSource);
             configGetInt(configOPL, CONFIG_OPL_BDMA_APPLY, &gBdmaApplyOnLaunch);
+            configGetInt(configOPL, CONFIG_OPL_VCD_HIDE_GAMEID, &gVcdHideGameId);
             configGetInt(configOPL, CONFIG_OPL_WRITE_POPS_NET, &gWritePopstarterNet);
         }
 
@@ -1780,6 +1782,7 @@ static void _saveConfig()
         configSetInt(configOPL, CONFIG_OPL_POPSTARTER_DEVICE, gPopstarterDevice);
         configSetInt(configOPL, CONFIG_OPL_BDMA_SOURCE, gBdmaSource);
         configSetInt(configOPL, CONFIG_OPL_BDMA_APPLY, gBdmaApplyOnLaunch);
+        configSetInt(configOPL, CONFIG_OPL_VCD_HIDE_GAMEID, gVcdHideGameId);
         configSetInt(configOPL, CONFIG_OPL_WRITE_POPS_NET, gWritePopstarterNet);
         configSetInt(configOPL, CONFIG_OPL_XSENSITIVITY, gXSensitivity);
         configSetInt(configOPL, CONFIG_OPL_YSENSITIVITY, gYSensitivity);
@@ -2466,6 +2469,7 @@ static void setDefaults(void)
     gBdmaSource = VCD_BDMA_SRC_USB;
     gBdmaMode = VCD_BDMA_FAT32;
     gBdmaApplyOnLaunch = 1; // auto-equip on launch by default (the MX4SIO->OSDSYS fix)
+    gVcdHideGameId = 0;     // show the raw filename by default; opt-in cosmetic prefix hide
     gWritePopstarterNet = 0;
     gDefaultDevice = APP_MODE;
     gAutosort = 1;

--- a/src/themes.c
+++ b/src/themes.c
@@ -1383,7 +1383,10 @@ static void drawItemText(struct menu_list *menu, struct submenu_list *item, conf
 {
     if (item) {
         item_list_t *support = menu->item->userdata;
-        fntRenderString(elem->font, elem->posX, elem->posY, elem->aligned, 0, 0, support->itemGetStartup(support, item->item.id), elem->color);
+        // In a VCD view itemGetStartup returns the (full) VCD name, so this is the name caption some
+        // CoverFlow/custom themes use instead of an ItemsList. Apply the same display-only game-ID
+        // hide (no-op for non-VCD views, where this shows the real startup/game-ID). Cosmetic only.
+        fntRenderString(elem->font, elem->posX, elem->posY, elem->aligned, 0, 0, vcdDisplayName(support->mode, support->itemGetStartup(support, item->item.id)), elem->color);
     }
 }
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -11,6 +11,7 @@
 #include "include/sound.h"
 #include "include/texcache.h"
 #include "include/favsupport.h"
+#include "include/vcdsupport.h" // vcdDisplayName -- display-only VCD game-ID prefix hide
 
 #include <time.h>
 #include <math.h>
@@ -1330,9 +1331,9 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
                     if (itemsList->decoratorImage->defaultTexture)
                         rmDrawPixmap(&itemsList->decoratorImage->defaultTexture->source, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol, 0);
                 }
-                textEndX = fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, submenuItemGetText(&ps->item), color);
+                textEndX = fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, vcdDisplayName(list ? list->mode : -1, submenuItemGetText(&ps->item)), color);
             } else
-                textEndX = fntRenderString(elem->font, elem->posX, posY, elem->aligned, elem->width, elem->height, submenuItemGetText(&ps->item), color);
+                textEndX = fntRenderString(elem->font, elem->posX, posY, elem->aligned, elem->width, elem->height, vcdDisplayName(list ? list->mode : -1, submenuItemGetText(&ps->item)), color);
 
             // Favourites: draw a small star just after the item text.
             if (ps->item.favourited) {

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -37,6 +37,52 @@ static void vcdExtractGameId(const char *name, char *idOut, int idSize)
     }
 }
 
+// Display-only prefix hider (aesthetic setting gVcdHideGameId). Returns the number of leading
+// characters to skip when `name` begins with a STRICT PS1 retail game-ID prefix AAAA_NNN.NN
+// followed by a '.' or '_' separator (= 12 chars, e.g. "SLUS_005.51." / "SCUS_941.63."), and only
+// when there is a non-empty title after it. Returns 0 otherwise, so clean titles are never cut.
+// Stricter than vcdExtractGameId's separator-only test on purpose: this drives what the user SEES,
+// so a false positive would eat a real title. The char checks short-circuit on the NUL, so a
+// name shorter than 12 chars is safe.
+static int vcdGameIdPrefixLen(const char *name)
+{
+    int i;
+    if (name == NULL)
+        return 0;
+    for (i = 0; i < 4; i++) // AAAA (letters/digits)
+        if (!((name[i] >= 'A' && name[i] <= 'Z') || (name[i] >= '0' && name[i] <= '9')))
+            return 0;
+    if (name[4] != '_')
+        return 0;
+    for (i = 5; i <= 7; i++) // NNN
+        if (name[i] < '0' || name[i] > '9')
+            return 0;
+    if (name[8] != '.')
+        return 0;
+    for (i = 9; i <= 10; i++) // NN
+        if (name[i] < '0' || name[i] > '9')
+            return 0;
+    if (name[11] != '.' && name[11] != '_') // trailing separator before the title
+        return 0;
+    if (name[12] == '\0') // nothing after the prefix -- keep the raw name rather than blank it
+        return 0;
+    return 12;
+}
+
+// Render-time display name for the VCD list. PURELY COSMETIC: returns a pointer PAST a leading
+// game-ID prefix when the "hide game ID" option is on AND this is a VCD view AND the name really
+// starts with one; otherwise returns `text` unchanged. The stored name is never modified, so
+// launch selectors, cover-art keys, favourites match-by-name and config keys all keep the full
+// name -- callers MUST use the result for drawing only.
+const char *vcdDisplayName(int mode, const char *text)
+{
+    int n;
+    if (!gVcdHideGameId || text == NULL || !vcdViewActive(mode))
+        return text;
+    n = vcdGameIdPrefixLen(text);
+    return n ? text + n : text;
+}
+
 // Core scan: opendir `dirPath` and collect *.VCD basenames into a fresh vcd_entry_t list. POSIX dir
 // IO only (newlib-port rule). Shared by vcdScanDir (POPS subfolder) and vcdScanDirRoot (path as-is).
 static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)


### PR DESCRIPTION
## What

A new **General Settings** toggle — **"Hide PS1 Game ID (VCD list)"**, default **OFF** — that hides a leading PS1 game-ID prefix from PS1/VCD list names, so dumps named with game-ID crap (`SLUS_005.51.Resident_Evil_Director`) read cleanly. Requested from a user whose VCD listing was cluttered with `SXXX_NNN.NN.` prefixes.

**Smart, not blunt** (maintainer's call): only names that *strictly* match a PS1 game-ID shape (`AAAA_NNN.NN` + `.`/`_` separator) are stripped. Clean titles are shown untouched:

| Name | ON |
|---|---|
| `SLUS_005.51.Resident_Evil_Director` | `Resident_Evil_Director` |
| `SCUS_941.63.D1_Fin_Fan_VII` | `D1_Fin_Fan_VII` |
| `Castlevania_Symphony_o` | `Castlevania_Symphony_o` *(no game ID — untouched)* |
| `Resident_Evil_3_Nemesi` | `Resident_Evil_3_Nemesi` *(untouched)* |

## Purely aesthetic — the guarantee

The strip happens at **exactly one point**: the game-list font render in `themes.c drawItemsList`, via a new `vcdDisplayName(mode, text)` helper that returns a pointer *past* the prefix. **The stored name is never modified**, so every functional path keeps the full name:

- POPSTARTER launch selector (`XX.<name>.ELF`)
- cover-art lookup (both ID-keyed and name-keyed)
- favourites match-by-name (stars/resolution)
- per-game config keys

Gated on `gVcdHideGameId && vcdViewActive(mode)` → touches only VCD views (BDM/MMCE/ETH/HDD/Favourites), never an ISO or app list. No list rebuild on toggle; the next frame just renders clean.

**Scope** is the list view (the "listing pages" asked for). The per-game options/info title still shows the full name with the ID — useful for identification.

## Implementation
- Wiring mirrors `gBdmaApplyOnLaunch` exactly: config key `vcd_hide_gameid`, global `gVcdHideGameId`, load/save/default-off, `UI_BOOL` row + `diaSet/GetInt`.
- Strict matcher `vcdGameIdPrefixLen` (validates `AAAA_NNN.NN` char classes, not just separators) so a real title is never eaten; OOB-safe on short/empty/NULL (checks short-circuit on the NUL).
- 2 lang labels appended at the END of `lng_tmpl/_base.yml` (append-only rule; `lang_autogen.*` are build-generated).

## Verification
- Builds clean in **both** containers (`ps2dev:latest` and `ps2max/dev`) — `opl.elf` links in each.
- **Two-lens adversarial review, zero findings**: confirmed (1) the stripped result flows *only* into `fntRenderString` and never to any resolution path (repo-wide grep), favourites store the full name; (2) the matcher is memory-safe and correct on the screenshot examples and edge names (`_` separator, bare 12-char prefix, empty/NULL).
- clang-format (v12) clean.