### PR TITLE
fix(mmce): reduce MX4SIO<->mmceman SIO2 menu contention (B/C/E of the MMCE-instability fix)

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -93,4 +93,7 @@ int bdmSupportIsUDPBD(item_list_t *support); // 1 if this support is the UDPBD b
 // Re-evaluate every BDM device's presence + page visibility on the next refresh (bumps the latch
 // generation). Call after a device-enable toggle so a latched-hidden tab re-shows without a replug.
 void bdmForceDeviceRefresh(void);
+// Current BDM device-change generation (bumped on hotplug / Device-Settings apply). The menu hook
+// reads this to bypass its background SIO2 rescan throttle when a real device change occurs.
+unsigned int bdmGetGeneration(void);
 #endif

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -290,6 +290,14 @@ void bdmForceDeviceRefresh(void)
     BdmGeneration++;
 }
 
+// Read-only accessor so the menu hook can detect a real BDM device change (hotplug via bdmEventHandler
+// or a Device-Settings apply) and bypass its background-rescan throttle for immediate detection.
+// Plain single-word read, matching the existing non-atomic BdmGeneration read at bdmNeedsUpdate.
+unsigned int bdmGetGeneration(void)
+{
+    return BdmGeneration;
+}
+
 static int bdmShouldQueueModuleLoad(void)
 {
     if (gEnableUSB && !iUSBModLoaded)

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -29,6 +29,10 @@ static time_t mmceModifiedCDPrev;
 static time_t mmceModifiedDVDPrev;
 static int mmceGameCount = 0;
 static base_game_info_t *mmceGames;
+// Auto-slot (gMMCESlot==2) resolution cache: mmceDetectSlot()'s last result (2=mmce0, 3=mmce1,
+// -1=unresolved). Avoids re-probing BOTH slots over SIO2 every menu refresh -- that steady devctl
+// drip contends with MX4SIO on the shared bus. Reset by mmceInit (tab re-enable / settings apply).
+static int mmceResolvedDevice = -1;
 
 // Card-switch wait: poll the MMCE busy bit every 500 ms for up to ~7.5 s, matching mmceman's own
 // switch handshake. On a CROSS-DEVICE launch (a USB/HDD/SMB game whose per-game card lives on the
@@ -228,8 +232,27 @@ void mmceSetPrefix(void)
         sprintf(mmcePrefix, "mmce0:/%s", gMMCEPrefix);
     else if (gMMCESlot == 1)
         sprintf(mmcePrefix, "mmce1:/%s", gMMCEPrefix);
-    else if (gMMCESlot == 2)
-        (void)mmceDetectSlot();
+    else if (gMMCESlot == 2) {
+        // Auto: reuse the previously-detected slot instead of probing BOTH slots every refresh.
+        // On a cache hit, ONE presence devctl on the resolved slot confirms the card is still there
+        // (mmcePrefix from the prior detect is still correct); a miss means the card was pulled, so
+        // invalidate and fall through to a full re-detect. Net: 1 SIO2 probe/cycle instead of 2, and
+        // card removal is now noticed (mmceDetectSlot alone leaves a stale prefix on a lost card).
+        if (mmceResolvedDevice > 0) {
+            const char *root = (mmceResolvedDevice == 2) ? "mmce0:/" : "mmce1:/";
+            if (fileXioDevctl(root, 0x1, NULL, 0, NULL, 0) == -1) {
+                mmceResolvedDevice = -1;
+                mmcePrefix[0] = '\0';
+            } else {
+                // Still present. Rebuild mmcePrefix from the CURRENT gMMCEPrefix (a Device-Settings
+                // prefix change must apply immediately -- initSupport does not re-init an already-
+                // enabled MMCE tab) using the cached slot; we skip only the second SIO2 slot probe.
+                sprintf(mmcePrefix, "mmce%d:/%s", (mmceResolvedDevice == 2) ? 0 : 1, gMMCEPrefix);
+            }
+        }
+        if (mmceResolvedDevice <= 0)
+            mmceResolvedDevice = mmceDetectSlot();
+    }
 
     mmceRefreshArtRoots();
 }
@@ -268,6 +291,7 @@ void mmceInit(item_list_t *itemList)
     mmceModifiedDVDPrev = 0;
     mmceGameCount = 0;
     mmceGames = NULL;
+    mmceResolvedDevice = -1; // re-detect the Auto slot on a fresh init (tab re-enable / settings apply)
 
     configGetInt(configGetByType(CONFIG_OPL), "usb_frames_delay", &mmceGameList.delay);
     mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;

--- a/src/opl.c
+++ b/src/opl.c
@@ -112,6 +112,12 @@ static void deferredAudioInit(void);
 
 // frame counter
 static unsigned int frameCounter;
+// Per-mode background-rescan throttle (Fix B): the every-frame (updateDelay==0) device rescans
+// enumerate the SIO2/mass bus; space them by a minimum wall-clock interval so they don't run
+// unthrottled when cover art is off (art-pending used to incidentally pace them -- the "art off made
+// MMCE worse" bug). A real device change bypasses the throttle via bdmGetGeneration().
+static clock_t lastBgRescan[MODE_COUNT];
+static unsigned int lastSeenBdmGeneration;
 
 static char errorMessage[256];
 
@@ -891,7 +897,12 @@ void menuDeferredUpdate(void *data)
     }
 }
 
-#define MENU_GENERAL_UPDATE_DELAY 60
+#define MENU_GENERAL_UPDATE_DELAY         60
+// Minimum wall-clock gap between background rescans of the SAME updateDelay==0 device (Fix B). At
+// ~2 s this drops the steady SIO2/mass enumeration rate (and, for MMCE, the slot-probe drip) well
+// below the old every-60-frames cadence, cutting MX4SIO<->mmceman bus contention, while a real
+// device change still refreshes immediately (BdmGeneration bypass below). clock() = microseconds.
+#define MENU_BG_RESCAN_MIN_INTERVAL_TICKS (2 * CLOCKS_PER_SEC)
 
 static void menuUpdateHook()
 {
@@ -919,11 +930,27 @@ static void menuUpdateHook()
         }
     }
 
-    // Schedule updates of all list handlers that are to run every frame, regardless of whether auto refresh is active or not.
+    // Schedule updates of the every-frame (updateDelay==0) list handlers -- all BDM/MX4SIO, and MMCE
+    // while no card is present. These enumerate the SIO2/mass bus, so throttle each to a minimum
+    // wall-clock interval instead of firing every MENU_GENERAL_UPDATE_DELAY frames. That interval used
+    // to be supplied incidentally by cover-art-pending suppressing the whole hook (line above); with
+    // art OFF that never fired, so the rescans ran unthrottled and contended on SIO2 (the "cover art
+    // off made MMCE worse" bug). A genuine BDM device change (hotplug/removal via BdmGeneration, or a
+    // Device-Settings apply) bypasses the throttle so detection stays immediate.
     if (frameCounter % MENU_GENERAL_UPDATE_DELAY == 0) {
+        unsigned int gen = bdmGetGeneration();
+        int genChanged = (gen != lastSeenBdmGeneration);
+        clock_t now = clock();
+        lastSeenBdmGeneration = gen;
         for (i = 0; i < MODE_COUNT; i++) {
-            if ((list_support[i].support && list_support[i].support->enabled) && (list_support[i].support->updateDelay == 0))
-                ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+            if ((list_support[i].support && list_support[i].support->enabled) && (list_support[i].support->updateDelay == 0)) {
+                int mode = list_support[i].support->mode;
+                // elapsed form is single-wrap-safe; zero-initialized timestamp allows one immediate rescan
+                if (genChanged || (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS) {
+                    ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+                    lastBgRescan[mode] = now;
+                }
+            }
         }
     }
 }

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -372,6 +372,16 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
             count++;
         }
         closedir(dir);
+    } else {
+        // opendir() failed: the directory could not be READ (device unreadable / bus wedged), which
+        // is DISTINCT from a readable-but-empty directory (that opens fine and returns count 0). Signal
+        // a read FAILURE with a negative return so sbReadList can preserve the last-good list instead
+        // of blanking it on a transient wedge (MMCE<->MX4SIO SIO2 contention). Crucially, do NOT call
+        // updateISOGameList here -- writing count 0 would rewrite the on-disk list cache to EMPTY,
+        // persisting a transient failure across reboots.
+        if (cacheLoaded)
+            freeISOGameListCache(&cache);
+        return -1;
     }
 
     if (cacheLoaded) {
@@ -386,26 +396,32 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
 
 int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gamecount)
 {
-    int fd, size, id = 0, result;
-    int count;
+    int fd, size, id = 0;
+    int count, cdRet, dvdRet;
     char path[256];
 
-    free(*list);
-    *list = NULL;
-    *fsize = -1;
-    *gamecount = 0;
+    // Build into a LOCAL list and leave the caller's *list/*gamecount/*fsize UNTOUCHED until we know
+    // the scan actually reached the device. On a TOTAL device-read failure (every directory's opendir
+    // failed AND no ul.cfg) we keep the old list -- so a transient bus wedge (e.g. the MMCE<->MX4SIO
+    // SIO2 contention) preserves the last-good list on screen instead of blanking it (issue: MMCE
+    // lists vanish on a contended bus). A readable-but-empty device still shows empty (scan returns 0,
+    // not < 0). Device removal is handled separately by page-visibility, not here.
+    base_game_info_t *newlist = NULL;
+    int newfsize = -1;
 
     // temporary storage for the game names
     struct game_list_t *dlist_head = NULL;
 
     // count iso games in "cd" directory
     snprintf(path, sizeof(path), "%sCD", prefix);
-    count = scanForISO(path, SCECdPS2CD, &dlist_head);
+    cdRet = scanForISO(path, SCECdPS2CD, &dlist_head);
+    count = cdRet;
 
     // count iso games in "dvd" directory
     snprintf(path, sizeof(path), "%sDVD", prefix);
-    if ((result = scanForISO(path, SCECdPS2DVD, &dlist_head)) >= 0) {
-        count = count < 0 ? result : count + result;
+    dvdRet = scanForISO(path, SCECdPS2DVD, &dlist_head);
+    if (dvdRet >= 0) {
+        count = count < 0 ? dvdRet : count + dvdRet;
     }
 
     // count and process games in ul.cfg
@@ -417,15 +433,15 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
         if (count < 0)
             count = 0;
         size = getFileSize(fd);
-        *fsize = size;
+        newfsize = size;
         count += size / sizeof(USBExtreme_game_entry_t);
 
         if (count > 0) {
-            if ((*list = (base_game_info_t *)malloc(sizeof(base_game_info_t) * count)) != NULL) {
-                memset(*list, 0, sizeof(base_game_info_t) * count);
+            if ((newlist = (base_game_info_t *)malloc(sizeof(base_game_info_t) * count)) != NULL) {
+                memset(newlist, 0, sizeof(base_game_info_t) * count);
 
                 while (size > 0) {
-                    base_game_info_t *g = &(*list)[id++];
+                    base_game_info_t *g = &newlist[id++];
 
                     // populate game entry in list even if entry corrupted
                     read(fd, &GameEntry, sizeof(USBExtreme_game_entry_t));
@@ -463,17 +479,17 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
         }
         close(fd);
     } else if (count > 0) {
-        *list = (base_game_info_t *)malloc(sizeof(base_game_info_t) * count);
+        newlist = (base_game_info_t *)malloc(sizeof(base_game_info_t) * count);
     }
 
-    if (*list != NULL) {
+    if (newlist != NULL) {
         // copy the dlist into the list
         while ((id < count) && dlist_head) {
             // copy one game, advance
             struct game_list_t *cur = dlist_head;
             dlist_head = dlist_head->next;
 
-            memcpy(&(*list)[id++], &cur->gameinfo, sizeof(base_game_info_t));
+            memcpy(&newlist[id++], &cur->gameinfo, sizeof(base_game_info_t));
             free(cur);
         }
     } else
@@ -486,8 +502,18 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
         free(cur);
     }
 
-    if (count > 0)
-        *gamecount = count;
+    // TOTAL device-read failure (both dir scans failed to open AND no ul.cfg): keep the caller's
+    // current list rather than blanking it. newlist is NULL here; nothing to publish or leak.
+    if (cdRet < 0 && dvdRet < 0 && fd < 0) {
+        free(newlist);
+        return *gamecount; // *list / *gamecount / *fsize untouched -> last-good list stays on screen
+    }
+
+    // Success or genuinely-empty: publish the freshly-built list (frees the previous one).
+    free(*list);
+    *list = newlist;
+    *fsize = newfsize;
+    *gamecount = (count > 0) ? count : 0;
 
     return count;
 }


### PR DESCRIPTION
## The report (FifthFox — SCPH-70001, WOPLSDK, MMCE + MX4SIO + USB)

MMCE nav very slow, cover art randomly shows/doesn't, PS1/VCD-on-MMCE **crashed the list**, then **all MMCE lists vanished** (apps still showed), **persisting across reboot**. **Removing MX4SIO stabilized it.** Turning cover art **off made it worse**.

## Root cause (4-agent investigation, high confidence)

**MX4SIO (`mx4sio_bd`) and mmceman both drive the one physical SIO2 / memory-card bus with no arbitration**, and RiptOPL keeps both resident + active during menu browse. Two bus masters fighting one slow serial link → slow/garbled/wedged MMCE transfers. This is the *same* shared-bus conflict OPL already documents for MX4SIO↔PADEMU (`bdmsupport.c:947`, issue #53). Your "removing MX4SIO stabilized it" is the confirmation. WOPLSDK's mmceman is coherent-by-construction, so this is pure contention, not a bad driver.

## What this PR fixes (the 3 safe amplifiers; the interlock itself — part A — is deferred)

- **B — "art off made it worse".** The background device rescans were throttled *only* by the incidental `cacheHasPendingArt()` early-return in `menuUpdateHook`; with art off they ran at full ~1s cadence and hammered the contended bus. Now each `updateDelay==0` device has a **2 s minimum rescan interval** independent of art, bypassed by a real device change (new `bdmGetGeneration()`) so hotplug stays immediate.
- **C — "lists vanish, persist across reboot".** `sbReadList` blanked `*list` at entry, so a wedged scan left a permanently empty tab; and `scanForISO` **rewrote the on-disk list cache to empty** on an opendir failure (persisting a transient failure across reboots). Now `scanForISO` returns `-1` on a real opendir failure (vs `0` for readable-but-empty) *without* clobbering the cache, and `sbReadList` builds into a local and swaps only on success/genuine-empty — **preserving the last-good list on a transient device-read failure**. (This also activates the pre-existing, dead `count<0` handling as the original author intended.)
- **E — the SIO2 slot-probe drip.** `mmceSetPrefix` re-probed *both* slots every refresh under Auto. Now the resolved slot is cached (1 presence probe on a hit, and it now notices card removal), while still rebuilding the prefix from the current `gMMCEPrefix` so a settings change applies immediately.

## Deferred: D (cover cache/retry)

The one fix with a genuine correctness hazard (a no-`value` cache path could surface the *wrong* cover), and its benefit is largely subsumed by B+E reducing the contention that makes covers fail, plus the existing retry-on-scroll. Recommend testing B/C/E first and adding D only if art is still flaky.

## Verification & honest caveats

- **Hardware-only** — MMCE isn't emulable, so this is a hardware trial. Built clean in **both** `ps2dev:latest` and `ps2max/dev`.
- **3-lens adversarial review** ran and earned its keep: it caught **C being inert** (my `scanForISO`-returns-negative assumption was wrong — all fixed here) and **E's stale-prefix** regression (fixed here).
- **Known minor tradeoff (B):** a dead UDPBD *network* tab auto-hides in ~10 s instead of ~5 s (art off only); bounded and self-completing. The interval is a labeled constant to tune.
- **The key HW signal:** turning cover art **off** should no longer make MMCE navigation worse. Also worth testing: MMCE list surviving a bus wedge instead of blanking, and the MMCE prefix setting still applying live.