### PR TITLE
hotfix: remove info-art prewarm — wedges MMCE fileXio channel on VCD info (Beta-3083 regression, #120)

### DIFF
--- a/include/menusys.h
+++ b/include/menusys.h
@@ -113,9 +113,6 @@ char *menuItemGetText(menu_item_t *it);
 config_set_t *menuLoadConfig();
 config_set_t *menuLoadConfigDirect(void);
 void menuRequestInfoSize(void);
-// Prewarm the selected item's info-page art (BG/SCR/SCR2). entry!=0 = Square-entry (immediate,
-// interactive); entry==0 = browse-settle prefetch. #120 follow-up; see thmPrewarmInfoArt.
-void menuPrewarmInfoArt(int entry);
 config_set_t *gameMenuLoadConfig(struct UIItem *ui);
 void menuSaveConfig();
 

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -83,12 +83,6 @@ int cacheCancelPendingImageLoadsTimed(int timeoutTicks);
  */
 int cacheAbortMmceImageLoadsTimed(int timeoutTicks);
 
-/** Interactive art request that skips the inactivity settle (info-screen entry prewarm). */
-GSTEXTURE *cacheWarmTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value);
-
-/** Prefetch art request allowed onto MMCE and past the prefetch cap (browse-settle info prewarm). */
-GSTEXTURE *cachePrefetchTexturePrewarm(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value);
-
 /** Advances the failure-retry generation and demotes loaded art to displayable. Queued and
  *  in-flight loads are LEFT to finish and land in cache (wOPL persist-and-load); teardown paths
  *  must use the cacheCancelPendingImageLoads / cacheAbortMmceImageLoadsTimed family instead.

--- a/include/themes.h
+++ b/include/themes.h
@@ -164,10 +164,6 @@ extern theme_t *gTheme;
 extern int gCoverflowCount, gCoverflowCenterScale, gCoverflowAnimSpeed, gCoverflowDimCovers;
 void thmTriggerCoverflowAnim(int dir);
 
-/** Prewarm one item's info-page art (BG/SCR/SCR2). entry!=0 = Square-entry (interactive priority,
- *  settle skipped); entry==0 = browse-settle (prefetch priority, allowed onto MMCE). #120 follow-up. */
-void thmPrewarmInfoArt(theme_elems_t *elems, item_list_t *list, submenu_item_t *item, int entry);
-
 void thmInit(void);
 void thmReinit(const char *path);
 void thmReloadScreenExtents(void);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -88,12 +88,8 @@ static s32 menuSemaId = -1;
 static s32 menuListSemaId = -1;
 static ee_sema_t menuSema;
 
-#define MENU_MMCE_CONFIG_IDLE_FRAMES  20
-#define MENU_APP_CONFIG_IDLE_FRAMES   1
-// Browse-settle info-art prewarm (#120 follow-up): after this many idle frames (~2s) with the art
-// pipeline empty, the SELECTED item's info art (BG/SCR/SCR2) is queued at prefetch priority on the
-// slow buses, so Square opens an already-warm info page.
-#define MENU_INFO_PREWARM_IDLE_FRAMES 120
+#define MENU_MMCE_CONFIG_IDLE_FRAMES 20
+#define MENU_APP_CONFIG_IDLE_FRAMES  1
 
 static void menuInvalidateArtSelection(void)
 {
@@ -1281,17 +1277,6 @@ void menuRenderMain(void)
         menuRenderElements(&gTheme->mainElems, allowItemConfig, renderConfig);
         gTheme->itemsList = gTheme->gamesItemsList;
     }
-
-    // Browse-time info-art prewarm, slow buses only: once the selection has settled ~2s and the art
-    // pipeline is idle, queue the SELECTED item's info art (BG/SCR/SCR2) at PREFETCH priority so
-    // Square opens a warm page. Idempotent per frame: QUEUED/LOADING/DISPLAYABLE entries and the
-    // FAILED generation marker all no-op inside the cache, so no one-shot latch is needed and a
-    // card with no SCR/SCR2 art is probed at most once per settle. (HDD note: an in-flight HDD
-    // prewarm read is not abortable and can share the PFS/ATA channel with the first post-settle
-    // scroll for up to one file read -- the same exposure class as the existing HDD cover prefetch.)
-    if (list != NULL && (list->mode == MMCE_MODE || list->mode == HDD_MODE) &&
-        guiInactiveFrames >= MENU_INFO_PREWARM_IDLE_FRAMES && !cacheHasPendingArt())
-        menuPrewarmInfoArt(0);
 }
 
 // Coverflow rotates the nav axis on the MAIN screen only: Left/Right step through the
@@ -1410,25 +1395,6 @@ void menuRenderInfo(void)
     } else {
         gTheme->itemsList = gTheme->gamesItemsList;
     }
-}
-
-// Prewarm the SELECTED item's info-page art. entry!=0 from itemExecSquare (Square just pressed);
-// entry==0 from the browse-settle hook in menuRenderMain. Bounded: only fires when the info screen
-// is reachable (same gTheme->infoElems.first condition as the Square hint / itemExecSquare) and art
-// is enabled (checked inside thmPrewarmInfoArt). GUI thread only (itemExecSquare / menuRenderMain),
-// same unlocked selected_item access discipline as itemExecSquare.
-void menuPrewarmInfoArt(int entry)
-{
-    item_list_t *list;
-
-    if (selected_item == NULL || selected_item->item == NULL || selected_item->item->current == NULL)
-        return;
-    if (gTheme == NULL || gTheme->infoElems.first == NULL)
-        return;
-    list = selected_item->item->userdata;
-    if (list == NULL || !list->enabled)
-        return;
-    thmPrewarmInfoArt(menuGetInfoElems(list), list, &selected_item->item->current->item, entry);
 }
 
 void menuHandleInputInfo()

--- a/src/opl.c
+++ b/src/opl.c
@@ -379,11 +379,6 @@ static void itemExecSquare(struct menu_item *curMenu)
         // #Size is skipped while scrolling so the badges paint instantly; resolve it now (async).
         menuRequestInfoSize();
         guiSwitchScreen(GUI_SCREEN_INFO);
-        // Fire the info art (BG -> SCR -> SCR2) NOW at interactive priority, bypassing the settle:
-        // the slow-bus reads run under the screen-switch fade instead of trickling in draw order
-        // after it (#120 follow-up). Placed AFTER guiSwitchScreen so its generation advance never
-        // touches these fresh requests; on exit the in-flight read finishes and stays cached.
-        menuPrewarmInfoArt(1);
     }
 }
 

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1683,18 +1683,3 @@ GSTEXTURE *cachePrefetchTexture(image_cache_t *cache, item_list_t *list, int *ca
 {
     return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_PREFETCH, 0, 0);
 }
-
-GSTEXTURE *cacheWarmTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
-{
-    // Info-screen ENTRY prewarm: interactive priority with the inactivity settle skipped, so the
-    // info art starts loading immediately under the screen-switch fade instead of after it.
-    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_INTERACTIVE, 0, 1);
-}
-
-GSTEXTURE *cachePrefetchTexturePrewarm(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
-{
-    // Browse-settle info-art prewarm: prefetch priority (never queues ahead of post-scroll covers)
-    // allowed onto MMCE and past the per-cache prefetch cap. Callers bound when it fires (long
-    // idle, art pipeline empty).
-    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_PREFETCH, 1, 0);
-}

--- a/src/themes.c
+++ b/src/themes.c
@@ -703,45 +703,6 @@ static void prefetchAdjacentGameImages(image_cache_t *cache, void *support, stru
     }
 }
 
-// Prewarm the info screen's per-game art (BG/SCR/SCR2 GameImage + Background elements) for ONE
-// item, outside the draw path (#120 follow-up: MMCE VCD info art trickled in on-demand on the slow
-// SIO2 bus). entry!=0: Square was just pressed -- interactive priority with the settle gate
-// skipped, so the reads start under the screen-switch fade in element order (BG -> SCR -> SCR2).
-// entry==0: browse-settle prewarm -- PREFETCH priority (never queues ahead of post-scroll covers),
-// explicitly allowed onto MMCE. Uses the item's own cache_id/cache_uid slots so the info screen's
-// normal draws dedupe against these requests and display them the moment they land. AttributeImage
-// caches (userId < 0, value-keyed by config attribute) are skipped. Once an entry drains READY, the
-// repeated browse-settle call flips it to DISPLAYABLE (the returned pointer is discarded), which
-// skips the idle VRAM pre-upload -- harmless, the first info draw uploads inline via TexManager.
-void thmPrewarmInfoArt(theme_elems_t *elems, item_list_t *list, submenu_item_t *item, int entry)
-{
-    theme_element_t *elem;
-    char *value;
-
-    if (!gEnableArt || elems == NULL || list == NULL || item == NULL)
-        return;
-    if (item->cache_id == NULL || item->cache_uid == NULL)
-        return;
-    value = list->itemGetStartup(list, item->id);
-    if (value == NULL || value[0] == '\0')
-        return;
-
-    for (elem = elems->first; elem != NULL; elem = elem->next) {
-        mutable_image_t *img;
-
-        if (elem->type != ELEM_TYPE_BACKGROUND && elem->type != ELEM_TYPE_GAME_IMAGE)
-            continue;
-        img = (mutable_image_t *)elem->extended;
-        if (img == NULL || img->cache == NULL || img->cache->userId < 0 || img->cache->userId >= gTheme->gameCacheCount)
-            continue;
-
-        if (entry)
-            cacheWarmTexture(img->cache, list, &item->cache_id[img->cache->userId], &item->cache_uid[img->cache->userId], value);
-        else
-            cachePrefetchTexturePrewarm(img->cache, list, &item->cache_id[img->cache->userId], &item->cache_uid[img->cache->userId], value);
-    }
-}
-
 // Favourites element redirection (defined in the Coverflow section below; used by both draw
 // paths so an APP favourite renders with the apps element, not the game cover element).
 static theme_element_t *thmGetElemForItem(struct menu_list *menu, struct submenu_list *item, theme_element_t *elem);


### PR DESCRIPTION
## Regression
AndrewBento reports on Beta-3083 ([#120](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/120)): repeatedly opening/closing a **PS1/VCD** game's info screen makes **all art stop loading**, then **both game lists vanish**, config save fails (*"Error writing settings!"*), and *Return to Boot Card* fails (*"could not run the item"*). USB/Apps lists survive; PS2-game info does **not** trigger it.

## Root cause (adversarial 4-hypothesis workflow — this one confirmed `holds` **and** `isTheCause`)
The **info-art prewarm** I added in `67dc581b` (a #120 follow-up). `itemExecSquare` fired the prewarm on every Square-enter with the settle **skipped**, so BG/SCR/SCR2 reads hit the slow MMCE (SIO2) bus immediately — and the VCD art path (`vcdLoadArt`) does **up to 3 failing opens per suffix** (~9 for a PS1 title, which rarely ships screenshots) vs one attempt for a PS2 game. Those plus the browse-settle prewarm pile onto the **single shared fileXio/mmceman channel** that MMCE art, list rescans, config writes and boot-card loads all use → the channel wedges. VCD-only because VCD info drives ~3× the MMCE opens; USB/Apps survive because their lists are already in RAM.

## Fix
Remove the prewarm entirely — both call sites plus the now-dead `thmPrewarmInfoArt` / `menuPrewarmInfoArt` / `cacheWarmTexture` / `cachePrefetchTexturePrewarm` and their decls. Info art returns to the **shipped-and-tested on-demand path** (Andrew's original slow-but-safe spinner, not a wedge).

Deliberately minimal: the `cacheGetTextureInternal` `prewarm`/`skipSettle` params are **left in place, now always 0** — behaviorally identical to pre-prewarm — so the fragile texcache gate logic is untouched in a hotfix. `menuGetInfoElems` is kept (`menuRenderInfo` uses it).

## What is NOT reverted (workflow cleared them)
- ③ value-field / guiLock (`80f09bac`) — memory-safe (VCD clone goes through the zeroed `cacheInitCache`), guiLock non-recursive but not nested on these paths; needed for the neighbour-cover fix.
- ⑤ nav-relax (`72285ffc`) — the removed abort was already inert on info enter/exit (nav-inactive), so reverting wouldn't have fixed this.

Local build green (ps2dev:latest); all changed files clang-format-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)