### PR TITLE
fix(mmce): 7 confirmed fixes from the MMCE subsystem audit (art-not-loading root cause + inert priority throttle)

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -798,6 +798,12 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
     mmceSendGameID(game->startup, neutrinoPath,
                    (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0));
 
+    // game->startup lives inside bdmGames / gAutoLaunchBDMGame, both freed below (deinitEx's
+    // itemCleanUp, or the explicit free in the autolaunch branch). Copy it before the teardown so
+    // sysLaunchNeutrino's -elf build reads valid stack memory instead of freed heap (UAF).
+    char bdmStartup[GAME_STARTUP_MAX + 1];
+    snprintf(bdmStartup, sizeof(bdmStartup), "%s", game->startup);
+
     if (gAutoLaunchBDMGame == NULL) {
         // Keep-IOP handoff: keep BOTH the game device and the neutrino.elf device mounted
         // (Neutrino reads its -cwd config/modules and the ISO through our mounts pre-reset).
@@ -813,7 +819,7 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
 
     // gPS2Logo passes the user's preference straight through: Neutrino performs its own logo
     // read/validation for -logo, so the native path's CheckPS2Logo disc pass is not needed here.
-    sysLaunchNeutrino(bdmCurrentDriver, partname, game->startup, compatmask, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, neutrinoBsdfs, &neutrinoVmc);
+    sysLaunchNeutrino(bdmCurrentDriver, partname, bdmStartup, compatmask, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, neutrinoBsdfs, &neutrinoVmc);
     return 1;
 
 fail:

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -718,6 +718,11 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
     // MMCE cross-device game-id (#261); HDD emits no -mc args (VMC->neutrino deferred), mask 0.
     mmceSendGameID(game->startup, neutrinoPath, 0);
 
+    // game->startup lives in hddGames / gAutoLaunchGame, freed below (deinitEx's itemCleanUp or the
+    // explicit free). Copy it before the teardown so sysLaunchNeutrino's -elf build is not a UAF read.
+    char apaStartup[sizeof(game->startup)];
+    snprintf(apaStartup, sizeof(apaStartup), "%s", game->startup);
+
     if (gAutoLaunchGame == NULL) {
         // Keep-IOP handoff: keep the HDD stack up (NHDDL hands off with its full ATA stack
         // resident) AND the neutrino.elf device (-cwd config/module reads).
@@ -733,7 +738,7 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
 
     LOG("[NEUTRINO] apa partition_name=[%s]\n", apaPart);
     // gPS2Logo passes the preference straight through (Neutrino does its own logo work).
-    sysLaunchNeutrino("apa", apaPart, game->startup, compatMode, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11 inert: APA is always -bsdfs=hdl */, NULL /* HDD VMC->neutrino deferred (APA/pfs) */);
+    sysLaunchNeutrino("apa", apaPart, apaStartup, compatMode, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11 inert: APA is always -bsdfs=hdl */, NULL /* HDD VMC->neutrino deferred (APA/pfs) */);
     return 1;
 }
 

--- a/src/ioman.c
+++ b/src/ioman.c
@@ -371,7 +371,12 @@ int ioBlockOpsTimed(int block, int timeoutTicks)
         isIOBlocked = 1;
 
         ThreadID = GetThreadId();
-        int haveStatus = (ReferThreadStatus(ThreadID, &status) == 0);
+        // EE ReferThreadStatus() returns the thread status (>= 0) or a negative error, NOT 0 on
+        // success (that is the IOP thbase variant). The old `== 0` test was always false, so
+        // haveStatus was always 0 and the saved priority below was never restored -- every
+        // ioBlockOps(1) caller left this (usually the main GUI) thread pinned at priority 90 for
+        // the rest of the session. `>= 0` is the correct success test.
+        int haveStatus = (ReferThreadStatus(ThreadID, &status) >= 0);
         ChangeThreadPriority(ThreadID, 90);
 
         // Wait for the in-flight IO handler(s) to finish. timeoutTicks < 0 waits

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -33,6 +33,11 @@ static base_game_info_t *mmceGames;
 // -1=unresolved). Avoids re-probing BOTH slots over SIO2 every menu refresh -- that steady devctl
 // drip contends with MX4SIO on the shared bus. Reset by mmceInit (tab re-enable / settings apply).
 static int mmceResolvedDevice = -1;
+// sbCreateFolders() issues ~10 mkdir devctls; on an mmceN: card each is an SIO2 round-trip that
+// contends with MX4SIO. Remember the prefix we last created folders for so a refresh on an unchanged
+// card/slot skips the redundant burst (mirrors BDM's FoldersCreated one-shot). Reset by mmceInit and
+// on card removal (empty prefix) so a freshly inserted card still gets its folders.
+static char mmceFoldersCreatedFor[40] = {0};
 
 // Card-switch wait: poll the MMCE busy bit every 500 ms for up to ~7.5 s, matching mmceman's own
 // switch handshake. On a CROSS-DEVICE launch (a USB/HDD/SMB game whose per-game card lives on the
@@ -292,6 +297,7 @@ void mmceInit(item_list_t *itemList)
     mmceGameCount = 0;
     mmceGames = NULL;
     mmceResolvedDevice = -1; // re-detect the Auto slot on a fresh init (tab re-enable / settings apply)
+    mmceFoldersCreatedFor[0] = '\0';
 
     configGetInt(configGetByType(CONFIG_OPL), "usb_frames_delay", &mmceGameList.delay);
     mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
@@ -323,6 +329,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
 
     if (mmcePrefix[0] == '\0') {
         mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
+        mmceFoldersCreatedFor[0] = '\0'; // card gone: recreate folders on the next (possibly different) card
         return (mmceGameCount > 0);
     }
 
@@ -334,8 +341,15 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     if (vcdViewActive(itemList->mode))
         return 0;
 
-    if (mmceULSizePrev == -2)
+    if (mmceULSizePrev == -2) {
+        // First scan not yet successful. If it wedges on a contended SIO2 bus, sbReadList leaves
+        // mmceULSizePrev at its -2 sentinel and the tab stays empty; the NOUPDATE latch above would
+        // then strand it with no auto-retry (the reported "all MMCE lists vanished"). Keep the ~2s
+        // background retry alive until a scan populates the list -- a genuinely-empty readable card
+        // sets mmceULSizePrev via *fsize, so this still quiesces once the bus is readable.
+        mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
         result = 1;
+    }
 
     sprintf(path, "%sCD", mmcePrefix);
     if (stat(path, &st) != 0)
@@ -372,15 +386,31 @@ static int mmceNeedsUpdate(item_list_t *itemList)
             LanguagesLoaded = 1;
     }
 
-    sbCreateFolders(mmcePrefix, 1);
+    // Create the library folders once per card/slot, not on every refresh (each is an SIO2 mkdir).
+    if (strcmp(mmceFoldersCreatedFor, mmcePrefix) != 0) {
+        sbCreateFolders(mmcePrefix, 1);
+        snprintf(mmceFoldersCreatedFor, sizeof(mmceFoldersCreatedFor), "%s", mmcePrefix);
+    }
 
     return result;
 }
 
 static int mmceUpdateGameList(item_list_t *itemList)
 {
-    if (mmcePrefix[0] == '\0')
-        return mmceGameCount;
+    if (mmcePrefix[0] == '\0') {
+        // Card absent / slot unresolved (Auto mode after removal). Actually CLEAR the list rather
+        // than returning the stale count: mmceNeedsUpdate keeps reporting "update needed" while
+        // mmceGameCount > 0, so returning the stale count here leaves the removed card's games on
+        // screen and spins a menu-rebuild + apps-rescan + favourites-reload loop every ~2s. Freeing
+        // lets updateMenuFromGameList empty the menu and drives needsUpdate's (count > 0) test to 0.
+        if (mmceGames != NULL) {
+            free(mmceGames);
+            mmceGames = NULL;
+        }
+        mmceGameCount = 0;
+        mmceULSizePrev = -2; // force a fresh scan when a card returns
+        return 0;
+    }
 
     if (vcdViewActive(itemList->mode))
         mmceGameCount = vcdFillGameList(mmcePrefix, &mmceGames);
@@ -645,6 +675,11 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     if (coreLoader) {
         char mmcePartname[256];
         snprintf(mmcePartname, sizeof(mmcePartname), "%s", partname); // defensive copy across the deinit teardown (partname is a stack buffer, not freed by deinit)
+        // game (== &mmceGames[id]) is freed by deinitEx() below (moduleCleanup -> mmceCleanUp frees
+        // mmceGames), but sysLaunchNeutrino still reads game->startup afterwards to build its -elf
+        // argument -- a use-after-free read. Copy startup onto this stack frame like mmcePartname.
+        char mmceStartup[GAME_STARTUP_MAX + 1];
+        snprintf(mmceStartup, sizeof(mmceStartup), "%s", game->startup);
         // Neutrino bypasses OPL's mcemu, so the VMC fds opened above go unused on this path --
         // close them instead of leaking until the IOP reset (B3). Closed BEFORE the GameID push
         // below (Beta-2947 hardware report): the 0x8 switch physically re-mounts the card, and
@@ -714,7 +749,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
             return;
         int neutrinoDevMode = oplPath2Mode(neutrinoPath);
         deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode);
-        sysLaunchNeutrino("mmce", mmcePartname, game->startup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: mmce is fileid, no fs layer */, &neutrinoVmc);
+        sysLaunchNeutrino("mmce", mmcePartname, mmceStartup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: mmce is fileid, no fs layer */, &neutrinoVmc);
         return;
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1379,6 +1379,14 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_ENABLE_ART_TAR, &gEnableArtTar);
             configGetInt(configOPL, CONFIG_OPL_WIDESCREEN, &gWideScreen);
             configGetInt(configOPL, CONFIG_OPL_DEFAULT_GAME_VIEW, &gDefaultGameView);
+            // A boot default-view locked to one type (VCD or ISO) must force the same one-shot
+            // rescan the settings dialog does on a view change (gui.c). Without it, vcdViewActive()
+            // short-circuits mmce/bdm/hdd/eth NeedsUpdate before the initial-scan trigger and the
+            // list stays blank on boot -- a manual SELECT does not recover it (NeedsUpdate still
+            // returns 0), only re-toggling the view does. This runs before applyConfig()'s first
+            // support scans, so each VCD-capable page consumes the dirty flag on its first refresh.
+            if (gDefaultGameView != GAME_VIEW_BOTH)
+                vcdMarkAllDirty();
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, &gCoverflowCount);
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_SCALE, &gCoverflowCenterScale);
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_ANIM, &gCoverflowAnimSpeed);

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -85,7 +85,6 @@ enum {
 
 #define CACHE_SLOW_MODE_INTERACTIVE_DELAY 4
 #define CACHE_MMCE_INTERACTIVE_MAX_DELAY  12
-#define CACHE_MMCE_INTERACTIVE_DEBOUNCE   2
 #define CACHE_APP_INTERACTIVE_MAX_DELAY   4
 #define CACHE_APP_PREFETCH_DELAY          10
 #define CACHE_PRIME_IDLE_DELAY            12
@@ -113,8 +112,6 @@ static int gArtActiveCount = 0;
 static int gArtInteractiveActiveCount = 0;
 static int gCacheGeneration = 1;
 static load_image_request_t *gArtCurrentReq = NULL;
-static int gMmceInteractiveDebounceUntilFrame = -1;
-static char gMmceInteractiveDebounceValue[64];
 /* Navigation-active snapshot. getKey() mutates GUI-thread-only pad-repeat state,
  * so the art worker thread must not call it; the GUI thread refreshes this flag
  * (via cacheIsNavigationActive) each frame and the worker reads the snapshot. */
@@ -172,7 +169,12 @@ int cacheLowerCallerPriority(void)
     int callerPriority = -1;
 
     memset(&status, 0, sizeof(status));
-    if (ReferThreadStatus(GetThreadId(), &status) == 0) {
+    /* EE ReferThreadStatus() returns the thread STATUS (THS_RUN=1 for the running thread that
+     * GetThreadId() names here), or a negative error -- it does NOT return 0 on success (that is
+     * the IOP thbase variant). The old `== 0` guard was therefore ALWAYS false, so this function
+     * never actually lowered the caller and always returned -1: the #45/#111 priority handoff was
+     * silently inert. `>= 0` is the correct success test. */
+    if (ReferThreadStatus(GetThreadId(), &status) >= 0) {
         callerPriority = status.current_priority;
         if (callerPriority < CACHE_MMCE_LOAD_THREAD_PRIORITY + 1)
             ChangeThreadPriority(GetThreadId(), CACHE_MMCE_LOAD_THREAD_PRIORITY + 1);
@@ -300,8 +302,6 @@ static void cacheResetRequestTrackingLocked(void)
     gArtInteractiveReqEnd = NULL;
     gArtPrefetchReqList = NULL;
     gArtPrefetchReqEnd = NULL;
-    gMmceInteractiveDebounceUntilFrame = -1;
-    gMmceInteractiveDebounceValue[0] = '\0';
     gArtQueuedCount = 0;
     gArtActiveCount = 0;
     gArtInteractiveActiveCount = 0;
@@ -488,20 +488,6 @@ static void cacheDropQueuedInteractiveMmceDifferentValueLocked(const char *value
         if (req->effectiveMode == MMCE_MODE && strcmp(req->value, value) != 0)
             cacheDropQueuedRequestLocked(req);
     }
-}
-
-static int cacheShouldDebounceMmceInteractiveLocked(int effectiveMode, const char *value)
-{
-    if (effectiveMode != MMCE_MODE || value == NULL)
-        return 0;
-
-    if (strcmp(gMmceInteractiveDebounceValue, value) != 0) {
-        snprintf(gMmceInteractiveDebounceValue, sizeof(gMmceInteractiveDebounceValue), "%s", value);
-        gMmceInteractiveDebounceUntilFrame = guiFrameId + CACHE_MMCE_INTERACTIVE_DEBOUNCE;
-        return 1;
-    }
-
-    return guiFrameId < gMmceInteractiveDebounceUntilFrame;
 }
 
 static int cacheGetLoadThreadPriority(const load_image_request_t *req)
@@ -901,7 +887,11 @@ static void cacheLoadImage(load_image_request_t *req)
     threadId = GetThreadId();
     loadPriority = cacheGetLoadThreadPriority(req);
     memset(&status, 0, sizeof(status));
-    if (ReferThreadStatus(threadId, &status) == 0) {
+    /* EE ReferThreadStatus() returns the thread status (>= 0) or a negative error, not 0-on-success
+     * -- see cacheLowerCallerPriority(). The old `== 0` guard was always false, so the art worker
+     * was never re-prioritized to its per-mode load priority (0x5A for MMCE / 0x38 for APP) and
+     * stayed at the default 0x40 -- i.e. the whole MMCE read deprioritization was inert. */
+    if (ReferThreadStatus(threadId, &status) >= 0) {
         originalPriority = status.current_priority;
         if (originalPriority != loadPriority)
             ChangeThreadPriority(threadId, loadPriority);
@@ -968,8 +958,6 @@ void cacheInit()
     gArtInteractiveReqEnd = NULL;
     gArtPrefetchReqList = NULL;
     gArtPrefetchReqEnd = NULL;
-    gMmceInteractiveDebounceUntilFrame = -1;
-    gMmceInteractiveDebounceValue[0] = '\0';
 
     gArtSema.init_count = 1;
     gArtSema.max_count = 1;
@@ -1442,8 +1430,19 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     }
 
     if (priority == CACHE_REQ_PRIORITY_INTERACTIVE) {
-        if (cacheShouldDeferInteractiveArtOnInput(list, value) ||
-            cacheShouldDebounceMmceInteractiveLocked(effectiveMode, value)) {
+        /* The MMCE interactive-art debounce that used to sit here keyed its whole state on a
+         * single process-wide (value, until-frame) pair, so ANY frame that drew more than one
+         * distinct MMCE value (a coverflow carousel draws ~10 covers/frame; an attribute-art
+         * theme draws the cover plus #System/#Media/#DiscType) had every value overwrite the
+         * global left by the previous draw, re-arm the window, and return "defer" -- so no MMCE
+         * cover was ever enqueued and art never loaded on those themes. It was also redundant:
+         * the interactive settle is already enforced below by guiInactiveFrames < delay (4-12
+         * MMCE frames) and, during an active scroll, by cacheShouldDeferInteractiveArtOnInput.
+         * The 2-frame debounce window was strictly shorter than that settle, so its only
+         * distinct effect was to block a cover that scrolled into view while the user was
+         * already settled -- exactly when it should load. Removed; the two gates below are the
+         * complete throttle. */
+        if (cacheShouldDeferInteractiveArtOnInput(list, value)) {
             cacheUnlock();
             return NULL;
         }


### PR DESCRIPTION
## MMCE subsystem audit — the 7 CONFIRMED fixes

Output of an exhaustive, adversarially-verified audit of the MMCE subsystem (prompted by the "cover art wasn't loading **at all**" report). Every fix here is a finding that survived verification against the actual code; the PLAUSIBLE/HW-dependent findings are queued separately (listed at the bottom). Both containers build clean (WOPLSDK + PS2DEVLATESTSDK), clang-format clean, zero new warnings.

### The headline — why art didn't load at all
**① Single-global MMCE art debounce (BLOCKER).** `cacheShouldDebounceMmceInteractiveLocked` keyed its debounce on one process-wide `(value, until-frame)` pair. Any frame drawing >1 distinct MMCE value — a **coverflow** carousel (~10 covers/frame) or an **attribute-art theme** (cover + `#System`/`#Media`/`#DiscType`) — had every value overwrite the global, re-arm the window, and return "defer", so **no MMCE cover was ever enqueued**. The default theme draws one value/frame, which is exactly why art worked there and on USB/HDD but never on coverflow/attribute themes. It was also redundant with the `guiInactiveFrames` settle (4–12 frames) + the input-active defer, both strictly longer than the 2-frame window. Removed. → *covers now load.*

**② EE `ReferThreadStatus() == 0` was always false (MAJOR, fork-wide).** EE returns the thread **status** (`THS_RUN=1` for the running thread), not 0-on-success (that's the IOP variant). Confirmed against `ee/include/kernel.h`. The `== 0` guards (from ba82e47e) never ran, so **the entire MMCE art-priority throttle and the #45/#111 priority-inversion mitigations were inert** — MMCE reads fought MX4SIO/mmceman on SIO2 exactly as if unthrottled (why removing MX4SIO helped), and `ioBlockOps` pinned the GUI thread at priority 90 all session. Fixed to `>= 0` at all three sites.

> ①+② together explain the whole report: ① = covers never appear on coverflow; ② = even when they load, the bus-relief never engaged. #111 (input-steal) stands; its complementary priority relief needed ②.

### The rest (all CONFIRMED)
| Fix | Symptom it addresses |
|-----|----------------------|
| **③** Clear the stale list on Auto-slot card removal | Removed card's games stayed on screen + a menu-rebuild/apps-rescan/favourites-reload loop every ~2s (regression from part E) |
| **④** Force the boot rescan when Default Game View is locked | VCD-locked PS1 list **blank on boot**, SELECT didn't recover it |
| **⑤** Retry a wedged first MMCE scan | Empty tab with no auto-retry on a contended-bus first scan ("all MMCE lists vanished") |
| **⑥** Latch folder creation per card/slot | 10 redundant `mkdir` devctls on the shared SIO2 bus every refresh |
| **⑦** Copy `game->startup` before deinit (mmce + bdm + hdd) | Use-after-free read in the Neutrino `-elf` build (default-off `neutrino_elf_arg=1`) |

### Hardware test (WOPLSDK)
1. **MMCE cover art actually appears on a coverflow / attribute-art theme** — the headline.
2. With MX4SIO also installed, MMCE nav should be materially smoother (throttle now live).
3. Auto slot: pull the card → the list clears (no frozen stale games, no 2s churn).
4. Default Game View = VCD → the PS1 list populates on boot without a manual refresh.

### Not in this PR (queued, PLAUSIBLE / needs HW)
FAILED covers never auto-retry (texcache analog of the #110 C list fix); launch-time `cacheEnd(1)` can wedge the fileXio RPC channel; VMC page r/w swallow driver errors (save-corruption risk); coverflow deprioritizes the center cover; `mmceModLoaded` latched before load succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
