### PR TITLE
ci(rolling): trim the MEGA archive to the installable payload (~233MB -> ~22MB)

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -750,12 +750,30 @@ jobs:
 
           # Build the archive OUTSIDE rolling/ (requirement): if it lived in rolling/ it could zip
           # itself and, worse, be swept into the GitHub release by `gh release upload rolling/*`.
-          # Publish already ran, so rolling/ holds EXACTLY the set uploaded to the GitHub release --
-          # archive all of it (ELFs, every release zip, SHA256SUMS.txt, IRX manifests, src snapshot,
-          # and anything else present) at the archive root.
+          #
+          # Archive the INSTALLABLE + REPRODUCIBLE payload only. The two big diagnostic BUNDLES are
+          # deliberately EXCLUDED from the permanent MEGA copy:
+          #   RIPTOPL-VARIANTS-*.zip  (~120 MB -- every EXTRA_FEATURES x PADEMU combo x 3 SDKs)
+          #   RIPTOPL-DEBUG-*.zip     (~91 MB  -- iopcore/ingame/eesio/ppctty/DTL debug builds x 3 SDKs)
+          # They dominate the size (~10x: ~233 MB -> ~22 MB), they still ship on the GitHub rolling
+          # release for the CURRENT build, and a *permanent* per-build archive is for restoring or
+          # rebuilding an installable build -- not for old diagnostic permutations (when you debug,
+          # it is almost always the current build). Everything a restorer needs is kept: the
+          # installable package zip, the bare loader ELFs, the source snapshot, SHA256SUMS.txt, the
+          # IRX manifests and the language pack.
           rm -rf mega-out
           mkdir -p mega-out
-          ( cd rolling && zip -r -X "../mega-out/${ARCHIVE}" . >/dev/null )
+          MEGA_FILES=""
+          for f in rolling/*; do
+            b="$(basename "$f")"
+            case "$b" in
+              RIPTOPL-VARIANTS-*.zip|RIPTOPL-DEBUG-*.zip)
+                echo "MEGA archive: excluding diagnostic bundle $b" ;;
+              *)
+                MEGA_FILES="$MEGA_FILES $b" ;;
+            esac
+          done
+          ( cd rolling && zip -r -X "../mega-out/${ARCHIVE}" $MEGA_FILES >/dev/null )
 
           echo "MEGA_ARCHIVE=mega-out/${ARCHIVE}" >> "$GITHUB_ENV"
           # Suggested layout: /RiptOPL/Rolling/<version>/run_<run number>/ -- run number keeps every

--- a/README.md
+++ b/README.md
@@ -252,8 +252,9 @@ contains and how to pull it.
 
 > 🗄️ **Permanent archive (MEGA):** the GitHub `rolling` pre-release only ever holds the *latest*
 > build — every push overwrites it. So **every** rolling build is also archived permanently to MEGA
-> as one self-contained zip of the full release payload (all three loader ELFs, the installable
-> package zip, the source snapshot, `SHA256SUMS.txt`, and the IRX manifests). Click the **MEGA**
+> as one self-contained zip of the installable payload (all three loader ELFs, the installable
+> package zip, the source snapshot, `SHA256SUMS.txt`, and the IRX manifests — the large VARIANTS
+> and DEBUG diagnostic bundles stay on the GitHub release only). Click the **MEGA**
 > badge at the top of this README — or [browse the archive here](https://mega.nz/folder/74pRHKRB#9SLDkrkvZAbeKO4Qvxg9LQ) —
 > to fetch any past build. Each is stored immutably under `RiptOPL/Rolling/<version>/run_<number>/`,
 > so nothing is ever overwritten.


### PR DESCRIPTION
## Why
The first MEGA-enabled rolling build produced a **~233 MB** archive. Breakdown:

| Entry | Size |
|---|---|
| `RIPTOPL-VARIANTS-*.zip` (EXTRA_FEATURES × PADEMU × 3 SDKs) | ~120 MB |
| `RIPTOPL-DEBUG-*.zip` (debug builds × 3 SDKs) | ~91 MB |
| installable package zip + bare ELFs + source + checksums + manifests + langs | ~22 MB |

So ~90% of the permanent, immutable, one-per-push archive was diagnostic build permutations almost nobody restores from an *old* build. At 233 MB/build that fills a 20 GB MEGA tier in ~85 builds.

## Change
Exclude `RIPTOPL-VARIANTS-*.zip` and `RIPTOPL-DEBUG-*.zip` from the MEGA archive only. They **still ship on the GitHub rolling release** for the current build — they're just not archived to MEGA forever. Everything a person restoring/rebuilding an old build needs is kept: the installable package zip, the bare loader ELFs, the source snapshot, `SHA256SUMS.txt`, the IRX manifests, and the language pack.

Result: **~233 MB → ~22 MB** (~10× smaller, MEGA lasts ~10× longer). GitHub release behavior is unchanged; the `unzip -l` in the archive step will show the reduced set on the next master build. README's Archive blurb updated to say "installable payload" and note the bundles stay on the GitHub release only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
