### PR TITLE
fix(vcd): guard the L3 view-toggle window against a separate-array OOB crash (MMCE + HDD)

### DIFF
--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -543,14 +543,36 @@ static int hddGetGameCount(item_list_t *itemList)
     return vcdViewActive(itemList->mode) ? hddVcdGameCount : (int)hddGames.count;
 }
 
+// Toggle-window guard (Codex/Fable audit), mirroring mmceActiveGame. HDD_MODE is vcdModeSupported, so the L3
+// toggle flips vcdViewActive() SYNCHRONOUSLY ahead of the DEFERRED per-__.POPS pfs rebuild -- a WIDER window
+// than MMCE. During it an OLD-view id can index the freshly-switched other array (hddGames.games is {NULL,0}
+// on a PS1-only HDD; hddVcdGames NULL/shorter if that view never scanned) -> NULL/OOB deref + crash. Resolve
+// every id through these: an out-of-range id returns a static empty entry so a stale READ is safe empty data
+// and LAUNCH/delete/rename early-return on the sentinel. HDD needs TWO resolvers -- ISO is hdl_game_info_t,
+// VCD is base_game_info_t.
+static base_game_info_t hddEmptyVcd = {0};
+static hdl_game_info_t hddEmptyHdl = {0};
+static base_game_info_t *hddActiveVcd(int id)
+{
+    if (hddVcdGames == NULL || id < 0 || id >= hddVcdGameCount)
+        return &hddEmptyVcd;
+    return &hddVcdGames[id];
+}
+static hdl_game_info_t *hddActiveHdl(int id)
+{
+    if (hddGames.games == NULL || id < 0 || id >= (int)hddGames.count)
+        return &hddEmptyHdl;
+    return &hddGames.games[id];
+}
+
 static void *hddGetGame(item_list_t *itemList, int id)
 {
-    return vcdViewActive(itemList->mode) ? (void *)&hddVcdGames[id] : (void *)&hddGames.games[id];
+    return vcdViewActive(itemList->mode) ? (void *)hddActiveVcd(id) : (void *)hddActiveHdl(id);
 }
 
 static char *hddGetGameName(item_list_t *itemList, int id)
 {
-    return vcdViewActive(itemList->mode) ? hddVcdGames[id].name : hddGames.games[id].name;
+    return vcdViewActive(itemList->mode) ? hddActiveVcd(id)->name : hddActiveHdl(id)->name;
 }
 
 static int hddGetGameNameLength(item_list_t *itemList, int id)
@@ -561,14 +583,17 @@ static int hddGetGameNameLength(item_list_t *itemList, int id)
 static char *hddGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game CFG/art off the VCD filename (game->name), not a disc id.
-    return vcdViewActive(itemList->mode) ? hddVcdGames[id].name : hddGames.games[id].startup;
+    return vcdViewActive(itemList->mode) ? hddActiveVcd(id)->name : hddActiveHdl(id)->startup;
 }
 
 static void hddDeleteGame(item_list_t *itemList, int id)
 {
     if (vcdViewActive(itemList->mode))
         return; // a VCD is not an HDL partition -- no delete in VCD view
-    hddDeleteHDLGame(&hddGames.games[id]);
+    hdl_game_info_t *game = hddActiveHdl(id);
+    if (game == &hddEmptyHdl)
+        return; // stale id in the VCD->ISO toggle window -> don't delete a wrong/OOB HDL partition
+    hddDeleteHDLGame(game);
     hddForceUpdate = 1;
 }
 
@@ -576,9 +601,11 @@ static void hddRenameGame(item_list_t *itemList, int id, char *newName)
 {
     if (vcdViewActive(itemList->mode))
         return; // a VCD is not an HDL partition -- no rename in VCD view
-    hdl_game_info_t *game = &hddGames.games[id];
+    hdl_game_info_t *game = hddActiveHdl(id);
+    if (game == &hddEmptyHdl)
+        return; // stale id in the VCD->ISO toggle window -> don't rename a wrong/OOB HDL partition
     strcpy(game->name, newName);
-    hddSetHDLGameInfo(&hddGames.games[id]);
+    hddSetHDLGameInfo(game);
     hddForceUpdate = 1;
 }
 
@@ -778,13 +805,18 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // selector/partition contract is hardware-testable -- POPSLoader proved the shape with a vendored
     // loader; we use the stock ps2sdk loader, the same one the shipping USB/MMCE/SMB VCD launch uses.
     if (gAutoLaunchGame == NULL && vcdViewActive(itemList->mode)) {
-        hddDoLaunchVcd(itemList, hddVcdGames[id].name, hddVcdParts[id]);
+        base_game_info_t *vcd = hddActiveVcd(id);
+        if (vcd == &hddEmptyVcd)
+            return; // stale id in the L3 toggle window -> nothing to launch (hddVcdParts[id] would also OOB)
+        hddDoLaunchVcd(itemList, vcd->name, hddVcdParts[id]);
         return;
     }
 
-    if (gAutoLaunchGame == NULL)
-        game = &hddGames.games[id];
-    else
+    if (gAutoLaunchGame == NULL) {
+        game = hddActiveHdl(id);
+        if (game == &hddEmptyHdl)
+            return; // stale id in the L3 toggle window -> nothing to launch
+    } else
         game = gAutoLaunchGame;
 
     // D8: Neutrino core gets its own lean path FIRST -- everything below is native-core prep it
@@ -984,7 +1016,7 @@ static config_set_t *hddGetConfig(item_list_t *itemList, int id)
     // {games=NULL,count=0} on a PS1-only HDD). Mirror the other VCD-aware accessors and key the per-game
     // CFG off the VCD basename, instead of dereferencing &hddGames.games[id] off a NULL base (crash).
     if (vcdViewActive(itemList->mode)) {
-        base_game_info_t *g = &hddVcdGames[id];
+        base_game_info_t *g = hddActiveVcd(id); // toggle-window safe: empty entry on a stale id (no OOB)
         snprintf(path, sizeof(path), "%sCFG/%s.cfg", gHDDPrefix, g->name);
         config_set_t *vcdConfig = configAlloc(0, NULL, path);
         configRead(vcdConfig);
@@ -1000,7 +1032,7 @@ static config_set_t *hddGetConfig(item_list_t *itemList, int id)
         return vcdConfig;
     }
 
-    hdl_game_info_t *game = &hddGames.games[id];
+    hdl_game_info_t *game = hddActiveHdl(id); // toggle-window safe: empty entry on a stale id (no OOB)
 
     snprintf(path, sizeof(path), "%sCFG/%s.cfg", gHDDPrefix, game->startup);
     config_set_t *config = configAlloc(0, NULL, path);

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -448,35 +448,58 @@ static int mmceGetGameCount(item_list_t *itemList)
     return vcdViewActive(itemList->mode) ? mmceVcdGameCount : mmceGameCount;
 }
 
+// Toggle-window guard (Codex/Fable audit). The L3 view toggle flips vcdViewActive() SYNCHRONOUSLY
+// (vcdToggleView) but rebuilds the submenu on the DEFERRED IO thread. On a contended MMCE bus that rebuild
+// lags, so for a window the OLD submenu's ids are still live while vcdViewActive() already reports the NEW
+// view -- and an id from the old view can index the freshly-switched other-view array, which may be NULL
+// (that view never scanned this session), shorter, or mid-scan. The direct &mmceVcdGames[id]/&mmceGames[id]
+// indexing then NULL/OOB-derefs and crashes. (The shared store the #120 split replaced could not OOB: one
+// array + one count stayed self-consistent.) Resolve every id through here: an out-of-range id returns a
+// STATIC EMPTY entry, so a stale-id READ is safe empty data instead of a crash; LAUNCH treats &mmceEmptyGame
+// as "nothing to launch" (mmceLaunchGame, below).
+static base_game_info_t mmceEmptyGame = {0};
+static base_game_info_t *mmceActiveGame(item_list_t *itemList, int id)
+{
+    int vcd = vcdViewActive(itemList->mode);
+    base_game_info_t *arr = vcd ? mmceVcdGames : mmceGames;
+    int count = vcd ? mmceVcdGameCount : mmceGameCount;
+    if (arr == NULL || id < 0 || id >= count)
+        return &mmceEmptyGame;
+    return &arr[id];
+}
+
 static void *mmceGetGame(item_list_t *itemList, int id)
 {
-    return vcdViewActive(itemList->mode) ? (void *)&mmceVcdGames[id] : (void *)&mmceGames[id];
+    return (void *)mmceActiveGame(itemList, id);
 }
 
 static char *mmceGetGameName(item_list_t *itemList, int id)
 {
-    return vcdViewActive(itemList->mode) ? mmceVcdGames[id].name : mmceGames[id].name;
+    return mmceActiveGame(itemList, id)->name;
 }
 
 static int mmceGetGameNameLength(item_list_t *itemList, int id)
 {
-    base_game_info_t *g = vcdViewActive(itemList->mode) ? &mmceVcdGames[id] : &mmceGames[id];
+    base_game_info_t *g = mmceActiveGame(itemList, id);
     return ((g->format != GAME_FORMAT_USBLD) ? ISO_GAME_NAME_MAX + 1 : UL_GAME_NAME_MAX + 1);
 }
 
 static char *mmceGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
+    base_game_info_t *g = mmceActiveGame(itemList, id);
     if (vcdViewActive(itemList->mode))
-        return mmceVcdGames[id].name;
-    return mmceGames[id].startup;
+        return g->name;
+    return g->startup;
 }
 
 static void mmceDeleteGame(item_list_t *itemList, int id)
 {
     if (vcdViewActive(itemList->mode))
-        return; // #120: a VCD is not an ISO game -- no delete in VCD view (id indexes mmceVcdGames, and
-                // sbDelete would deref the ISO array mmceGames[id] out of range -> NULL/OOB + wrong unlink)
+        return; // #120: a VCD is not an ISO game -- no delete in VCD view
+    if (mmceActiveGame(itemList, id) == &mmceEmptyGame)
+        return; // stale id in the VCD->ISO toggle window (vcdViewActive already flipped, old VCD submenu id
+                // still live): sbDelete does NOT bounds-check, so this avoids an OOB/NULL deref + wrong unlink
     sbDelete(&mmceGames, mmcePrefix, "/", mmceGameCount, id);
     mmceULSizePrev = -2;
 }
@@ -484,7 +507,9 @@ static void mmceDeleteGame(item_list_t *itemList, int id)
 static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
 {
     if (vcdViewActive(itemList->mode))
-        return; // #120: no rename in VCD view (same ISO-array OOB hazard as mmceDeleteGame above)
+        return; // #120: no rename in VCD view
+    if (mmceActiveGame(itemList, id) == &mmceEmptyGame)
+        return; // stale id in the VCD->ISO toggle window (see mmceDeleteGame) -> avoid sbRename OOB
     sbRename(&mmceGames, mmcePrefix, "/", mmceGameCount, id, newName);
     mmceULSizePrev = -2;
 }
@@ -524,9 +549,11 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     unsigned short int layer1_part;
 
     // No Autolaunch yet
-    if (gAutoLaunchBDMGame == NULL)
-        game = vcdViewActive(itemList->mode) ? &mmceVcdGames[id] : &mmceGames[id];
-    else
+    if (gAutoLaunchBDMGame == NULL) {
+        game = mmceActiveGame(itemList, id);
+        if (game == &mmceEmptyGame)
+            return; // stale id during the L3 toggle window (see mmceActiveGame) -> nothing to launch
+    } else
         game = gAutoLaunchBDMGame;
 
     // VCD view: hand off to POPSTARTER (by name) instead of the disc path below. Menu-launch only.
@@ -833,11 +860,10 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
 static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 {
-    // VCD view: config (CFG + #Format/#System/#DiscType badges) comes from the VCD array, keyed off the
-    // VCD basename -- never &mmceGames[id] (the ISO array, possibly shorter/empty in VCD view -> OOB).
-    if (vcdViewActive(itemList->mode))
-        return sbPopulateConfig(&mmceVcdGames[id], mmcePrefix, "/");
-    return sbPopulateConfig(&mmceGames[id], mmcePrefix, "/");
+    // Config (CFG + #Format/#System/#DiscType badges) comes from the ACTIVE view's array; mmceActiveGame
+    // picks it (VCD keys off the basename) and returns a safe empty entry for a stale id during the toggle
+    // window -- so this can never index the wrong/NULL array out of range.
+    return sbPopulateConfig(mmceActiveGame(itemList, id), mmcePrefix, "/");
 }
 
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)


### PR DESCRIPTION
**Found by an external Codex/Fable-5.6 audit** of the just-rolled changes — a real crash regression the #120 separate-array split introduced. (My own adversarial verify had under-rated it as *"low / ~1-2 frame race"* — it missed that the window is **long on a contended bus**, the exact condition #120 is about. Good argument for a second independent reviewer.)

### Mechanism
The L3 toggle (`itemExecToggleView` → `vcdToggleView`) flips `vcdViewActive()` **synchronously** but rebuilds the submenu on the **deferred IO thread**. On a contended MMCE/SIO2 bus — or HDD's per-`__.POPS` pfs mount — that rebuild lags, so there's a window where the **old** submenu's ids are live while `vcdViewActive()` already reports the **new** view. Since #120 split the backing store into separate per-view arrays, an old-view id then indexes the freshly-switched other-view array, which may be **NULL** (that view never scanned this session; a PS1-only HDD leaves `hddGames = {NULL,0}`), shorter, or mid-scan → the raw `&arr[id]` deref **NULL/OOB-crashes**. Pre-#120's single shared store couldn't OOB (id always in range). Reachable in the tester's exact flow: *press the PS2 toggle → nothing happens (long window) → keep pressing Square/Cross.*

### Fix — restore the shared-store invariant explicitly for the split arrays
- **MMCE** (`mmcesupport.c`): new `mmceActiveGame(id)` returns a file-static zeroed sentinel (`&mmceEmptyGame`) for `arr==NULL || id<0 || id>=count`. All six id-getters route through it (stale read = safe empty data); `mmceLaunchGame` early-returns on the sentinel; **delete/rename** gain the same bounds guard — closing the VCD→ISO direction where the `vcdView` guard alone let a stale id reach `sbDelete`/`sbRename` (unbounded → **wrong `unlink()`/`rename()` = data loss**).
- **HDD** (`hddsupport.c`): the *same* reachable OOB was unguarded, with a **wider** window (pfs-per-partition rebuild) on the device family **currently under HW investigation (FifthFox cluster)**. Ported the pattern with **two** resolvers (ISO is `hdl_game_info_t`, VCD is `base_game_info_t`): `hddActiveVcd`/`hddActiveHdl` + `hddEmptyVcd`/`hddEmptyHdl`, routed through the getters, `hddLaunchGame` (both branches; the parallel `hddVcdParts[id]` read is covered by the VCD resolver's bound), and delete/rename.

### Verification
In-range behavior is byte-identical; the empty sentinels are all-value-type structs so every read getter and `sbPopulateConfig`/`hddGetConfig` on them is crash-safe. `hddGetGameNameLength` needs no guard (returns a constant, never indexes). Adversarially verified (MMCE half + HDD port): type-correct, bounds-correct, no new regression. Built green (opl.elf 11390564), clang-format-12 clean.

**Known follow-ups** (pre-existing, *not* introduced here, also flagged by the audit): the lock-free realloc race between the render read and the IO-thread list rebuild (needs `guiLock` serialization); `vcdLoadArt` memoizing a *transient* read failure as absent (self-heals on rescan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)