### PR TITLE
fix(#120): recover a desynced MMCE card instead of staying wedged until reboot

### DIFF
--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -30,4 +30,9 @@ int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMa
 // Arm the GameID transport at menu/settings time (idempotent; no-op when the feature is off).
 void mmceArmGameIDTransport(void);
 
+// Resync a desynced MMCE card via the mmceman RESET devctl (bounded, no TerminateThread). Called from the
+// art worker on a mid-file read-fail streak to recover from the #120 card-side bus wedge. Returns <0 on
+// no-card/failure (harmless). See mmcesupport.c.
+int mmceResetChannel(void);
+
 #endif

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -193,6 +193,27 @@ static void mmceGetDeviceRoot(char *root, size_t size)
         root[0] = '\0';
 }
 
+// mmceman FS-channel RESET devctl (mmce_fs_devctl -> mmce_cmd_reset, verified vs ps2-mmce/mmceman @
+// db3e93f0: MMCE_CMD_RESET is the 9th cmd, PING=0x1..RESET). A 5-byte command bounded by mmceman's own
+// ~1s SIO2 alarm, so it can NEVER hang -- and it takes NO TerminateThread. OPL already speaks this
+// protocol (mmceSendGameID uses devctl 0x1 ping / 0x8 set-gameid).
+#define MMCE_DEVCTL_RESET 0x9
+
+// Recover a DESYNCED MMCE card (#120). Under a heavy art-read burst the card firmware's FS command
+// sequencer can desync mid-transfer; from then on EVERY read fails (art, POPSTARTER.ELF, ISO, boot-card)
+// until reboot -- and with TK==0 (no OPL TerminateThread involved -- confirmed on HW via the on-screen
+// diagnostic). Issue the mmceman RESET devctl to resync it: bounded, no thread kill, so the shared channel
+// is left intact and subsequent reads recover. Called from the art worker on a read-fail streak
+// (texcache.c). Returns the devctl result; a no-card/failure is harmless (the next read just retries).
+int mmceResetChannel(void)
+{
+    char root[sizeof(mmcePrefix)];
+    mmceGetDeviceRoot(root, sizeof(root));
+    if (root[0] == '\0' || strlen(root) < 5)
+        return -1;
+    return fileXioDevctl(root, MMCE_DEVCTL_RESET, NULL, 0, NULL, 0);
+}
+
 static void mmceRefreshArtRoots(void)
 {
     int len;
@@ -563,8 +584,14 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     }
 
     if (!cacheAbortMmceImageLoadsTimed(MMCE_ART_ABORT_WAIT_TICKS)) {
-        cacheEnd(1);
-        cacheInit();
+        // #120: the art worker is wedged in a blocking fileXio on a slow/desynced card. Do NOT cacheEnd(1)
+        // here -- its TerminateThread(gArtThreadId) kills the worker MID-RPC and orphans the SHARED mmceman
+        // channel (TK>0). The launch reads below then FAIL and RETURN to a still-running OPL (unlike a launch
+        // that LoadExecPS2's away), poisoning every later card read. Abandon-and-retry instead (mirrors
+        // thmLoad's redesign): toast and bail; the card-recovery path (mmceResetChannel, texcache.c) may
+        // resync it, and the user retries once it's calm. NEVER a hard freeze -- guiWarning is non-blocking.
+        guiWarning(_l(_STR_ERR_FILE_INVALID), 8);
+        return;
     }
 
     void *irx = &mmce_cdvdman_irx;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -952,8 +952,11 @@ static void cacheLoadImage(load_image_request_t *req)
     // the card's FS command sequencer has desynced under the art-read load -- and (HW-confirmed via the
     // on-screen diagnostic: TK==0) NOT because OPL TerminateThread'd the worker. Once desynced, every later
     // read fails until reboot. Resync the card with the mmceman RESET devctl (bounded ~1s, no thread kill,
-    // shared channel intact) so art / POPSTARTER.ELF / ISO / boot-card reads recover. A single good read
-    // clears the streak. Runs only on the single art worker thread, so the counter needs no locking.
+    // shared channel intact) so art / POPSTARTER.ELF / ISO / boot-card reads recover. Runs only on the single
+    // art worker thread, so the counter needs no locking. Only ERR_FILE_IO (opened, mid-transfer read fail)
+    // is the desync signal; a successful read OR a clean ERR_BAD_FILE (the card completed the lookup and
+    // reported "not there" -- proof the sequencer is synced this instant) clears the streak. ERR_LOAD_ABORTED
+    // was cut short by nav, so its outcome is unknown -- leave the streak untouched.
     if (req->effectiveMode == MMCE_MODE) {
         static int mmceEioStreak = 0;
         if (result == ERR_FILE_IO) {
@@ -961,7 +964,7 @@ static void cacheLoadImage(load_image_request_t *req)
                 mmceEioStreak = 0;
                 mmceResetChannel();
             }
-        } else if (result >= 0) {
+        } else if (result != ERR_LOAD_ABORTED) {
             mmceEioStreak = 0;
         }
     }

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -4,6 +4,7 @@
 #include "include/pad.h"
 #include "include/texcache.h"
 #include "include/textures.h"
+#include "include/mmcesupport.h" // mmceResetChannel (card-side wedge recovery, #120)
 #include "include/gui.h"
 #include "include/util.h"
 #include "include/renderman.h"
@@ -86,6 +87,10 @@ enum {
 
 #define CACHE_SLOW_MODE_INTERACTIVE_DELAY 4
 #define CACHE_MMCE_INTERACTIVE_MAX_DELAY  12
+// Consecutive mid-file MMCE read failures (ERR_FILE_IO) that mean the card FS sequencer has desynced ->
+// issue the mmceman RESET devctl to resync it (#120 card-side wedge recovery). 3 avoids reacting to a
+// one-off transient; the card firmware fails EVERY read once desynced, so a real wedge hits it fast.
+#define CACHE_MMCE_EIO_RESET_STREAK       3
 #define CACHE_APP_INTERACTIVE_MAX_DELAY   4
 #define CACHE_APP_PREFETCH_DELAY          10
 #define CACHE_PRIME_IDLE_DELAY            12
@@ -942,6 +947,24 @@ static void cacheLoadImage(load_image_request_t *req)
     if (result < 0)
         result = req->list->itemGetImage(req->list, req->cache->prefix, req->cache->isPrefixRelative, req->value, req->cache->suffix, &req->texture, GS_PSM_CT24);
     texSetLoadAbortFlag(NULL);
+    // #120 card-side wedge RECOVERY. A mid-file read() failure on MMCE surfaces as ERR_FILE_IO (distinct
+    // from ERR_BAD_FILE = genuine open() miss and ERR_LOAD_ABORTED = nav abort). A STREAK of these means
+    // the card's FS command sequencer has desynced under the art-read load -- and (HW-confirmed via the
+    // on-screen diagnostic: TK==0) NOT because OPL TerminateThread'd the worker. Once desynced, every later
+    // read fails until reboot. Resync the card with the mmceman RESET devctl (bounded ~1s, no thread kill,
+    // shared channel intact) so art / POPSTARTER.ELF / ISO / boot-card reads recover. A single good read
+    // clears the streak. Runs only on the single art worker thread, so the counter needs no locking.
+    if (req->effectiveMode == MMCE_MODE) {
+        static int mmceEioStreak = 0;
+        if (result == ERR_FILE_IO) {
+            if (++mmceEioStreak >= CACHE_MMCE_EIO_RESET_STREAK) {
+                mmceEioStreak = 0;
+                mmceResetChannel();
+            }
+        } else if (result >= 0) {
+            mmceEioStreak = 0;
+        }
+    }
     cacheCompleteRequest(req, result);
     cacheProcessCleanupRequests();
 


### PR DESCRIPTION
Andrew's on-screen diagnostic (Beta-3113) finally settled the #120 mechanism. Reading the `#120` HUD line *after* the wedge: **`TK:0`** — OPL did **not** `TerminateThread` the art worker, so the RPC channel wasn't corrupted by us. The card's FS command sequencer **desyncs on its own** under the cover-art read burst (card-side). Once desynced, *every* card read fails for the session: art won't load, `POPSTARTER.ELF` can't be `open()`'d (→ "Missing POPSTARTER.ELF"), the PS2 ISO can't be read (→ launch silently does nothing), the boot-card option breaks. Prior fixes (list-preserve, art miss-memo) fixed *symptoms*; this recovers the actual wedge.

### 1. RECOVER — the cure
A mid-file `read()` failure on MMCE already surfaces as `ERR_FILE_IO` (added last change; distinct from `ERR_BAD_FILE` = genuine miss and `ERR_LOAD_ABORTED` = nav abort). The art worker (single thread → the streak counter is lock-free) counts these; at **3** it calls the new `mmceResetChannel()`, which issues the mmceman **`MMCE_CMD_RESET`** devctl (`fileXioDevctl 0x9`, verified against `ps2-mmce/mmceman @ db3e93f0`). That resyncs the card's FS sequencer — a 5-byte command bounded by mmceman's **always-armed ~1s PIO alarm** (cannot hang, even on a wedged card or with alarms off) and with **no `TerminateThread`**, so the shared channel stays intact and subsequent reads recover. A single good read clears the streak.

### 2. LAUNCH HARDENING — a separate latent `TK>0` corruptor
`mmceLaunchGame`'s abort-timeout path did `cacheEnd(1)` (which *does* `TerminateThread` → corrupts the shared channel) then failed the launch on the slow card and returned to a running OPL. Replaced with abandon-and-retry: a non-blocking toast + `return` (mirrors the proven `thmLoad` redesign). Healthy path is byte-identical (branch only taken when the worker is stuck); wedged path no longer corrupts the channel. **Together:** RECOVER un-sticks browsing, the launch guard keeps launching from re-sticking it.

### Verification
Gated on `MMCE_MODE` (HDD/USB/ETH art untouched). **Adversarially verified against the vendored driver + the `texLoadAll`→`vcdLoadArt` chain:** `RESET=0x9` correct, reset hard-bounded/no-hang, streak lock-free single-thread, `ERR_FILE_IO` propagates for both MMCE views, launch return leaves no half-state — **SHIP, no blocker/high/medium**. Built green (opl.elf 11392152), clang-format-12 clean.

**Hardware test (Andrew):** enter PS1 info as before — the `#120` line will still show `AO` climbing, but after an `ERR_FILE_IO` streak the card should **reset and recover**, so art loads, games launch, and the boot-card option works again instead of staying dead until reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)