### PR TITLE
fix(mmceman): don't NULL privdata on a failed dclose (Gemini high-sev review of #127)

### DIFF
--- a/.github/patches/mmceman-fs-close-fd-leak.patch
+++ b/.github/patches/mmceman-fs-close-fd-leak.patch
@@ -1,8 +1,8 @@
 diff --git a/mmceman/src/mmce_fs.c b/mmceman/src/mmce_fs.c
-index ca6f618..bfcff1b 100644
+index ca6f618..6bc0d0e 100644
 --- a/mmceman/src/mmce_fs.c
 +++ b/mmceman/src/mmce_fs.c
-@@ -164,22 +164,29 @@ int mmce_fs_close(iomanX_iop_file_t *file)
+@@ -164,22 +164,31 @@ int mmce_fs_close(iomanX_iop_file_t *file)
      res = mmce_sio2_tx_rx_pio(sizeof(wrbuf), sizeof(rdbuf), wrbuf, rdbuf, &timeout_1s);
      mmce_sio2_unlock();
  
@@ -11,7 +11,9 @@ index ca6f618..bfcff1b 100644
 +    // its slot to the 16-entry pool. Otherwise a transient close failure strands the slot for the
 +    // life of the (session-singleton) driver, and after ~16 such failures every mmceN: open()/
 +    // opendir() fails permanently (observed downstream: contended VCD-info art reads exhaust the
-+    // pool -> blank game lists / boot fails until reboot).
++    // pool -> blank game lists / boot fails until reboot). NB: we only reset the slot value here,
++    // NOT file->privdata (the pointer) -- close is entered only after a successful open, so privdata
++    // is always valid; keeping it non-NULL avoids any deref-of-NULL on a hypothetical re-entry.
      if (res == -1) {
          DPRINTF("%s ERROR: P1 - Timedout waiting for /ACK\n", __func__);
 +        *(int*)file->privdata = -1;
@@ -35,30 +37,29 @@ index ca6f618..bfcff1b 100644
  
      return res;
  }
-@@ -659,18 +666,26 @@ int mmce_fs_dclose(iomanX_iop_file_t *file)
+@@ -659,18 +668,25 @@ int mmce_fs_dclose(iomanX_iop_file_t *file)
      res = mmce_sio2_tx_rx_pio(0x4, 0x6, wrbuf, rdbuf, &timeout_1s);
      mmce_sio2_unlock();
  
-+    // Free the handle slot on EVERY exit (same rationale as mmce_fs_close): a timed-out or errored
-+    // dclose must still return its slot to the pool, or a transient failure strands it permanently.
++    // Free the handle slot on EVERY exit (same rationale as mmce_fs_close). Only the slot VALUE is
++    // reset on the failure paths -- file->privdata (the pointer) is left non-NULL there and cleared
++    // to NULL only on the clean path (as upstream did), so a failed dclose can never leave a NULL
++    // privdata behind for a later deref.
      if (res == -1) {
          DPRINTF("%s ERROR: P1 - Timedout waiting for /ACK\n", __func__);
 +        *(int*)file->privdata = -1;
-+        file->privdata = NULL;
          return -1;
      }
  
      if (rdbuf[0x1] != MMCE_REPLY_CONST) {
          DPRINTF("%s ERROR: Invalid response from card. Got 0x%x, Expected 0x%x\n", __func__, rdbuf[0x1], MMCE_REPLY_CONST);
 +        *(int*)file->privdata = -1;
-+        file->privdata = NULL;
          return -1;
      }
  
      if (rdbuf[0x4] != 0x0) {
          DPRINTF("%s ERROR: Card failed to close dir %i, return value %i\n", __func__, (u8)*(int*)file->privdata, rdbuf[0x1]);
 +        *(int*)file->privdata = -1;
-+        file->privdata = NULL;
          return -1;
      }
  


### PR DESCRIPTION
Follow-up to #127 acting on Gemini's **high-severity** review of that patch.

## The flag
Gemini flagged a potential NULL-deref: #127's patch set `file->privdata = NULL` on `mmce_fs_dclose`'s **failure** paths (mirroring the clean path). If anything ever re-derefs `privdata` after a failed `dclose`, that's an IOP NULL-deref → crash.

## Assessment
Mostly a false alarm — both functions *already* deref `file->privdata` unguarded at their first line (`close:147`, `dclose:653`) in the original upstream code, and that's safe because `close`/`dclose` are only entered after a **successful** open (a failed open sets `privdata = NULL` and returns before `close` is ever called). So `privdata` is non-NULL throughout, and adding NULL guards only to the new lines would be inconsistent theater.

**But** the review has a real point about the *one* genuinely-new NULL state I introduced: nulling `privdata` on the *failure* paths of `dclose`. The leak fix never needed the pointer nulled — only the **slot value** freed. So:

- Failure paths now do `*(int*)file->privdata = -1` (free the slot) and **leave `privdata` non-NULL**.
- The clean path still clears the pointer (as upstream did).
- `close` is unchanged (it never nulled the pointer).

Net: the fd leak is still fully fixed, and the one new NULL the review worried about is gone — with no inconsistent guards bolted onto a vendored driver. Rebuilt locally: patched driver compiles, ELF embeds it. Applies clean to the pinned source.

**Hardware-only** (no mmceman on PCSX2). Supersedes #127's patch content; primary `ps2dev-latest` flavour only, same as #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)