### PR TITLE
fix(mmceman): free the FS handle slot on a FAILED close — the real #120 VCD-info cascade

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,6 @@ pops/* binary
 *.PDF  diff=astextplain
 *.rtf  diff=astextplain
 *.RTF  diff=astextplain
+
+# Vendored-driver patches must stay LF so git apply works on the Linux CI runner
+.github/patches/*.patch text eol=lf

--- a/.github/patches/mmceman-fs-close-fd-leak.patch
+++ b/.github/patches/mmceman-fs-close-fd-leak.patch
@@ -1,0 +1,64 @@
+diff --git a/mmceman/src/mmce_fs.c b/mmceman/src/mmce_fs.c
+index ca6f618..bfcff1b 100644
+--- a/mmceman/src/mmce_fs.c
++++ b/mmceman/src/mmce_fs.c
+@@ -164,22 +164,29 @@ int mmce_fs_close(iomanX_iop_file_t *file)
+     res = mmce_sio2_tx_rx_pio(sizeof(wrbuf), sizeof(rdbuf), wrbuf, rdbuf, &timeout_1s);
+     mmce_sio2_unlock();
+ 
++    // Free the EE/IOP-side handle slot on EVERY exit, not just a clean close: the fd is being torn
++    // down regardless of what the card reports, so a timed-out or errored close must still return
++    // its slot to the 16-entry pool. Otherwise a transient close failure strands the slot for the
++    // life of the (session-singleton) driver, and after ~16 such failures every mmceN: open()/
++    // opendir() fails permanently (observed downstream: contended VCD-info art reads exhaust the
++    // pool -> blank game lists / boot fails until reboot).
+     if (res == -1) {
+         DPRINTF("%s ERROR: P1 - Timedout waiting for /ACK\n", __func__);
++        *(int*)file->privdata = -1;
+         return -1;
+     }
+ 
+     if (rdbuf[0x1] != MMCE_REPLY_CONST) {
+         DPRINTF("%s ERROR: Invalid response from card. Got 0x%x, Expected 0x%x\n", __func__, rdbuf[0x1], MMCE_REPLY_CONST);
++        *(int*)file->privdata = -1;
+         return -1;
+     }
+ 
+-    if (rdbuf[0x4] == 0x0) {
+-        *(int*)file->privdata = -1;
+-    } else {
++    if (rdbuf[0x4] != 0x0) {
+         res = rdbuf[0x4];
+         DPRINTF("%s ERROR: got return value %i\n", __func__, res);
+     }
++    *(int*)file->privdata = -1;
+ 
+     return res;
+ }
+@@ -659,18 +666,26 @@ int mmce_fs_dclose(iomanX_iop_file_t *file)
+     res = mmce_sio2_tx_rx_pio(0x4, 0x6, wrbuf, rdbuf, &timeout_1s);
+     mmce_sio2_unlock();
+ 
++    // Free the handle slot on EVERY exit (same rationale as mmce_fs_close): a timed-out or errored
++    // dclose must still return its slot to the pool, or a transient failure strands it permanently.
+     if (res == -1) {
+         DPRINTF("%s ERROR: P1 - Timedout waiting for /ACK\n", __func__);
++        *(int*)file->privdata = -1;
++        file->privdata = NULL;
+         return -1;
+     }
+ 
+     if (rdbuf[0x1] != MMCE_REPLY_CONST) {
+         DPRINTF("%s ERROR: Invalid response from card. Got 0x%x, Expected 0x%x\n", __func__, rdbuf[0x1], MMCE_REPLY_CONST);
++        *(int*)file->privdata = -1;
++        file->privdata = NULL;
+         return -1;
+     }
+ 
+     if (rdbuf[0x4] != 0x0) {
+         DPRINTF("%s ERROR: Card failed to close dir %i, return value %i\n", __func__, (u8)*(int*)file->privdata, rdbuf[0x1]);
++        *(int*)file->privdata = -1;
++        file->privdata = NULL;
+         return -1;
+     }
+ 

--- a/.github/scripts/install_coherent_mmce.sh
+++ b/.github/scripts/install_coherent_mmce.sh
@@ -40,6 +40,23 @@ echo "== Building menu-coherent mmceman from ps2-mmce @ ${MMCE_PIN} =="
 git clone --quiet "$MMCE_REPO" "$WORK/mmceman"
 git -C "$WORK/mmceman" checkout --quiet "$MMCE_PIN"
 
+# Local fix on top of the pin: mmce_fs_close/dclose leak their handle slot from the 16-entry FS
+# pool on ANY failed close (SIO2 timeout / bad reply / card error) -- only a clean close frees it.
+# On a contended card those close failures accumulate and, since mmceman is a session singleton,
+# after ~16 the pool is permanently drained and every mmceN: open()/opendir() fails (RiptOPL #120:
+# repeated VCD-info art reads -> blank game lists, boot fails, until reboot). The patch frees the
+# slot on every teardown path. Applied here (not a pin bump) so it is visible/reviewable and rides
+# the existing rebuild; drop it once the fix is upstream in ps2-mmce/mmceman. Fail LOUD if it stops
+# applying after a pin bump -- shipping the leak silently is the failure mode to avoid.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FS_LEAK_PATCH="$SCRIPT_DIR/../patches/mmceman-fs-close-fd-leak.patch"
+if [ ! -f "$FS_LEAK_PATCH" ]; then
+    echo "ERROR: expected mmceman fd-leak patch not found at $FS_LEAK_PATCH" >&2
+    exit 1
+fi
+echo "== Applying mmceman fd-leak fix (mmce_fs_close/dclose slot free-on-failure) =="
+git -C "$WORK/mmceman" apply --verbose "$FS_LEAK_PATCH"
+
 # Older-SDK make quirk: the per-module obj dir isn't auto-created by every Makefile.iopglobal
 # vintage -- pre-create it so the first compile step doesn't fail on a missing directory.
 mkdir -p "$WORK/mmceman/mmceman/obj"


### PR DESCRIPTION
## The real root cause (the prewarm fix didn't hold)
Andrew's MMCE cascade (game lists vanish after repeated PS1/VCD info) **survived the prewarm removal**, so that earlier diagnosis was wrong. A re-investigation — required to explain **all** the Beta-3093 symptoms *together* — found the actual defect, in the **`mmceman` driver itself**:

`mmceman` keeps FS handles in a **16-slot pool**. A slot is returned to the pool **only on a fully successful close** — `mmce_fs_close`/`mmce_fs_dclose` set `*privdata = -1` on the clean path only. On **any failed close** (SIO2 timeout, bad reply, card-reported error) they return **without freeing the slot**, so it's stranded permanently (the driver is a session singleton). On a contended card those failures accumulate; after ~16, `mmce_fs_find_free_handle` returns NULL and **every** `mmceN:` `open()`/`opendir()` fails at once.

## Why this explains everything the prewarm theory couldn't
| Symptom | Mechanism |
|---|---|
| Threshold ("after some games") | the 16-slot pool draining |
| VCD-only, not PS2 | VCD info does far more `mmceN:` open/close cycles (`vcdLoadArt` 3-tier fallback per suffix) → crosses the threshold |
| Both MMCE lists vanish | list rebuild `opendir`s `mmceN:` → no handle → empty |
| USB/Apps survive | different IOP drivers, own handle pools |
| **Config save now works** | config is on the emulated `mc0:` (mcman) — a *different driver*, untouched by mmceman exhaustion |
| L3 toggle sticky | display-name un-hides IDs instantly, but the rescan can't rebuild |
| "Return to Boot Card" fails | launching the boot ELF needs an `mmceN:` handle |

## Fix
Patch the vendored driver so `mmce_fs_close`/`dclose` free the slot on **every** teardown path — the EE fd is destroyed regardless of what the card reports, so a transient close failure can no longer strand a handle. Applied as a **reviewable patch file** that `install_coherent_mmce.sh` `git apply`s on top of the pin (**fails loudly** if it stops applying after a pin bump). `asm/mmceman.c` regenerates from the rebuilt `.irx`. Built locally: patched driver compiles, ELF embeds the 17017-byte `.irx`.

## Scope & caveats (honest)
- Reaches the **primary `ps2dev-latest` flavour** (the main `RIPTOPL-v…zip`), which already rebuilds mmceman via this script.
- **WOPLSDK / PS2MAXSDK** flavours ship their container's **stock** mmceman and still carry this **upstream** leak until fixed upstream — to be reported/PR'd to `ps2-mmce/mmceman`.
- **Hardware-only** (no mmceman on PCSX2): validate on Andrew's SD2PSX / MemCard PRO2, on the **main** build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)