### PR TITLE
fix(coverflow): advancing slides the expected direction (FifthFox HW report)

### DIFF
--- a/src/themes.c
+++ b/src/themes.c
@@ -907,7 +907,10 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     }
 
     // Slide animation (cubic ease-out). clock() wrap is clamped to snap-complete.
-    // NOTE: the slide/shrink sign convention is HW-tunable polish (one sign flip).
+    // Sign convention (FifthFox HW report: coverflow "advances in the opposite direction you'd expect"):
+    // advancing (Next / Right, dir=+1) must bring the incoming cover in from the RIGHT -> the strip starts
+    // shifted +right and eases to 0 (i.e. slides LEFT), and the OUTGOING old-center (now at centerIndex-dir)
+    // is the cover that shrinks. The prior (eased-1.0f) / centerIndex+dir convention slid the opposite way.
     float eased = 1.0f;
     int animOffset = 0;
     if (gCoverflowAnimSpeed <= 0) {
@@ -925,9 +928,9 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
             cfIsAnimating = 0;
         }
         eased = 1.0f - powf(1.0f - t, 3.0f);
-        animOffset = (int)(cfAnimDirection * coverDistance * (eased - 1.0f));
+        animOffset = (int)(cfAnimDirection * coverDistance * (1.0f - eased));
     }
-    int leavingIndex = centerIndex + cfAnimDirection; // neighbour swapping with center
+    int leavingIndex = centerIndex - cfAnimDirection; // the OUTGOING old-center shrinks (opposite the slide-in side)
 
     rmSetReflectionYOffset(elem->reflectionOffset); // theme reflection_offset; reset after the loop
 


### PR DESCRIPTION
**Reporter:** FifthFox (hardware, SCPH-700012) — *"Coverflow works, but advances in the opposite direction you would expect from the keys."*

The nav mapping and static layout are already correct (Left = prev, Right = next; prev cover on the left, selection centered, next cover on the right). The bug is the **animation sign** — which the original author had explicitly flagged as HW-tunable:

> `// NOTE: the slide/shrink sign convention is HW-tunable polish (one sign flip).`

FifthFox's report is that determination. `drawCoverFlow` rebuilds the carousel around the **new** selection each frame, so on Next (Right, `dir=+1`) the incoming cover sits at `centerIndex` and should appear to enter from the **right** — the strip starts shifted `+coverDistance` and eases to 0 (sliding **left**), and the **outgoing** old-center (now at `centerIndex-dir`) is the cover that shrinks. The shipped math did the opposite on both counts, so both flip together (one convention):

| | before | after |
|---|---|---|
| slide | `dir * coverDistance * (eased - 1.0f)` → starts `-coverDistance` (slides right on Next) | `dir * coverDistance * (1.0f - eased)` → starts `+coverDistance` (slides left on Next) |
| shrink | `leavingIndex = centerIndex + dir` (shrinks the *incoming* cover) | `leavingIndex = centerIndex - dir` (shrinks the *outgoing* old-center) |

Traced with `coverCount=3`: on Next, the fixed animation starts with the old selection at center and the next cover at right (matching the pre-press frame), then slides left to seat the next cover — the expected motion. Only affects the slide animation (`gCoverflowAnimSpeed > 0`); instant mode was already correct.

Built green (opl.elf 11372992), clang-format-12 clean. **Hardware-only visual confirm (FifthFox):** advancing now moves the way the keys imply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)