### PR TITLE
style(texcache): Gemini #121 follow-up -- cacheFreeRequest on the OOM enqueue bail

### DIFF
--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1653,7 +1653,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     // every frame and re-enqueue forever.
     oldestEntry->value = malloc(strlen(value) + 1);
     if (oldestEntry->value == NULL) {
-        free(req);
+        cacheFreeRequest(req); // the encapsulated release (equivalent to free(req) here: the fresh request owns no texture memory yet)
         cacheUnlock();
         return NULL;
     }


### PR DESCRIPTION
One-line follow-up from Gemini's review of #121: use the encapsulated `cacheFreeRequest(req)` instead of `free(req)` on the identity-copy OOM bail. Functionally identical today; future-proof.

The review's other two suggestions are deliberately declined (detailed in the commit message):
- **renderman.c inlay NULL-guard**: unreachable — the function already dereferences `inlay` unconditionally before the reflection block, and every caller guarantees non-NULL.
- **supportbase.c `static char probe` → stack**: would introduce a dangling-pointer bug — the function returns a pointer into that buffer, used by callers long after return. The `static` is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)