### PR TITLE
fix(textures): plug a Clut leak + finish the ERR_FILE_IO reclassify (Gemini review of #134)

### DIFF
--- a/src/textures.c
+++ b/src/textures.c
@@ -566,6 +566,8 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
     texture->Mem = memalign(128, size);
 
     if (!texture->Mem) {
+        texFree(texture); // free the already-allocated paletted-PNG Clut before bailing (Gemini review);
+                          // matches the rowBuffer-OOM path just below
         LOG("TEXTURES PngReadData: Failed to allocate %d bytes\n", size);
         return ERR_FILE_IO; // OOM mid-decode: the file EXISTS, this is transient -- don't memoize as absent
     }
@@ -724,7 +726,7 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
                 texture->PSM = GS_PSM_T4;
                 texture->Clut = memalign(128, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
                 if (texture->Clut == NULL)
-                    return texEnd(pngPtr, infoPtr, pFileBuffer, fd, ERR_BAD_FILE);
+                    return texEnd(pngPtr, infoPtr, pFileBuffer, fd, ERR_FILE_IO); // Clut OOM: file present -> transient, not absent
                 memset(texture->Clut, 0, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
                 texPrepareClut(texture, 16);
                 texPngReadRow = &texReadPixels4Row;
@@ -732,7 +734,7 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
                 texture->PSM = GS_PSM_T8;
                 texture->Clut = memalign(128, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
                 if (texture->Clut == NULL)
-                    return texEnd(pngPtr, infoPtr, pFileBuffer, fd, ERR_BAD_FILE);
+                    return texEnd(pngPtr, infoPtr, pFileBuffer, fd, ERR_FILE_IO); // Clut OOM: file present -> transient, not absent
                 memset(texture->Clut, 0, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
                 texPrepareClut(texture, 256);
                 texPngReadRow = &texReadPixels8Row;


### PR DESCRIPTION
Follow-up to #134 (already merged) — two valid points from **Gemini's review**:

1. **Memory leak (HIGH):** the PNG row-reader's `texture->Mem` OOM path returned without `texFree()`, leaking an already-allocated paletted-PNG `Clut` (the palette is `memalign`'d earlier in the decode, before the row reader runs). The very next OOM path (`rowBuffer` alloc) already `texFree()`s — this one was inconsistent. Added `texFree(texture)` before the early return.

2. **`ERR_FILE_IO` consistency (MEDIUM):** #134 missed the two `Clut`-allocation OOM sites (4-bit / 8-bit paletted PNGs), which still returned `ERR_BAD_FILE`. A `Clut` OOM is present-but-transient (the file opened and is mid-decode), so under #134's memo gate a paletted-PNG cover that OOM'd on its palette would be **false-memoized as absent** — exactly the bug #134 set out to kill. Reclassified both to `ERR_FILE_IO` so they re-probe instead of caching.

`ERR_BAD_FILE` now means strictly "open() failed / no source = genuine absence" at the only three remaining sites. Built green (opl.elf 11391476), clang-format-12 clean. No behavior change for sign-checking callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)