### PR TITLE
feat(#120): on-screen MMCE-cascade diagnostics + separate PS1/PS2 arrays (unwasteable tester build)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -5,10 +5,12 @@
 */
 
 #include "include/opl.h"
+#include "include/diag.h" // #120 diag: latch the config-write errno at the failure site (below)
 #include "include/util.h"
 #include "include/ioman.h"
 #include "include/sound.h"
 #include <string.h>
+#include <errno.h>
 
 // FIXME: We should not need this function.
 //        Use newlib's 'stat' to get GMT time.
@@ -681,7 +683,12 @@ int configWrite(config_set_t *configSet)
             }
 
             ok = (closeFileBuffer(fileBuffer) == 0);
+            if (!ok)
+                gDiag.lastSaveErrno = errno; // #120 diag: flush/close failure errno, captured before bgmUnMute
             bgmUnMute();
+        } else {
+            gDiag.lastSaveErrno = errno; // #120 diag: write-open failure errno (wedged card = EIO/ENODEV),
+                                         // captured HERE before the restore-path opens below clobber it
         }
 
         if (!ok) {

--- a/src/gui.c
+++ b/src/gui.c
@@ -5,6 +5,7 @@
  */
 
 #include "include/opl.h"
+#include "include/diag.h"
 #include "include/gui.h"
 #include "include/renderman.h"
 #include "include/menusys.h"
@@ -2048,6 +2049,19 @@ static void guiDrawOverlays()
     // BLURT output
     // if (gEnableDebug)
     //     fntRenderString(gTheme->fonts[0], 0, screenHeight - 24, ALIGN_NONE, 0, 0, blurttext, GS_SETREG_RGBA(255, 255, 0, 128));
+
+    // #120 MMCE-cascade diagnostic line (see include/diag.h). Ships in the RELEASE binary (NOT behind
+    // __DEBUG) so a hardware tester can surface it by flipping one already-existing switch (Settings ->
+    // debug info), no special build. Rendered here on the EE main thread every frame, independent of the
+    // (possibly wedged) art worker, reading plain volatile counters -> zero MMCE-bus traffic. TK > 0 is
+    // the smoking gun (art watchdog corrupted the shared RPC channel).
+    if (gEnableDebug) {
+        char diag[128];
+        snprintf(diag, sizeof(diag), "#120 AO:%u MH:%u MM:%u TK:%u Vp:%u Ip:%u SE:%d",
+                 gDiag.artOpens, gDiag.memoHit, gDiag.memoMiss, gDiag.artTerminate,
+                 gDiag.vcdRescanPreserved, gDiag.isoScanPreserved, gDiag.lastSaveErrno);
+        fntRenderString(gTheme->fonts[0], 0, screenHeight - 24, ALIGN_NONE, 0, 0, diag, GS_SETREG_RGBA(255, 255, 0, 128));
+    }
 }
 
 static void guiReadPads()

--- a/src/include/diag.h
+++ b/src/include/diag.h
@@ -1,0 +1,59 @@
+#ifndef __OPL_DIAG_H
+#define __OPL_DIAG_H
+
+// Always-on, ship-in-release diagnostic counters for the MMCE #120 cascade investigation.
+//
+// Every serial/__DEBUG log path is compiled out on a stock retail PS2, and a log file on the MMCE card
+// would itself write to the (possibly wedged) mmceman SIO2 bus we are trying to observe. So the ONLY
+// diagnostic channel that reaches a hardware tester is the screen: these counters are bumped at existing
+// choke points on whatever thread reaches them, and rendered as ONE line by the GUI (gui.c) every frame
+// on the EE main thread -- proven alive during the cascade (the busy spinner keeps animating and the
+// USB/Apps tabs stay live while MMCE art is wedged). The overlay only READS these ints; it issues no
+// fileXio / SIO2 / card IO, so it adds ZERO traffic to the bus under investigation.
+//
+// Thread model: no field has more than one MEANINGFUL writer, and the GUI only reads. artOpens is bumped
+// from BOTH the art worker AND the EE main thread (texDiscoverLoad also loads theme PNGs during thmLoad),
+// so its non-atomic ++ can lose a rare update -- harmless for a delta-read diagnostic. memoHit/memoMiss are
+// art-worker-only; artTerminate from the launch/theme path; vcdRescanPreserved/isoScanPreserved/lastSaveErrno
+// from the deferred-IO (or config-write) path. Aligned 32-bit loads/stores are atomic on the EE, so a read
+// is at most one frame stale (torn reads impossible) -- acceptable for diagnostics; no locks are taken.
+//
+// Reading the line (shown only when the user enables debug info, so it costs nothing in normal use). Read
+// the counters as a DELTA while performing the repro (they are cumulative and some are not MMCE-exclusive):
+//   AO artOpens          - EVERY texDiscoverLoad() entry: ISO + VCD art opens AND theme-element PNGs (theme
+//                          loads spike it on a theme switch, NOT the MMCE bus). So don't read the absolute
+//                          value -- watch whether AO keeps CLIMBING while parked on ONE PS1 info screen /
+//                          scrolling a cover-less PS1 list: if it does, the miss-memo is NOT suppressing
+//                          re-probes (epoch/key bug) and the storm is still live.
+//   MH memoHit           - vcdLoadArt short-circuits with ZERO opens (memo working). This is the precise
+//                          VCD-storm signal: AO plateauing while MH climbs == the storm is bounded.
+//   MM memoMiss          - full VCD art misses recorded into the memo (first probe of each cover).
+//   TK artTerminate      - **THE smoking gun.** The art watchdog TerminateThread'd the worker, which
+//                          corrupts the shared mmceman RPC channel for the rest of the session. TK > 0
+//                          means every reduce-the-opens fix is MOOT and we need a no-terminate / channel-
+//                          reset fix instead. We have never been able to SEE this before.
+//   Vp vcdRescanPreserved- a VCD (PS1) list rebuild kept its last-good list on a failed device read.
+//                          NOTE: bumped for ANY VCD backend (mmce/bdm/eth/udpfs/hdd), so on a multi-device
+//                          rig it is not MMCE-exclusive -- reliable as an MMCE signal only if MMCE is the
+//                          rig's only VCD source (Andrew's case).
+//   Ip isoScanPreserved  - an ISO (PS2) list rebuild kept its last-good list on a failed read (same all-
+//                          backend caveat as Vp). Ip ticking up when the tester presses "show PS2 games"
+//                          confirms the toggle is failing on the contended bus, not a handler that never fired.
+//   SE lastSaveErrno     - errno of the last failed settings write (0 = none), latched at the actual write-
+//                          failure site inside configWrite() (config.c). EIO/ENODEV here confirms the config
+//                          save failed because the card itself is wedged, not a path problem.
+
+typedef struct
+{
+    volatile unsigned int artOpens;
+    volatile unsigned int memoHit;
+    volatile unsigned int memoMiss;
+    volatile unsigned int artTerminate;
+    volatile unsigned int vcdRescanPreserved;
+    volatile unsigned int isoScanPreserved;
+    volatile int lastSaveErrno;
+} opl_diag_t;
+
+extern opl_diag_t gDiag;
+
+#endif

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -29,6 +29,14 @@ static time_t mmceModifiedCDPrev;
 static time_t mmceModifiedDVDPrev;
 static int mmceGameCount = 0;
 static base_game_info_t *mmceGames;
+// #120: the PS2 (ISO) and PS1 (VCD) views must NOT share one backing store. When they did, a failed
+// ISO rescan on a contended MMCE bus fell into sbReadList's preserve-on-failure and re-published the
+// STALE list -- which, being shared, was the VCD list -> pressing "show PS2 games" silently kept the PS1
+// list on screen (Andrew's #129 "can't switch to PS2 list"). Separate arrays (mirroring hddGames vs
+// hddVcdGames) make a failed scan of one view preserve only THAT view's last-good (empty if never
+// scanned), so it can never resurrect the other view's contents.
+static int mmceVcdGameCount = 0;
+static base_game_info_t *mmceVcdGames = NULL;
 // Auto-slot (gMMCESlot==2) resolution cache: mmceDetectSlot()'s last result (2=mmce0, 3=mmce1,
 // -1=unresolved). Avoids re-probing BOTH slots over SIO2 every menu refresh -- that steady devctl
 // drip contends with MX4SIO on the shared bus. Reset by mmceInit (tab re-enable / settings apply).
@@ -298,6 +306,8 @@ void mmceInit(item_list_t *itemList)
     mmceModifiedDVDPrev = 0;
     mmceGameCount = 0;
     mmceGames = NULL;
+    mmceVcdGameCount = 0;
+    mmceVcdGames = NULL;
     mmceResolvedDevice = -1; // re-detect the Auto slot on a fresh init (tab re-enable / settings apply)
     mmceFoldersCreatedFor[0] = '\0';
 
@@ -332,7 +342,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     if (mmcePrefix[0] == '\0') {
         mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
         mmceFoldersCreatedFor[0] = '\0'; // card gone: recreate folders on the next (possibly different) card
-        return (mmceGameCount > 0);
+        return (mmceGameCount > 0 || mmceVcdGameCount > 0);
     }
 
     mmceGameList.updateDelay = MENU_UPD_DELAY_NOUPDATE;
@@ -409,56 +419,70 @@ static int mmceUpdateGameList(item_list_t *itemList)
             free(mmceGames);
             mmceGames = NULL;
         }
+        if (mmceVcdGames != NULL) {
+            free(mmceVcdGames);
+            mmceVcdGames = NULL;
+        }
         mmceGameCount = 0;
+        mmceVcdGameCount = 0;
         mmceULSizePrev = -2; // force a fresh scan when a card returns
         return 0;
     }
 
+    // Each view scans into its OWN array (#120): a failed rescan preserves only that view's last-good and
+    // can never resurrect the other view's list (see the mmceVcdGames comment at the declarations).
     if (vcdViewActive(itemList->mode)) {
-        int r = vcdFillGameList(mmcePrefix, &mmceGames);
-        if (r >= 0) // r < 0: transient scan failure (contended bus) -> keep the last-good list, do NOT blank
-            mmceGameCount = r;
-    } else
-        sbReadList(&mmceGames, mmcePrefix, &mmceULSizePrev, &mmceGameCount);
+        int r = vcdFillGameList(mmcePrefix, &mmceVcdGames);
+        if (r >= 0) // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
+            mmceVcdGameCount = r;
+        return mmceVcdGameCount;
+    }
+    sbReadList(&mmceGames, mmcePrefix, &mmceULSizePrev, &mmceGameCount);
     return mmceGameCount;
 }
 
 static int mmceGetGameCount(item_list_t *itemList)
 {
-    return mmceGameCount;
+    return vcdViewActive(itemList->mode) ? mmceVcdGameCount : mmceGameCount;
 }
 
 static void *mmceGetGame(item_list_t *itemList, int id)
 {
-    return (void *)&mmceGames[id];
+    return vcdViewActive(itemList->mode) ? (void *)&mmceVcdGames[id] : (void *)&mmceGames[id];
 }
 
 static char *mmceGetGameName(item_list_t *itemList, int id)
 {
-    return mmceGames[id].name;
+    return vcdViewActive(itemList->mode) ? mmceVcdGames[id].name : mmceGames[id].name;
 }
 
 static int mmceGetGameNameLength(item_list_t *itemList, int id)
 {
-    return ((mmceGames[id].format != GAME_FORMAT_USBLD) ? ISO_GAME_NAME_MAX + 1 : UL_GAME_NAME_MAX + 1);
+    base_game_info_t *g = vcdViewActive(itemList->mode) ? &mmceVcdGames[id] : &mmceGames[id];
+    return ((g->format != GAME_FORMAT_USBLD) ? ISO_GAME_NAME_MAX + 1 : UL_GAME_NAME_MAX + 1);
 }
 
 static char *mmceGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
     if (vcdViewActive(itemList->mode))
-        return mmceGames[id].name;
+        return mmceVcdGames[id].name;
     return mmceGames[id].startup;
 }
 
 static void mmceDeleteGame(item_list_t *itemList, int id)
 {
+    if (vcdViewActive(itemList->mode))
+        return; // #120: a VCD is not an ISO game -- no delete in VCD view (id indexes mmceVcdGames, and
+                // sbDelete would deref the ISO array mmceGames[id] out of range -> NULL/OOB + wrong unlink)
     sbDelete(&mmceGames, mmcePrefix, "/", mmceGameCount, id);
     mmceULSizePrev = -2;
 }
 
 static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
 {
+    if (vcdViewActive(itemList->mode))
+        return; // #120: no rename in VCD view (same ISO-array OOB hazard as mmceDeleteGame above)
     sbRename(&mmceGames, mmcePrefix, "/", mmceGameCount, id, newName);
     mmceULSizePrev = -2;
 }
@@ -499,7 +523,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
     // No Autolaunch yet
     if (gAutoLaunchBDMGame == NULL)
-        game = &mmceGames[id];
+        game = vcdViewActive(itemList->mode) ? &mmceVcdGames[id] : &mmceGames[id];
     else
         game = gAutoLaunchBDMGame;
 
@@ -807,6 +831,10 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
 static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 {
+    // VCD view: config (CFG + #Format/#System/#DiscType badges) comes from the VCD array, keyed off the
+    // VCD basename -- never &mmceGames[id] (the ISO array, possibly shorter/empty in VCD view -> OOB).
+    if (vcdViewActive(itemList->mode))
+        return sbPopulateConfig(&mmceVcdGames[id], mmcePrefix, "/");
     return sbPopulateConfig(&mmceGames[id], mmcePrefix, "/");
 }
 
@@ -842,6 +870,9 @@ static void mmceCleanUp(item_list_t *itemList, int exception)
         LOG("MMCESUPPORT CleanUp\n");
 
         free(mmceGames);
+        mmceGames = NULL;
+        free(mmceVcdGames); // #120: free the separate VCD array too; NULL both (CleanUp + Shutdown both run)
+        mmceVcdGames = NULL;
 
         //      if ((exception & UNMOUNT_EXCEPTION) == 0)
         //          ...
@@ -855,6 +886,9 @@ static void mmceShutdown(item_list_t *itemList)
         LOG("MMCESUPPORT Shutdown\n");
 
         free(mmceGames);
+        mmceGames = NULL;
+        free(mmceVcdGames);
+        mmceVcdGames = NULL;
     }
 
     // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.

--- a/src/opl.c
+++ b/src/opl.c
@@ -5,6 +5,7 @@
 */
 
 #include "include/opl.h"
+#include "include/diag.h"
 #include "include/ioman.h"
 #include "include/gui.h"
 #include "include/guigame.h"
@@ -130,6 +131,10 @@ int ps2_ip[4];
 int ps2_netmask[4];
 int ps2_gateway[4];
 int ps2_dns[4];
+// #120 diagnostic counters (see include/diag.h). Ships in the release binary; visible only when the
+// user enables the debug-info overlay. The sole definition; every other TU externs it via diag.h.
+opl_diag_t gDiag = {0};
+
 int gETHOpMode; // See ETH_OP_MODES.
 int gPCShareAddressIsNetBIOS;
 int pc_ip[4];
@@ -385,17 +390,14 @@ static void itemExecSquare(struct menu_item *curMenu)
         // busy spinner (Andrew, #120). Skipping it for VCD strictly REDUCES channel traffic and drops
         // no displayed data (the info page shows no size for a VCD anyway).
         item_list_t *support = curMenu->userdata;
-        if (support == NULL || !vcdViewActive(support->mode)) {
+        if (support == NULL || !vcdViewActive(support->mode))
             menuRequestInfoSize();
-        } else {
-            // VCD: the info page's #Format/#System/#DiscType badges are AttributeImages, so the info
-            // RENDER path would otherwise queue an ASYNC item-config read (the badge values), raising
-            // the busy spinner on the slow MMCE bus for ~0.4s+ with nothing else to show (Andrew, #120,
-            // separate from the #Size stat above). Load that config SYNCHRONOUSLY here instead -- same
-            // proven API itemExecSelect uses at launch -- so the render path finds itemConfig already
-            // set and takes its no-op branch: no async request, no spinner, badges still populated.
-            menuLoadConfigDirect();
-        }
+        // NOTE: do NOT force a synchronous menuLoadConfigDirect() here for VCD to pre-load the
+        // #Format/#System/#DiscType badge config. That read runs on the GUI thread, and on a WEDGED
+        // MMCE card it would block the whole UI outright instead of the (harmless, non-blocking) busy
+        // spinner the async render path raises -- strictly worse than the spinner it was meant to hide
+        // (Andrew, #120: the card wedges card-side during browsing, so any GUI-thread card read is a
+        // freeze risk). The badges resolve fine via the render's own async config read.
         guiSwitchScreen(GUI_SCREEN_INFO);
     }
 }
@@ -1942,6 +1944,9 @@ static void _saveConfig()
         if (lscret > 0)
             writeConfigPathRedirect(configGetDir());
     }
+    // #120 diag: gDiag.lastSaveErrno is latched at the actual write-failure site inside configWrite()
+    // (config.c) -- NOT here, where later config-set snapshot-opens have already clobbered errno with a
+    // spurious ENOENT (adversarial review). See config.c.
     lscstatus = 0;
 }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -385,8 +385,17 @@ static void itemExecSquare(struct menu_item *curMenu)
         // busy spinner (Andrew, #120). Skipping it for VCD strictly REDUCES channel traffic and drops
         // no displayed data (the info page shows no size for a VCD anyway).
         item_list_t *support = curMenu->userdata;
-        if (support == NULL || !vcdViewActive(support->mode))
+        if (support == NULL || !vcdViewActive(support->mode)) {
             menuRequestInfoSize();
+        } else {
+            // VCD: the info page's #Format/#System/#DiscType badges are AttributeImages, so the info
+            // RENDER path would otherwise queue an ASYNC item-config read (the badge values), raising
+            // the busy spinner on the slow MMCE bus for ~0.4s+ with nothing else to show (Andrew, #120,
+            // separate from the #Size stat above). Load that config SYNCHRONOUSLY here instead -- same
+            // proven API itemExecSelect uses at launch -- so the render path finds itemConfig already
+            // set and takes its no-op branch: no async request, no spinner, badges still populated.
+            menuLoadConfigDirect();
+        }
         guiSwitchScreen(GUI_SCREEN_INFO);
     }
 }

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1,4 +1,5 @@
 #include "include/opl.h"
+#include "include/diag.h"
 #include "include/lang.h"
 #include "include/util.h"
 #include "include/iosupport.h"
@@ -505,6 +506,7 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
     // TOTAL device-read failure (both dir scans failed to open AND no ul.cfg): keep the caller's
     // current list rather than blanking it. newlist is NULL here; nothing to publish or leak.
     if (cdRet < 0 && dvdRet < 0 && fd < 0) {
+        gDiag.isoScanPreserved++; // #120 diag: ISO list kept last-good on a failed read (the PS2-toggle no-op)
         free(newlist);
         return *gamecount; // *list / *gamecount / *fsize untouched -> last-good list stays on screen
     }

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1,4 +1,5 @@
 #include "include/opl.h"
+#include "include/diag.h"
 #include "include/appsupport.h"
 #include "include/pad.h"
 #include "include/texcache.h"
@@ -1043,6 +1044,7 @@ void cacheEnd(int forceStop)
     cacheRestoreCallerPriority(savedPriority);
 
     if (gArtRunning && gArtThreadId >= 0 && forceStop) {
+        gDiag.artTerminate++; // #120 diag: THE smoking gun -- this corrupts the shared mmceman RPC channel
         TerminateThread(gArtThreadId);
         DeleteThread(gArtThreadId);
         gArtRunning = 0;

--- a/src/textures.c
+++ b/src/textures.c
@@ -1,4 +1,5 @@
 #include "include/opl.h"
+#include "include/diag.h"
 #include "include/textures.h"
 #include "include/util.h"
 #include "include/ioman.h"
@@ -772,6 +773,8 @@ int texDiscoverLoad(GSTEXTURE *texture, const char *path, int texId)
 {
     char filePath[256];
     int result;
+
+    gDiag.artOpens++; // #120 diag: the single funnel for every ISO+VCD cover/bg/screenshot open probe
 
     LOG("texDiscoverLoad(%s)\n", path);
 

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -16,6 +16,7 @@
 #include <sys/stat.h> // mkdir (POSIX, used like util.c / OSDHistory.c)
 
 #include "include/opl.h"         // pulls <dirent.h> (opendir/readdir/DIR) + strcasecmp, like supportbase.c
+#include "include/diag.h"        // #120 diagnostic counters (memo hit/miss, VCD rescan preserve)
 #include "include/system.h"      // POPS_FOLDER
 #include "include/textures.h"    // texDiscoverLoad (VCD cover-art fallback)
 #include "include/ioman.h"       // LOG (BDMA equip probe trace)
@@ -83,6 +84,8 @@ const char *vcdDisplayName(int mode, const char *text)
     return n ? text + n : text;
 }
 
+static void vcdArtMissInvalidate(void); // defined below; bumped once per SUCCESSFUL scan (see vcdScanOpenDir)
+
 // Core scan: opendir `dirPath` and collect *.VCD basenames into a fresh vcd_entry_t list. POSIX dir
 // IO only (newlib-port rule). Shared by vcdScanDir (POPS subfolder) and vcdScanDirRoot (path as-is).
 static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
@@ -116,6 +119,14 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
         count++;
     }
     closedir(dir);
+
+    // The directory was readable (opened + fully enumerated) -> the VCD set may have changed since last
+    // time, so art that was previously absent might now exist: drop the art miss-memo (#120). Placed HERE,
+    // on the single shared scan success path, so it fires for EVERY VCD device -- including the HDD/APA
+    // path via vcdScanDirRoot, which does NOT go through vcdFillGameList (Gemini review of #130). Fires
+    // ONLY on success: the opendir-fail / OOM returns above never reach here, so a transient wedge does
+    // NOT wipe the memo and re-ignite the failing-open storm.
+    vcdArtMissInvalidate();
 
     if (count == 0) {
         free(list);
@@ -433,8 +444,10 @@ int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const cha
     int r = -1;
 
     unsigned int missKey = vcdArtMissKey(devPrefix, value, suffix);
-    if (vcdArtMissKnown(missKey))
-        return -1; // known-absent this epoch -> skip the failing-open storm on the slow MMCE bus (#120)
+    if (vcdArtMissKnown(missKey)) {
+        gDiag.memoHit++; // #120 diag: storm avoided -- zero opens this probe
+        return -1;       // known-absent this epoch -> skip the failing-open storm on the slow MMCE bus (#120)
+    }
 
     vcdExtractGameId(value, discId, sizeof(discId));
     if (discId[0] != '\0') {
@@ -451,6 +464,7 @@ int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const cha
             return r;
     }
 
+    gDiag.memoMiss++;            // #120 diag: full miss recorded (first probe of this cover this epoch)
     vcdArtMissRemember(missKey); // all tiers missed -> a repeat probe skips them until the next rescan
     return r;
 }
@@ -500,12 +514,12 @@ int vcdFillGameList(const char *devPrefix, base_game_info_t **outGames)
 
     vcd_entry_t *vcds = NULL;
     int n = vcdScanDir(devPrefix, &vcds); // NOTE: does NOT touch *outGames
-    if (n < 0)
-        return -1; // could not read the device -> preserve the caller's current list (leave it intact)
-
-    // The device was readable and the list is being rebuilt -> art may have been added since; drop the
-    // VCD art miss-memo so previously-absent covers/screenshots are re-probed (see vcdArtMissInvalidate).
-    vcdArtMissInvalidate();
+    if (n < 0) {
+        gDiag.vcdRescanPreserved++; // #120 diag: VCD list kept last-good on a failed device read
+        return -1;                  // could not read the device -> preserve the caller's current list
+    }
+    // NOTE: the art miss-memo invalidation now lives in vcdScanOpenDir (the shared scan success path) so
+    // it also covers the HDD vcdScanDirRoot path -- do NOT re-invalidate here (it already fired).
 
     base_game_info_t *games = NULL;
     int kept = 0;

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -364,17 +364,77 @@ const char *vcdArtPopsDir(const char *suffix)
     return NULL;
 }
 
+// Bounded miss-memo for VCD art (issue #120): a VCD info view probes up to ~2-3 filenames per art
+// suffix (see vcdLoadArt), almost all MISSING for PS1 games that ship no covers/screenshots. Opening
+// PS1 info repeatedly re-ran that failing-open STORM on the slow shared MMCE (SIO2) bus every time,
+// contending/desyncing the card. Remember a FULL miss per (device+value+suffix) so a subsequent probe
+// of the same art skips the opens entirely -- STRICTLY FEWER bus opens, never more. Invalidated
+// wholesale by an epoch bump on any VCD list rescan (art may now exist), so nothing is permanently
+// hidden. Thread model: the memo ARRAY is written ONLY on the art worker thread (vcdLoadArt runs there
+// via every getImage); the epoch is a lone volatile int bumped from the IO thread -- so there is no
+// cross-thread array access, aligned-int writes are atomic on EE, and a stale-epoch entry is ignored.
+#define VCD_ART_MISS_MEMO 128
+static struct
+{
+    unsigned int key;
+    unsigned int epoch;
+} vcdArtMiss[VCD_ART_MISS_MEMO];
+static int vcdArtMissNext = 0;
+static volatile unsigned int vcdArtMissEpoch = 1; // 0 reserved = a never-written slot
+
+static void vcdArtMissInvalidate(void)
+{
+    unsigned int e = vcdArtMissEpoch + 1; // bump on a VCD rescan -> every prior miss is re-probed
+    vcdArtMissEpoch = e ? e : 1;
+}
+
+static unsigned int vcdArtMissKey(const char *devPrefix, const char *value, const char *suffix)
+{
+    unsigned int h = 2166136261u; // FNV-1a over devPrefix, value, suffix (each NUL-separated)
+    const char *p;
+    for (p = devPrefix; p && *p; p++)
+        h = (h ^ (unsigned char)*p) * 16777619u;
+    h = (h ^ 0xffu) * 16777619u;
+    for (p = value; p && *p; p++)
+        h = (h ^ (unsigned char)*p) * 16777619u;
+    h = (h ^ 0xffu) * 16777619u;
+    for (p = suffix; p && *p; p++)
+        h = (h ^ (unsigned char)*p) * 16777619u;
+    return h ? h : 1; // 0 reserved
+}
+
+static int vcdArtMissKnown(unsigned int key)
+{
+    unsigned int ep = vcdArtMissEpoch;
+    for (int i = 0; i < VCD_ART_MISS_MEMO; i++)
+        if (vcdArtMiss[i].epoch == ep && vcdArtMiss[i].key == key)
+            return 1;
+    return 0;
+}
+
+static void vcdArtMissRemember(unsigned int key)
+{
+    vcdArtMiss[vcdArtMissNext].key = key;
+    vcdArtMiss[vcdArtMissNext].epoch = vcdArtMissEpoch;
+    vcdArtMissNext = (vcdArtMissNext + 1) % VCD_ART_MISS_MEMO;
+}
+
 // 3-level cover/icon fallback for VCD (PS1) games, so one art file can serve OPL and POPSLoader:
 //   (1) OPL ART keyed by the PS1 disc id  -> <dev>ART/<SXXX_NNN.NN>_<suffix>.png  (interoperable serial)
 //   (2) OPL ART keyed by the VCD basename -> <dev>ART/<name>_<suffix>.png         (long-standing behaviour)
 //   (3) POPSLoader layout next to the .VCD -> <dev><popsDir>/<name>.png            (no _suffix; POPSLoader's)
 // Returns the first texDiscoverLoad hit (>= 0), else the last miss. popsDir == NULL skips step (3).
-// `sep` is '/' for local/MMCE/HDD prefixes and '\\' for SMB (ethPrefix) -- mirror the caller's getImage.
+// A repeat probe of known-absent art short-circuits with NO opens (miss-memo above). `sep` is '/' for
+// local/MMCE/HDD prefixes and '\\' for SMB (ethPrefix) -- mirror the caller's getImage.
 int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const char *value, const char *suffix, const char *popsDir, GSTEXTURE *tex)
 {
     char path[256];
     char discId[VCD_ID_MAX];
     int r = -1;
+
+    unsigned int missKey = vcdArtMissKey(devPrefix, value, suffix);
+    if (vcdArtMissKnown(missKey))
+        return -1; // known-absent this epoch -> skip the failing-open storm on the slow MMCE bus (#120)
 
     vcdExtractGameId(value, discId, sizeof(discId));
     if (discId[0] != '\0') {
@@ -383,11 +443,16 @@ int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const cha
             return r;
     }
     snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, value, suffix);
-    r = texDiscoverLoad(tex, path, -1);
-    if (r >= 0 || popsDir == NULL)
+    if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
         return r;
-    snprintf(path, sizeof(path), "%s%s%c%s", devPrefix, popsDir, sep, value);
-    return texDiscoverLoad(tex, path, -1);
+    if (popsDir != NULL) {
+        snprintf(path, sizeof(path), "%s%s%c%s", devPrefix, popsDir, sep, value);
+        if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
+            return r;
+    }
+
+    vcdArtMissRemember(missKey); // all tiers missed -> a repeat probe skips them until the next rescan
+    return r;
 }
 
 // #118: a multi-disc PS1 game is a set of separate .VCD files whose titles carry a disc token, e.g.
@@ -437,6 +502,10 @@ int vcdFillGameList(const char *devPrefix, base_game_info_t **outGames)
     int n = vcdScanDir(devPrefix, &vcds); // NOTE: does NOT touch *outGames
     if (n < 0)
         return -1; // could not read the device -> preserve the caller's current list (leave it intact)
+
+    // The device was readable and the list is being rebuilt -> art may have been added since; drop the
+    // VCD art miss-memo so previously-absent covers/screenshots are re-probed (see vcdArtMissInvalidate).
+    vcdArtMissInvalidate();
 
     base_game_info_t *games = NULL;
     int kept = 0;


### PR DESCRIPTION
Andrew's #129 build stopped the game list **vanishing** (confirmed) but three symptoms remained: art won't load, settings won't save, can't switch to the PS2 list. A four-tracer adversarial read of the actual code established the key fact: **the browse-time wedge is card-side** (the browse path never force-kills the art thread), so no EE-side change can un-wedge an already-desynced card — and **every serial/`__DEBUG` log path is compiled out on Andrew's stock console**, which is exactly why two prior guesses shipped blind and missed.

This build makes his next test **unwasteable** and fixes what is cleanly fixable, without over-reaching on the wedge itself.

### 1. On-screen diagnostic HUD — the payload (`src/include/diag.h`, rendered by `gui.c`)
Ships in the **release** binary, surfaced by the **existing** debug-info toggle (one switch, no special build). One line:

```
#120 AO:<artOpens> MH:<memoHit> MM:<memoMiss> TK:<artTerminate> Vp:<vcdRescanPreserved> Ip:<isoScanPreserved> SE:<lastSaveErrno>
```

Rendered on the EE main thread (proven alive during the cascade — the spinner keeps animating, USB/Apps tabs stay live), reading plain `volatile` ints → **zero MMCE-bus traffic**. The killer signal is **`TK` (artTerminate)**: `TK > 0` means the watchdog `TerminateThread`'d the art worker and corrupted the shared mmceman RPC channel — so every reduce-the-opens fix is moot and we pivot to a no-terminate / channel-reset fix. We have never been able to *see* this before. `SE` is latched at the **actual** write-failure site in `configWrite()` (not at `saveConfig`, where later snapshot-opens clobber `errno` with a spurious `ENOENT` — adversarial review).

### 2. Separate MMCE PS1/PS2 arrays — real fix for the #129-exposed "can't switch to PS2 list"
The ISO and VCD views **shared one backing store**; a failed ISO rescan on the contended bus fell into `sbReadList`'s preserve-on-failure and re-published the stale list — which, being shared, was the *VCD* list, so the toggle silently kept showing PS1. Split into `mmceVcdGames`/`mmceVcdGameCount` vs `mmceGames`/`mmceGameCount` (mirroring `hddsupport.c`), every getter view-branched. A failed scan now preserves only **that** view's last-good → the toggle shows an honest empty "unavailable", never the wrong list. Includes HDD's `vcdViewActive` **delete/rename guard** (adversarial review caught its absence as a NULL/OOB + wrong-`unlink()` crash regression).

### 3. Reverted the synchronous badge pre-load (was "change B" of this PR)
It ran a card read on the GUI thread; on a **wedged** card that *freezes* the UI instead of the harmless async spinner — strictly worse, on exactly the hardware that wedges. Badges resolve via the async path.

### 4. Memo invalidation folded into `vcdScanOpenDir` (Gemini review of #130)
So it also covers the HDD/APA `vcdScanDirRoot` path that bypasses `vcdFillGameList`. Fires only on a successful read → a wedged scan can't wipe the memo and re-ignite the storm.

### Verification
Built green (opl.elf 11381204), clang-format-12 clean. Adversarially verified across three lenses (MMCE-split correctness, gDiag thread-safety, revert/regression) — the one blocker found (VCD delete/rename OOB) is fixed here.

**Hardware-only (Andrew):** enable debug info, cover art **ON**, hammer PS1 info across various VCDs + press the PS2-list toggle. Either it behaves, or the on-screen line tells us exactly which failure class we're in (**`TK>0`** especially) so the next build is aimed, not guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)