### PR TITLE
perf(mmce): stage cover art in 32 KB reads not 4 KB — ~8x fewer SIO2 round-trips (#120 slow art)

### DIFF
--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -49,9 +49,11 @@ static char mmceFoldersCreatedFor[40] = {0};
 #define MMCE_GAMEID_POLL_US       (200 * 1000) // 200 ms between polls -> ~3 s total budget (was 500 ms x 15 = 7.5 s)
 /* Allow up to 500 ms for the art thread to drain before resorting to
  * TerminateThread.  The MMCE worker checks the abort flag between every
- * 4 KB read chunk (~16 ms at typical card speeds), so 500 ms covers
- * even very slow cards and avoids the fileXio RPC corruption that
- * TerminateThread can cause mid-read. */
+ * staged read chunk (TEX_MMCE_STAGE_READ_SIZE = 32 KB, ~128 ms at the
+ * pessimistic ~256 KB/s slow-card rate), so 500 ms keeps a ~4x margin
+ * even on a slow card and avoids the fileXio RPC corruption that
+ * TerminateThread can cause mid-read. (If that chunk is ever enlarged,
+ * re-check this margin: 128 KB would approach the 500 ms watchdog.) */
 #define MMCE_ART_ABORT_WAIT_TICKS 500
 
 // forward declaration

--- a/src/textures.c
+++ b/src/textures.c
@@ -109,7 +109,18 @@ extern void *case_overlay_png;
 
 // Not related to screen size, just to limit at some point
 static int maxSize = 720 * 512 * 4;
-#define TEX_MMCE_STAGE_READ_SIZE 4096
+// Per-read() chunk for staging an MMCE cover into RAM. Each read() is one COMPLETE mmceman FS RPC
+// over the shared SIO2 channel (command handshake + bulk DMA + trailer + a card-side seek/read-ahead
+// prime), and mmceman has NO read-size cap (its length field is a full 32 bits), so a big chunk is
+// served in ONE RPC. At 4 KB a ~100 KB cover cost ~25 RPCs; 32 KB serves it in ~4 -- an ~8x cut in
+// that fixed per-RPC overhead (the actual cause of slow MMCE art), moving the same bytes and keeping
+// the card's sequential read-ahead saturated. This is the same "few large reads" the in-game mmcedrv
+// block driver uses. DO NOT raise past 32 KB: the art worker only checks the abort flag BETWEEN
+// chunks, and mmcesupport.c's MMCE_ART_ABORT_WAIT_TICKS gives it 500 ms to reach a checkpoint before
+// TerminateThread (which corrupts the fileXio RPC channel = issue #120). 32 KB ~= 128 ms at the
+// pessimistic ~256 KB/s slow-card rate = a ~4x margin; 64 KB halves it for little gain, 128 KB+ risks
+// crossing the watchdog. A one-shot getStat+single-read is rejected for the same reason.
+#define TEX_MMCE_STAGE_READ_SIZE 32768
 
 typedef struct
 {
@@ -426,7 +437,7 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
     // read the file sequentially (read()-only, the same access the working USB reader uses) and stop
     // at EOF, so no up-front file length is needed. We keep the bulk-into-RAM staging (the reason this
     // path exists: MMCE streaming reads during decode are unreliable) -- only the size probe changes.
-    capacity = TEX_MMCE_STAGE_READ_SIZE * 16; // 64 KB; doubles on demand for larger covers
+    capacity = TEX_MMCE_STAGE_READ_SIZE * 2; // 64 KB; doubles on demand for larger covers
     fileBuffer = malloc(capacity);
     if (fileBuffer == NULL)
         return ERR_BAD_FILE;


### PR DESCRIPTION
## The actual reason MMCE art is slow
Found by cross-referencing the `mmceman` FS driver against the in-game `mmcedrv` block driver (the maintainer's tip: *"even our POPSLoader doesn't have this problem"*). `texStageExternalFileIntoMemory` staged each cover into RAM in **4 KB chunks**. Every `read()` is **one complete mmceman FS RPC** over the shared SIO2 channel — a command handshake + bulk DMA + trailer + a card-side seek/read-ahead prime — and that fixed per-RPC overhead is paid **once per `read()` regardless of size**. So a ~100 KB cover cost **~25 RPCs** where a few would move the identical bytes.

`mmceman` imposes **no read-size cap** (its FS-read length is a full 32-bit field — confirmed against `ps2-mmce/mmceman` source), so the 4 KB was purely our own throttle. This is exactly why POPSLoader / in-game loading is fast: `mmcedrv` reads **few large blocks** per RPC — *same driver, same bus, only request granularity differs.*

## Fix
`TEX_MMCE_STAGE_READ_SIZE` **4096 → 32768**. A ~100 KB cover now stages in **~4 reads instead of ~25** — ~8× fewer handshakes / trailers / sio2 lock windows / card seeks, moving the same total bytes and keeping the card's sequential read-ahead saturated. Initial staging buffer decoupled back to 64 KB.

## Card-safe by construction
Strictly **traffic-reducing** on the shared channel (fewer RPC envelopes, identical payload) — the **opposite** of the reverted prewarm; it cannot reintroduce the #120 wedge.

## Why 32 KB (not more, not a one-shot read)
The art worker checks the abort flag only **between** chunks, and `MMCE_ART_ABORT_WAIT_TICKS` gives it 500 ms to reach a checkpoint before `TerminateThread` — which corrupts the fileXio RPC channel and **is** the #120 failure. 32 KB ≈ 128 ms at the pessimistic ~256 KB/s slow-card rate = a ~4× margin. 64 KB halves it for little gain; **128 KB+ / an unbounded one-shot `getStat`+read risks crossing the watchdog and is rejected.** The `MMCE_ART_ABORT_WAIT_TICKS` comment is updated to match.

Contained to the MMCE staging path (`texShouldUseMemoryReader`); USB/BDM art loading unchanged. Local build green, clang-format clean.

### ⚠️ Hardware validation
PCSX2 has no `mmceman`, so this needs confirmation on Andrew's SD2PSX / MemCard PRO2, like the other #120 fixes. Expected: PS2/PS1 cover art and info screenshots load noticeably faster on MMCE, with no new stalls or wedges under rapid navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)