### PR TITLE
perf(mmce): break art staging on short read — saves 1 RPC/cover (Gemini review of #125)

### DIFF
--- a/src/textures.c
+++ b/src/textures.c
@@ -465,10 +465,17 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
             free(fileBuffer);
             return ERR_BAD_FILE;
         }
-        if (result == 0)
-            break; // EOF -- the whole file is staged
-
         bytesRead += result;
+
+        // A SHORT read means EOF here -- break without the extra read()==0 RPC (and the buffer
+        // realloc it would trigger). This is safe ONLY because of how mmceman serves an FS read
+        // (verified against ps2-mmce/mmceman mmce_fs_read + mmce_sio2_rx_mixed @ db3e93f0): the card
+        // always transfers the FULL requested size on the wire and reports the valid byte count
+        // separately, and any mid-transfer stall returns -1 (handled above) -- never a partial
+        // positive count. So result<SIZE is only ever the card's file running out, i.e. EOF; there
+        // is no "short now, more later" case. Do NOT copy this short==EOF break to a non-mmce reader.
+        if (result < TEX_MMCE_STAGE_READ_SIZE)
+            break;
     }
 
     if (bytesRead == 0) {


### PR DESCRIPTION
Follow-up to #125 (the 32 KB chunk change), acting on Gemini's review of that PR.

## What
The MMCE art staging loop only broke on `read() == 0`, so after the final data read it always did **one more `read()`** — a full SIO2 RPC returning 0 — plus the buffer `realloc` its headroom check triggered. Break on a **short read** instead.

## Why it's safe (verified, not assumed)
Gemini flagged this and I initially declined it, because "short read == EOF" is a classic file-truncation trap on a custom device. So I **verified it against the actual driver source** (`ps2-mmce/mmceman` at the pinned `db3e93f0`):

- `mmce_sio2_rx_mixed` transfers the **full requested size** on the wire and returns **−1 on any timeout** — never a partial positive count.
- `mmce_fs_read` then reads the **valid byte count** from a separate trailer packet.

So a positive `result < TEX_MMCE_STAGE_READ_SIZE` can *only* mean the card's file ran out = **EOF**; there is no "short now, more later" path that could truncate a cover, and a mid-transfer stall is already handled by the existing `result < 0` → `ERR_BAD_FILE` check. The comment documents this and warns against copying the `short == EOF` break to a non-mmce reader (where it would be unsafe).

## Net
A typical cover drops one more RPC + one `realloc`, on top of the ~8× already banked by #125. Small but real, and now provably correct on this driver.

Local build green, clang-format clean. **Hardware-only** (no `mmceman` on PCSX2) — validate on SD2PSX / MemCard PRO2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)