### PR TITLE
fix(mmce): stop the cover-art code from eating d-pad repeats (MMCE nav lag root cause)

### DIFF
--- a/src/texcache.c
+++ b/src/texcache.c
@@ -437,23 +437,25 @@ static int cacheIsAbortableMmceRequest(load_image_request_t *req)
     return req != NULL && req->priority == CACHE_REQ_PRIORITY_INTERACTIVE && req->effectiveMode == MMCE_MODE;
 }
 
-static int cacheShouldDiscardCompletedRequestLocked(load_image_request_t *req)
-{
-    return cacheIsAbortableMmceRequest(req) && req->generation != gCacheGeneration;
-}
 
 static int cacheIsNavigationActive(void)
 {
-    /* getKey() mutates shared pad-repeat state, so only the GUI thread may call
-     * it. The art worker (which reaches here via cacheShouldDeferInteractiveArtOnInput
-     * while dequeuing) reads the most recent GUI-thread snapshot instead. The GUI
-     * thread evaluates this every frame while drawing the MMCE cover, keeping the
-     * snapshot fresh. */
+    /* Use getKeyPressed() (a pure `paddata & mask` read), NOT getKey(): getKey() CONSUMES
+     * the button-repeat -- it resets delaycnt when a repeat fires (pad.c). This runs on the
+     * GUI thread while DRAWING the MMCE cover, which happens BEFORE the input handler in the
+     * SAME frame, so getKey() here stole the held-d-pad repeat from menuNextV/menuPrevV and
+     * the MMCE cursor failed to advance while scrolling (the "MMCE nav is laggy / not working"
+     * report -- MMCE-only because only MMCE reaches this defer path). getKeyPressed() reads the
+     * raw held state with no side effects, so the cursor advances normally AND the snapshot
+     * stays true for the WHOLE hold (not just repeat-fire frames), keeping interactive MMCE
+     * cover reads correctly deferred off the SIO2 bus during a scroll. The art worker still
+     * reads the snapshot; getKeyPressed is side-effect free so the thread guard below is no
+     * longer strictly required, but is kept unchanged. */
     if (gArtThreadId >= 0 && GetThreadId() == gArtThreadId)
         return gNavInputActive;
 
-    gNavInputActive = (getKey(KEY_LEFT) || getKey(KEY_RIGHT) || getKey(KEY_UP) ||
-                       getKey(KEY_DOWN) || getKey(KEY_L1) || getKey(KEY_R1));
+    gNavInputActive = (getKeyPressed(KEY_LEFT) || getKeyPressed(KEY_RIGHT) || getKeyPressed(KEY_UP) ||
+                       getKeyPressed(KEY_DOWN) || getKeyPressed(KEY_L1) || getKeyPressed(KEY_R1));
     return gNavInputActive;
 }
 
@@ -839,7 +841,13 @@ static void cacheCompleteRequest(load_image_request_t *req, int result)
         req->entry->qr = NULL;
         req->entry->primeFrame = -1;
 
-        if (result == ERR_LOAD_ABORTED || cacheShouldDiscardCompletedRequestLocked(req)) {
+        // Only a genuinely ABORTED read is discarded. A read that COMPLETES is stored even if the
+        // cursor moved during it (generation advanced): the 844 guard already proved this entry still
+        // belongs to THIS request (qr==req && UID==cacheUID, and UIDs are monotonic per request), so
+        // the texture can only ever be shown for its own item. Discarding a finished cover just because
+        // the user scrolled forced a full re-read on the slow MMCE link when they scrolled back -- the
+        // "MMCE covers never stick / pop in and out" churn.
+        if (result == ERR_LOAD_ABORTED) {
             cacheClearItem(req->entry, 0);
         } else if (result < 0 || req->texture.Mem == NULL) {
             req->entry->lastUsed = 0;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -842,8 +842,8 @@ static void cacheCompleteRequest(load_image_request_t *req, int result)
         req->entry->primeFrame = -1;
 
         // Only a genuinely ABORTED read is discarded. A read that COMPLETES is stored even if the
-        // cursor moved during it (generation advanced): the 844 guard already proved this entry still
-        // belongs to THIS request (qr==req && UID==cacheUID, and UIDs are monotonic per request), so
+        // cursor moved during it (generation advanced): the enclosing guard above already proved this
+        // entry still belongs to THIS request (qr==req && UID==cacheUID, and UIDs are monotonic per request), so
         // the texture can only ever be shown for its own item. Discarding a finished cover just because
         // the user scrolled forced a full re-read on the slow MMCE link when they scrolled back -- the
         // "MMCE covers never stick / pop in and out" churn.


### PR DESCRIPTION
## The bug, in one line

The cover-art code was **eating your d-pad scroll inputs** on the MMCE page.

## How we got here

After B/C/E ([PR #110](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/110), Beta-3027), MMCE navigation was still *"inconsistent, laggy, buffery, not working as intended"* — but **other pages were fine**, and crucially, **turning cover art OFF made MMCE navigation smooth.** That `art-off = smooth` test pinned it on the cover-art path, and a 3-agent investigation found the exact mechanism.

## Root cause: input theft

To decide whether to defer interactive art while you scroll, `cacheIsNavigationActive()` called **`getKey()`** — but `getKey()` **consumes the button-repeat** (it resets `delaycnt` when a repeat fires). This runs on the GUI thread **while drawing the MMCE cover, which happens *before* the input handler in the same frame**. So the render-time `getKey()` stole the held-d-pad repeat, and `menuNextV`/`menuPrevV` then saw `getKey()==0` — **the cursor didn't advance while scrolling.**

- **MMCE-exclusive** because only MMCE reaches the defer path (`cacheShouldDeferInteractiveArtOnInput` gates on `effectiveMode==MMCE_MODE`) — which is exactly why every other page navigated fine.
- The old comment guarded the *cross-thread* hazard of `getKey()` but missed the *same-thread, same-frame* render-before-input ordering.

## The fix (two surgical changes)

1. **`getKey()` → `getKeyPressed()`** (a pure `paddata & mask` read, no side effects). The cursor advances normally again, and because it reflects the *raw held state* (not just repeat-fire frames), interactive MMCE cover reads stay deferred off the SIO2 bus for the whole scroll. **This should also fix "Apps loads forever"** — the mid-scroll MMCE reads were holding the single fileXio channel the Apps-list build needs.
2. **Stop discarding completed covers** (the "pop in/out, never stick" churn). A finished cover was thrown away if the cursor moved during the read → full re-read on the slow link. The existing guard (`entry->qr==req && entry->UID==req->cacheUID`, UIDs monotonic per request) already proves the texture can only be shown for its own item, so caching a completed read is safe. Removes the now-unused helper.

## Verification & caveats

- **Hardware-only** — MMCE isn't emulable and the defer path is MMCE-mode-gated. Built clean in **both** `ps2dev:latest` and `ps2max/dev`.
- **Not a regression** from B/C/E — this path is pre-existing and untouched by them.
- **Key HW signal:** with cover art **ON**, the MMCE cursor should scroll normally and covers should **stick** instead of popping in and out; the Apps page should load.
- Follow-ups still available if needed after testing: re-enable idle MMCE neighbor-prefetch, raise the MMCE art-load priority (further fileXio relief), tune the after-stop cover latency, and the deferred MX4SIO↔mmceman interlock (part A).