### PR TITLE
Tester batch 2026-07-09/10: settings reorg, #120 fixes, Nad rounds 1+2, plasma, neighbor covers, MMCE nav, prewarm

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -99,6 +99,9 @@ by saildot4k
 Testing, bug reports and real-hardware feedback
 by eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573
 
+Financial support
+by Akilluminati47
+
 If you want the canonical, actively-maintained project, it lives at
 https://github.com/ps2homebrew/Open-PS2-Loader - please support it. This fork is a
 downstream labor of love, not a replacement, and it exists only because that

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ PNG_ASSETS = load0 load1 load2 load3 load4 load5 load6 load7 usb usb_bd ilk_bd \
 	Index_0 Index_1 Index_2 Index_3 Index_4 fav fav_mark R3 L3 PS1 PS2 case_overlay
 	# unused icons - up down l1 l2 r1 r2
 
-GFX_OBJS = $(PNG_ASSETS:%=%_png.o) poeveticanew.o icon_sys.o icon_icn.o
+GFX_OBJS = $(PNG_ASSETS:%=%_png.o) poeveticanew.o
 
 # NOTE: audio/bgm.ogg is intentionally NOT compiled into the ELF (saves ~324 KB).
 # It is kept in the repo only as a reference/default track. BGM is loaded at
@@ -814,12 +814,6 @@ $(EE_ASM_DIR)mcserv.c: $(PS2SDK)/iop/irx/mcserv.irx | $(EE_ASM_DIR)
 
 $(EE_ASM_DIR)poeveticanew.c: thirdparty/PoeVeticaNew.ttf | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ $(*F)_raw
-
-$(EE_ASM_DIR)icon_sys.c: gfx/icon.sys | $(EE_ASM_DIR)
-	$(BIN2C) $< $@ $(*F)
-
-$(EE_ASM_DIR)icon_icn.c: gfx/opl.icn | $(EE_ASM_DIR)
-	$(BIN2C) $< $@ $(*F)
 
 $(EE_ASM_DIR)icon_sys_A.c: misc/icon_A.sys | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ $(*F)

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ Enormous thanks to the testers who run every rolling build on real consoles and 
 reports that shape the fixes — **eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz
 and nuno6573**.
 
+### Financial support (this fork)
+
+Heartfelt thanks to **Akilluminati47** for generously **funding this fork's development** — a
+kindness that keeps the rolling builds coming and is deeply appreciated.
+
 If you want the canonical, actively-maintained project, it lives at
 **[ps2homebrew/Open-PS2-Loader](https://github.com/ps2homebrew/Open-PS2-Loader)** — please
 support it. This fork is a downstream labor of love, not a replacement, and it exists only

--- a/include/config.h
+++ b/include/config.h
@@ -99,7 +99,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_OVERSCAN             "overscan"
 #define CONFIG_OPL_DISABLE_DEBUG        "disable_debug"
 #define CONFIG_OPL_PS2LOGO              "ps2logo"
-#define CONFIG_OPL_DEFAULT_CORE         "default_core"      // global default Loader Core (0=<OPL>, 1=Neutrino); a game's per-game "$CoreLoader" overrides it, absent = follow this
+#define CONFIG_OPL_DEFAULT_CORE         "default_core" // global default Loader Core (0=<OPL>, 1=Neutrino); a game's per-game "$CoreLoader" overrides it, absent = follow this
 #define CONFIG_OPL_NEUTRINO_ARGS        "neutrino_args"
 #define CONFIG_OPL_NEUTRINO_PATH        "neutrino_path"
 #define CONFIG_OPL_NEUTRINO_DEVICE      "neutrino_device"   // legacy device-INDEX (mc0/mass0/mmce0); read-only, migrated

--- a/include/config.h
+++ b/include/config.h
@@ -99,6 +99,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_OVERSCAN             "overscan"
 #define CONFIG_OPL_DISABLE_DEBUG        "disable_debug"
 #define CONFIG_OPL_PS2LOGO              "ps2logo"
+#define CONFIG_OPL_DEFAULT_CORE         "default_core"      // global default Loader Core (0=<OPL>, 1=Neutrino); a game's per-game "$CoreLoader" overrides it, absent = follow this
 #define CONFIG_OPL_NEUTRINO_ARGS        "neutrino_args"
 #define CONFIG_OPL_NEUTRINO_PATH        "neutrino_path"
 #define CONFIG_OPL_NEUTRINO_DEVICE      "neutrino_device"   // legacy device-INDEX (mc0/mass0/mmce0); read-only, migrated

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -78,6 +78,7 @@ enum UI_ITEMS {
     CFG_BOOT_SND_VOLUME,
     CFG_BGM_VOLUME,
     CFG_DEFAULT_BGM_PATH,
+    CFG_DEFAULT_CORE, // global default Loader Core (gDefaultCoreLoader); per-game "Default" follows it
     CFG_NEUTRINO_ARGS,
     CFG_NEUTRINO_DEVICE,
     CFG_POPSTARTER_DEVICE,

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -293,5 +293,7 @@ extern struct UIItem diaOSDConfig[];
 extern struct UIItem diaCoverflowConfig[];
 extern struct UIItem diaNeutrinoArgs[];
 extern struct UIItem diaDeviceConfig[];
+extern struct UIItem diaVcdConfig[];
+extern struct UIItem diaMmceConfig[];
 
 #endif

--- a/include/gui.h
+++ b/include/gui.h
@@ -136,6 +136,8 @@ void guiShowCoverflowConfig(void);
 void guiShowNeutrinoArgsConfig(char *argsBuf, int bufSize);
 void guiShowNetConfig();
 void guiShowDeviceConfig(void);
+void guiShowVcdConfig(void);
+void guiShowMmceConfig(void);
 void guiShowParentalLockConfig();
 
 void guiCheckNotifications(int checkTheme, int checkLang);

--- a/include/menusys.h
+++ b/include/menusys.h
@@ -113,6 +113,9 @@ char *menuItemGetText(menu_item_t *it);
 config_set_t *menuLoadConfig();
 config_set_t *menuLoadConfigDirect(void);
 void menuRequestInfoSize(void);
+// Prewarm the selected item's info-page art (BG/SCR/SCR2). entry!=0 = Square-entry (immediate,
+// interactive); entry==0 = browse-settle prefetch. #120 follow-up; see thmPrewarmInfoArt.
+void menuPrewarmInfoArt(int entry);
 config_set_t *gameMenuLoadConfig(struct UIItem *ui);
 void menuSaveConfig();
 

--- a/include/opl.h
+++ b/include/opl.h
@@ -242,7 +242,8 @@ enum { NEUTRINO_DEV_AUTO = 0,     // game device, then mc0/mc1 (legacy behaviour
        NEUTRINO_DEV_MX4SIO,       // BDM "mx4sio"/sdc -> the mounted massN:
        NEUTRINO_DEV_MMCE,         // mmce0: / mmce1:
        NEUTRINO_DEV_EXFAT_HDD,    // BDM "ata" internal exFAT HDD -> the mounted massN:
-       NEUTRINO_DEV_APA_HDD };    // APA HDD: the mounted OPL data partition (pfs0:)
+       NEUTRINO_DEV_APA_HDD,      // APA HDD: the mounted OPL data partition (pfs0:)
+       NEUTRINO_DEV_GAME };       // the active game's OWN device ONLY (co-located neutrino.elf); no MC/boot fallback (a miss toasts "not found"). Appended at the enum end to keep saved neutrino_devtype ints stable.
 extern int gNeutrinoDevice;       // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy neutrino_path
 extern int gNeutrinoElfArg;       // opt-in (settings key only, no UI): auto-emit -elf=cdrom0:\<startup>;1 on Neutrino launches
 extern char gPopstarterPath[256]; // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
@@ -259,7 +260,8 @@ enum { POPS_DEV_DEFAULT = 0,    // cwd (gBootDir) /POPS/, then the VCD's own dev
        POPS_DEV_MMCE,           // mmce0: / mmce1:
        POPS_DEV_EXFAT_HDD,      // BDM "ata" internal exFAT HDD -> the mounted massN:
        POPS_DEV_APA_HDD,        // APA HDD: the mounted OPL data partition (pfs0:)
-       POPS_DEV_CUSTOM };       // free-text gPopstarterPath
+       POPS_DEV_CUSTOM,         // free-text gPopstarterPath
+       POPS_DEV_GAME };         // the VCD's OWN device ONLY (<devPrefix>/POPS/POPSTARTER.ELF); no boot/cwd fallback (a miss toasts "not found"). Appended at the enum end to keep saved popstarter_device ints stable.
 extern int gPopstarterDevice;   // POPSTARTER.ELF device (POPS_DEV_*); legacy non-empty popstarter_path -> Custom
 extern int gBdmaSource;         // BDMA SOURCE device family (VCD_BDMA_SRC_*); persisted in conf
 extern int gBdmaMode;           // BDMA MODE mirrored from the mc?:/POPSTARTER/ marker (VCD_BDMA_*)

--- a/include/opl.h
+++ b/include/opl.h
@@ -245,6 +245,7 @@ enum { NEUTRINO_DEV_AUTO = 0,     // game device, then mc0/mc1 (legacy behaviour
        NEUTRINO_DEV_APA_HDD,      // APA HDD: the mounted OPL data partition (pfs0:)
        NEUTRINO_DEV_GAME };       // the active game's OWN device ONLY (co-located neutrino.elf); no MC/boot fallback (a miss toasts "not found"). Appended at the enum end to keep saved neutrino_devtype ints stable.
 extern int gNeutrinoDevice;       // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy neutrino_path
+extern int gDefaultCoreLoader;    // global default Loader Core: 0 = <OPL> (native), 1 = Neutrino. A game's per-game $CoreLoader overrides it; absent per-game key = follow this global.
 extern int gNeutrinoElfArg;       // opt-in (settings key only, no UI): auto-emit -elf=cdrom0:\<startup>;1 on Neutrino launches
 extern char gPopstarterPath[256]; // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
 extern char gBootDir[256];        // boot directory (cwd) OPL launched from, e.g. "mass0:/APPS"; "" if undeterminable

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -72,9 +72,15 @@ void cacheCancelPendingImageLoads(void);
  */
 int cacheCancelPendingImageLoadsTimed(int timeoutTicks);
 
-/** Cancels queued MMCE-backed interactive art and waits up to timeoutTicks for active MMCE art to drain.
+/** Cancels queued MMCE-backed art (both queues) and waits up to timeoutTicks for active MMCE art to drain.
  */
 int cacheAbortMmceImageLoadsTimed(int timeoutTicks);
+
+/** Interactive art request that skips the inactivity settle (info-screen entry prewarm). */
+GSTEXTURE *cacheWarmTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value);
+
+/** Prefetch art request allowed onto MMCE and past the prefetch cap (browse-settle info prewarm). */
+GSTEXTURE *cachePrefetchTexturePrewarm(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value);
 
 /** Advances the failure-retry generation and demotes loaded art to displayable. Queued and
  *  in-flight loads are LEFT to finish and land in cache (wOPL persist-and-load); teardown paths

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -76,7 +76,10 @@ int cacheCancelPendingImageLoadsTimed(int timeoutTicks);
  */
 int cacheAbortMmceImageLoadsTimed(int timeoutTicks);
 
-/** Invalidates queued art loads without blocking on the IO worker.
+/** Advances the failure-retry generation and demotes loaded art to displayable. Queued and
+ *  in-flight loads are LEFT to finish and land in cache (wOPL persist-and-load); teardown paths
+ *  must use the cacheCancelPendingImageLoads / cacheAbortMmceImageLoadsTimed family instead.
+ *  Never blocks on the IO worker.
  */
 void cacheAdvanceGeneration(void);
 

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -22,6 +22,13 @@ typedef struct
     int lastUsed;
 
     int UID;
+
+    // Identity of the art this entry holds (heap copy of the request value, e.g. the game's
+    // startup). The instant-return path validates it against the caller's value so a poisoned or
+    // stale per-item (cacheId, UID) pair self-heals in one frame instead of permanently rendering
+    // another title's art (the CoverFlow wrong-neighbour-cover bug). Owned by the entry: freed in
+    // cacheClearItem / cacheDestroyCache.
+    char *value;
 } cache_entry_t;
 
 /// One texture cache instance

--- a/include/themes.h
+++ b/include/themes.h
@@ -164,6 +164,10 @@ extern theme_t *gTheme;
 extern int gCoverflowCount, gCoverflowCenterScale, gCoverflowAnimSpeed, gCoverflowDimCovers;
 void thmTriggerCoverflowAnim(int dir);
 
+/** Prewarm one item's info-page art (BG/SCR/SCR2). entry!=0 = Square-entry (interactive priority,
+ *  settle skipped); entry==0 = browse-settle (prefetch priority, allowed onto MMCE). #120 follow-up. */
+void thmPrewarmInfoArt(theme_elems_t *elems, item_list_t *list, submenu_item_t *item, int entry);
+
 void thmInit(void);
 void thmReinit(const char *path);
 void thmReloadScreenExtents(void);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -316,6 +316,8 @@ gui_strings:
   string: Coders
 - label: QANDA
   string: Quality Assurance
+- label: FINANCIAL_SUPPORT
+  string: Financial Support
 - label: BDM_PREFIX
   string: BDM Prefix Path
 - label: HINT_EXITPATH

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -758,6 +758,10 @@ gui_strings:
   string: OFF may help performance but can cause MMCE timeouts to result in freezes
 - label: CORE_LOADER
   string: Loader Core
+- label: DEFAULT_CORE
+  string: Default Loader Core
+- label: HINT_DEFAULT_CORE
+  string: Global default core for games whose per-game Loader Core is set to Default. <OPL> is the native core; Neutrino chains the external neutrino.elf. A per-game choice always overrides this.
 - label: NEUTRINO_BAD_FORMAT
   string: Neutrino does not support this file format, launching with <OPL> core
 - label: NEUTRINO_NOT_FOUND

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -182,8 +182,6 @@ gui_strings:
   string: Applications Start Mode
 - label: AUTO
   string: Auto
-- label: GAMES_DEVICE
-  string: Game's Device
 - label: MANUAL
   string: Manual
 - label: STARTNBD
@@ -758,10 +756,6 @@ gui_strings:
   string: OFF may help performance but can cause MMCE timeouts to result in freezes
 - label: CORE_LOADER
   string: Loader Core
-- label: DEFAULT_CORE
-  string: Default Loader Core
-- label: HINT_DEFAULT_CORE
-  string: Global default core for games whose per-game Loader Core is set to Default. <OPL> is the native core; Neutrino chains the external neutrino.elf. A per-game choice always overrides this.
 - label: NEUTRINO_BAD_FORMAT
   string: Neutrino does not support this file format, launching with <OPL> core
 - label: NEUTRINO_NOT_FOUND
@@ -967,3 +961,12 @@ gui_strings:
   string: First disc only (multi-disc PS1)
 - label: HINT_VCD_FIRST_DISC
   string: Show only Disc 1 of a multi-disc PS1 game in the device lists (POPSLoader style). Hides files named (Disc 2), (CD 2), etc. All discs stay on the card for in-game swapping; Favourites are not filtered.
+# APPEND-ONLY BELOW: external lang_*.lng files are matched by POSITION with no version check, so new
+# labels must only ever be added at the END -- a mid-list insert shifts every later string and makes a
+# stale translation file render wrong text across most of the UI.
+- label: GAMES_DEVICE
+  string: Game's Device
+- label: DEFAULT_CORE
+  string: Default Loader Core
+- label: HINT_DEFAULT_CORE
+  string: Global default core for games whose per-game Loader Core is set to Default. <OPL> is the native core; Neutrino chains the external neutrino.elf. A per-game choice always overrides this.

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -742,6 +742,8 @@ gui_strings:
   string: Advanced
 - label: MMCE_SETTINGS
   string: MMCE Settings
+- label: VCD_SETTINGS
+  string: VCD Settings
 - label: MMCE_SEMA
   string: Lock Sema Enqueuing Method
 - label: HINT_MMCE_SEMA

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -316,8 +316,6 @@ gui_strings:
   string: Coders
 - label: QANDA
   string: Quality Assurance
-- label: FINANCIAL_SUPPORT
-  string: Financial Support
 - label: BDM_PREFIX
   string: BDM Prefix Path
 - label: HINT_EXITPATH
@@ -744,8 +742,6 @@ gui_strings:
   string: Advanced
 - label: MMCE_SETTINGS
   string: MMCE Settings
-- label: VCD_SETTINGS
-  string: VCD Settings
 - label: MMCE_SEMA
   string: Lock Sema Enqueuing Method
 - label: HINT_MMCE_SEMA
@@ -965,12 +961,13 @@ gui_strings:
   string: First disc only (multi-disc PS1)
 - label: HINT_VCD_FIRST_DISC
   string: Show only Disc 1 of a multi-disc PS1 game in the device lists (POPSLoader style). Hides files named (Disc 2), (CD 2), etc. All discs stay on the card for in-game swapping; Favourites are not filtered.
-# APPEND-ONLY BELOW: external lang_*.lng files are matched by POSITION with no version check, so new
-# labels must only ever be added at the END -- a mid-list insert shifts every later string and makes a
-# stale translation file render wrong text across most of the UI.
 - label: GAMES_DEVICE
   string: Game's Device
 - label: DEFAULT_CORE
   string: Default Loader Core
 - label: HINT_DEFAULT_CORE
   string: Global default core for games whose per-game Loader Core is set to Default. <OPL> is the native core; Neutrino chains the external neutrino.elf. A per-game choice always overrides this.
+- label: VCD_SETTINGS
+  string: VCD Settings
+- label: FINANCIAL_SUPPORT
+  string: Financial Support

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -182,6 +182,8 @@ gui_strings:
   string: Applications Start Mode
 - label: AUTO
   string: Auto
+- label: GAMES_DEVICE
+  string: Game's Device
 - label: MANUAL
   string: Manual
 - label: STARTNBD
@@ -795,7 +797,7 @@ gui_strings:
 - label: NEUTRINO_DEVICE
   string: Neutrino Device
 - label: HINT_NEUTRINO_DEVICE
-  string: Device holding neutrino.elf (in a NEUTRINO/ or neutrino/ folder). Auto scans mc0 then mc1.
+  string: Device holding neutrino.elf (in a NEUTRINO/ or neutrino/ folder). Auto = the game's own device then mc0/mc1. Game's Device = the game's device only.
 - label: NARGS_QB
   string: Quick Boot (-qb)
 - label: NARGS_CWD
@@ -817,7 +819,7 @@ gui_strings:
 - label: POPSTARTER_DEVICE
   string: POPSTARTER.ELF Device
 - label: HINT_POPSTARTER_DEVICE
-  string: Device holding POPS/POPSTARTER.ELF for PS1 VCD launches. Default = boot device (cwd) then the VCD's own device. Custom reveals a free-text path.
+  string: Device holding POPS/POPSTARTER.ELF for PS1 VCD launches. Default = boot device (cwd) then the VCD's own device. Game's Device = the VCD's device only. Custom reveals a free-text path.
 - label: POPSTARTER_PATH
   string: POPSTARTER.ELF Path
 - label: HINT_POPSTARTER_PATH

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -319,7 +319,7 @@ gui_strings:
 - label: BDM_PREFIX
   string: BDM Prefix Path
 - label: HINT_EXITPATH
-  string: Boots custom ELF after an IGR.
+  string: "Boots a custom ELF after an IGR. Keep it on the memory card (mc0:/mc1:) -- the post-reset loader can't reach MMCE; for MMCE, chain through an MC loader like PS2BBL."
 - label: HINT_SPINDOWN
   string: Value in minute(s), 0 to disable spin down.
 - label: HDD_SPINDOWN

--- a/misc/conf_theme_OPL.cfg
+++ b/misc/conf_theme_OPL.cfg
@@ -1,7 +1,3 @@
-bg_color=#182580
-sel_text_color=#ffffff
-text_color=#324d9e
-ui_text_color=#00FFFF
 main0:
 	type=Background
 	pattern=BG

--- a/misc/theme_coverflow.cfg
+++ b/misc/theme_coverflow.cfg
@@ -1,6 +1,5 @@
 font1=builtin
 font1_size=20
-plasma_blend_color=#182580
 coverflow_cover_offset=0
 bg_color=#182580
 sel_text_color=#ffffff

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -737,7 +737,7 @@ static int bdmNeutrinoFragBudgetOk(const char *isoPath, const neutrino_vmc_args_
 // 0 = proceed with the native launch (core is OPL, or Neutrino unavailable on a non-udp device).
 static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, bdm_device_data_t *pDeviceData, config_set_t *configSet)
 {
-    int coreLoader = 0;
+    int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
     configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
     // UDPBD/UDPFS have no embedded cdvdman backend -- the "udp" BDM device can ONLY boot via
     // Neutrino, so force the core and treat every Neutrino failure below as a clean abort

--- a/src/config.c
+++ b/src/config.c
@@ -180,7 +180,11 @@ static char cfgDevice[8];
 
 char *configGetDir(void)
 {
-    if (!strncmp(cfgDevice, "mc", 2)) {
+    // Substitute the wildcard slot digit ONLY when it actually is the "mc?:" wildcard AND a card was
+    // detected. Blind substitution stamped getmcID()'s -1 (0xFF) -- or a probe-time other-card digit --
+    // over a CONCRETE "mc0:"/"mc1:" prefix from an appdir-on-MC boot, so the "Settings saved to %s"
+    // toast rendered a garbage byte or the wrong card. Legacy "mc?:" homes keep today's behaviour.
+    if (!strncmp(cfgDevice, "mc", 2) && cfgDevice[2] == '?' && getmcID() >= 0) {
         cfgDevice[2] = getmcID();
     }
 

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1100,6 +1100,15 @@ struct UIItem diaAbout[] = {
     {UI_LABEL, 0, 1, 1, -1, 0, 15, {.label = {"icyson55", -1}}},
     {UI_BREAK},
 
+    // Financial Support (RiptOPL fork)
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, 0, 15, {.label = {NULL, _STR_FINANCIAL_SUPPORT}}},
+    {UI_BREAK},
+
+    {UI_SPACER},
+    {UI_LABEL, 0, 1, 1, -1, 0, 15, {.label = {"Akilluminati47", -1}}},
+    {UI_BREAK},
+
     // Build Options
     {UI_BREAK},
     {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_BUILD_DETAILS}}},

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -160,6 +160,11 @@ struct UIItem diaConfig[] = {
     {UI_STRING, CFG_EXITTO, 1, 1, _STR_HINT_EXITPATH, 0, 0, {.stringvalue = {"", "", NULL}}},
     {UI_BREAK},
 
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_DEFAULT_CORE}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_DEFAULT_CORE, 1, 1, _STR_HINT_DEFAULT_CORE, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     {UI_BUTTON, CFG_NEUTRINO_ARGS, 1, 1, _STR_HINT_NEUTRINO_ARGS, 0, 0, {.label = {NULL, _STR_NEUTRINO_ARGS}}},
     {UI_BREAK},
 

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -173,40 +173,6 @@ struct UIItem diaConfig[] = {
     {UI_ENUM, CFG_NEUTRINO_DEVICE, 1, 1, _STR_HINT_NEUTRINO_DEVICE, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_POPSTARTER_DEVICE}}},
-    {UI_SPACER},
-    {UI_ENUM, CFG_POPSTARTER_DEVICE, 1, 1, _STR_HINT_POPSTARTER_DEVICE, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, CFG_LBL_POPSTARTER_PATH, 1, 1, -1, -40, 0, {.label = {NULL, _STR_POPSTARTER_PATH}}},
-    {UI_SPACER},
-    {UI_STRING, CFG_POPSTARTER_PATH, 1, 1, _STR_HINT_POPSTARTER_PATH, 0, 0, {.stringvalue = {"", "", NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMA_APPLY}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_BDMA_APPLY, 1, 1, _STR_HINT_BDMA_APPLY, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, CFG_LBL_BDMASOURCE, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMA_SOURCE}}},
-    {UI_SPACER},
-    {UI_ENUM, CFG_BDMASOURCE, 1, 1, _STR_HINT_BDMA_SOURCE, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, CFG_LBL_BDMAMODE, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMA_MODE}}},
-    {UI_SPACER},
-    {UI_ENUM, CFG_BDMAMODE, 1, 1, _STR_HINT_BDMA_MODE, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_HIDE_GAMEID}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_VCD_HIDE_GAMEID, 1, 1, _STR_HINT_VCD_HIDE_GAMEID, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_FIRST_DISC}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_VCD_FIRST_DISC_ONLY, 1, 1, _STR_HINT_VCD_FIRST_DISC, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_WRITE}}},
     {UI_SPACER},
     {UI_BOOL, CFG_ENWRITEOP, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
@@ -347,8 +313,64 @@ struct UIItem diaDeviceConfig[] = {
     {UI_INT, CFG_SMBCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 4, 0, 32, NULL}}},
     {UI_BREAK},
 
+    // buttons
+    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
     {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MMCE_SETTINGS}}},
+
+    // end of dialog
+    {UI_TERMINATOR}};
+
+// VCD Settings Menu (PS1-via-POPSTARTER launch config + BDMA equip + VCD list display options).
+// All rows relocated out of General Settings; CFG ids unchanged so saved config loads identically.
+struct UIItem diaVcdConfig[] = {
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_VCD_SETTINGS}}},
+    {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_POPSTARTER_DEVICE}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_POPSTARTER_DEVICE, 1, 1, _STR_HINT_POPSTARTER_DEVICE, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, CFG_LBL_POPSTARTER_PATH, 1, 1, -1, -40, 0, {.label = {NULL, _STR_POPSTARTER_PATH}}},
+    {UI_SPACER},
+    {UI_STRING, CFG_POPSTARTER_PATH, 1, 1, _STR_HINT_POPSTARTER_PATH, 0, 0, {.stringvalue = {"", "", NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMA_APPLY}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_BDMA_APPLY, 1, 1, _STR_HINT_BDMA_APPLY, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, CFG_LBL_BDMASOURCE, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMA_SOURCE}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_BDMASOURCE, 1, 1, _STR_HINT_BDMA_SOURCE, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, CFG_LBL_BDMAMODE, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMA_MODE}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_BDMAMODE, 1, 1, _STR_HINT_BDMA_MODE, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_HIDE_GAMEID}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_VCD_HIDE_GAMEID, 1, 1, _STR_HINT_VCD_HIDE_GAMEID, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_FIRST_DISC}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_VCD_FIRST_DISC_ONLY, 1, 1, _STR_HINT_VCD_FIRST_DISC, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    // buttons
+    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
+    {UI_BREAK},
+
+    // end of dialog
+    {UI_TERMINATOR}};
+
+// MMCE Settings Menu (SD2PSX / MemCard PRO2 tuning). Relocated out of Device Settings; CFG ids unchanged.
+struct UIItem diaMmceConfig[] = {
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MMCE_SETTINGS}}},
     {UI_SPLITTER},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_MMCE_SLOT}}},

--- a/src/gui.c
+++ b/src/gui.c
@@ -459,25 +459,34 @@ void guiShowNetCompatUpdateSingle(int id, item_list_t *support, config_set_t *co
 static int guiUpdater(int modified)
 {
     int showAutoStartLast;
-    int bdmaApply;
-    int popsDev;
 
     if (modified) {
         diaGetInt(diaConfig, CFG_LASTPLAYED, &showAutoStartLast);
         diaSetVisible(diaConfig, CFG_LBL_AUTOSTARTLAST, showAutoStartLast);
         diaSetVisible(diaConfig, CFG_AUTOSTARTLAST, showAutoStartLast);
+    }
+    return 0;
+}
 
+// VCD Settings live-updater: same BDMA-apply + POPSTARTER-Custom visibility logic that used to run
+// in guiUpdater, now bound to the diaVcdConfig dialog.
+static int guiVcdUpdater(int modified)
+{
+    int bdmaApply;
+    int popsDev;
+
+    if (modified) {
         // Hide the manual BDMA Source/Mode pickers while "VCD BDMA Apply on Launch" is ON (it auto-equips).
-        diaGetInt(diaConfig, CFG_BDMA_APPLY, &bdmaApply);
-        diaSetVisible(diaConfig, CFG_LBL_BDMASOURCE, !bdmaApply);
-        diaSetVisible(diaConfig, CFG_BDMASOURCE, !bdmaApply);
-        diaSetVisible(diaConfig, CFG_LBL_BDMAMODE, !bdmaApply);
-        diaSetVisible(diaConfig, CFG_BDMAMODE, !bdmaApply);
+        diaGetInt(diaVcdConfig, CFG_BDMA_APPLY, &bdmaApply);
+        diaSetVisible(diaVcdConfig, CFG_LBL_BDMASOURCE, !bdmaApply);
+        diaSetVisible(diaVcdConfig, CFG_BDMASOURCE, !bdmaApply);
+        diaSetVisible(diaVcdConfig, CFG_LBL_BDMAMODE, !bdmaApply);
+        diaSetVisible(diaVcdConfig, CFG_BDMAMODE, !bdmaApply);
 
         // Reveal the free-text POPSTARTER.ELF Path field only when the device picker is "Custom".
-        diaGetInt(diaConfig, CFG_POPSTARTER_DEVICE, &popsDev);
-        diaSetVisible(diaConfig, CFG_LBL_POPSTARTER_PATH, popsDev == POPS_DEV_CUSTOM);
-        diaSetVisible(diaConfig, CFG_POPSTARTER_PATH, popsDev == POPS_DEV_CUSTOM);
+        diaGetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, &popsDev);
+        diaSetVisible(diaVcdConfig, CFG_LBL_POPSTARTER_PATH, popsDev == POPS_DEV_CUSTOM);
+        diaSetVisible(diaVcdConfig, CFG_POPSTARTER_PATH, popsDev == POPS_DEV_CUSTOM);
     }
     return 0;
 }
@@ -535,38 +544,10 @@ void guiShowConfig()
     const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", _l(_STR_GAMES_DEVICE), NULL}; // device TYPE holding /neutrino/neutrino.elf (NEUTRINO_DEV_*); "Game's Device" (NEUTRINO_DEV_GAME) appended last to match the enum tail
     diaSetEnum(diaConfig, CFG_NEUTRINO_DEVICE, neutrinoDevStrs);
     diaSetInt(diaConfig, CFG_NEUTRINO_DEVICE, gNeutrinoDevice);
-    // POPSTARTER.ELF device TYPE holding POPS/POPSTARTER.ELF (POPS_DEV_*). MUST stay in sync with the
-    // resolution switch in vcdResolvePopstarter() (vcdsupport.c). Custom reveals the free-text path below.
-    const char *popsDevStrs[] = {_l(_STR_DEFAULT), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", "Custom", _l(_STR_GAMES_DEVICE), NULL}; // "Game's Device" (POPS_DEV_GAME) appended last to match the enum tail
-    diaSetEnum(diaConfig, CFG_POPSTARTER_DEVICE, popsDevStrs);
-    diaSetInt(diaConfig, CFG_POPSTARTER_DEVICE, gPopstarterDevice);
-    diaSetString(diaConfig, CFG_POPSTARTER_PATH, gPopstarterPath);
-    // These path fields auto-resolve a built-in default when blank, so show a dim "Default"
-    // placeholder rather than "<not set>" -- the empty value (and thus the fallback) is kept.
+    // IGR Path auto-resolves a built-in default when blank, so show a dim "Default" placeholder
+    // rather than "<not set>" -- the empty value (and thus the fallback) is kept. (VCD/POPSTARTER
+    // and BDMA settings moved to their own "VCD Settings" page -- see guiShowVcdConfig.)
     diaSetShowDefaultWhenEmpty(diaConfig, CFG_EXITTO, 1);
-    diaSetShowDefaultWhenEmpty(diaConfig, CFG_POPSTARTER_PATH, 1);
-
-    // BDMA (BDMAssault exFAT driver) equip. MODE reflects what's ACTUALLY on the card (read the
-    // mc?:/POPSTARTER/ marker), so the menu is honest even if POPSLoader or a prior session set it.
-    const char *bdmaSourceStrs[] = {_l(_STR_BDMA_SRC_USB), _l(_STR_BDMA_SRC_MX4SIO), _l(_STR_BDMA_SRC_MMCE), _l(_STR_BDMA_SRC_HDD), NULL};
-    const char *bdmaModeStrs[] = {_l(_STR_BDMA_MODE_FAT32), _l(_STR_BDMA_MODE_USBEXFAT), _l(_STR_BDMA_MODE_MX4SIO), _l(_STR_BDMA_MODE_MMCE), _l(_STR_BDMA_MODE_ATA), NULL};
-    gBdmaMode = vcdReadBdmaMode();
-    diaSetEnum(diaConfig, CFG_BDMASOURCE, bdmaSourceStrs);
-    diaSetEnum(diaConfig, CFG_BDMAMODE, bdmaModeStrs);
-    diaSetInt(diaConfig, CFG_BDMASOURCE, gBdmaSource);
-    diaSetInt(diaConfig, CFG_BDMAMODE, gBdmaMode);
-    // "VCD BDMA Apply on Launch": when ON the launch auto-equips the matching driver, so the manual
-    // SOURCE/MODE pickers are hidden; flipping it OFF (live, via guiUpdater) reveals them.
-    diaSetInt(diaConfig, CFG_BDMA_APPLY, gBdmaApplyOnLaunch);
-    diaSetInt(diaConfig, CFG_VCD_HIDE_GAMEID, gVcdHideGameId);
-    diaSetInt(diaConfig, CFG_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
-    diaSetVisible(diaConfig, CFG_LBL_BDMASOURCE, !gBdmaApplyOnLaunch);
-    diaSetVisible(diaConfig, CFG_BDMASOURCE, !gBdmaApplyOnLaunch);
-    diaSetVisible(diaConfig, CFG_LBL_BDMAMODE, !gBdmaApplyOnLaunch);
-    diaSetVisible(diaConfig, CFG_BDMAMODE, !gBdmaApplyOnLaunch);
-    // POPSTARTER.ELF Path is the Custom-only escape hatch; seed it hidden unless the picker is Custom.
-    diaSetVisible(diaConfig, CFG_LBL_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
-    diaSetVisible(diaConfig, CFG_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
 
     diaSetInt(diaConfig, CFG_ENWRITEOP, gEnableWrite);
     diaSetInt(diaConfig, CFG_LASTPLAYED, gRememberLastPlayed);
@@ -588,44 +569,85 @@ reshow_config:
         diaGetString(diaConfig, CFG_EXITTO, gExitPath, sizeof(gExitPath));
         diaGetInt(diaConfig, CFG_DEFAULT_CORE, &gDefaultCoreLoader);
         diaGetInt(diaConfig, CFG_NEUTRINO_DEVICE, &gNeutrinoDevice);
-        diaGetInt(diaConfig, CFG_POPSTARTER_DEVICE, &gPopstarterDevice);
+        diaGetInt(diaConfig, CFG_ENWRITEOP, &gEnableWrite);
+        diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
+        diaGetInt(diaConfig, CFG_AUTOSTARTLAST, &gAutoStartLastPlayed);
+        DisableCron = 1; // Disable Auto Start Last Played counter (we don't want to call it right after enable it on GUI)
+
+        applyConfig(-1, -1, 0);
+        menuReinitMainMenu();
+    }
+}
+
+// VCD Settings: PS1-via-POPSTARTER launch config (POPSTARTER.ELF device/path), BDMA exFAT-driver
+// equip, and VCD list display options. All relocated out of General Settings; CFG ids are shared with
+// the old General rows, so saved config values map through unchanged.
+void guiShowVcdConfig(void)
+{
+    // POPSTARTER.ELF device TYPE (POPS_DEV_*). MUST stay in sync with vcdResolvePopstarter() (vcdsupport.c).
+    const char *popsDevStrs[] = {_l(_STR_DEFAULT), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", "Custom", _l(_STR_GAMES_DEVICE), NULL}; // "Game's Device" (POPS_DEV_GAME) appended last to match the enum tail
+    diaSetEnum(diaVcdConfig, CFG_POPSTARTER_DEVICE, popsDevStrs);
+    diaSetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, gPopstarterDevice);
+    diaSetString(diaVcdConfig, CFG_POPSTARTER_PATH, gPopstarterPath);
+    diaSetShowDefaultWhenEmpty(diaVcdConfig, CFG_POPSTARTER_PATH, 1);
+
+    // BDMA (BDMAssault exFAT driver) equip. MODE reflects what's ACTUALLY on the card (marker read),
+    // so the menu is honest even if POPSLoader or a prior session set it.
+    const char *bdmaSourceStrs[] = {_l(_STR_BDMA_SRC_USB), _l(_STR_BDMA_SRC_MX4SIO), _l(_STR_BDMA_SRC_MMCE), _l(_STR_BDMA_SRC_HDD), NULL};
+    const char *bdmaModeStrs[] = {_l(_STR_BDMA_MODE_FAT32), _l(_STR_BDMA_MODE_USBEXFAT), _l(_STR_BDMA_MODE_MX4SIO), _l(_STR_BDMA_MODE_MMCE), _l(_STR_BDMA_MODE_ATA), NULL};
+    gBdmaMode = vcdReadBdmaMode();
+    diaSetEnum(diaVcdConfig, CFG_BDMASOURCE, bdmaSourceStrs);
+    diaSetEnum(diaVcdConfig, CFG_BDMAMODE, bdmaModeStrs);
+    diaSetInt(diaVcdConfig, CFG_BDMASOURCE, gBdmaSource);
+    diaSetInt(diaVcdConfig, CFG_BDMAMODE, gBdmaMode);
+    diaSetInt(diaVcdConfig, CFG_BDMA_APPLY, gBdmaApplyOnLaunch);
+    diaSetInt(diaVcdConfig, CFG_VCD_HIDE_GAMEID, gVcdHideGameId);
+    diaSetInt(diaVcdConfig, CFG_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
+    // "VCD BDMA Apply on Launch" ON auto-equips, so hide the manual SOURCE/MODE pickers (guiVcdUpdater
+    // re-reveals them live when toggled off). POPSTARTER Path is the Custom-only escape hatch.
+    diaSetVisible(diaVcdConfig, CFG_LBL_BDMASOURCE, !gBdmaApplyOnLaunch);
+    diaSetVisible(diaVcdConfig, CFG_BDMASOURCE, !gBdmaApplyOnLaunch);
+    diaSetVisible(diaVcdConfig, CFG_LBL_BDMAMODE, !gBdmaApplyOnLaunch);
+    diaSetVisible(diaVcdConfig, CFG_BDMAMODE, !gBdmaApplyOnLaunch);
+    diaSetVisible(diaVcdConfig, CFG_LBL_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
+    diaSetVisible(diaVcdConfig, CFG_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
+
+    int ret = diaExecuteDialog(diaVcdConfig, -1, 1, &guiVcdUpdater);
+    if (ret) {
+        diaGetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, &gPopstarterDevice);
         {
             // The dialog field is char[32]; only adopt the typed value if it actually changed, so
-            // opening+saving General Settings never truncates a longer path stored via the cfg.
+            // opening+saving VCD Settings never truncates a longer path stored via the cfg.
             char tmpPop[sizeof(gPopstarterPath)];
-            diaGetString(diaConfig, CFG_POPSTARTER_PATH, tmpPop, sizeof(tmpPop));
+            diaGetString(diaVcdConfig, CFG_POPSTARTER_PATH, tmpPop, sizeof(tmpPop));
             if (strncmp(tmpPop, gPopstarterPath, 31) != 0)
                 snprintf(gPopstarterPath, sizeof(gPopstarterPath), "%s", tmpPop);
         }
-        diaGetInt(diaConfig, CFG_BDMA_APPLY, &gBdmaApplyOnLaunch);
-        diaGetInt(diaConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId); // display-only; next list draw reflects it, no rebuild needed
+        diaGetInt(diaVcdConfig, CFG_BDMA_APPLY, &gBdmaApplyOnLaunch);
+        diaGetInt(diaVcdConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId); // display-only; next list draw reflects it, no rebuild needed
         {
             // #118: first-disc-only changes the VCD list CONTENTS (discs hidden/shown), so unlike the
             // cosmetic hide-gameid it must rebuild every VCD-capable device page when toggled. Device
             // lists only -- Favourites are intentionally left unfiltered (an explicit user pick).
             int previousFirstDiscOnly = gVcdFirstDiscOnly;
-            diaGetInt(diaConfig, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
+            diaGetInt(diaVcdConfig, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
             if (gVcdFirstDiscOnly != previousFirstDiscOnly)
                 vcdMarkAllDirty();
         }
         {
-            // Equip BDMA modules only when SOURCE or MODE actually changed (the equip copies
-            // files to the memory card). vcdEquipBdma is free-space-gated + truncation-safe, so a
-            // failure never corrupts the card; report it and resync MODE to what's really equipped.
+            // Equip BDMA modules only when SOURCE or MODE actually changed (the equip copies files to
+            // the memory card). vcdEquipBdma is free-space-gated + truncation-safe, so a failure never
+            // corrupts the card; report it and resync MODE to what's really equipped.
             int oldSrc = gBdmaSource, oldMode = gBdmaMode; // baselines (MODE = card's actual state)
             int newSrc = oldSrc, newMode = oldMode;
-            diaGetInt(diaConfig, CFG_BDMASOURCE, &newSrc);
-            diaGetInt(diaConfig, CFG_BDMAMODE, &newMode);
+            diaGetInt(diaVcdConfig, CFG_BDMASOURCE, &newSrc);
+            diaGetInt(diaVcdConfig, CFG_BDMAMODE, &newMode);
             // Re-equip on any MODE change, and on a SOURCE change only when MODE installs modules. FAT32
-            // mode ignores the source entirely, so a SOURCE-only move while already FAT32 must NOT re-run
-            // the pointless unlink + marker rewrite.
+            // ignores the source, so a SOURCE-only move while already FAT32 must NOT re-run the pointless work.
             if (newMode != oldMode || (newMode != VCD_BDMA_FAT32 && newSrc != oldSrc)) {
                 char bdmaDiag[160];
                 int er = vcdEquipBdma(newSrc, newMode, bdmaDiag, sizeof(bdmaDiag));
                 if (er == -4) {
-                    // Append what the equip actually probed (needed files + which source devices were
-                    // mounted) so a tester can screenshot it -- tells us "device not seen" vs "files
-                    // mis-named/placed" in one shot instead of another guess.
                     char msg[256];
                     snprintf(msg, sizeof(msg), "%s\n%s", _l(_STR_BDMA_ERR_SRC), bdmaDiag);
                     guiMsgBox(msg, 0, NULL);
@@ -637,11 +659,37 @@ reshow_config:
             }
             gBdmaSource = newSrc; // remember the source preference regardless of equip outcome
         }
-        diaGetInt(diaConfig, CFG_ENWRITEOP, &gEnableWrite);
-        diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
-        diaGetInt(diaConfig, CFG_AUTOSTARTLAST, &gAutoStartLastPlayed);
-        DisableCron = 1; // Disable Auto Start Last Played counter (we don't want to call it right after enable it on GUI)
+        applyConfig(-1, -1, 0);
+        menuReinitMainMenu();
+    }
+}
 
+// MMCE Settings: SD2PSX / MemCard PRO2 tuning (memory-card slot, IGR slot, GameID push, SIO2 ack-wait
+// pacing, alarm usage). Relocated out of Device Settings; CFG ids shared with the old Device rows.
+void guiShowMmceConfig(void)
+{
+    const char *deviceSlots[] = {"0", "1", _l(_STR_AUTO), NULL};
+    const char *deviceAckWaitCycles[] = {"0", "1", "2", "3", "4", "5", NULL};
+    const char *deviceOnOff[] = {"OFF", "ON", NULL};
+    const char *deviceIGRSlots[] = {"NONE", "0", "1", "BOTH", NULL};
+
+    diaSetEnum(diaMmceConfig, CFG_MMCESLOT, deviceSlots);
+    diaSetInt(diaMmceConfig, CFG_MMCESLOT, gMMCESlot);
+    diaSetEnum(diaMmceConfig, CFG_MMCEIGRSLOT, deviceIGRSlots);
+    diaSetInt(diaMmceConfig, CFG_MMCEIGRSLOT, gMMCEIGRSlot);
+    diaSetInt(diaMmceConfig, CFG_MMCEGAMEID, gMMCEEnableGameID);
+    diaSetEnum(diaMmceConfig, CFG_MMCE_WAIT_CYCLES, deviceAckWaitCycles);
+    diaSetInt(diaMmceConfig, CFG_MMCE_WAIT_CYCLES, gMMCEAckWaitCycles);
+    diaSetEnum(diaMmceConfig, CFG_MMCE_USE_ALARMS, deviceOnOff);
+    diaSetInt(diaMmceConfig, CFG_MMCE_USE_ALARMS, gMMCEUseAlarms);
+
+    int ret = diaExecuteDialog(diaMmceConfig, -1, 1, NULL);
+    if (ret) {
+        diaGetInt(diaMmceConfig, CFG_MMCESLOT, &gMMCESlot);
+        diaGetInt(diaMmceConfig, CFG_MMCEIGRSLOT, &gMMCEIGRSlot);
+        diaGetInt(diaMmceConfig, CFG_MMCEGAMEID, &gMMCEEnableGameID);
+        diaGetInt(diaMmceConfig, CFG_MMCE_WAIT_CYCLES, &gMMCEAckWaitCycles);
+        diaGetInt(diaMmceConfig, CFG_MMCE_USE_ALARMS, &gMMCEUseAlarms);
         applyConfig(-1, -1, 0);
         menuReinitMainMenu();
     }
@@ -1013,10 +1061,6 @@ void guiShowDeviceConfig(void)
 {
     const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), _l(_STR_FAV), NULL};
     const char *deviceModes[] = {_l(_STR_OFF), _l(_STR_MANUAL), _l(_STR_AUTO), NULL};
-    const char *deviceSlots[] = {"0", "1", _l(_STR_AUTO), NULL};
-    const char *deviceAckWaitCycles[] = {"0", "1", "2", "3", "4", "5", NULL};
-    const char *deviceOnOff[] = {"OFF", "ON", NULL};
-    const char *deviceIGRSlots[] = {"NONE", "0", "1", "BOTH", NULL};
     const char *netProtocols[] = {"Off", "SMB", "UDPFS", "UDPBD", NULL}; // UDPBD kept for users on the older SUDPBDv2 server
     const char *udpfsModes[] = {"Files", "Image", NULL};                 // Files=udpfs_ioman filesystem, Image=udpfs_bd block
 
@@ -1072,18 +1116,10 @@ void guiShowDeviceConfig(void)
     diaSetInt(diaDeviceConfig, CFG_HDDCACHE, hddCacheSize);
     diaSetInt(diaDeviceConfig, CFG_SMBCACHE, smbCacheSize);
 
-    // MMCE
+    // MMCE Start Mode stays with the other device start modes; the MMCE game-config (slot / IGR slot /
+    // GameID / ack-wait / alarms) moved to its own "MMCE Settings" page -- see guiShowMmceConfig.
     diaSetEnum(diaDeviceConfig, CFG_MMCEMODE, deviceModes);
     diaSetInt(diaDeviceConfig, CFG_MMCEMODE, gMMCEStartMode);
-    diaSetEnum(diaDeviceConfig, CFG_MMCESLOT, deviceSlots);
-    diaSetInt(diaDeviceConfig, CFG_MMCESLOT, gMMCESlot);
-    diaSetEnum(diaDeviceConfig, CFG_MMCEIGRSLOT, deviceIGRSlots);
-    diaSetInt(diaDeviceConfig, CFG_MMCEIGRSLOT, gMMCEIGRSlot);
-    diaSetEnum(diaDeviceConfig, CFG_MMCE_WAIT_CYCLES, deviceAckWaitCycles);
-    diaSetInt(diaDeviceConfig, CFG_MMCE_WAIT_CYCLES, gMMCEAckWaitCycles);
-    diaSetEnum(diaDeviceConfig, CFG_MMCE_USE_ALARMS, deviceOnOff);
-    diaSetInt(diaDeviceConfig, CFG_MMCE_USE_ALARMS, gMMCEUseAlarms);
-    diaSetInt(diaDeviceConfig, CFG_MMCEGAMEID, gMMCEEnableGameID);
 
     int ret = diaExecuteDialog(diaDeviceConfig, -1, 1, &guiDeviceUpdater);
     if (ret) {
@@ -1131,11 +1167,6 @@ void guiShowDeviceConfig(void)
         diaGetInt(diaDeviceConfig, CFG_SMBCACHE, &smbCacheSize);
 
         diaGetInt(diaDeviceConfig, CFG_MMCEMODE, &gMMCEStartMode);
-        diaGetInt(diaDeviceConfig, CFG_MMCESLOT, &gMMCESlot);
-        diaGetInt(diaDeviceConfig, CFG_MMCEIGRSLOT, &gMMCEIGRSlot);
-        diaGetInt(diaDeviceConfig, CFG_MMCEGAMEID, &gMMCEEnableGameID);
-        diaGetInt(diaDeviceConfig, CFG_MMCE_WAIT_CYCLES, &gMMCEAckWaitCycles);
-        diaGetInt(diaDeviceConfig, CFG_MMCE_USE_ALARMS, &gMMCEUseAlarms);
 
         // The UDP transports' ministack has no DHCP client; with DHCP on, ps2_ip[] is never refreshed, so
         // they need a static PS2 IP. Warn when switching TO a UDP protocol (UDPFS/UDPFSBD/UDPBD) from a

--- a/src/gui.c
+++ b/src/gui.c
@@ -526,12 +526,12 @@ void guiShowConfig()
     diaSetString(diaConfig, CFG_EXITTO, gExitPath);
     // Neutrino lives at <root>:/neutrino/neutrino.elf on ANY device -- offer the common roots.
     // MUST stay in sync with the roots[] table in sbResolveNeutrinoPath() (supportbase.c).
-    const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", NULL}; // device TYPE holding /neutrino/neutrino.elf (NEUTRINO_DEV_*)
+    const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", _l(_STR_GAMES_DEVICE), NULL}; // device TYPE holding /neutrino/neutrino.elf (NEUTRINO_DEV_*); "Game's Device" (NEUTRINO_DEV_GAME) appended last to match the enum tail
     diaSetEnum(diaConfig, CFG_NEUTRINO_DEVICE, neutrinoDevStrs);
     diaSetInt(diaConfig, CFG_NEUTRINO_DEVICE, gNeutrinoDevice);
     // POPSTARTER.ELF device TYPE holding POPS/POPSTARTER.ELF (POPS_DEV_*). MUST stay in sync with the
     // resolution switch in vcdResolvePopstarter() (vcdsupport.c). Custom reveals the free-text path below.
-    const char *popsDevStrs[] = {_l(_STR_DEFAULT), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", "Custom", NULL};
+    const char *popsDevStrs[] = {_l(_STR_DEFAULT), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", "Custom", _l(_STR_GAMES_DEVICE), NULL}; // "Game's Device" (POPS_DEV_GAME) appended last to match the enum tail
     diaSetEnum(diaConfig, CFG_POPSTARTER_DEVICE, popsDevStrs);
     diaSetInt(diaConfig, CFG_POPSTARTER_DEVICE, gPopstarterDevice);
     diaSetString(diaConfig, CFG_POPSTARTER_PATH, gPopstarterPath);

--- a/src/gui.c
+++ b/src/gui.c
@@ -524,6 +524,12 @@ void guiShowConfig()
     diaSetInt(diaConfig, CFG_DEBUG, gEnableDebug);
     diaSetInt(diaConfig, CFG_PS2LOGO, gPS2Logo);
     diaSetString(diaConfig, CFG_EXITTO, gExitPath);
+    // Global default Loader Core: the core a game uses when its per-game selector is "Default".
+    // <OPL> = OPL's native ee-core; Neutrino = the external neutrino.elf. Indices 0/1 match the
+    // stored value (0=<OPL>, 1=Neutrino) and the first two per-game COMPAT_LOADER options.
+    const char *defaultCoreStrs[] = {"<OPL>", "Neutrino", NULL};
+    diaSetEnum(diaConfig, CFG_DEFAULT_CORE, defaultCoreStrs);
+    diaSetInt(diaConfig, CFG_DEFAULT_CORE, gDefaultCoreLoader);
     // Neutrino lives at <root>:/neutrino/neutrino.elf on ANY device -- offer the common roots.
     // MUST stay in sync with the roots[] table in sbResolveNeutrinoPath() (supportbase.c).
     const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", _l(_STR_GAMES_DEVICE), NULL}; // device TYPE holding /neutrino/neutrino.elf (NEUTRINO_DEV_*); "Game's Device" (NEUTRINO_DEV_GAME) appended last to match the enum tail
@@ -580,6 +586,7 @@ reshow_config:
         diaGetInt(diaConfig, CFG_DEBUG, &gEnableDebug);
         diaGetInt(diaConfig, CFG_PS2LOGO, &gPS2Logo);
         diaGetString(diaConfig, CFG_EXITTO, gExitPath, sizeof(gExitPath));
+        diaGetInt(diaConfig, CFG_DEFAULT_CORE, &gDefaultCoreLoader);
         diaGetInt(diaConfig, CFG_NEUTRINO_DEVICE, &gNeutrinoDevice);
         diaGetInt(diaConfig, CFG_POPSTARTER_DEVICE, &gPopstarterDevice);
         {

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -976,6 +976,11 @@ static unsigned char gameEffectiveFlags(item_list_t *support)
 // updater re-runs guiGameSetCoreAwareState on EVERY dialog change with no device handle -- a
 // one-shot diaSetEnabled here would be clobbered (same pattern as the UDPBD loader lock).
 static int bsdfsDeviceCapable = 1;
+// VCD (PS1) view: launches ONLY via POPSTARTER -- never OPL's core nor Neutrino. Set once per dialog
+// entry (same one-shot pattern as bsdfsDeviceCapable) so the core-aware grey keeps every Neutrino-only
+// row greyed for a VCD game even when the global default core is Neutrino (the locked "Default" row
+// would otherwise resolve to the global and un-grey them).
+static int coreNeverNeutrino = 0;
 
 static void guiGameSetCoreAwareState(void)
 {
@@ -985,6 +990,8 @@ static void guiGameSetCoreAwareState(void)
     // iff explicitly Neutrino, OR "Default" while the global gDefaultCoreLoader is Neutrino -- so the
     // Neutrino-only rows grey correctly even when the game defers its core to the global setting.
     neutrino = (coreChoice == 1) || (coreChoice == 2 && gDefaultCoreLoader == 1);
+    if (coreNeverNeutrino)
+        neutrino = 0; // VCD (POPSTARTER-only): keep all Neutrino-only rows greyed regardless of the global
     diaGetInt(diaCompatConfig, COMPAT_NEUTRINO_VIDEO, &neutrinoVideo);
 
     diaSetEnabled(diaCompatConfig, COMPAT_NEUTRINO_ARGS, neutrino);  // Neutrino-only field
@@ -1046,6 +1053,9 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
     bsdfsDeviceCapable = (support == NULL) ||
                          ((support->mode >= BDM_MODE && support->mode <= BDM_MODE6 && !vcdViewActive(support->mode)) ||
                           support->mode == FAV_MODE);
+    // VCD games launch through POPSTARTER only, so the Loader Core is inert for them -- keep every
+    // Neutrino-only row greyed even under a Neutrino global default (guiGameSetCoreAwareState reads this).
+    coreNeverNeutrino = (support != NULL && vcdViewActive(support->mode));
 
     // UDPBD games have no OPL core backend -- they always launch via Neutrino
     // (bdmsupport.c forces it). Lock the selector to Neutrino so the screen matches;

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -1137,9 +1137,9 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
         configRemoveKey(configSet, CONFIG_ITEM_COMPAT);
 
     diaGetInt(diaCompatConfig, COMPAT_LOADER, &coreLoader);
-    if (coreLoader == 2)                                     // "Default" -> drop the per-game key so the game follows gDefaultCoreLoader
+    if (coreLoader == 2) // "Default" -> drop the per-game key so the game follows gDefaultCoreLoader
         configRemoveKey(configSet, CONFIG_ITEM_CORE_LOADER);
-    else                                                     // 0=<OPL>, 1=Neutrino -> explicit per-game override (writes even 0 so it beats a Neutrino global)
+    else // 0=<OPL>, 1=Neutrino -> explicit per-game override (writes even 0 so it beats a Neutrino global)
         result = configSetInt(configSet, CONFIG_ITEM_CORE_LOADER, coreLoader);
 
     /// GSM ///

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -979,8 +979,12 @@ static int bsdfsDeviceCapable = 1;
 
 static void guiGameSetCoreAwareState(void)
 {
-    int neutrino = 0, neutrinoVideo = 0;
-    diaGetInt(diaCompatConfig, COMPAT_LOADER, &neutrino);
+    int coreChoice = 0, neutrino = 0, neutrinoVideo = 0;
+    diaGetInt(diaCompatConfig, COMPAT_LOADER, &coreChoice);
+    // COMPAT_LOADER: 0=<OPL>, 1=Neutrino, 2=Default(follow global). The effective core is Neutrino
+    // iff explicitly Neutrino, OR "Default" while the global gDefaultCoreLoader is Neutrino -- so the
+    // Neutrino-only rows grey correctly even when the game defers its core to the global setting.
+    neutrino = (coreChoice == 1) || (coreChoice == 2 && gDefaultCoreLoader == 1);
     diaGetInt(diaCompatConfig, COMPAT_NEUTRINO_VIDEO, &neutrinoVideo);
 
     diaSetEnabled(diaCompatConfig, COMPAT_NEUTRINO_ARGS, neutrino);  // Neutrino-only field
@@ -1016,7 +1020,10 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
         diaSetEnum(diaCompatConfig, COMPAT_DMA, dmaModes);
     }
 
-    const char *loaders[] = {"<OPL>", "Neutrino", NULL};
+    // Index 0/1 == the stored $CoreLoader value (0=<OPL>, 1=Neutrino); index 2 "Default" = no per-game
+    // key -> follow the global gDefaultCoreLoader. Keeping 0/1 aligned with the stored ints means the
+    // UDPBD lock (index 1) and the launch-side value semantics are untouched -- only "Default" is new.
+    const char *loaders[] = {"<OPL>", "Neutrino", _l(_STR_DEFAULT), NULL};
     diaSetEnum(diaCompatConfig, COMPAT_LOADER, loaders);
 
     // Indices map 1:1 onto system.c's gsmVideoTokens (fp1/fp2/1080ix1/ix2/ix3) -- old configs
@@ -1045,9 +1052,10 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
     // re-enable it for every other device (the dialog struct is reused across games).
     if (support != NULL && vcdViewActive(support->mode)) {
         // VCD (PS1) games launch ONLY via POPSTARTER -- neither OPL's core nor Neutrino is used, so the
-        // Loader Core choice is meaningless. Pin it to the inert <OPL> label and lock the row so the
-        // screen doesn't imply a VCD game could run under a different core.
-        diaSetInt(diaCompatConfig, COMPAT_LOADER, 0);
+        // Loader Core choice is meaningless. Pin it to the inert "Default" row (index 2 -> no per-game
+        // $CoreLoader key persisted, as before) and lock the row so the screen doesn't imply a VCD game
+        // could run under a different core.
+        diaSetInt(diaCompatConfig, COMPAT_LOADER, 2);
         diaSetEnabled(diaCompatConfig, COMPAT_LOADER, 0);
     } else if (bdmSupportIsUDPBD(support)) {
         diaSetInt(diaCompatConfig, COMPAT_LOADER, 1);
@@ -1119,10 +1127,10 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
         configRemoveKey(configSet, CONFIG_ITEM_COMPAT);
 
     diaGetInt(diaCompatConfig, COMPAT_LOADER, &coreLoader);
-    if (coreLoader != 0)
-        result = configSetInt(configSet, CONFIG_ITEM_CORE_LOADER, coreLoader);
-    else
+    if (coreLoader == 2)                                     // "Default" -> drop the per-game key so the game follows gDefaultCoreLoader
         configRemoveKey(configSet, CONFIG_ITEM_CORE_LOADER);
+    else                                                     // 0=<OPL>, 1=Neutrino -> explicit per-game override (writes even 0 so it beats a Neutrino global)
+        result = configSetInt(configSet, CONFIG_ITEM_CORE_LOADER, coreLoader);
 
     /// GSM ///
     diaGetInt(diaGSConfig, GSMCFG_ENABLEGSM, &EnableGSM);
@@ -1655,8 +1663,10 @@ void guiGameLoadConfig(item_list_t *support, config_set_t *configSet)
     for (i = 0; i < COMPAT_MODE_COUNT; ++i)
         diaSetInt(diaCompatConfig, COMPAT_MODE_BASE + i, (compatMode & (1 << i)) > 0 ? 1 : 0);
 
-    coreLoader = 0;
-    configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+    // COMPAT_LOADER index == the stored $CoreLoader value when present (0=<OPL>, 1=Neutrino); a missing
+    // key maps to index 2 "Default" so the game defers its core to the global gDefaultCoreLoader.
+    if (!configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader))
+        coreLoader = 2;
     diaSetInt(diaCompatConfig, COMPAT_LOADER, coreLoader);
 
     guiGameLoadGSMConfig(configSet, configGame);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -694,7 +694,7 @@ static void hddLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
 // OPL, or any Neutrino-side failure -- ZSO, no install, preflight -- since HDL always boots natively).
 static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
 {
-    int coreLoader = 0;
+    int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
     configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
     if (!coreLoader)
         return 0;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -990,6 +990,10 @@ static config_set_t *hddGetConfig(item_list_t *itemList, int id)
         configRead(vcdConfig);
         configSetStr(vcdConfig, CONFIG_ITEM_NAME, g->name);
         configSetStr(vcdConfig, CONFIG_ITEM_STARTUP, g->name);
+        // HDD bypasses sbPopulateConfig, which is what sets #Format="VCD" for every other device's VCD
+        // list (supportbase.c). Without it the info-page #Format AttributeImage has no value and falls
+        // back to the theme default (ELF glyph) -- so set it here to render the VCD badge like the rest.
+        configSetStr(vcdConfig, CONFIG_ITEM_FORMAT, "VCD");
         // HDD bypasses sbPopulateConfig, so set the #System/#Media/#DiscType badge attributes via the
         // shared helper (FR #49) -- a POPS disc is always a PS1 CD. Without it those badges never render.
         sbSetDiscAttributes(vcdConfig, 1, 1);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -27,6 +27,8 @@
 enum MENU_IDs {
     MENU_SETTINGS = 0,
     MENU_DEVICE_SETTINGS,
+    MENU_VCD_SETTINGS,
+    MENU_MMCE_SETTINGS,
     MENU_GFX_SETTINGS,
     MENU_AUDIO_SETTINGS,
     MENU_CONTROLLER_SETTINGS,
@@ -435,6 +437,8 @@ static void menuInitMainMenu(void)
     submenuAppendItem(&mainMenu, -1, NULL, MENU_LAUNCH_PS2_DISC, _STR_LAUNCH_PS2_DISC, NULL);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_SETTINGS, _STR_GENERAL_SETTINGS, NULL);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_DEVICE_SETTINGS, _STR_DEVICE_SETTINGS, NULL);
+    submenuAppendItem(&mainMenu, -1, NULL, MENU_VCD_SETTINGS, _STR_VCD_SETTINGS, NULL);
+    submenuAppendItem(&mainMenu, -1, NULL, MENU_MMCE_SETTINGS, _STR_MMCE_SETTINGS, NULL);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_GFX_SETTINGS, _STR_GFX_SETTINGS, NULL);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_AUDIO_SETTINGS, _STR_AUDIO_SETTINGS, NULL);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_CONTROLLER_SETTINGS, _STR_CONTROLLER_SETTINGS, NULL);
@@ -1146,6 +1150,12 @@ void menuHandleInputMenu()
         } else if (id == MENU_DEVICE_SETTINGS) {
             if (menuCheckParentalLock() == 0)
                 guiShowDeviceConfig();
+        } else if (id == MENU_VCD_SETTINGS) {
+            if (menuCheckParentalLock() == 0)
+                guiShowVcdConfig();
+        } else if (id == MENU_MMCE_SETTINGS) {
+            if (menuCheckParentalLock() == 0)
+                guiShowMmceConfig();
         } else if (id == MENU_GFX_SETTINGS) {
             if (menuCheckParentalLock() == 0)
                 guiShowUIConfig();

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -90,6 +90,10 @@ static ee_sema_t menuSema;
 
 #define MENU_MMCE_CONFIG_IDLE_FRAMES 20
 #define MENU_APP_CONFIG_IDLE_FRAMES  1
+// Browse-settle info-art prewarm (#120 follow-up): after this many idle frames (~2s) with the art
+// pipeline empty, the SELECTED item's info art (BG/SCR/SCR2) is queued at prefetch priority on the
+// slow buses, so Square opens an already-warm info page.
+#define MENU_INFO_PREWARM_IDLE_FRAMES 120
 
 static void menuInvalidateArtSelection(void)
 {
@@ -1270,6 +1274,17 @@ void menuRenderMain(void)
         menuRenderElements(&gTheme->mainElems, allowItemConfig, renderConfig);
         gTheme->itemsList = gTheme->gamesItemsList;
     }
+
+    // Browse-time info-art prewarm, slow buses only: once the selection has settled ~2s and the art
+    // pipeline is idle, queue the SELECTED item's info art (BG/SCR/SCR2) at PREFETCH priority so
+    // Square opens a warm page. Idempotent per frame: QUEUED/LOADING/DISPLAYABLE entries and the
+    // FAILED generation marker all no-op inside the cache, so no one-shot latch is needed and a
+    // card with no SCR/SCR2 art is probed at most once per settle. (HDD note: an in-flight HDD
+    // prewarm read is not abortable and can share the PFS/ATA channel with the first post-settle
+    // scroll for up to one file read -- the same exposure class as the existing HDD cover prefetch.)
+    if (list != NULL && (list->mode == MMCE_MODE || list->mode == HDD_MODE) &&
+        guiInactiveFrames >= MENU_INFO_PREWARM_IDLE_FRAMES && !cacheHasPendingArt())
+        menuPrewarmInfoArt(0);
 }
 
 // Coverflow rotates the nav axis on the MAIN screen only: Left/Right step through the
@@ -1357,27 +1372,56 @@ void menuHandleInputMain()
     }
 }
 
+// Info-element family for a list: mirrors menuRenderInfo's dispatch (VCD view first -- it also
+// covers the Favourites tab's L3 VCD view -- then FAV/APP, else the games family). Shared with the
+// info-art prewarm so render and prewarm can never pick different families.
+static theme_elems_t *menuGetInfoElems(item_list_t *list)
+{
+    if (list != NULL && vcdViewActive(list->mode))
+        return &gTheme->vcdInfoElems;
+    if (list != NULL && list->mode == FAV_MODE)
+        return &gTheme->favsInfoElems;
+    if (list != NULL && list->mode == APP_MODE)
+        return &gTheme->appsInfoElems;
+    return &gTheme->infoElems;
+}
+
 void menuRenderInfo(void)
 {
     item_list_t *list = selected_item->item->userdata;
 
+    menuRenderElements(menuGetInfoElems(list), 1, itemConfig);
+
     if (vcdViewActive(list->mode)) {
-        // VCD info uses the vcd family (vcdInfo*, falling back to info* -- the GAME info layout, so VCDs
-        // keep their rich game-style metadata page unless a theme overrides it). The list uses
-        // vcdItemsList (its own cover cache); falls back to the games list when absent so itemsList is
-        // never NULL. Also covers the Favourites tab's VCD view (its L3 toggle).
-        menuRenderElements(&gTheme->vcdInfoElems, 1, itemConfig);
+        // The VCD list uses vcdItemsList (its own cover cache); falls back to the games list when
+        // absent so itemsList is never NULL. Also covers the Favourites tab's VCD view (L3 toggle).
         gTheme->itemsList = gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList;
     } else if (list->mode == FAV_MODE) {
-        menuRenderElements(&gTheme->favsInfoElems, 1, itemConfig);
         gTheme->itemsList = gTheme->favsItemsList ? gTheme->favsItemsList : gTheme->gamesItemsList;
     } else if (list->mode == APP_MODE) {
-        menuRenderElements(&gTheme->appsInfoElems, 1, itemConfig);
         gTheme->itemsList = gTheme->appsItemsList ? gTheme->appsItemsList : gTheme->gamesItemsList;
     } else {
-        menuRenderElements(&gTheme->infoElems, 1, itemConfig);
         gTheme->itemsList = gTheme->gamesItemsList;
     }
+}
+
+// Prewarm the SELECTED item's info-page art. entry!=0 from itemExecSquare (Square just pressed);
+// entry==0 from the browse-settle hook in menuRenderMain. Bounded: only fires when the info screen
+// is reachable (same gTheme->infoElems.first condition as the Square hint / itemExecSquare) and art
+// is enabled (checked inside thmPrewarmInfoArt). GUI thread only (itemExecSquare / menuRenderMain),
+// same unlocked selected_item access discipline as itemExecSquare.
+void menuPrewarmInfoArt(int entry)
+{
+    item_list_t *list;
+
+    if (selected_item == NULL || selected_item->item == NULL || selected_item->item->current == NULL)
+        return;
+    if (gTheme == NULL || gTheme->infoElems.first == NULL)
+        return;
+    list = selected_item->item->userdata;
+    if (list == NULL || !list->enabled)
+        return;
+    thmPrewarmInfoArt(menuGetInfoElems(list), list, &selected_item->item->current->item, entry);
 }
 
 void menuHandleInputInfo()

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1466,6 +1466,15 @@ static int gameMenuCoreIsNeutrino(void)
     int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
     if (itemConfig != NULL)
         configGetInt(itemConfig, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+    // VCD (PS1) games launch ONLY via POPSTARTER -- never Neutrino -- so a keyless VCD must not
+    // inherit a Neutrino global default here, or its Cheats/GSM/OSD menu entries get blocked with
+    // the wrong "not available under Neutrino" message (same exemption as the compat dialog's
+    // coreNeverNeutrino flag in guigame.c).
+    if (selected_item != NULL && selected_item->item != NULL) {
+        item_list_t *support = (item_list_t *)selected_item->item->userdata;
+        if (support != NULL && vcdViewActive(support->mode))
+            return 0;
+    }
     // UDPBD games are Neutrino-only even while $CoreLoader is still its OPL default.
     if (!coreLoader && selected_item != NULL && selected_item->item != NULL)
         coreLoader = bdmSupportIsUDPBD(selected_item->item->userdata);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -88,8 +88,8 @@ static s32 menuSemaId = -1;
 static s32 menuListSemaId = -1;
 static ee_sema_t menuSema;
 
-#define MENU_MMCE_CONFIG_IDLE_FRAMES 20
-#define MENU_APP_CONFIG_IDLE_FRAMES  1
+#define MENU_MMCE_CONFIG_IDLE_FRAMES  20
+#define MENU_APP_CONFIG_IDLE_FRAMES   1
 // Browse-settle info-art prewarm (#120 follow-up): after this many idle frames (~2s) with the art
 // pipeline empty, the SELECTED item's info art (BG/SCR/SCR2) is queued at prefetch priority on the
 // slow buses, so Square opens an already-warm info page.

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1463,7 +1463,7 @@ void menuRenderGameMenu()
 // honored under Neutrino.)
 static int gameMenuCoreIsNeutrino(void)
 {
-    int coreLoader = 0;
+    int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
     if (itemConfig != NULL)
         configGetInt(itemConfig, CONFIG_ITEM_CORE_LOADER, &coreLoader);
     // UDPBD games are Neutrino-only even while $CoreLoader is still its OPL default.

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -605,10 +605,17 @@ void menuAppendItem(menu_item_t *item)
 
 static void refreshMenuPosition(void)
 {
-    // Find the first menu in the list that is visible and set it as the active menu.
     if (menu == NULL)
         return;
 
+    // Nad #6: this runs on EVERY start-menu exit -- if the current tab is still visible there is
+    // nothing to refresh, so KEEP it. The old unconditional reseat below positionally dumped the
+    // selection onto the first visible tab (BDM devices register first, so typically MX4SIO) on
+    // every settings/start-menu round trip, overriding the user's Default Menu landing.
+    if (selected_item != NULL && selected_item->item != NULL && selected_item->item->visible)
+        return;
+
+    // Find the first menu in the list that is visible and set it as the active menu.
     menu_list_t *cur = menu;
     while (cur->item->visible == 0 && cur->next)
         cur = cur->next;

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -645,7 +645,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
     // Per-game Neutrino core: gate BEFORE opening iso_file so no fd is leaked on
     // the Neutrino path (game is still valid here for the format check).
-    int coreLoader = 0;
+    int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
     configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
     const char *neutrinoPath = NULL;
     char neutrinoExtraArgs[256] = "";      // per-game Neutrino flags; copied before deinit teardown

--- a/src/opl.c
+++ b/src/opl.c
@@ -371,6 +371,11 @@ static void itemExecSquare(struct menu_item *curMenu)
         // #Size is skipped while scrolling so the badges paint instantly; resolve it now (async).
         menuRequestInfoSize();
         guiSwitchScreen(GUI_SCREEN_INFO);
+        // Fire the info art (BG -> SCR -> SCR2) NOW at interactive priority, bypassing the settle:
+        // the slow-bus reads run under the screen-switch fade instead of trickling in draw order
+        // after it (#120 follow-up). Placed AFTER guiSwitchScreen so its generation advance never
+        // touches these fresh requests; on exit the in-flight read finishes and stays cached.
+        menuPrewarmInfoArt(1);
     }
 }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -2701,10 +2701,31 @@ static void deferredInit(void)
     if (id)
         guiDeferUpdate(id);
 
-    if (list_support[gDefaultDevice].support) {
+    // Nad #6: never silently SKIP the boot select -- doing so left the GUI on the start-menu screen
+    // with the first-appended tab (a BDM instance, typically MX4SIO) as the implicit selection. If
+    // the configured Default Menu's mode is not registered, fall back MMCE -> APP -> the first
+    // registered mode (mirroring applyConfig's clamp); only when NOTHING is registered is there no
+    // main screen worth selecting and the start menu stays.
+    int bootMode = gDefaultDevice;
+    if (list_support[bootMode].support == NULL) {
+        if (list_support[MMCE_MODE].support != NULL)
+            bootMode = MMCE_MODE;
+        else if (list_support[APP_MODE].support != NULL)
+            bootMode = APP_MODE;
+        else {
+            bootMode = -1;
+            for (int i = 0; i < MODE_COUNT; i++) {
+                if (list_support[i].support != NULL) {
+                    bootMode = i;
+                    break;
+                }
+            }
+        }
+    }
+    if (bootMode >= 0 && list_support[bootMode].support) {
         id = guiOpCreate(GUI_OP_SELECT_MENU);
         if (id) {
-            id->menu.menu = &list_support[gDefaultDevice].menuItem;
+            id->menu.menu = &list_support[bootMode].menuItem;
             guiDeferUpdate(id);
         }
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -200,6 +200,7 @@ char gExitPath[256];
 char gNeutrinoArgs[256];   // extra command-line flags appended to every Neutrino launch
 char gNeutrinoPath[256];   // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
 int gNeutrinoDevice;       // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy gNeutrinoPath
+int gDefaultCoreLoader;    // global default Loader Core (0=<OPL>, 1=Neutrino); per-game $CoreLoader overrides, absent key = follow this
 int gNeutrinoElfArg;       // opt-in (settings key only, no UI): auto-emit -elf=cdrom0: on Neutrino launches (parity Delta-10)
 char gPopstarterPath[256]; // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
 int gPopstarterDevice;     // POPSTARTER.ELF device (POPS_DEV_*); Default = cwd then VCD device; legacy path -> Custom
@@ -1540,6 +1541,9 @@ static void _loadConfig()
             // change), migrate the legacy device-INDEX value -- 0=Auto, 1/2=mc0/mc1 -> MC, 11/12=
             // mmce0/mmce1 -> MMCE, 3-10=mass* -> Auto (a bare massN index can't name a driver type).
             configGetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, &gNeutrinoElfArg);
+            // Global default Loader Core (0=<OPL>, 1=Neutrino). Absent in legacy configs -> keep the
+            // reset default (0/<OPL>), so existing installs behave exactly as before this key existed.
+            configGetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, &gDefaultCoreLoader);
             if (!configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, &gNeutrinoDevice)) {
                 int legacyDev = 0;
                 if (configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVICE, &legacyDev)) {
@@ -1824,6 +1828,7 @@ static void _saveConfig()
         configSetStr(configOPL, CONFIG_OPL_DEFAULT_BGM_PATH, gDefaultBGMPath);
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs);
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath);
+        configSetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, gDefaultCoreLoader);  // global default Loader Core (0=<OPL>, 1=Neutrino)
         configSetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, gNeutrinoDevice); // device-TYPE (NEUTRINO_DEV_*); the legacy neutrino_device key is left as-is
         configSetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, gNeutrinoElfArg);
         configSetStr(configOPL, CONFIG_OPL_POPSTARTER_PATH, gPopstarterPath);
@@ -2512,6 +2517,7 @@ static void setDefaults(void)
     gNeutrinoArgs[0] = '\0';
     gNeutrinoPath[0] = '\0';
     gNeutrinoDevice = NEUTRINO_DEV_AUTO;
+    gDefaultCoreLoader = 0; // <OPL> (native) -- preserves pre-existing behaviour until the user opts into Neutrino globally
     gNeutrinoElfArg = 0; // experimental Delta-10 -elf emission stays opt-in
     gPopstarterPath[0] = '\0';
     gPopstarterDevice = POPS_DEV_DEFAULT;

--- a/src/opl.c
+++ b/src/opl.c
@@ -1863,8 +1863,16 @@ static void _saveConfig()
         configSetStr(configNet, CONFIG_NET_SMB_PASSW, gPCPassword);
     }
 
+    // Create/refresh the legacy mc?:OPL home ONLY in legacy-discovery mode (no known boot dir). The
+    // "mc" prefix test alone cannot tell the legacy mc?:OPL config root from an APPDIR THAT LIVES ON
+    // A MEMORY CARD (FMCB-style mc0:/APPS install: configGetDir() truncates either to "mc0:"), so an
+    // appdir-on-MC boot used to sprout an unwanted mc?:/OPL folder (+ icons) on every settings/theme/
+    // last-played save while the .cfg files themselves correctly stayed in the appdir -- and the
+    // configPrepareNotifications(gBaseMCDir) call re-pointed the "Settings saved to %s" toast at the
+    // wildcard card instead of the real appdir. gBootDir is the authoritative gate, same as the
+    // alternate-save logic below: non-empty means the appdir IS the config root, MC stays untouched.
     char *path = configGetDir();
-    if (!strncmp(path, "mc", 2)) {
+    if (gBootDir[0] == '\0' && !strncmp(path, "mc", 2)) {
         checkMCFolder();
         configPrepareNotifications(gBaseMCDir);
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -2724,6 +2724,10 @@ static void miniInit(int mode)
             configGetInt(configOPL, CONFIG_OPL_PS2LOGO, &gPS2Logo);
             configGetStrCopy(configOPL, CONFIG_OPL_EXIT_PATH, gExitPath, sizeof(gExitPath));
             configGetInt(configOPL, CONFIG_OPL_HDD_SPINDOWN, &gHDDSpindown);
+            // Honor the global default Loader Core on the autolaunch/argv path too, exactly like the
+            // interactive _loadConfig read -- else a keyless "Default" game boots under <OPL> here even
+            // when the user set the global to Neutrino (absent key keeps the setDefaults() 0 = <OPL>).
+            configGetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, &gDefaultCoreLoader);
             if (mode == BDM_MODE) {
                 configGetStrCopy(configOPL, CONFIG_OPL_BDM_PREFIX, gBDMPrefix, sizeof(gBDMPrefix));
                 configGetInt(configOPL, CONFIG_OPL_BDM_CACHE, &bdmCacheSize);

--- a/src/opl.c
+++ b/src/opl.c
@@ -292,8 +292,16 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
 
     // refresh Cache
     if (themeChanged) {
-        if (mod->subMenu)
+        if (mod->subMenu) {
+            // Serialize the per-item cache_id/cache_uid array reallocation with rendering: this runs
+            // on the IO thread during a mid-session theme reload while the GUI thread draws the
+            // carousel THROUGH those arrays (read + write on enqueue). Unserialized, a draw racing
+            // the free()+malloc() wrote a fresh (index, uid) pair through a freed pointer into a
+            // NEIGHBOUR's reallocated array -- the permanent wrong-cover mapping (test note #2).
+            guiLock();
             submenuRebuildCache(mod->subMenu);
+            guiUnlock();
+        }
         guiCheckNotifications(themeChanged, 0);
     }
 }
@@ -1963,10 +1971,14 @@ void applyConfig(int themeID, int langID, int skipDeviceRefresh)
         }
     } else {
         if (changed) {
+            // Same serialization as moduleUpdateMenuInternal: never realloc the per-item art-pair
+            // arrays while the GUI thread may be drawing through them (test note #2).
+            guiLock();
             for (int i = 0; i < MODE_COUNT; i++) {
                 if (list_support[i].support && list_support[i].subMenu)
                     submenuRebuildCache(list_support[i].subMenu);
             }
+            guiUnlock();
         }
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -2467,21 +2467,27 @@ void setDefaultColors(void)
     gDefaultPlasBlendColor[0] = 0x00;
     gDefaultPlasBlendColor[1] = 0x00;
     gDefaultPlasBlendColor[2] = 0x00;
-    gDefaultBgColor[0] = 0x28;
-    gDefaultBgColor[1] = 0xC5;
-    gDefaultBgColor[2] = 0xF9;
+    // The fork's navy <OPL> reskin lives HERE, not in the embedded conf_theme_OPL.cfg: theme-cfg
+    // color keys OVERRIDE the user's picked colors on every thmLoad(NULL) reload (boot vmode change,
+    // language change, theme-device unplug), while thmSetColors re-applies the user picks on other
+    // paths -- so cfg-embedded colors made the look flip-flop and user picks not stick (tester
+    // report: "changing settings makes it default look"). As defaults they seed the same navy
+    // scheme, survive every reload once the user re-picks, and "Reset Colors" restores the fork look.
+    gDefaultBgColor[0] = 0x18;
+    gDefaultBgColor[1] = 0x25;
+    gDefaultBgColor[2] = 0x80;
 
-    gDefaultTextColor[0] = 0xFF;
-    gDefaultTextColor[1] = 0xFF;
-    gDefaultTextColor[2] = 0xFF;
+    gDefaultTextColor[0] = 0x32;
+    gDefaultTextColor[1] = 0x4d;
+    gDefaultTextColor[2] = 0x9e;
 
-    gDefaultSelTextColor[0] = 0x00;
-    gDefaultSelTextColor[1] = 0xAE;
+    gDefaultSelTextColor[0] = 0xFF;
+    gDefaultSelTextColor[1] = 0xFF;
     gDefaultSelTextColor[2] = 0xFF;
 
-    gDefaultUITextColor[0] = 0x58;
-    gDefaultUITextColor[1] = 0x68;
-    gDefaultUITextColor[2] = 0xB4;
+    gDefaultUITextColor[0] = 0x00;
+    gDefaultUITextColor[1] = 0xFF;
+    gDefaultUITextColor[2] = 0xFF;
 }
 
 static void setDefaults(void)

--- a/src/opl.c
+++ b/src/opl.c
@@ -2559,7 +2559,7 @@ static void setDefaults(void)
     gNeutrinoPath[0] = '\0';
     gNeutrinoDevice = NEUTRINO_DEV_AUTO;
     gDefaultCoreLoader = 0; // <OPL> (native) -- preserves pre-existing behaviour until the user opts into Neutrino globally
-    gNeutrinoElfArg = 0; // experimental Delta-10 -elf emission stays opt-in
+    gNeutrinoElfArg = 0;    // experimental Delta-10 -elf emission stays opt-in
     gPopstarterPath[0] = '\0';
     gPopstarterDevice = POPS_DEV_DEFAULT;
     gBdmaSource = VCD_BDMA_SRC_USB;

--- a/src/opl.c
+++ b/src/opl.c
@@ -1364,6 +1364,35 @@ static void resolveBootDirToMass(void)
     }
 }
 
+// Shared reader for the Neutrino-launch globals (args/path/-elf opt-in/global default core/device
+// TYPE incl. the legacy device-INDEX migration). Factored out so the interactive _loadConfig and the
+// autolaunch miniInit can never drift again -- the argv/autolaunch path previously read none of these
+// (then only DEFAULT_CORE), so a keyless "Default" game booted Neutrino with a stale AUTO device and
+// empty global args there, silently diverging from an interactive launch of the same game.
+static void configReadNeutrinoGlobals(config_set_t *configOPL)
+{
+    configGetStrCopy(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs, sizeof(gNeutrinoArgs));
+    configGetStrCopy(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath, sizeof(gNeutrinoPath));
+    configGetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, &gNeutrinoElfArg);
+    // Global default Loader Core (0=<OPL>, 1=Neutrino). Absent in legacy configs -> keep the
+    // reset default (0/<OPL>), so existing installs behave exactly as before this key existed.
+    configGetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, &gDefaultCoreLoader);
+    // Neutrino Device: prefer the new device-TYPE key; if absent (config predates the picker
+    // change), migrate the legacy device-INDEX value -- 0=Auto, 1/2=mc0/mc1 -> MC, 11/12=
+    // mmce0/mmce1 -> MMCE, 3-10=mass* -> Auto (a bare massN index can't name a driver type).
+    if (!configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, &gNeutrinoDevice)) {
+        int legacyDev = 0;
+        if (configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVICE, &legacyDev)) {
+            if (legacyDev == 1 || legacyDev == 2)
+                gNeutrinoDevice = NEUTRINO_DEV_MC;
+            else if (legacyDev == 11 || legacyDev == 12)
+                gNeutrinoDevice = NEUTRINO_DEV_MMCE;
+            else
+                gNeutrinoDevice = NEUTRINO_DEV_AUTO;
+        }
+    }
+}
+
 static void _loadConfig()
 {
     int value, themeID = -1, langID = -1;
@@ -1535,26 +1564,7 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_BOOT_SND_VOLUME, &gBootSndVolume);
             configGetInt(configOPL, CONFIG_OPL_BGM_VOLUME, &gBGMVolume);
             configGetStrCopy(configOPL, CONFIG_OPL_DEFAULT_BGM_PATH, gDefaultBGMPath, sizeof(gDefaultBGMPath));
-            configGetStrCopy(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs, sizeof(gNeutrinoArgs));
-            configGetStrCopy(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath, sizeof(gNeutrinoPath));
-            // Neutrino Device: prefer the new device-TYPE key; if absent (config predates the picker
-            // change), migrate the legacy device-INDEX value -- 0=Auto, 1/2=mc0/mc1 -> MC, 11/12=
-            // mmce0/mmce1 -> MMCE, 3-10=mass* -> Auto (a bare massN index can't name a driver type).
-            configGetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, &gNeutrinoElfArg);
-            // Global default Loader Core (0=<OPL>, 1=Neutrino). Absent in legacy configs -> keep the
-            // reset default (0/<OPL>), so existing installs behave exactly as before this key existed.
-            configGetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, &gDefaultCoreLoader);
-            if (!configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, &gNeutrinoDevice)) {
-                int legacyDev = 0;
-                if (configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVICE, &legacyDev)) {
-                    if (legacyDev == 1 || legacyDev == 2)
-                        gNeutrinoDevice = NEUTRINO_DEV_MC;
-                    else if (legacyDev == 11 || legacyDev == 12)
-                        gNeutrinoDevice = NEUTRINO_DEV_MMCE;
-                    else
-                        gNeutrinoDevice = NEUTRINO_DEV_AUTO;
-                }
-            }
+            configReadNeutrinoGlobals(configOPL); // args/path/-elf/global core/device TYPE (+legacy migration); shared with miniInit
             configGetStrCopy(configOPL, CONFIG_OPL_POPSTARTER_PATH, gPopstarterPath, sizeof(gPopstarterPath));
             // POPSTARTER device TYPE (POPS_DEV_*). Absent in legacy configs: a non-empty custom
             // popstarter_path migrates to Custom (honour the old override); otherwise Default (cwd).
@@ -2724,10 +2734,11 @@ static void miniInit(int mode)
             configGetInt(configOPL, CONFIG_OPL_PS2LOGO, &gPS2Logo);
             configGetStrCopy(configOPL, CONFIG_OPL_EXIT_PATH, gExitPath, sizeof(gExitPath));
             configGetInt(configOPL, CONFIG_OPL_HDD_SPINDOWN, &gHDDSpindown);
-            // Honor the global default Loader Core on the autolaunch/argv path too, exactly like the
-            // interactive _loadConfig read -- else a keyless "Default" game boots under <OPL> here even
-            // when the user set the global to Neutrino (absent key keeps the setDefaults() 0 = <OPL>).
-            configGetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, &gDefaultCoreLoader);
+            // Honor ALL the Neutrino-launch globals on the autolaunch/argv path exactly like the
+            // interactive _loadConfig -- not just the default core: an autolaunched keyless "Default"
+            // game must resolve the SAME neutrino.elf (device pick / custom path) with the SAME global
+            // args as an interactive launch, or it silently boots a different/stale core without flags.
+            configReadNeutrinoGlobals(configOPL);
             if (mode == BDM_MODE) {
                 configGetStrCopy(configOPL, CONFIG_OPL_BDM_PREFIX, gBDMPrefix, sizeof(gBDMPrefix));
                 configGetInt(configOPL, CONFIG_OPL_BDM_CACHE, &bdmCacheSize);

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -476,6 +476,10 @@ void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w,
         rm_quad_t iquad = quad;
         iquad.ul.x = quad.ul.x + ((ulx < blx) ? ulx : blx);
         iquad.br.x = quad.ul.x + ((urx > brx) ? urx : brx);
+        // Base the mirror height on the inlay WINDOW's top (uly/ury, already Y_SCALEd into the same
+        // screen space as quad.ul.y), not the frame's top -- otherwise reflH spans the padded frame
+        // height and the mirrored art renders vertically stretched, overflowing the frame's mirror.
+        iquad.ul.y = quad.ul.y + ((uly < ury) ? uly : ury);
         iquad.ul.u = 0.0f;
         iquad.br.u = inlay->Width;
         iquad.ul.v = 0.0f;

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -464,7 +464,23 @@ void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w,
         int coverBottomOff = (bly > bry) ? bly : bry;              // scaled, screen space
         int frameBottom = (origBly > origBry) ? origBly : origBry; // unscaled, element space
         float botV = (h > 0) ? (float)frameBottom * overlay->Height / h : overlay->Height;
-        rmDrawReflection(overlay, &quad, quad.ul.y + coverBottomOff, botV);
+        float waterline = quad.ul.y + coverBottomOff;
+        // Mirror the INLAY (the actual game cover art) too -- previously only the case FRAME was
+        // reflected, so the cover box mirrored but the artwork inside it had no reflection at all
+        // (the disc/frame appeared to mirror, the cover did not). Reuse the same rmDrawReflection the
+        // plain-cover path uses; the inlay occupies the cover WINDOW inside the frame, so span its x
+        // from the inlay's own (scaled) left/right corners and its u/v over the whole inlay texture.
+        // Share the frame's waterline + height so the art and frame reflections track together, and
+        // draw the inlay mirror FIRST so the frame mirror lands on top (matching the upright
+        // inlay-then-frame draw order above). Non-coverflow callers pass reflection=0, so unaffected.
+        rm_quad_t iquad = quad;
+        iquad.ul.x = quad.ul.x + ((ulx < blx) ? ulx : blx);
+        iquad.br.x = quad.ul.x + ((urx > brx) ? urx : brx);
+        iquad.ul.u = 0.0f;
+        iquad.br.u = inlay->Width;
+        iquad.ul.v = 0.0f;
+        rmDrawReflection(inlay, &iquad, waterline, inlay->Height);
+        rmDrawReflection(overlay, &quad, waterline, botV);
     }
 }
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -636,6 +636,46 @@ static const char *sbNeutrinoResolved(const char *path)
     return path;
 }
 
+// Probe the ACTIVE game device for a co-located neutrino.elf: (A) the games-folder prefix, then
+// (B) the bare device root. Returns the resolved path of the first COMPLETE install (Δ1), or NULL.
+// Shared by the AUTO tier (one candidate among several) and the "Game's Device" pick (the ONLY
+// candidate -- a NULL here is surfaced to the user, no MC fallback). activePrefix NULL/"" -> NULL
+// (e.g. HDD passes NULL: raw APA is not POSIX-open()-reachable).
+static const char *sbNeutrinoProbeGameDevice(const char *activePrefix)
+{
+    if (activePrefix == NULL || activePrefix[0] == '\0')
+        return NULL;
+
+    char devRoot[64]; // bare device-root token, e.g. "mass0:" (everything up to & incl. ':')
+    const char *colon = strchr(activePrefix, ':');
+    size_t rootLen = (colon != NULL) ? (size_t)(colon - activePrefix + 1) : 0;
+    if (rootLen > 0 && rootLen < sizeof(devRoot)) {
+        memcpy(devRoot, activePrefix, rootLen);
+        devRoot[rootLen] = '\0';
+    } else {
+        devRoot[0] = '\0';
+    }
+    const char *bases[2] = {activePrefix, devRoot}; // (A) the games-folder prefix, (B) the device root
+    static const char *forms[] = {
+        "%sNEUTRINO/neutrino.elf",
+        "%sneutrino/neutrino.elf",
+        "%sNEUTRINO/NEUTRINO.ELF",
+        "%sneutrino/NEUTRINO.ELF",
+    };
+    static char probe[160];
+    for (int b = 0; b < 2; b++) {
+        if (bases[b] == NULL || bases[b][0] == '\0')
+            continue;
+        for (int i = 0; i < (int)(sizeof(forms) / sizeof(forms[0])); i++) {
+            snprintf(probe, sizeof(probe), forms[i], bases[b]);
+            // Δ1: a stale elf-only folder on the game device must NOT count as a valid install.
+            if (sbFileExists(probe) && sbNeutrinoInstallComplete(probe))
+                return sbNeutrinoResolved(probe);
+        }
+    }
+    return NULL;
+}
+
 // Resolve the Neutrino core ELF: probe the install locations users actually use (folder-case
 // and leading-slash variants on mc0/mc1) and return the first COMPLETE install (Δ1), or NULL.
 // Centralised so the bdm + mmce launch paths stay in sync.
@@ -645,6 +685,13 @@ const char *sbResolveNeutrinoPath(const char *activePrefix)
     // <root>:/neutrino/neutrino.elf. Resolve the type to its live device-name token(s) -- USB/MX4SIO/
     // exFAT-HDD via the mounted BDM device, MC/MMCE by slot, APA-HDD via the mounted OPL data partition
     // (pfs0:) -- then probe each first. The token has NO trailing ':' so the forms[] below add it.
+    // GAME'S DEVICE: resolve ONLY on the active game's own device (co-located neutrino.elf); no
+    // legacy-custom-path / MC fallback. A miss returns NULL so the launch path toasts "not found"
+    // and aborts in a live menu (every caller handles NULL that way) rather than silently using an
+    // MC core the user did not pick.
+    if (gNeutrinoDevice == NEUTRINO_DEV_GAME)
+        return sbNeutrinoProbeGameDevice(activePrefix);
+
     char cand[2][BDM_DEVICE_ROOT_MAX];
     int nCand = 0;
     switch (gNeutrinoDevice) {
@@ -711,37 +758,13 @@ const char *sbResolveNeutrinoPath(const char *activePrefix)
 
     // PR #300: in AUTO, probe the ACTIVE game device for a co-located neutrino.elf BEFORE the mc0/mc1
     // fallbacks, so a neutrino.elf dropped next to the games (USB/MMCE) just works with zero config.
-    // sbFileExists() uses POSIX open(), which reaches mc/mass/mmce (the same path art loads through);
-    // callers pass only a POSIX-reachable prefix (HDD passes NULL -- raw APA is not open()-reachable).
-    if (activePrefix != NULL && activePrefix[0] != '\0') {
-        char devRoot[64]; // bare device-root token, e.g. "mass0:" (everything up to & incl. ':')
-        const char *colon = strchr(activePrefix, ':');
-        size_t rootLen = (colon != NULL) ? (size_t)(colon - activePrefix + 1) : 0;
-        if (rootLen > 0 && rootLen < sizeof(devRoot)) {
-            memcpy(devRoot, activePrefix, rootLen);
-            devRoot[rootLen] = '\0';
-        } else {
-            devRoot[0] = '\0';
-        }
-        const char *bases[2] = {activePrefix, devRoot}; // (A) the games-folder prefix, (B) the device root
-        static const char *forms[] = {
-            "%sNEUTRINO/neutrino.elf",
-            "%sneutrino/neutrino.elf",
-            "%sNEUTRINO/NEUTRINO.ELF",
-            "%sneutrino/NEUTRINO.ELF",
-        };
-        static char probe[160];
-        for (int b = 0; b < 2; b++) {
-            if (bases[b] == NULL || bases[b][0] == '\0')
-                continue;
-            for (int i = 0; i < (int)(sizeof(forms) / sizeof(forms[0])); i++) {
-                snprintf(probe, sizeof(probe), forms[i], bases[b]);
-                // Δ1: a stale elf-only folder on the ACTIVE game device must NOT shadow a complete
-                // mc0/mc1 install below (the exact "worked once then never" failure) -- skip it.
-                if (sbFileExists(probe) && sbNeutrinoInstallComplete(probe))
-                    return sbNeutrinoResolved(probe);
-            }
-        }
+    // Δ1 (inside the helper): a stale elf-only folder on the game device must NOT shadow a complete
+    // mc0/mc1 install below (the "worked once then never" failure). Same probe as NEUTRINO_DEV_GAME,
+    // but here a miss falls through to the mc0/mc1 candidates instead of returning NULL.
+    {
+        const char *gameHit = sbNeutrinoProbeGameDevice(activePrefix);
+        if (gameHit != NULL)
+            return gameHit;
     }
 
     static const char *candidates[] = {

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -612,19 +612,20 @@ static void cacheInvalidateEntryLocked(cache_entry_t *entry, int freeTxt, int pr
             break;
         case CACHE_ENTRY_LOADING:
             if (req != NULL) {
-                // Teardown (preserveLoaded==0) aborts everything. But a per-scroll generation advance
-                // (preserveLoaded==1) should only abort slow in-flight MMCE loads -- let a local
-                // BDM/HDD/USB cover or disc icon FINISH and land in cache instead of being cancelled and
-                // re-queued on every scroll step. With one art worker and #DiscType now adding a 2nd
-                // request per game, the blanket abort starved both cover and disc (temperamental loading).
-                // #120: gate the MMCE abort on ACTIVE navigation. On a STATIC screen (VCD info page, a
-                // settled list) the exit/refresh generation advance must NOT kill the in-flight MMCE
-                // read -- otherwise the 2nd VCD screenshot (SCR2, always last on the single worker) is
-                // discarded and only reappears after an exit+re-enter. Info-exit is Circle/Cross (not
-                // nav keys), so this gate is false there and SCR2 completes; while scrolling the abort
-                // still fires, preserving the #116 slow-cover behaviour. Completion is UID-guarded, so a
-                // late-landing read can never show a wrong-item texture.
-                if (!preserveLoaded || (cacheIsAbortableMmceRequest(req) && cacheIsNavigationActive()))
+                // Teardown (preserveLoaded==0: cacheEnd / cacheDestroyCache / the timed cancel+abort
+                // family) aborts the in-flight read. A generation advance (preserveLoaded==1: per-
+                // scroll step, tab/page switch, screen switch, list sort/clear) NEVER does -- wOPL
+                // semantics (test note #3): the read finishes, lands in its entry (completion is
+                // UID-guarded in cacheCompleteRequest -- qr==req && UID==cacheUID -- and every draw
+                // keys on a per-item UID match, so a late texture can never render on a wrong item)
+                // and persists for the scroll-back / tab-switch-back. The old nav-gated MMCE abort
+                // (#116 "held in reserve", #120 static-screen gate) cancelled the in-flight read on
+                // every held-nav carousel step, discarding partial SIO2 progress and forcing a full
+                // re-read after settle -- the residual "backs up like it's buffering". It bought
+                // nothing: during a hold, cacheShouldDeferInteractiveArtOnInput already blocks new
+                // MMCE/HDD enqueues (cacheGetTextureInternal) AND worker dequeues (cacheDequeueRequest),
+                // so at most this ONE read finishes into an otherwise idle bus.
+                if (!preserveLoaded)
                     req->abortRequested = 1;
             } else {
                 entry->qr = NULL;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -430,7 +430,9 @@ static int cacheHasPendingInteractiveArtLocked(void)
     return gArtInteractiveReqList != NULL || gArtInteractiveActiveCount > 0;
 }
 
-static int cacheHasQueuedInteractiveModeLocked(int mode)
+// Mode checks span BOTH queues: since the info-art prewarm, MMCE-backed requests can sit on the
+// PREFETCH queue too, and every quiesce path (launch, theme swap, config IO) must drain those as well.
+static int cacheHasQueuedModeLocked(int mode)
 {
     load_image_request_t *req;
 
@@ -438,18 +440,25 @@ static int cacheHasQueuedInteractiveModeLocked(int mode)
         if (req->effectiveMode == mode)
             return 1;
     }
+    for (req = gArtPrefetchReqList; req != NULL; req = req->next) {
+        if (req->effectiveMode == mode)
+            return 1;
+    }
 
     return 0;
 }
 
-static int cacheHasActiveInteractiveModeLocked(int mode)
+static int cacheHasActiveModeLocked(int mode)
 {
-    return gArtCurrentReq != NULL && gArtCurrentReq->priority == CACHE_REQ_PRIORITY_INTERACTIVE && gArtCurrentReq->effectiveMode == mode;
+    return gArtCurrentReq != NULL && gArtCurrentReq->effectiveMode == mode;
 }
 
 static int cacheIsAbortableMmceRequest(load_image_request_t *req)
 {
-    return req != NULL && req->priority == CACHE_REQ_PRIORITY_INTERACTIVE && req->effectiveMode == MMCE_MODE;
+    // Any MMCE-backed read is abortable, whatever its queue: the abort flag is polled by the same
+    // 4KB staging loop regardless of priority, and a prewarm PREFETCH read holds the SIO2 bus just
+    // like an interactive one.
+    return req != NULL && req->effectiveMode == MMCE_MODE;
 }
 
 
@@ -808,6 +817,13 @@ static load_image_request_t *cacheDequeueRequest(void)
         if (gArtInteractiveReqEnd == req)
             gArtInteractiveReqEnd = NULL;
     } else if (gArtPrefetchReqList != NULL) {
+        // Same nav-time defer the interactive head gets: a prewarm (or HDD cover) prefetch read
+        // must never START mid-scroll on a slow shared bus.
+        if (cacheShouldDeferInteractiveArtOnInput(gArtPrefetchReqList->list, gArtPrefetchReqList->value)) {
+            cacheUnlock();
+            return NULL;
+        }
+
         req = gArtPrefetchReqList;
         gArtPrefetchReqList = req->next;
         req->next = NULL;
@@ -1200,6 +1216,13 @@ int cacheAbortMmceImageLoadsTimed(int timeoutTicks)
         if (req->effectiveMode == MMCE_MODE)
             cacheDropQueuedRequestLocked(req);
     }
+    // Prewarm can queue MMCE art at PREFETCH priority too -- every quiesce caller (launch, theme
+    // swap, deferred config IO, deinit) needs those off the SIO2 bus just the same.
+    for (load_image_request_t *req = gArtPrefetchReqList, *next; req != NULL; req = next) {
+        next = req->next;
+        if (req->effectiveMode == MMCE_MODE)
+            cacheDropQueuedRequestLocked(req);
+    }
 
     cacheUnlock();
 
@@ -1211,7 +1234,7 @@ int cacheAbortMmceImageLoadsTimed(int timeoutTicks)
         int pending;
 
         cacheLock();
-        pending = cacheHasActiveInteractiveModeLocked(MMCE_MODE) || cacheHasQueuedInteractiveModeLocked(MMCE_MODE);
+        pending = cacheHasActiveModeLocked(MMCE_MODE) || cacheHasQueuedModeLocked(MMCE_MODE);
         cacheUnlock();
 
         if (!pending) {
@@ -1323,7 +1346,10 @@ void cacheWakeInteractiveArtOnInputIdle(void)
     int wakeWorker = 0;
 
     cacheLock();
-    if (gArtRunning && gArtThreadId >= 0 && gArtActiveCount == 0 && gArtInteractiveReqList != NULL)
+    // Prefetch heads can be nav-parked too (prewarm / HDD covers defer at dequeue), so wake the
+    // worker for parked work on EITHER queue once input goes idle.
+    if (gArtRunning && gArtThreadId >= 0 && gArtActiveCount == 0 &&
+        (gArtInteractiveReqList != NULL || gArtPrefetchReqList != NULL))
         wakeWorker = 1;
     cacheUnlock();
 
@@ -1373,7 +1399,10 @@ GSTEXTURE *cacheGetTextureIfReady(image_cache_t *cache, int *cacheId, int *UID)
     return result;
 }
 
-static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value, unsigned char priority)
+// prewarm: an explicit info-art prewarm request -- lifts the MMCE prefetch exemption and the
+// per-cache prefetch cap for THIS call only (the caller bounds when it fires). skipSettle: skip the
+// interactive inactivity settle (Square-entry prewarm fires the reads immediately, under the fade).
+static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value, unsigned char priority, int prewarm, int skipSettle)
 {
     cache_entry_t *entry;
     cache_entry_t *oldestEntry = NULL;
@@ -1466,7 +1495,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
             return NULL;
         }
 
-        {
+        if (!skipSettle) {
             int delay = cacheGetInteractiveDelay(list, value);
             /* In MMCE mode, give Cover art a 1-frame inactivity head start over
              * other art types (Background, Screenshot, etc.).  The default theme
@@ -1486,7 +1515,10 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
             }
         }
     } else {
-        if (list == NULL || effectiveMode == MMCE_MODE || guiInactiveFrames < cacheGetPrefetchDelay(list, value)) {
+        // MMCE is prefetch-exempt (browse-time prefetch hurt nav on the SIO2 bus) EXCEPT for an
+        // explicit info-art prewarm, whose caller only fires after a long settle with the art
+        // pipeline idle.
+        if (list == NULL || (effectiveMode == MMCE_MODE && !prewarm) || guiInactiveFrames < cacheGetPrefetchDelay(list, value)) {
             cacheUnlock();
             return NULL;
         }
@@ -1530,7 +1562,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     // worker; match that. The queue is still bounded by the 10-slot LRU cache (a full cache yields no
     // free victim, so no unbounded growth).
 
-    if (priority == CACHE_REQ_PRIORITY_PREFETCH && cache->queuedPrefetchRequests >= cacheGetPrefetchLimit(cache)) {
+    if (priority == CACHE_REQ_PRIORITY_PREFETCH && !prewarm && cache->queuedPrefetchRequests >= cacheGetPrefetchLimit(cache)) {
         cacheUnlock();
         return NULL;
     }
@@ -1608,10 +1640,25 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
 
 GSTEXTURE *cacheGetTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
 {
-    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_INTERACTIVE);
+    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_INTERACTIVE, 0, 0);
 }
 
 GSTEXTURE *cachePrefetchTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
 {
-    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_PREFETCH);
+    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_PREFETCH, 0, 0);
+}
+
+GSTEXTURE *cacheWarmTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
+{
+    // Info-screen ENTRY prewarm: interactive priority with the inactivity settle skipped, so the
+    // info art starts loading immediately under the screen-switch fade instead of after it.
+    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_INTERACTIVE, 0, 1);
+}
+
+GSTEXTURE *cachePrefetchTexturePrewarm(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
+{
+    // Browse-settle info-art prewarm: prefetch priority (never queues ahead of post-scroll covers)
+    // allowed onto MMCE and past the per-cache prefetch cap. Callers bound when it fires (long
+    // idle, art pipeline empty).
+    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_PREFETCH, 1, 0);
 }

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -298,6 +298,27 @@ static void cacheResetRequestTrackingLocked(void)
 {
     cache_registry_entry_t *registry = gCacheRegistry;
 
+    // Drain the queued requests instead of just NULLing the list heads: each queued request owns
+    // heap memory AND its cache entry's qr backpointer. Dropping the heads leaked every request
+    // still queued at reset time and left entry->qr dangling -- a later invalidate pass would then
+    // dereference freed memory through it. Clear the entry linkage first, then finalize + free.
+    load_image_request_t *queues[2] = {gArtInteractiveReqList, gArtPrefetchReqList};
+    for (int q = 0; q < 2; q++) {
+        load_image_request_t *req = queues[q];
+        while (req != NULL) {
+            load_image_request_t *next = req->next;
+            req->next = NULL;
+            if (req->entry != NULL && req->entry->qr == req) {
+                req->entry->qr = NULL;
+                if (req->entry->state == CACHE_ENTRY_QUEUED)
+                    cacheClearItem(req->entry, 1);
+            }
+            cacheFinalizeRequestLocked(req);
+            cacheFreeRequest(req);
+            req = next;
+        }
+    }
+
     gArtInteractiveReqList = NULL;
     gArtInteractiveReqEnd = NULL;
     gArtPrefetchReqList = NULL;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -596,7 +596,14 @@ static void cacheInvalidateEntryLocked(cache_entry_t *entry, int freeTxt, int pr
                 // BDM/HDD/USB cover or disc icon FINISH and land in cache instead of being cancelled and
                 // re-queued on every scroll step. With one art worker and #DiscType now adding a 2nd
                 // request per game, the blanket abort starved both cover and disc (temperamental loading).
-                if (!preserveLoaded || cacheIsAbortableMmceRequest(req))
+                // #120: gate the MMCE abort on ACTIVE navigation. On a STATIC screen (VCD info page, a
+                // settled list) the exit/refresh generation advance must NOT kill the in-flight MMCE
+                // read -- otherwise the 2nd VCD screenshot (SCR2, always last on the single worker) is
+                // discarded and only reappears after an exit+re-enter. Info-exit is Circle/Cross (not
+                // nav keys), so this gate is false there and SCR2 completes; while scrolling the abort
+                // still fires, preserving the #116 slow-cover behaviour. Completion is UID-guarded, so a
+                // late-landing read can never show a wrong-item texture.
+                if (!preserveLoaded || (cacheIsAbortableMmceRequest(req) && cacheIsNavigationActive()))
                     req->abortRequested = 1;
             } else {
                 entry->qr = NULL;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1089,6 +1089,10 @@ static void cacheClearItem(cache_entry_t *item, int freeTxt)
         texFree(&item->texture);
     }
 
+    // The identity string belongs to the MAPPING, not the texture: free it on every clear
+    // (the memset below then leaves value = NULL for the reused slot).
+    free(item->value);
+
     memset(item, 0, sizeof(cache_entry_t));
     cacheResetTextureState(&item->texture);
     item->qr = NULL;
@@ -1142,6 +1146,10 @@ image_cache_t *cacheInitCache(int userId, const char *prefix, int isPrefixRelati
         return NULL;
     }
 
+    // MUST zero before the cacheClearItem loop: cacheClearItem free()s item->value, and a freshly
+    // malloc'd content block is recycled heap -- an uninitialized garbage pointer there would be
+    // free()d (heap corruption) on every cache creation.
+    memset(cache->content, 0, count * sizeof(cache_entry_t));
     for (int i = 0; i < count; ++i)
         cacheClearItem(&cache->content[i], 0);
 
@@ -1180,6 +1188,15 @@ void cacheDestroyCache(image_cache_t *cache)
 
     cacheWaitForCacheRequests(cache);
     cacheUnregister(cache);
+
+    // Free identity strings left on entries that never went through cacheClearItem -- e.g. a
+    // LOADING entry whose completion was skipped by the destroying flag above.
+    cacheLock();
+    for (int i = 0; i < cache->count; ++i) {
+        free(cache->content[i].value);
+        cache->content[i].value = NULL;
+    }
+    cacheUnlock();
 
     free(cache->prefix);
     free(cache->suffix);
@@ -1431,8 +1448,16 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     }
 
     if (*cacheId != -1) {
-        entry = &cache->content[*cacheId];
-        if (entry->UID == *UID) {
+        // Neighbor-covers fix: the instant-return used to trust the per-item (cacheId, UID) pair
+        // absolutely -- no bounds check (cacheGetTextureIfReady has one; this path did not) and no
+        // re-validation that the entry still holds THIS item's art. A pair poisoned by a racing
+        // per-item-array rebuild then validly matched ANOTHER title's entry and, because every
+        // instant-return refreshes lastUsed (exempting the entry from LRU), the wrong cover stuck
+        // PERMANENTLY. Validating the entry's identity string makes any stale/poisoned pair heal in
+        // one frame: mismatch -> *cacheId = -1 -> the normal by-value dedupe/enqueue re-associates.
+        if (*cacheId >= 0 && *cacheId < cache->count &&
+            (entry = &cache->content[*cacheId])->UID == *UID &&
+            entry->value != NULL && strcmp(entry->value, value) == 0) {
             switch (entry->state) {
                 case CACHE_ENTRY_QUEUED:
                     if (priority == CACHE_REQ_PRIORITY_INTERACTIVE && entry->qr != NULL)
@@ -1622,6 +1647,17 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
      * APPS and MMCE pages.  cacheClearItem() is the established
      * release pattern used by every other site in this file. */
     cacheClearItem(oldestEntry, 1);
+    // Record the entry's identity for the instant-return validation (neighbor-covers fix). Own
+    // heap copy -- req->value lives inline in the request, which is freed independently. On OOM
+    // FAIL the enqueue: an identity-less entry that ever reached READY would mismatch the gate
+    // every frame and re-enqueue forever.
+    oldestEntry->value = malloc(strlen(value) + 1);
+    if (oldestEntry->value == NULL) {
+        free(req);
+        cacheUnlock();
+        return NULL;
+    }
+    strcpy(oldestEntry->value, value);
     oldestEntry->qr = req;
     oldestEntry->state = CACHE_ENTRY_QUEUED;
     oldestEntry->UID = cache->nextUID;

--- a/src/themes.c
+++ b/src/themes.c
@@ -1976,6 +1976,11 @@ static void thmLoadFonts(config_set_t *themeConfig, const char *themePath, theme
     }
 }
 
+// #120: how long a theme (re)load waits for MMCE-backed art to abort before force-resetting the art
+// worker (mirrors mmcesupport.c's MMCE_ART_ABORT_WAIT_TICKS). A wedged MMCE read that never returns is
+// broken out of via cacheEnd(1)/cacheInit() after this bound, so a theme swap can never hang.
+#define THM_MMCE_ART_ABORT_WAIT_TICKS 500
+
 static void thmLoad(const char *themePath)
 {
     LOG("THEMES Load theme path=%s\n", themePath);
@@ -2013,6 +2018,18 @@ static void thmLoad(const char *themePath)
     newT->coverflowCoverOffset = 0;
     newT->loadingIcon = NULL;
     newT->loadingIconCount = LOAD7_ICON - LOAD0_ICON + 1;
+
+    // #120: a wedged MMCE art read (SD2PSX / MemCard PRO2 card still mid-mount at boot or right after an
+    // IGR return) holds the single shared fileXio channel; this theme (re)load's own blocking reads
+    // below -- and the terminal art drain further down -- would then wait on it forever, freezing the
+    // whole screen (game list stuck at 0,0) and needing a power cycle. Abort MMCE-backed art with a
+    // timeout FIRST, force-resetting the art worker if it will not drain (exactly like mmceLaunchGame),
+    // so the channel is free before we touch storage. Safe before cacheInit (thmInit runs first): with
+    // no MMCE requests queued this returns immediately and the reset branch is not taken.
+    if (!cacheAbortMmceImageLoadsTimed(THM_MMCE_ART_ABORT_WAIT_TICKS)) {
+        cacheEnd(1);
+        cacheInit();
+    }
 
     config_set_t *themeConfig = NULL;
     if (!themePath) {
@@ -2221,6 +2238,16 @@ static void thmLoad(const char *themePath)
 
     configFree(themeConfig); // all themeConfig reads are done now (last was use_settings_bg above)
 
+    // #120: bound the pre-swap art drain too. Abort MMCE art (force-resetting the worker on timeout) so
+    // the otherwise-UNBOUNDED cacheCancelPendingImageLoads() below can only ever wait on fast non-MMCE
+    // (USB / MC / VCD) requests -- never a wedged MMCE read -- and therefore cannot deadlock the theme
+    // swap. NOTE: cacheWaitForCacheRequests inside the subsequent thmFree() is deliberately left
+    // unbounded -- after this reset the only live requests are those fast non-MMCE loads, and bounding
+    // that wait could free a cache with a request still in flight (use-after-free).
+    if (!cacheAbortMmceImageLoadsTimed(THM_MMCE_ART_ABORT_WAIT_TICKS)) {
+        cacheEnd(1);
+        cacheInit();
+    }
     cacheCancelPendingImageLoads();
     gTheme = newT;
     thmFree(curT);

--- a/src/themes.c
+++ b/src/themes.c
@@ -2199,6 +2199,13 @@ static void thmLoad(const char *themePath)
     for (i = BDM_ICON; i <= START_ICON; i++)
         thmLoadResource(&newT->textures[i], i, themePath, GS_PSM_CT32, newT->useDefault);
 
+    // UDPFS_ICON is appended at the very END of the enum (after CASE_OVERLAY2) so that saved
+    // favourite icon_ids stay ABI-stable -- which puts it OUTSIDE the BDM_ICON..START_ICON device
+    // range above. Load it explicitly with the same disk-override + embedded-default semantics, or
+    // the UDPFS filesystem tab and the UDPFSBD block tab (bdmGetIconId returns UDPFS_ICON when
+    // gNetBootProtocol == NET_BOOT_UDPFS) draw no icon (thmGetTexture(UDPFS_ICON) returns NULL).
+    thmLoadResource(&newT->textures[UDPFS_ICON], UDPFS_ICON, themePath, GS_PSM_CT32, newT->useDefault);
+
     // Control-hint glyphs + Favourites tab icon/star: internal defaults only (theme-independent).
     // Contiguous L3_ICON..FAV_MARK in the enum -> the VCD L3 hint (L3_ICON), the Favourites R3 hint
     // (R3_ICON), the FAV tab icon (FAV_ICON) and the favourited-item star (FAV_MARK). Previously the

--- a/src/themes.c
+++ b/src/themes.c
@@ -732,10 +732,13 @@ static void drawGameImage(struct menu_list *menu, struct submenu_list *item, con
         if (!texture || !texture->Mem) {
             // #2: on the Favourites page a COVER element with no real art must not draw the embedded
             // placeholder wrapped in the case frame (the hollow grey "empty tray" box). Suppress the
-            // COVER only -- keyed on the cache suffix -- so info-page screenshots (SCR/SCR2) and the
-            // background keep their own placeholders/plasma.
+            // COVER only -- keyed on the cache suffix AND excluding Background elements (a theme may
+            // bind a COV pattern to its Background; that must keep its defaultTexture/plasma fallback)
+            // -- so info-page screenshots (SCR/SCR2) and backgrounds keep their placeholders. Only
+            // while Cover Art is ON: with gEnableArt off every favourite reads as "no art" and the
+            // suppression would blank the whole tab (Games/Apps show placeholders there; match them).
             int isCover = gameImage->cache != NULL && gameImage->cache->suffix != NULL && strcmp(gameImage->cache->suffix, "COV") == 0;
-            if (isCover && list != NULL && list->mode == FAV_MODE)
+            if (gEnableArt && isCover && elem->type != ELEM_TYPE_BACKGROUND && list != NULL && list->mode == FAV_MODE)
                 return; // no real art -> draw nothing (no empty case frame) for a Favourites cover
             if (gameImage->defaultTexture)
                 texture = &gameImage->defaultTexture->source;
@@ -948,8 +951,9 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         // #2 (Nadwislanski): a no-art Favourites entry (a favourited app / PS1 title / game with no
         // ART/<id>_COV.png) must NOT draw the embedded cover placeholder wrapped in the two-layer case
         // frame -- that reads as a hollow grey "empty tray" box. Skip the whole cover instead (draw
-        // nothing), leaving the games/apps pages and real-art favourites untouched.
-        if (!hasArt && sourceList != NULL && sourceList->mode == FAV_MODE)
+        // nothing), leaving the games/apps pages and real-art favourites untouched. Only while Cover
+        // Art is ON: with gEnableArt off every favourite is "no art" and the carousel would go blank.
+        if (gEnableArt && !hasArt && sourceList != NULL && sourceList->mode == FAV_MODE)
             continue;
         if (!hasArt)
             texture = cimg->defaultTexture ? &cimg->defaultTexture->source : thmGetTexture(COVER_DEFAULT);

--- a/src/themes.c
+++ b/src/themes.c
@@ -2354,8 +2354,22 @@ void thmInit(void)
 
 void thmReinit(const char *path)
 {
-    thmLoad(NULL);
-    guiThemeID = 0;
+    // Nad #5 (settings change reverts the look): this used to UNCONDITIONALLY thmLoad(NULL) +
+    // guiThemeID=0 -- reverting to the default <OPL> look even when the ACTIVE theme does not live
+    // on the device being removed. Worse, an SMB/ETH re-init calls in here on EVERY settings-OK
+    // while the network is in any error state (server asleep, cable out, or plain share-browse
+    // mode, which parks in an "error" state even when healthy), and a subsequent Save Changes then
+    // wrote the transient "<OPL>" over the user's saved theme name -- reverting it PERMANENTLY.
+    // Only fall back to the default when the active theme actually lives on the removed device;
+    // otherwise keep it and just re-index (the removal loop reshuffles ids, so re-find by name).
+    char activeName[64] = "";
+    int activeOnDevice = 0;
+    if (guiThemeID >= 1 && guiThemeID <= nThemes) {
+        snprintf(activeName, sizeof(activeName), "%s", themes[guiThemeID - 1].name);
+        activeOnDevice = strncmp(themes[guiThemeID - 1].filePath, path, strlen(path)) == 0;
+    } else if (guiThemeID == nThemes + 1) {
+        snprintf(activeName, sizeof(activeName), "<Coverflow>"); // built-in; its id (nThemes+1) shifts as themes are removed
+    }
 
     int i = 0;
     while (i < nThemes) {
@@ -2373,6 +2387,18 @@ void thmReinit(const char *path)
     }
 
     thmRebuildGuiNames();
+
+    if (activeOnDevice) {
+        // The displayed theme's files just went away with its device: drop to the built-in default.
+        // Honor thmLoad's abandon-and-retry (#120): commit the default id only if the swap happened,
+        // else keep the old id so the still-displayed theme and the saved config stay consistent.
+        if (thmLoad(NULL) == 0)
+            guiThemeID = 0;
+    } else if (guiThemeID != 0) {
+        // Active theme untouched (built-in coverflow, or a theme on another device): keep it. gTheme
+        // needs no reload -- its loaded resources are unaffected by the removed entries.
+        guiThemeID = thmFindGuiID(activeName);
+    }
 }
 
 void thmReloadScreenExtents(void)

--- a/src/themes.c
+++ b/src/themes.c
@@ -730,6 +730,13 @@ static void drawGameImage(struct menu_list *menu, struct submenu_list *item, con
         }
 
         if (!texture || !texture->Mem) {
+            // #2: on the Favourites page a COVER element with no real art must not draw the embedded
+            // placeholder wrapped in the case frame (the hollow grey "empty tray" box). Suppress the
+            // COVER only -- keyed on the cache suffix -- so info-page screenshots (SCR/SCR2) and the
+            // background keep their own placeholders/plasma.
+            int isCover = gameImage->cache != NULL && gameImage->cache->suffix != NULL && strcmp(gameImage->cache->suffix, "COV") == 0;
+            if (isCover && list != NULL && list->mode == FAV_MODE)
+                return; // no real art -> draw nothing (no empty case frame) for a Favourites cover
             if (gameImage->defaultTexture)
                 texture = &gameImage->defaultTexture->source;
             else {
@@ -937,7 +944,14 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         int csh = (coverElem->height > 0) ? coverElem->height : 1; // div-guard
 
         GSTEXTURE *texture = getGameImageTexture(cimg->cache, sourceList, &covers[i]->item);
-        if (!texture || !texture->Mem)
+        int hasArt = (texture && texture->Mem);
+        // #2 (Nadwislanski): a no-art Favourites entry (a favourited app / PS1 title / game with no
+        // ART/<id>_COV.png) must NOT draw the embedded cover placeholder wrapped in the two-layer case
+        // frame -- that reads as a hollow grey "empty tray" box. Skip the whole cover instead (draw
+        // nothing), leaving the games/apps pages and real-art favourites untouched.
+        if (!hasArt && sourceList != NULL && sourceList->mode == FAV_MODE)
+            continue;
+        if (!hasArt)
             texture = cimg->defaultTexture ? &cimg->defaultTexture->source : thmGetTexture(COVER_DEFAULT);
         if (!texture || !texture->Mem)
             continue;

--- a/src/themes.c
+++ b/src/themes.c
@@ -1981,7 +1981,11 @@ static void thmLoadFonts(config_set_t *themeConfig, const char *themePath, theme
 // broken out of via cacheEnd(1)/cacheInit() after this bound, so a theme swap can never hang.
 #define THM_MMCE_ART_ABORT_WAIT_TICKS 500
 
-static void thmLoad(const char *themePath)
+// Returns 0 on success, -1 when the load was ABANDONED because the art worker would not drain (a
+// wedged MMCE read holding the shared fileXio channel). On -1 the current theme stays untouched;
+// callers must not commit the new theme id, so a later trigger (another device's theme scan, a
+// settings re-apply) naturally retries once the card recovers.
+static int thmLoad(const char *themePath)
 {
     LOG("THEMES Load theme path=%s\n", themePath);
     char path[256];
@@ -2021,14 +2025,19 @@ static void thmLoad(const char *themePath)
 
     // #120: a wedged MMCE art read (SD2PSX / MemCard PRO2 card still mid-mount at boot or right after an
     // IGR return) holds the single shared fileXio channel; this theme (re)load's own blocking reads
-    // below -- and the terminal art drain further down -- would then wait on it forever, freezing the
+    // below -- and the pre-swap art drain at the end -- would then wait on it forever, freezing the
     // whole screen (game list stuck at 0,0) and needing a power cycle. Abort MMCE-backed art with a
-    // timeout FIRST, force-resetting the art worker if it will not drain (exactly like mmceLaunchGame),
-    // so the channel is free before we touch storage. Safe before cacheInit (thmInit runs first): with
-    // no MMCE requests queued this returns immediately and the reset branch is not taken.
-    if (!cacheAbortMmceImageLoadsTimed(THM_MMCE_ART_ABORT_WAIT_TICKS)) {
-        cacheEnd(1);
-        cacheInit();
+    // timeout FIRST so the channel is free before we touch storage; if the worker will NOT drain (a
+    // truly wedged read), BAIL OUT: keep the current theme and let a later trigger retry. NEVER force-
+    // reset here (cacheEnd(1)): its TerminateThread would kill the worker mid-fileXio and orphan the
+    // SHARED RPC channel while OPL keeps running, hanging every later fileXio user -- including this
+    // function's own reads. (mmceLaunchGame can afford that reset only because it execs away right
+    // after.) The very first load (curT == NULL) never bails: pre-cacheInit there are no requests, so
+    // the abort returns success immediately.
+    if (!cacheAbortMmceImageLoadsTimed(THM_MMCE_ART_ABORT_WAIT_TICKS) && curT != NULL) {
+        LOG("THEMES Load: MMCE art worker wedged -- keeping the current theme (retry later)\n");
+        free(newT);
+        return -1;
     }
 
     config_set_t *themeConfig = NULL;
@@ -2238,19 +2247,25 @@ static void thmLoad(const char *themePath)
 
     configFree(themeConfig); // all themeConfig reads are done now (last was use_settings_bg above)
 
-    // #120: bound the pre-swap art drain too. Abort MMCE art (force-resetting the worker on timeout) so
-    // the otherwise-UNBOUNDED cacheCancelPendingImageLoads() below can only ever wait on fast non-MMCE
-    // (USB / MC / VCD) requests -- never a wedged MMCE read -- and therefore cannot deadlock the theme
-    // swap. NOTE: cacheWaitForCacheRequests inside the subsequent thmFree() is deliberately left
-    // unbounded -- after this reset the only live requests are those fast non-MMCE loads, and bounding
-    // that wait could free a cache with a request still in flight (use-after-free).
-    if (!cacheAbortMmceImageLoadsTimed(THM_MMCE_ART_ABORT_WAIT_TICKS)) {
-        cacheEnd(1);
-        cacheInit();
+    // #120: bound the pre-swap art drain too (the UNBOUNDED cacheCancelPendingImageLoads() here was the
+    // original hard-freeze site). Abort MMCE art first so the drain normally waits only on fast local
+    // (USB / MC / VCD) reads; if either step times out on a wedged worker, BAIL: free the fully-built
+    // newT -- it was never rendered, so its caches have no outstanding requests and thmFree returns
+    // instantly -- and keep rendering the current theme. No force-reset, for the same RPC-orphaning
+    // reason as the top abort; and thmFree(curT) must never run while an in-flight request may still
+    // reference the old theme's caches (use-after-free), which the successful timed drain rules out.
+    if (curT != NULL &&
+        (!cacheAbortMmceImageLoadsTimed(THM_MMCE_ART_ABORT_WAIT_TICKS) ||
+         !cacheCancelPendingImageLoadsTimed(THM_MMCE_ART_ABORT_WAIT_TICKS))) {
+        LOG("THEMES Load: art drain timed out -- keeping the current theme (retry later)\n");
+        thmFree(newT);
+        return -1;
     }
-    cacheCancelPendingImageLoads();
+    if (curT == NULL)
+        cacheCancelPendingImageLoads(); // first load: pre-cacheInit, nothing queued -- plain no-op drain
     gTheme = newT;
     thmFree(curT);
+    return 0;
 }
 
 static void thmRebuildGuiNames(void)
@@ -2344,14 +2359,20 @@ int thmSetGuiValue(int themeID, int reload)
 {
     if (themeID != -1) {
         if (guiThemeID != themeID || reload) {
+            int loadResult;
             if (themeID == nThemes + 1) {
                 // built-in coverflow theme: load the embedded buffer via thmLoad(NULL).
                 // Checked BEFORE the themes[themeID - 1] access below (which would be OOB).
                 gLoadCoverflowBuiltin = 1;
-                thmLoad(NULL);
+                loadResult = thmLoad(NULL);
                 gLoadCoverflowBuiltin = 0;
             } else
-                thmLoad(themeID != 0 ? themes[themeID - 1].filePath : NULL);
+                loadResult = thmLoad(themeID != 0 ? themes[themeID - 1].filePath : NULL);
+
+            // #120: an abandoned load (wedged MMCE art worker) keeps the CURRENT theme -- do not
+            // commit the new id, so the next thmAddElements/settings-apply trigger retries it.
+            if (loadResult != 0)
+                return 0;
 
             guiThemeID = themeID;
             return 1;

--- a/src/themes.c
+++ b/src/themes.c
@@ -703,6 +703,45 @@ static void prefetchAdjacentGameImages(image_cache_t *cache, void *support, stru
     }
 }
 
+// Prewarm the info screen's per-game art (BG/SCR/SCR2 GameImage + Background elements) for ONE
+// item, outside the draw path (#120 follow-up: MMCE VCD info art trickled in on-demand on the slow
+// SIO2 bus). entry!=0: Square was just pressed -- interactive priority with the settle gate
+// skipped, so the reads start under the screen-switch fade in element order (BG -> SCR -> SCR2).
+// entry==0: browse-settle prewarm -- PREFETCH priority (never queues ahead of post-scroll covers),
+// explicitly allowed onto MMCE. Uses the item's own cache_id/cache_uid slots so the info screen's
+// normal draws dedupe against these requests and display them the moment they land. AttributeImage
+// caches (userId < 0, value-keyed by config attribute) are skipped. Once an entry drains READY, the
+// repeated browse-settle call flips it to DISPLAYABLE (the returned pointer is discarded), which
+// skips the idle VRAM pre-upload -- harmless, the first info draw uploads inline via TexManager.
+void thmPrewarmInfoArt(theme_elems_t *elems, item_list_t *list, submenu_item_t *item, int entry)
+{
+    theme_element_t *elem;
+    char *value;
+
+    if (!gEnableArt || elems == NULL || list == NULL || item == NULL)
+        return;
+    if (item->cache_id == NULL || item->cache_uid == NULL)
+        return;
+    value = list->itemGetStartup(list, item->id);
+    if (value == NULL || value[0] == '\0')
+        return;
+
+    for (elem = elems->first; elem != NULL; elem = elem->next) {
+        mutable_image_t *img;
+
+        if (elem->type != ELEM_TYPE_BACKGROUND && elem->type != ELEM_TYPE_GAME_IMAGE)
+            continue;
+        img = (mutable_image_t *)elem->extended;
+        if (img == NULL || img->cache == NULL || img->cache->userId < 0 || img->cache->userId >= gTheme->gameCacheCount)
+            continue;
+
+        if (entry)
+            cacheWarmTexture(img->cache, list, &item->cache_id[img->cache->userId], &item->cache_uid[img->cache->userId], value);
+        else
+            cachePrefetchTexturePrewarm(img->cache, list, &item->cache_id[img->cache->userId], &item->cache_uid[img->cache->userId], value);
+    }
+}
+
 // Favourites element redirection (defined in the Coverflow section below; used by both draw
 // paths so an APP favourite renders with the apps element, not the game cover element).
 static theme_element_t *thmGetElemForItem(struct menu_list *menu, struct submenu_list *item, theme_element_t *elem);

--- a/src/themes.c
+++ b/src/themes.c
@@ -968,7 +968,12 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         }
 
         int posX = basePosX + i * coverDistance + animOffset + recenterX * drawW / csw;
-        int posY = elem->posY + recenterY * drawH / csh;
+        // Covers draw ALIGN_CENTER at elem->posY, so a tall (portrait) cover's TOP overshoots a square
+        // cover's top by (drawH-drawW)/2 and touches the background frame. Shift portrait covers DOWN by
+        // that excess so every cover TOP-aligns at the square baseline -- square covers (Apps, square
+        // VCD art) get 0 and are unchanged, and a mixed tab (Favourites) keeps a consistent cover top.
+        int topAlign = (drawH > drawW) ? (drawH - drawW) / 2 : 0;
+        int posY = elem->posY + recenterY * drawH / csh + topAlign;
 
         u64 coverColor = (gCoverflowDimCovers && i != centerIndex) ? GS_SETREG_RGBA(0x80, 0x80, 0x80, 0x40) : gDefaultCol;
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -1028,6 +1028,21 @@ static void initCoverflow(const char *themePath, config_set_t *themeConfig, them
 
 // AttributeImage ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Maps an AttributeImage's current value to the embedded internal glyph texId, including the
+// "display/asset" suffix-value form ("NTSC/ntsc" with attribute "Vmode" -> "Vmode_ntsc").
+// Returns -1 when no embedded glyph exists (e.g. Players, custom attributes); thmGetTexture(-1)
+// safely yields NULL (unsigned wrap >= TEXTURES_COUNT).
+static int thmAttributeTexId(mutable_image_t *attributeImage)
+{
+    char *seppos = strchr(attributeImage->currentValue, '/');
+    if (!seppos)
+        return texLookupInternalTexId(attributeImage->currentValue);
+
+    char imgName[32];
+    snprintf(imgName, sizeof(imgName), "%s_%s", attributeImage->cache->suffix, &seppos[1]);
+    return texLookupInternalTexId(imgName);
+}
+
 static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
 {
     // No current item (empty list): clear, don't redraw the stale cached image -- same guard as
@@ -1045,16 +1060,7 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
         }
         if (attributeImage->currentValue) {
             if (thmGetGuiValue() == 0) {
-                int texId;
-                char *seppos = strchr(attributeImage->currentValue, '/');
-                if (!seppos)
-                    texId = texLookupInternalTexId(attributeImage->currentValue);
-                else {
-                    char imgName[32];
-                    snprintf(imgName, sizeof(imgName), "%s_%s", attributeImage->cache->suffix, &seppos[1]);
-                    texId = texLookupInternalTexId(&imgName[0]);
-                }
-                GSTEXTURE *texture = thmGetTexture(texId);
+                GSTEXTURE *texture = thmGetTexture(thmAttributeTexId(attributeImage));
                 if (texture && texture->Mem)
                     rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 
@@ -1072,6 +1078,19 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
                     } else
                         rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 
+                    return;
+                }
+                // #120 follow-up: the theme ships no glyph asset for this value (or its async ART
+                // load has not delivered yet) -- fall back to the embedded internal glyph before
+                // the element default, instead of e.g. a VCD badge rendering the theme's ELF
+                // default. cacheGetTexture above stays FIRST and this function re-runs every
+                // frame, so the embedded glyph only fills NULL frames: the moment the theme's own
+                // glyph finishes loading, it wins again -- the fallback can never shadow it. The
+                // glyph slots are decoded for every theme in thmLoad (embedded data only; the
+                // theme's own <value>_<attr>.png channel above is untouched).
+                texture = thmGetTexture(thmAttributeTexId(attributeImage));
+                if (texture && texture->Mem) {
+                    rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
                     return;
                 }
             }
@@ -2262,9 +2281,14 @@ static int thmLoad(const char *themePath)
     for (i = L3_ICON; i <= FAV_MARK; i++)
         thmLoadResource(&newT->textures[i], i, NULL, GS_PSM_CT32, 1);
 
-    if (!themePath)
-        for (i = ELF_FORMAT; i <= VMODE_PAL; i++)
-            thmLoadResource(&newT->textures[i], i, NULL, GS_PSM_CT32, 1);
+    // Embedded attribute glyphs (#Format/#Media/Aspect/Rating/Scan/Vmode values): loaded for EVERY
+    // theme, disk themes included, so drawAttributeImage can fall back to them when the theme ships
+    // no <value>_<attr>.png (issue #120 follow-up: MMCE VCD entries showed the theme's ELF element-
+    // default on custom themes). Embedded data only (themePath=NULL): the theme's own glyph channel
+    // is the attribute cache and always wins at draw time. Cost ~153 KB decoded EE RAM (31x 64x32 T8
+    // glyphs + 6x 256x32 Rating strips; the NULL-data Device_* slots are no-ops), freed by thmFree.
+    for (i = ELF_FORMAT; i <= VMODE_PAL; i++)
+        thmLoadResource(&newT->textures[i], i, NULL, GS_PSM_CT32, 1);
 
     // Optional settings/menu background (guiDrawBGSettings draws it instead of the plasma).
     // Theme-supplied only for now: a disk theme opts in with use_settings_bg=1 and ships its

--- a/src/util.c
+++ b/src/util.c
@@ -21,11 +21,6 @@
 extern int probed_fd;
 extern u32 probed_lba;
 
-extern unsigned char icon_sys[];
-extern unsigned int size_icon_sys;
-extern unsigned char icon_icn[];
-extern unsigned int size_icon_icn;
-
 static int mcID = -1;
 
 void guiWarning(const char *text, int count);
@@ -99,10 +94,13 @@ static int checkMC()
     return mcID;
 }
 
+// Ensure mc?:OPL/ exists so config/notification writes land. Previously this also wrote a browser
+// save icon (opl.icn + icon.sys) for the folder, but the 3D icon (~21 KB) was embedded in the ELF
+// purely for that cosmetic PS2-browser icon; dropped to reclaim the space (test note #11). The folder
+// still gets created here (and the config write's O_CREAT would create it anyway).
 void checkMCFolder(void)
 {
     char path[32];
-    int fd;
 
     if (checkMC() < 0) {
         return;
@@ -110,30 +108,6 @@ void checkMCFolder(void)
 
     snprintf(path, sizeof(path), "mc%d:OPL/", mcID & 1);
     mkdir(path, 0777);
-
-    snprintf(path, sizeof(path), "mc%d:OPL/opl.icn", mcID & 1);
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        fd = openFile(path, O_WRONLY | O_CREAT | O_TRUNC);
-        if (fd >= 0) {
-            write(fd, icon_icn, size_icon_icn);
-            close(fd);
-        }
-    } else {
-        close(fd);
-    }
-
-    snprintf(path, sizeof(path), "mc%d:OPL/icon.sys", mcID & 1);
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        fd = openFile(path, O_WRONLY | O_CREAT | O_TRUNC);
-        if (fd >= 0) {
-            write(fd, icon_sys, size_icon_sys);
-            close(fd);
-        }
-    } else {
-        close(fd);
-    }
 }
 
 static int checkFile(char *path, int mode)

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -184,6 +184,20 @@ int vcdResolvePopstarter(const char *devPrefix, char *out, int outSize)
     // NOTE: this serves the bdm/eth/mmce launch paths; the HDD VCD launch keeps its own freeze-guarded
     // hddResolveHddPopstarter (the __common/+OPL pfs search), so HDD VCDs always load POPSTARTER off the HDD.
 
+    // GAME'S DEVICE: resolve ONLY on the VCD's own device (devPrefix); no boot-device (cwd) tier and
+    // no Default fallthrough. A miss returns 0 so the launch path shows "Missing POPSTARTER.ELF"
+    // (every caller does) instead of silently loading a boot-device copy the user did not pick.
+    if (gPopstarterDevice == POPS_DEV_GAME) {
+        if (devPrefix == NULL)
+            return 0;
+        snprintf(out, outSize, "%s%s%cPOPSTARTER.ELF", devPrefix, POPS_FOLDER, vcdSep(devPrefix));
+        int fd = open(out, O_RDONLY);
+        if (fd < 0)
+            return 0;
+        close(fd);
+        return 1;
+    }
+
     // CUSTOM: the free-text path wins, if it exists.
     if (gPopstarterDevice == POPS_DEV_CUSTOM && gPopstarterPath[0] != '\0') {
         int cfd = open(gPopstarterPath, O_RDONLY);


### PR DESCRIPTION
Integration of this batch's 8 feature/fix branches, each adversarially root-caused and verified by multi-agent workflow before implementation, with a full clean local build (ps2dev:latest) at every structural change and on the final merged tip. Backup of this exact tip: `backup/2026-07-10-pre-round2-roll`.

## Settings & features
- **Settings reorg (#4-#7)**: new **VCD Settings** + **MMCE Settings** pages; Device page = device hub; General slimmed. No CFG-id changes — saved configs load identically.
- **Global Default Loader Core (#8)** (`<OPL>`/Neutrino) + per-game tri-state {`<OPL>`, Neutrino, Default}; autolaunch reads ALL Neutrino globals via shared helper.
- **"Game's Device"** pick in the Neutrino + POPSTARTER device selectors (#12/#13).
- **UDPFS/UDPFSBD device tab icon** (#10): UDPFS_ICON sat outside the theme icon-load loop.
- **Save-icon removal (#11)**: −25 KB; mc?:OPL mkdir kept.
- **Credits**: Financial Support — Akilluminati47 (About page, README, CREDITS).

## Issue #120 (AndrewBento, MMCE)
- VCD info **#Format badge** fixed on HDD + **embedded-glyph fallback** for all attribute badges on custom disk themes.
- MMCE disk-theme **hard freeze** at boot/IGR: thmLoad redesigned to **abandon-and-retry** (never TerminateThread near the shared fileXio channel); texcache queued-request leak fixed.
- VCD info **2nd screenshot drop** fixed; **info-page art prewarm** (Square-entry warm start + browse-settle prefetch on MMCE/HDD).
- IGR-path MC-only limitation documented in the hint (post-IGR IOP cannot reach mmce0:).

## Nadwiślański rounds 1+2
- **Grey "empty tray"** on Favourites + **missing game-cover mirror** in CoverFlow (r1).
- **mc?:/OPL created on every save** from an appdir-on-MC boot: MC-home maintenance now gated to legacy-discovery mode; "Settings saved to %s" toast fixed.
- **#5 settings→default look**: thmReinit no longer reverts the theme unless it actually lives on the removed device (SMB-error settings-OK chain; also stops the permanent saved-theme clobber).
- **#6 MMCE-auto → MX4SIO menu**: refreshMenuPosition keeps the current tab when still visible; deferredInit boot select falls back instead of silently skipping.

## Visual/perf (workflow-verified)
- **Plasma "miffed"**: `plasma_blend_color==bg_color` self-cancelling gradient in the coverflow cfg (generator is byte-identical to upstream); embedded `<OPL>` cfg colors no longer clobber user picks (moved to defaults).
- **Wrong neighbor covers (persistent)**: cache entries carry an identity string validated on instant-return (poisoned pairs heal in one frame); per-item art-array rebuilds serialized under guiLock.
- **MMCE nav "buffering"**: in-flight art reads are never aborted on generation advances (wOPL persist-and-load); teardown-only aborts.
- Coverflow portrait covers top-align; append-only lng rule restored (stale translation packs render correctly).

## Known open
- Nad r1 #1 (screen artifacts after live List→CoverFlow switch) — awaiting reporter detail (freeze vs garbled vs wrong covers).
- Follow-up: rerun the lng_fork overlay for the 5 new labels + force-refresh HINT_EXITPATH translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)