### PR TITLE
fix(vcd): skip the #Size stat on VCD info entry — kills the MMCE spinner card-safely (#120)

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -376,8 +376,17 @@ static void itemExecCircle(struct menu_item *curMenu)
 static void itemExecSquare(struct menu_item *curMenu)
 {
     if (curMenu->current && gTheme->infoElems.first) {
-        // #Size is skipped while scrolling so the badges paint instantly; resolve it now (async).
-        menuRequestInfoSize();
+        // #Size is skipped while scrolling so the badges paint instantly; resolve it now (async) --
+        // but NEVER for a VCD (PS1) list. A VCD carries no meaningful #Size: vcdFillGameList tags the
+        // entry .VCD/GAME_FORMAT_ISO (vcdsupport.c), so sbPopulateConfig stats the CD/DVD folder while
+        // .VCDs actually live in POPS/ -- the stat always misses, game->sizeMB stays 0 and never
+        // caches, so it re-runs on EVERY entry. That makes the resolve a pure redundant CFG re-read +
+        // failing stat on the shared MMCE/fileXio channel whose only visible effect is raising the
+        // busy spinner (Andrew, #120). Skipping it for VCD strictly REDUCES channel traffic and drops
+        // no displayed data (the info page shows no size for a VCD anyway).
+        item_list_t *support = curMenu->userdata;
+        if (support == NULL || !vcdViewActive(support->mode))
+            menuRequestInfoSize();
         guiSwitchScreen(GUI_SCREEN_INFO);
     }
 }


### PR DESCRIPTION
## The other half of Andrew's #120
Opening a PS1/VCD info screen on MMCE shows a loading spinner. A 4-approach adversarial design workflow established (and re-confirmed against current code) that **the spinner is the `#Size` CFG stat, not the art**: `itemExecSquare` → `menuRequestInfoSize` → `_menuResolveInfoSize` → `sbPopulateConfig` with `sbSetConfigStatSize(1)`, which re-reads the CFG and stats the game file on the shared MMCE/fileXio bus; the busy overlay keys purely on `ioHasPendingRequests()`.

## Why the stat is pure waste for VCD
`vcdFillGameList` tags the entry `.VCD` / `GAME_FORMAT_ISO`, so `sbPopulateConfig` stats the **CD/DVD folder while `.VCD`s live in `POPS/`** → it **always misses**, `game->sizeMB` stays 0 and never caches, and it re-runs on **every** entry. The VCD info page shows no size either way.

## Fix
Gate `menuRequestInfoSize()` on `!vcdViewActive(support->mode)`. VCD info entry now issues **zero** `#Size` IO (−1 CFG read, −1 stat per entry); non-VCD ISOs are byte-for-byte unchanged.

## Card-safe by construction (the anti-regression that matters)
This is the **opposite** of the reverted Beta-3087 prewarm. Under the exact repeated VCD-info enter/exit pattern that wedged the shared fileXio/mmceman channel, this does **strictly fewer** channel ops (−1 read, −1 stat, **+0 added**) — so it *cannot* reintroduce the wedge; it slightly relieves it. Single call site; does **not** touch the texcache lifecycle or the `#Size` path for real ISOs.

## Scope
The art-slow half of #120 (`vcdLoadArt`'s ~6 failing opens per entry) is deliberately left for a separate, separately-verified PR (workflow approach **D**). Prewarm (approach C) was **disqualified** — it only helps by adding speculative MMCE reads.

Local build green (ps2dev:latest), clang-format clean.

### Verify
1. **Anti-regression first:** repeatedly enter/exit a VCD info screen on MMCE ≥20× interleaved with a list refresh + a settings save — must never wedge (strictly lighter than today, so it can't).
2. VCD info entry on MMCE/SMB — no spinner, Circle returns instantly.
3. Real PS2 ISO/HDL info (BDM/MMCE/HDD/SMB, and Favourites disc view) — `#Size` still resolves (unchanged).
4. L3 + Favourites VCD views, and the global default-view lock paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)