### PR TITLE
fix(vcd): only memoize genuine art absence, not transient read failures

### DIFF
--- a/include/textures.h
+++ b/include/textures.h
@@ -122,7 +122,7 @@ enum INTERNAL_TEXTURE {
     TEXTURES_COUNT
 };
 
-#define ERR_BAD_FILE      -1
+#define ERR_BAD_FILE      -1 // open() failed = the file is not there (genuine absence)
 #define ERR_READ_STRUCT   -2
 #define ERR_INFO_STRUCT   -3
 #define ERR_SET_JMP       -4
@@ -130,6 +130,11 @@ enum INTERNAL_TEXTURE {
 #define ERR_MISSING_ALPHA -6
 #define ERR_BAD_DEPTH     -7
 #define ERR_LOAD_ABORTED  -8
+// The file OPENED but its bytes could not be staged/read (read() error on a contended bus, OOM, empty
+// file). Distinct from ERR_BAD_FILE (absent) so the VCD art miss-memo caches only GENUINE absence and
+// re-probes a transient/present failure instead of false-hiding a real cover (#120). Callers that only
+// test the sign are unaffected.
+#define ERR_FILE_IO       -9
 
 int texLookupInternalTexId(const char *name);
 int texLoadInternal(GSTEXTURE *texture, int texId);

--- a/src/textures.c
+++ b/src/textures.c
@@ -430,7 +430,7 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
     unsigned char *fileBuffer;
 
     if (buffer == NULL)
-        return ERR_BAD_FILE;
+        return ERR_FILE_IO;
 
     // Do NOT size the file with lseek(SEEK_END) first: the MMCE newlib device (mmceman) does not
     // support SEEK_END, so it returned <= 0 and EVERY MMCE cover failed here with ERR_BAD_FILE (ISO
@@ -441,7 +441,7 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
     capacity = TEX_MMCE_STAGE_READ_SIZE * 2; // 64 KB; doubles on demand for larger covers
     fileBuffer = malloc(capacity);
     if (fileBuffer == NULL)
-        return ERR_BAD_FILE;
+        return ERR_FILE_IO;
 
     for (;;) {
         int result;
@@ -455,7 +455,7 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
             unsigned char *grown = realloc(fileBuffer, capacity * 2);
             if (grown == NULL) {
                 free(fileBuffer);
-                return ERR_BAD_FILE;
+                return ERR_FILE_IO;
             }
             fileBuffer = grown;
             capacity *= 2;
@@ -464,7 +464,7 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
         result = read(fd, fileBuffer + bytesRead, TEX_MMCE_STAGE_READ_SIZE);
         if (result < 0) {
             free(fileBuffer);
-            return ERR_BAD_FILE;
+            return ERR_FILE_IO; // read() error (e.g. contended-bus EIO) -- the file EXISTS, retry later
         }
         bytesRead += result;
 
@@ -481,7 +481,7 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
 
     if (bytesRead == 0) {
         free(fileBuffer);
-        return ERR_BAD_FILE; // empty file -> not a valid PNG
+        return ERR_FILE_IO; // empty file -> present but not a valid PNG (don't memoize as absent)
     }
 
     *buffer = fileBuffer;
@@ -567,14 +567,14 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
 
     if (!texture->Mem) {
         LOG("TEXTURES PngReadData: Failed to allocate %d bytes\n", size);
-        return ERR_BAD_FILE;
+        return ERR_FILE_IO; // OOM mid-decode: the file EXISTS, this is transient -- don't memoize as absent
     }
 
     rowBuffer = malloc(rowBytes);
     if (!rowBuffer) {
         texFree(texture);
         LOG("TEXTURES PngReadData: Failed to allocate memory for PNG row\n");
-        return ERR_BAD_FILE;
+        return ERR_FILE_IO; // OOM mid-decode (see above)
     }
 
     for (int row = 0; row < texture->Height; row++) {

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -449,23 +449,42 @@ int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const cha
         return -1;       // known-absent this epoch -> skip the failing-open storm on the slow MMCE bus (#120)
     }
 
+    // Did every probed tier miss with ERR_BAD_FILE (open() failed = file GENUINELY not there)? A
+    // transient/present miss instead -- ERR_FILE_IO (a staged read that errored on a contended MMCE bus),
+    // ERR_LOAD_ABORTED, or a PNG decode error -- means the cover may EXIST and just failed to load this
+    // time. Memoizing that would false-hide a real cover until the next rescan (Codex/Fable audit + my own
+    // verify both flagged it). So only a GENUINE absence is cached below.
+    int allAbsent = 1;
+
     vcdExtractGameId(value, discId, sizeof(discId));
     if (discId[0] != '\0') {
         snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, discId, suffix);
         if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
             return r;
+        if (r != ERR_BAD_FILE)
+            allAbsent = 0;
     }
     snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, value, suffix);
     if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
         return r;
+    if (r != ERR_BAD_FILE)
+        allAbsent = 0;
     if (popsDir != NULL) {
         snprintf(path, sizeof(path), "%s%s%c%s", devPrefix, popsDir, sep, value);
         if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
             return r;
+        if (r != ERR_BAD_FILE)
+            allAbsent = 0;
     }
 
-    gDiag.memoMiss++;            // #120 diag: full miss recorded (first probe of this cover this epoch)
-    vcdArtMissRemember(missKey); // all tiers missed -> a repeat probe skips them until the next rescan
+    // Cache ONLY a genuine absence, so a repeat probe of a cover-less PS1 game skips the failing-open storm
+    // (the #120 win). A transient/present failure is left UN-memoized -> it re-probes next generation, when
+    // the bus may have recovered, so a real cover isn't hidden. The texcache FAILED sentinel still bounds
+    // within-generation repeats, so not memoizing here does not reopen the storm.
+    if (allAbsent) {
+        gDiag.memoMiss++;            // #120 diag: genuine full miss recorded (first probe this epoch)
+        vcdArtMissRemember(missKey); // repeat probes skip the opens until the next rescan
+    }
     return r;
 }
 


### PR DESCRIPTION
Hardens the #120 VCD art miss-memo — the finding both the **Codex/Fable audit** and my own adversarial verify flagged, deliberately kept out of the #133 crash-fix to land on its own.

### The problem
`vcdLoadArt`'s miss-memo recorded **every** negative `texDiscoverLoad` result as "absent" and cached it across cache generations until the next list rescan. But a negative result also covers a **transient/present** failure — a staged read that errored on a contended MMCE bus, an OOM mid-decode, an aborted load — not just a genuinely-missing file. So on exactly the bus contention #120 is about, a cover that *does* exist could fail to load once, get memoized as absent, and **stay blank until a rescan or reboot**.

### Root cause
The texture loader conflated the two: `ERR_BAD_FILE (-1)` was returned for **both** `open()` failing (file not there) **and** every staged-read / decode failure (file present, couldn't read it).

### Fix
- **New `ERR_FILE_IO (-9)`** — "the file *opened* but its bytes couldn't be staged/read" (contended-bus `read()` error, staging/decode OOM, empty file). Applied to all five staging returns + the two decode-OOM returns. (Abort already had `ERR_LOAD_ABORTED`; PNG decode errors already had their own codes.)
- **`ERR_BAD_FILE` now means specifically "open() failed = genuine absence"** — left only at the `open()` / no-source sites. No caller compares the value (all sign-check), so the reclassify is transparent to everything except the gate.
- **`vcdLoadArt` caches only when every probed tier missed with `ERR_BAD_FILE`** (`allAbsent`). A transient/present failure is left un-memoized → it re-probes next generation when the bus may have recovered (no false-hide). The within-generation texcache FAILED sentinel still bounds same-generation repeats, so this does **not** reopen the failing-open storm — and genuinely cover-less PS1 games are still memoized (**the #120 win is preserved**).

Chose the distinct-code approach over an `errno==ENOENT` check specifically to **not** depend on mmceman returning `ENOENT` for a missing file. Built green (opl.elf 11391400), clang-format-12 clean. Hardware-only class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)