### PR TITLE
feat(vcd): full art on VCD/favourite info pages + multi-disc hiding (fixes #118)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -108,7 +108,8 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_POPSTARTER_DEVICE    "popstarter_device" // device TYPE holding POPS/POPSTARTER.ELF (POPS_DEV_*)
 #define CONFIG_OPL_BDMA_SOURCE          "bdma_source"
 #define CONFIG_OPL_BDMA_APPLY           "bdma_apply_launch"
-#define CONFIG_OPL_VCD_HIDE_GAMEID      "vcd_hide_gameid" // display-only: hide a leading PS1 game-ID prefix from the VCD list
+#define CONFIG_OPL_VCD_HIDE_GAMEID      "vcd_hide_gameid"     // display-only: hide a leading PS1 game-ID prefix from the VCD list
+#define CONFIG_OPL_VCD_FIRST_DISC_ONLY  "vcd_first_disc_only" // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists
 #define CONFIG_OPL_WRITE_POPS_NET       "write_popstarter_net"
 #define CONFIG_OPL_HDD_GAME_LIST_CACHE  "hdd_game_list_cache"
 #define CONFIG_OPL_EXIT_PATH            "exit_path"

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -88,7 +88,8 @@ enum UI_ITEMS {
     CFG_BDMASOURCE,
     CFG_LBL_BDMAMODE,
     CFG_BDMAMODE,
-    CFG_VCD_HIDE_GAMEID, // display-only: hide a leading PS1 game-ID prefix from the VCD list
+    CFG_VCD_HIDE_GAMEID,     // display-only: hide a leading PS1 game-ID prefix from the VCD list
+    CFG_VCD_FIRST_DISC_ONLY, // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists
 
     CFG_XSENSITIVITY,
     CFG_YSENSITIVITY,

--- a/include/opl.h
+++ b/include/opl.h
@@ -265,6 +265,7 @@ extern int gBdmaSource;         // BDMA SOURCE device family (VCD_BDMA_SRC_*); p
 extern int gBdmaMode;           // BDMA MODE mirrored from the mc?:/POPSTARTER/ marker (VCD_BDMA_*)
 extern int gBdmaApplyOnLaunch;  // auto-equip the launched VCD's matching exFAT driver before boot (1=on)
 extern int gVcdHideGameId;      // display-only: hide a leading PS1 game-ID prefix from the VCD list (1=on, default off)
+extern int gVcdFirstDiscOnly;   // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists (1=on, default off)
 extern int gWritePopstarterNet; // mirror network settings into POPSTARTER's IPCONFIG/SMBCONFIG on save
 // Enable Debug Colors
 extern int gEnableDebug;

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -63,12 +63,19 @@ void vcdMarkAllDirty(void);
 // Fill a base_game_info_t list (memalign'd like sbReadList; frees *outGames first) from
 // <devPrefix>POPS/*.VCD. Returns the count. name = VCD basename, startup = PS1 id (or "" = no art).
 int vcdFillGameList(const char *devPrefix, base_game_info_t **outGames);
+// #118: 1 if a .VCD filename is disc 2+ of a multi-disc PS1 set ("(Disc N)"/"(CD N)"/"(Disk N)", N>=2,
+// case-insensitive). Callers hide it from the device lists when gVcdFirstDiscOnly is on.
+int vcdIsHiddenDisc(const char *name);
 
 // 3-level cover/icon fallback for a VCD game: ID-keyed OPL art -> name-keyed OPL art -> POPSLoader's
 // next-to-VCD "<dev>/POPS/<name>.png". Call from a support's getImage for VCD games + "COV"/"ICO". `sep`
 // matches the device prefix ('/' local/MMCE/HDD, '\\' SMB); popsDir e.g. "POPS" (NULL skips step 3).
 // Returns the first texDiscoverLoad hit (>= 0), else the last miss.
 int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const char *value, const char *suffix, const char *popsDir, GSTEXTURE *tex);
+// popsDir to pass vcdLoadArt for a given art suffix: "POPS" for COV/ICO (POPSLoader interop), NULL
+// otherwise (BG/logo/screenshot must not fall to the suffix-less cover image). Shared so every VCD
+// getImage branch and favGetImage resolve the same art (issue #118).
+const char *vcdArtPopsDir(const char *suffix);
 
 // ---- safe memory-card copy (free-space gated) -------------------------------------
 // Used by the BDMA/SMB module equip + the POPSTARTER config writers so a full or interrupted

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -957,3 +957,7 @@ gui_strings:
   string: Hide PS1 Game ID (VCD list)
 - label: HINT_VCD_HIDE_GAMEID
   string: Cosmetic only -- hide a leading game-ID prefix (e.g. SLUS_005.51.) from PS1/VCD list names. Names without an ID are shown as-is. Does not change launch, cover art, or favourites.
+- label: VCD_FIRST_DISC
+  string: First disc only (multi-disc PS1)
+- label: HINT_VCD_FIRST_DISC
+  string: Show only Disc 1 of a multi-disc PS1 game in the device lists (POPSLoader style). Hides files named (Disc 2), (CD 2), etc. All discs stay on the card for in-game swapping; Favourites are not filtered.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1146,13 +1146,15 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    // VCD (PS1) covers: fall back disc-id -> filename -> POPSLoader's next-to-VCD <dev>/POPS/<name>.png
-    // so a cover a POPSLoader user already has is found. Local devices use '/'. Root-anchored like the
-    // VCD scan itself (the POPS layout lives at the device root, outside any gBDMPrefix library folder).
-    if (isRelative && vcdViewActive(itemList->mode) && (!strcmp(suffix, "COV") || !strcmp(suffix, "ICO"))) {
+    // VCD (PS1) art (issue #118: ALL suffixes -- cover, background, logo, screenshot -- not just cover):
+    // disc-id -> filename in <dev>ART/, then the cover/icon-only POPSLoader next-to-VCD fallback
+    // (vcdArtPopsDir gives "POPS" for COV/ICO, NULL for BG/SCR so those never render the cover). Local
+    // devices use '/'. Root-anchored like the VCD scan (POPS layout lives at the device root, outside
+    // gBDMPrefix). AttributeImage glyphs are absolute (isRelative==0) so they stay out.
+    if (isRelative && vcdViewActive(itemList->mode)) {
         char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
         bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
-        return vcdLoadArt(vcdPrefix, '/', folder, value, suffix, "POPS", resultTex);
+        return vcdLoadArt(vcdPrefix, '/', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
     }
 
     if (isRelative)

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -197,6 +197,10 @@ struct UIItem diaConfig[] = {
     {UI_SPACER},
     {UI_BOOL, CFG_VCD_HIDE_GAMEID, 1, 1, _STR_HINT_VCD_HIDE_GAMEID, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_FIRST_DISC}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_VCD_FIRST_DISC_ONLY, 1, 1, _STR_HINT_VCD_FIRST_DISC, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_WRITE}}},
     {UI_SPACER},

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -801,10 +801,10 @@ static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char
 {
     char path[256];
 
-    // VCD (PS1) covers: fall back disc-id -> filename -> POPSLoader's next-to-VCD <share>\POPS\<name>.png.
-    // SMB paths use a backslash separator.
-    if (isRelative && vcdViewActive(itemList->mode) && (!strcmp(suffix, "COV") || !strcmp(suffix, "ICO")))
-        return vcdLoadArt(ethPrefix, '\\', folder, value, suffix, "POPS", resultTex);
+    // VCD (PS1) art (#118: ALL suffixes -- cover/BG/logo/screenshot): disc-id -> filename, then the
+    // cover/icon-only POPSLoader next-to-VCD fallback (vcdArtPopsDir NULLs it for BG/SCR). SMB uses '\\'.
+    if (isRelative && vcdViewActive(itemList->mode))
+        return vcdLoadArt(ethPrefix, '\\', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
 
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s\\%s_%s", ethPrefix, folder, value, suffix);

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -581,25 +581,27 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
         if (o == NULL)
             continue;
         // VCD favourite: art keys off the .VCD name (== favArray[i].text == value) via the shared
-        // 3-level VCD fallback against the owner's prefix -- mirrors each device's getImage VCD branch
-        // (covers + icons only). Local/MMCE prefixes use '/', SMB ('\\') is auto-detected from the prefix.
+        // 3-level VCD fallback against the owner's prefix -- mirrors each device's getImage VCD branch.
+        // #118: resolve ALL art suffixes (cover/BG/logo/screenshot), not just cover/icon, via the SAME
+        // vcdArtPopsDir helper the device branches use, so a VCD favourite's info page matches its source
+        // list. Local/MMCE prefixes use '/', SMB ('\\') is auto-detected from the prefix.
         if (favArray[i].isVcd) {
             if (strcmp(favArray[i].text, value) != 0)
                 continue;
-            // Same gate the device getImage VCD branches apply: covers/icons keyed RELATIVE to the
-            // device prefix only. An absolute-prefix attribute-image element falls through to -1.
-            if (!isRelative || (strcmp(suffix, "COV") != 0 && strcmp(suffix, "ICO") != 0))
+            // Relative art only (keyed to the device prefix); an absolute-prefix attribute-image element
+            // falls through to -1. Same isRelative gate as each device getImage VCD branch.
+            if (!isRelative)
                 return -1;
             char *prefix = (o->itemGetPrefix != NULL) ? o->itemGetPrefix(o) : NULL;
             if (prefix == NULL)
                 return -1;
-            // HDD VCD covers live at the APA partition ROOT /ART/ (mirroring the HDD VCD view), not the
+            // HDD VCD art lives at the APA partition ROOT /ART/ (mirroring the HDD VCD view), not the
             // OPL data subfolder its itemGetPrefix points at -- key off the partition root instead.
             if (favArray[i].mode == HDD_MODE)
                 prefix = "pfs0:/";
             int pl = (int)strlen(prefix);
             char sep = (pl > 0 && prefix[pl - 1] == '\\') ? '\\' : '/';
-            return vcdLoadArt(prefix, sep, folder, value, suffix, "POPS", resultTex);
+            return vcdLoadArt(prefix, sep, folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
         }
         if (o->itemGetStartup == NULL || o->itemGetImage == NULL || !favOwnerHasId(o, favArray[i].id))
             continue;

--- a/src/gui.c
+++ b/src/gui.c
@@ -553,6 +553,7 @@ void guiShowConfig()
     // SOURCE/MODE pickers are hidden; flipping it OFF (live, via guiUpdater) reveals them.
     diaSetInt(diaConfig, CFG_BDMA_APPLY, gBdmaApplyOnLaunch);
     diaSetInt(diaConfig, CFG_VCD_HIDE_GAMEID, gVcdHideGameId);
+    diaSetInt(diaConfig, CFG_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
     diaSetVisible(diaConfig, CFG_LBL_BDMASOURCE, !gBdmaApplyOnLaunch);
     diaSetVisible(diaConfig, CFG_BDMASOURCE, !gBdmaApplyOnLaunch);
     diaSetVisible(diaConfig, CFG_LBL_BDMAMODE, !gBdmaApplyOnLaunch);
@@ -591,6 +592,15 @@ reshow_config:
         }
         diaGetInt(diaConfig, CFG_BDMA_APPLY, &gBdmaApplyOnLaunch);
         diaGetInt(diaConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId); // display-only; next list draw reflects it, no rebuild needed
+        {
+            // #118: first-disc-only changes the VCD list CONTENTS (discs hidden/shown), so unlike the
+            // cosmetic hide-gameid it must rebuild every VCD-capable device page when toggled. Device
+            // lists only -- Favourites are intentionally left unfiltered (an explicit user pick).
+            int previousFirstDiscOnly = gVcdFirstDiscOnly;
+            diaGetInt(diaConfig, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
+            if (gVcdFirstDiscOnly != previousFirstDiscOnly)
+                vcdMarkAllDirty();
+        }
         {
             // Equip BDMA modules only when SOURCE or MODE actually changed (the equip copies
             // files to the memory card). vcdEquipBdma is free-space-gated + truncation-safe, so a

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -473,18 +473,22 @@ static int hddBuildVcdGameList(void)
         }
         hddVcdParts = grownParts;
 
+        int kept = 0;
         for (int i = 0; i < n; i++) {
-            base_game_info_t *g = &hddVcdGames[total + i];
+            if (gVcdFirstDiscOnly && vcdIsHiddenDisc(vcds[i].name))
+                continue; // #118: hide discs 2+ of a multi-disc PS1 set (device lists only)
+            base_game_info_t *g = &hddVcdGames[total + kept];
             memset(g, 0, sizeof(base_game_info_t));
             snprintf(g->name, sizeof(g->name), "%s", vcds[i].name);
             snprintf(g->startup, sizeof(g->startup), "%s", vcds[i].gameId); // PS1 id (or "" = no art)
             snprintf(g->extension, sizeof(g->extension), ".VCD");
             g->parts = 1;
             g->format = GAME_FORMAT_ISO; // harmless; the per-mode VCD flag gates the launch path
-            snprintf(hddVcdParts[total + i], APA_IDMAX + 1, "%s", parts.names[p]);
+            snprintf(hddVcdParts[total + kept], APA_IDMAX + 1, "%s", parts.names[p]);
+            kept++;
         }
         free(vcds);
-        total += n;
+        total += kept; // realloc over-allocated to (total+n); hidden discs leave harmless unused slots
     }
 
     hddFreePopsPartitionList(&parts);
@@ -1017,9 +1021,11 @@ static int hddGetImage(item_list_t *itemList, char *folder, int isRelative, char
     // VCD (PS1) covers: fall back disc-id -> filename in the OPL ART folder. POPSLoader's HDD layout keeps
     // art on the __common partition (POPS/ART/<name>.png), a different partition than gHDDPrefix, so that
     // step is a follow-up -- pass NULL to skip it rather than probe the wrong partition.
-    // VCD covers live at the APA partition ROOT /ART/ (pfs0:/ART/, whatever partition is mounted --
-    // common or +OPL), NOT the OPL data subfolder. pfs0: is already mounted while browsing, so no remount.
-    if (isRelative && vcdViewActive(itemList->mode) && (!strcmp(suffix, "COV") || !strcmp(suffix, "ICO")))
+    // VCD art (#118: ALL suffixes -- cover/BG/logo/screenshot) lives at the APA partition ROOT /ART/
+    // (pfs0:/ART/, whatever partition is mounted -- common or +OPL), NOT the OPL data subfolder. pfs0:
+    // is already mounted while browsing, so no remount. popsDir stays NULL here (HDD VCD art never used
+    // the next-to-VCD POPS image; it would be on a different partition).
+    if (isRelative && vcdViewActive(itemList->mode))
         return vcdLoadArt("pfs0:/", '/', folder, value, suffix, NULL, resultTex);
 
     if (isRelative)

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -809,8 +809,10 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     // VCD (PS1) covers: fall back disc-id -> filename -> POPSLoader's next-to-VCD <dev>/POPS/<name>.png.
-    if (isRelative && mmceArtPrimary[0] != '\0' && vcdViewActive(itemList->mode) && (!strcmp(suffix, "COV") || !strcmp(suffix, "ICO")))
-        return vcdLoadArt(mmceArtPrimary, '/', folder, value, suffix, "POPS", resultTex);
+    // #118: route ALL VCD art suffixes (cover/BG/logo/screenshot), not just cover; popsDir guard keeps
+    // BG/SCR off the cover-only POPSLoader fallback.
+    if (isRelative && mmceArtPrimary[0] != '\0' && vcdViewActive(itemList->mode))
+        return vcdLoadArt(mmceArtPrimary, '/', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
 
     return mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
 }

--- a/src/opl.c
+++ b/src/opl.c
@@ -207,6 +207,7 @@ int gBdmaSource;           // BDMA SOURCE device family (VCD_BDMA_SRC_*) to read
 int gBdmaMode;             // BDMA MODE last reflected from the mc?:/POPSTARTER/ marker (VCD_BDMA_*); not persisted
 int gBdmaApplyOnLaunch;    // auto-equip the launched VCD's matching exFAT driver before boot (1=on, default)
 int gVcdHideGameId;        // display-only: hide a leading PS1 game-ID prefix from the VCD list (1=on, default off)
+int gVcdFirstDiscOnly;     // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists (1=on, default off)
 int gWritePopstarterNet;   // mirror the network settings into POPSTARTER's IPCONFIG/SMBCONFIG on save
 int gEnableDebug;
 int gPS2Logo;
@@ -1558,6 +1559,7 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_BDMA_SOURCE, &gBdmaSource);
             configGetInt(configOPL, CONFIG_OPL_BDMA_APPLY, &gBdmaApplyOnLaunch);
             configGetInt(configOPL, CONFIG_OPL_VCD_HIDE_GAMEID, &gVcdHideGameId);
+            configGetInt(configOPL, CONFIG_OPL_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
             configGetInt(configOPL, CONFIG_OPL_WRITE_POPS_NET, &gWritePopstarterNet);
         }
 
@@ -1829,6 +1831,7 @@ static void _saveConfig()
         configSetInt(configOPL, CONFIG_OPL_BDMA_SOURCE, gBdmaSource);
         configSetInt(configOPL, CONFIG_OPL_BDMA_APPLY, gBdmaApplyOnLaunch);
         configSetInt(configOPL, CONFIG_OPL_VCD_HIDE_GAMEID, gVcdHideGameId);
+        configSetInt(configOPL, CONFIG_OPL_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
         configSetInt(configOPL, CONFIG_OPL_WRITE_POPS_NET, gWritePopstarterNet);
         configSetInt(configOPL, CONFIG_OPL_XSENSITIVITY, gXSensitivity);
         configSetInt(configOPL, CONFIG_OPL_YSENSITIVITY, gYSensitivity);
@@ -2516,6 +2519,7 @@ static void setDefaults(void)
     gBdmaMode = VCD_BDMA_FAT32;
     gBdmaApplyOnLaunch = 1; // auto-equip on launch by default (the MX4SIO->OSDSYS fix)
     gVcdHideGameId = 0;     // show the raw filename by default; opt-in cosmetic prefix hide
+    gVcdFirstDiscOnly = 0;  // #118: show every disc by default; opt-in first-disc-only hide
     gWritePopstarterNet = 0;
     gDefaultDevice = APP_MODE;
     gAutosort = 1;

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -341,9 +341,10 @@ static int udpfsGetImage(item_list_t *itemList, char *folder, int isRelative, ch
 {
     char path[256];
 
-    // VCD (PS1) covers: fall back disc-id -> filename -> POPSLoader's next-to-VCD <root>/POPS/<name>.png.
-    if (isRelative && vcdViewActive(itemList->mode) && (!strcmp(suffix, "COV") || !strcmp(suffix, "ICO")))
-        return vcdLoadArt(udpfsPrefix, '/', folder, value, suffix, "POPS", resultTex);
+    // VCD (PS1) art (#118: ALL suffixes -- cover/BG/logo/screenshot): disc-id -> filename, then the
+    // cover/icon-only POPSLoader next-to-VCD fallback (vcdArtPopsDir NULLs it for BG/SCR).
+    if (isRelative && vcdViewActive(itemList->mode))
+        return vcdLoadArt(udpfsPrefix, '/', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
 
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", udpfsPrefix, folder, value, suffix);

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -334,6 +334,18 @@ void vcdMarkAllDirty(void)
             vcdDirty[m] = 1;
 }
 
+// Which POPSLoader next-to-VCD image (step 3 of vcdLoadArt) applies to a given art suffix. Only the
+// cover/icon fall back to the single suffix-less POPS/<name>.png (interop with existing POPSLoader
+// users); background/logo/screenshot must NOT, or they would each render the cover instead. Shared by
+// every device getImage VCD branch AND favGetImage so the source-list and Favourites VCD art (issue
+// #118 -- BG/screenshot for PS1) resolve identically and never drift.
+const char *vcdArtPopsDir(const char *suffix)
+{
+    if (suffix != NULL && (!strcmp(suffix, "COV") || !strcmp(suffix, "ICO")))
+        return "POPS";
+    return NULL;
+}
+
 // 3-level cover/icon fallback for VCD (PS1) games, so one art file can serve OPL and POPSLoader:
 //   (1) OPL ART keyed by the PS1 disc id  -> <dev>ART/<SXXX_NNN.NN>_<suffix>.png  (interoperable serial)
 //   (2) OPL ART keyed by the VCD basename -> <dev>ART/<name>_<suffix>.png         (long-standing behaviour)
@@ -360,6 +372,38 @@ int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const cha
     return texDiscoverLoad(tex, path, -1);
 }
 
+// #118: a multi-disc PS1 game is a set of separate .VCD files whose titles carry a disc token, e.g.
+// "Game (Disc 2).VCD". With gVcdFirstDiscOnly on, the device VCD lists hide discs 2+ (POPSLoader
+// parity), leaving Disc 1 as the single entry -- the .VCD files are NOT touched, so every disc stays
+// on the card for in-game swapping. Detection is filename-only, case-insensitive: "(disc"/"[disc"/
+// "(cd"/"(disk" (optionally spaced) followed by an integer >= 2. Disc 1 / CD 1 always stay. Accepted
+// parity failure modes: a Disc 2 whose Disc 1 is absent vanishes; non-parenthesised schemes ("_2",
+// "CD2" mid-word) are not caught.
+int vcdIsHiddenDisc(const char *name)
+{
+    static const char *const tokens[] = {"(disc", "[disc", "(cd", "[cd", "(disk", "[disk"};
+    if (name == NULL)
+        return 0;
+    for (unsigned t = 0; t < sizeof(tokens) / sizeof(tokens[0]); t++) {
+        int toklen = (int)strlen(tokens[t]);
+        for (const char *p = name; *p != '\0'; p++) {
+            if (strncasecmp(p, tokens[t], toklen) != 0)
+                continue;
+            const char *d = p + toklen;
+            while (*d == ' ')
+                d++;
+            if (*d < '0' || *d > '9')
+                continue; // token not followed by a disc number
+            int num = 0;
+            while (*d >= '0' && *d <= '9')
+                num = num * 10 + (*d++ - '0');
+            if (num >= 2)
+                return 1;
+        }
+    }
+    return 0;
+}
+
 int vcdFillGameList(const char *devPrefix, base_game_info_t **outGames)
 {
     if (outGames == NULL)
@@ -378,16 +422,25 @@ int vcdFillGameList(const char *devPrefix, base_game_info_t **outGames)
         return 0;
     }
     memset(games, 0, n * sizeof(base_game_info_t));
+    int kept = 0;
     for (int i = 0; i < n; i++) {
-        snprintf(games[i].name, sizeof(games[i].name), "%s", vcds[i].name);
-        snprintf(games[i].startup, sizeof(games[i].startup), "%s", vcds[i].gameId); // "" -> no art lookup
-        snprintf(games[i].extension, sizeof(games[i].extension), ".VCD");
-        games[i].parts = 1;
-        games[i].format = GAME_FORMAT_ISO; // harmless; the per-mode VCD flag gates the launch path
+        if (gVcdFirstDiscOnly && vcdIsHiddenDisc(vcds[i].name))
+            continue; // #118: hide discs 2+ of a multi-disc PS1 set (device lists only)
+        snprintf(games[kept].name, sizeof(games[kept].name), "%s", vcds[i].name);
+        snprintf(games[kept].startup, sizeof(games[kept].startup), "%s", vcds[i].gameId); // "" -> no art lookup
+        snprintf(games[kept].extension, sizeof(games[kept].extension), ".VCD");
+        games[kept].parts = 1;
+        games[kept].format = GAME_FORMAT_ISO; // harmless; the per-mode VCD flag gates the launch path
+        kept++;
     }
     free(vcds);
-    *outGames = games;
-    return n;
+    if (kept == 0) { // every scanned entry was a hidden disc -> empty list (over-allocated buffer freed)
+        free(games);
+        *outGames = NULL;
+        return 0;
+    }
+    *outGames = games; // buffer over-allocated to n when some discs were hidden -- harmless
+    return kept;
 }
 
 // ---- safe memory-card copy (free-space gated) ---------------------------------------


### PR DESCRIPTION
## Fixes #118 — visual improvements for PS1 games

Investigated against **wOPL**, and the framing was overturned in a good way: **the VCD and Favourite info pages already exist** (Square→Info isn't mode-gated, and `menuRenderInfo` already routes VCD/FAV to their own layout with a PS2 fallback — shipped earlier). The real gap was art resolution, so this is a small, reuse-first change.

### Part A — full VCD art (background / screenshot)
Every device VCD art resolver (`bdm`/`mmce`/`eth`/`hdd`/`udpfs`) gated the `vcdLoadArt` fallback to the **cover/icon suffix only** — so the info page's background & screenshot elements fell to the wrong folder and rendered blank (AndrewBento's "only cover art"). Now **all** relative art suffixes route through `vcdLoadArt` in VCD view. A shared `vcdArtPopsDir(suffix)` helper passes the suffix-less POPSLoader image (`"POPS"`) only for COV/ICO and `NULL` for BG/SCR (else they'd each paint the cover). Users drop `<name>_BG.png` / `<name>_SCR.png` in the device-root `ART/` folder, same as `_COV`.

### Part B — favourites parity
`favGetImage` had its **own** duplicate COV/ICO gate that Part A didn't reach. Widened with the **same shared helper** so a VCD favourite's info page matches its source list. ISO favourites already worked via delegation.

### Part C — multi-disc hiding (POPSLoader-style)
New global **"First disc only (multi-disc PS1)"** toggle (**default OFF**). `vcdIsHiddenDisc()` hides `(Disc N)`/`(CD N)`/`(Disk N)` with N≥2 (case-insensitive, POPSLoader parity), filtered at **fill time** in `vcdFillGameList` + the HDD VCD builder. Applies to **device lists only** — Favourites stay unfiltered (explicit picks), and the `.VCD` files are never touched, so **in-game disc swapping still works**. Toggling triggers a VCD-list rebuild.

### Decisions (per maintainer)
- Multi-disc: **off by default, device lists only, POPSLoader-parity (N≥2)** detection.
- **No logo element added** — the bundled info view has no logo pattern even for PS2; deferred.

### Notes
- All VCD-art changes are `vcdViewActive`-gated, so PS2/ISO art is untouched.
- AndrewBento reported on Beta-3030; separate from this, he should update to current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
