### PR TITLE
fix(#120): revert the #136 card-reset, cut the PS1 art-read burst instead (REDUCE)

### DIFF
--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -30,9 +30,4 @@ int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMa
 // Arm the GameID transport at menu/settings time (idempotent; no-op when the feature is off).
 void mmceArmGameIDTransport(void);
 
-// Resync a desynced MMCE card via the mmceman RESET devctl (bounded, no TerminateThread). Called from the
-// art worker on a mid-file read-fail streak to recover from the #120 card-side bus wedge. Returns <0 on
-// no-card/failure (harmless). See mmcesupport.c.
-int mmceResetChannel(void);
-
 #endif

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -193,27 +193,6 @@ static void mmceGetDeviceRoot(char *root, size_t size)
         root[0] = '\0';
 }
 
-// mmceman FS-channel RESET devctl (mmce_fs_devctl -> mmce_cmd_reset, verified vs ps2-mmce/mmceman @
-// db3e93f0: MMCE_CMD_RESET is the 9th cmd, PING=0x1..RESET). A 5-byte command bounded by mmceman's own
-// ~1s SIO2 alarm, so it can NEVER hang -- and it takes NO TerminateThread. OPL already speaks this
-// protocol (mmceSendGameID uses devctl 0x1 ping / 0x8 set-gameid).
-#define MMCE_DEVCTL_RESET 0x9
-
-// Recover a DESYNCED MMCE card (#120). Under a heavy art-read burst the card firmware's FS command
-// sequencer can desync mid-transfer; from then on EVERY read fails (art, POPSTARTER.ELF, ISO, boot-card)
-// until reboot -- and with TK==0 (no OPL TerminateThread involved -- confirmed on HW via the on-screen
-// diagnostic). Issue the mmceman RESET devctl to resync it: bounded, no thread kill, so the shared channel
-// is left intact and subsequent reads recover. Called from the art worker on a read-fail streak
-// (texcache.c). Returns the devctl result; a no-card/failure is harmless (the next read just retries).
-int mmceResetChannel(void)
-{
-    char root[sizeof(mmcePrefix)];
-    mmceGetDeviceRoot(root, sizeof(root));
-    if (root[0] == '\0' || strlen(root) < 5)
-        return -1;
-    return fileXioDevctl(root, MMCE_DEVCTL_RESET, NULL, 0, NULL, 0);
-}
-
 static void mmceRefreshArtRoots(void)
 {
     int len;
@@ -588,8 +567,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // here -- its TerminateThread(gArtThreadId) kills the worker MID-RPC and orphans the SHARED mmceman
         // channel (TK>0). The launch reads below then FAIL and RETURN to a still-running OPL (unlike a launch
         // that LoadExecPS2's away), poisoning every later card read. Abandon-and-retry instead (mirrors
-        // thmLoad's redesign): toast and bail; the card-recovery path (mmceResetChannel, texcache.c) may
-        // resync it, and the user retries once it's calm. NEVER a hard freeze -- guiWarning is non-blocking.
+        // thmLoad's redesign): toast and bail so the user retries once the card is calm. NEVER a hard
+        // freeze -- guiWarning is non-blocking.
         guiWarning(_l(_STR_ERR_FILE_INVALID), 8);
         return;
     }

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1141,14 +1141,19 @@ config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const
     // VCD listings have no reliable disc ID, so their per-game data (CFG + cover art) is keyed by
     // the VCD FILENAME, not the startup ID (game->name, the full basename -- the user names the
     // .cfg/art to match the .VCD file). Everything else keys by the disc ID as before.
-    const char *cfgKey = (!strcasecmp(game->extension, ".VCD")) ? game->name : game->startup;
+    const int isVcd = !strcasecmp(game->extension, ".VCD");
+    const char *cfgKey = isVcd ? game->name : game->startup;
 
     snprintf(path, sizeof(path), "%sCFG%s%s.cfg", prefix, sep, cfgKey);
     config_set_t *config = configAlloc(0, NULL, path);
     configRead(config); // Does not matter if the config file could be loaded or not.
 
-    // Get game size if not already set (deferred off the scroll path; see sbConfigStatSize).
-    if (sbConfigStatSize && game->sizeMB == 0) {
+    // Get game size if not already set (deferred off the scroll path; see sbConfigStatSize). A .VCD (PS1) has
+    // no meaningful ISO size and its file lives in POPS/, not CD/DVD/, so statting the CD/DVD path always
+    // misses, leaves sizeMB at 0, never caches, and re-probes the shared MMCE bus on every info entry (#120).
+    // Hard-stop it by EXTENSION here (not mutable view state) so a .VCD can never reach the ISO stat path,
+    // even during the L3 view-toggle window (game->sizeMB stays 0 -> "0 MiB" is still written below).
+    if (sbConfigStatSize && !isVcd && game->sizeMB == 0) {
         char gamepath[256];
 
         if (game->format == GAME_FORMAT_ISO) {

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -4,7 +4,6 @@
 #include "include/pad.h"
 #include "include/texcache.h"
 #include "include/textures.h"
-#include "include/mmcesupport.h" // mmceResetChannel (card-side wedge recovery, #120)
 #include "include/gui.h"
 #include "include/util.h"
 #include "include/renderman.h"
@@ -87,10 +86,6 @@ enum {
 
 #define CACHE_SLOW_MODE_INTERACTIVE_DELAY 4
 #define CACHE_MMCE_INTERACTIVE_MAX_DELAY  12
-// Consecutive mid-file MMCE read failures (ERR_FILE_IO) that mean the card FS sequencer has desynced ->
-// issue the mmceman RESET devctl to resync it (#120 card-side wedge recovery). 3 avoids reacting to a
-// one-off transient; the card firmware fails EVERY read once desynced, so a real wedge hits it fast.
-#define CACHE_MMCE_EIO_RESET_STREAK       3
 #define CACHE_APP_INTERACTIVE_MAX_DELAY   4
 #define CACHE_APP_PREFETCH_DELAY          10
 #define CACHE_PRIME_IDLE_DELAY            12
@@ -947,27 +942,6 @@ static void cacheLoadImage(load_image_request_t *req)
     if (result < 0)
         result = req->list->itemGetImage(req->list, req->cache->prefix, req->cache->isPrefixRelative, req->value, req->cache->suffix, &req->texture, GS_PSM_CT24);
     texSetLoadAbortFlag(NULL);
-    // #120 card-side wedge RECOVERY. A mid-file read() failure on MMCE surfaces as ERR_FILE_IO (distinct
-    // from ERR_BAD_FILE = genuine open() miss and ERR_LOAD_ABORTED = nav abort). A STREAK of these means
-    // the card's FS command sequencer has desynced under the art-read load -- and (HW-confirmed via the
-    // on-screen diagnostic: TK==0) NOT because OPL TerminateThread'd the worker. Once desynced, every later
-    // read fails until reboot. Resync the card with the mmceman RESET devctl (bounded ~1s, no thread kill,
-    // shared channel intact) so art / POPSTARTER.ELF / ISO / boot-card reads recover. Runs only on the single
-    // art worker thread, so the counter needs no locking. Only ERR_FILE_IO (opened, mid-transfer read fail)
-    // is the desync signal; a successful read OR a clean ERR_BAD_FILE (the card completed the lookup and
-    // reported "not there" -- proof the sequencer is synced this instant) clears the streak. ERR_LOAD_ABORTED
-    // was cut short by nav, so its outcome is unknown -- leave the streak untouched.
-    if (req->effectiveMode == MMCE_MODE) {
-        static int mmceEioStreak = 0;
-        if (result == ERR_FILE_IO) {
-            if (++mmceEioStreak >= CACHE_MMCE_EIO_RESET_STREAK) {
-                mmceEioStreak = 0;
-                mmceResetChannel();
-            }
-        } else if (result != ERR_LOAD_ABORTED) {
-            mmceEioStreak = 0;
-        }
-    }
     cacheCompleteRequest(req, result);
     cacheProcessCleanupRequests();
 

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -449,39 +449,50 @@ int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const cha
         return -1;       // known-absent this epoch -> skip the failing-open storm on the slow MMCE bus (#120)
     }
 
-    // Only a tier that misses with ERR_BAD_FILE (open() failed = GENUINELY not there) is worth chasing to the
-    // next tier. A transient/present miss instead -- ERR_FILE_IO (a staged read that errored on a contended
-    // MMCE bus) or ERR_LOAD_ABORTED (nav) -- means the card is choking, so the remaining tiers would almost
-    // certainly fail too: STOP immediately and return the transient result (#120 REDUCE -- don't pile up to 2
-    // more failing opens per cover on an already-desyncing card). It isn't a hit (returned above) and isn't a
-    // genuine absence, so it is also left UN-memoized: the cover may EXIST and just failed this time, so it
-    // re-probes next generation when the bus may have recovered (the #134 memo-hardening intent, preserved).
+    // Chase the next art tier only when THIS tier is a clean miss worth a fallback: a genuine absence
+    // (ERR_BAD_FILE = open() failed) or a permanent PNG-decode error (the file existed but is corrupt, so a
+    // lower tier may still hold a good cover -- old behaviour, kept). But a TRANSIENT miss -- ERR_FILE_IO (a
+    // staged read that errored on a contended MMCE bus) or ERR_LOAD_ABORTED (nav) -- means the card is choking,
+    // so the remaining tiers would almost certainly fail too: STOP and return immediately (#120 REDUCE -- don't
+    // pile up to 2 more failing opens per cover on an already-desyncing card). Memoize ONLY a full genuine
+    // absence (every tier ERR_BAD_FILE); a decode error or a transient leaves it un-memoized so a real cover
+    // isn't false-hidden and re-probes next generation when the bus may have recovered (the #134 intent).
+    int allAbsent = 1;
+
     vcdExtractGameId(value, discId, sizeof(discId));
     if (discId[0] != '\0') {
         snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, discId, suffix);
         if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
             return r;
-        if (r != ERR_BAD_FILE)
+        if (r == ERR_FILE_IO || r == ERR_LOAD_ABORTED)
             return r;
+        if (r != ERR_BAD_FILE)
+            allAbsent = 0;
     }
     snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, value, suffix);
     if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
         return r;
-    if (r != ERR_BAD_FILE)
+    if (r == ERR_FILE_IO || r == ERR_LOAD_ABORTED)
         return r;
+    if (r != ERR_BAD_FILE)
+        allAbsent = 0;
     if (popsDir != NULL) {
         snprintf(path, sizeof(path), "%s%s%c%s", devPrefix, popsDir, sep, value);
         if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
             return r;
-        if (r != ERR_BAD_FILE)
+        if (r == ERR_FILE_IO || r == ERR_LOAD_ABORTED)
             return r;
+        if (r != ERR_BAD_FILE)
+            allAbsent = 0;
     }
 
-    // Reached here => every probed tier returned ERR_BAD_FILE (a genuine full absence). Cache it so a repeat
-    // probe of a cover-less PS1 game skips the failing-open storm (the #120 win). The texcache FAILED sentinel
-    // still bounds within-generation repeats regardless.
-    gDiag.memoMiss++;            // #120 diag: genuine full miss recorded (first probe this epoch)
-    vcdArtMissRemember(missKey); // repeat probes skip the opens until the next rescan
+    // Cache ONLY a full genuine absence (every tier ERR_BAD_FILE) so a repeat probe of a cover-less PS1 game
+    // skips the failing-open storm (the #120 win). The texcache FAILED sentinel still bounds within-generation
+    // repeats regardless.
+    if (allAbsent) {
+        gDiag.memoMiss++;            // #120 diag: genuine full miss recorded (first probe this epoch)
+        vcdArtMissRemember(missKey); // repeat probes skip the opens until the next rescan
+    }
     return r;
 }
 

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -449,42 +449,39 @@ int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const cha
         return -1;       // known-absent this epoch -> skip the failing-open storm on the slow MMCE bus (#120)
     }
 
-    // Did every probed tier miss with ERR_BAD_FILE (open() failed = file GENUINELY not there)? A
-    // transient/present miss instead -- ERR_FILE_IO (a staged read that errored on a contended MMCE bus),
-    // ERR_LOAD_ABORTED, or a PNG decode error -- means the cover may EXIST and just failed to load this
-    // time. Memoizing that would false-hide a real cover until the next rescan (Codex/Fable audit + my own
-    // verify both flagged it). So only a GENUINE absence is cached below.
-    int allAbsent = 1;
-
+    // Only a tier that misses with ERR_BAD_FILE (open() failed = GENUINELY not there) is worth chasing to the
+    // next tier. A transient/present miss instead -- ERR_FILE_IO (a staged read that errored on a contended
+    // MMCE bus) or ERR_LOAD_ABORTED (nav) -- means the card is choking, so the remaining tiers would almost
+    // certainly fail too: STOP immediately and return the transient result (#120 REDUCE -- don't pile up to 2
+    // more failing opens per cover on an already-desyncing card). It isn't a hit (returned above) and isn't a
+    // genuine absence, so it is also left UN-memoized: the cover may EXIST and just failed this time, so it
+    // re-probes next generation when the bus may have recovered (the #134 memo-hardening intent, preserved).
     vcdExtractGameId(value, discId, sizeof(discId));
     if (discId[0] != '\0') {
         snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, discId, suffix);
         if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
             return r;
         if (r != ERR_BAD_FILE)
-            allAbsent = 0;
+            return r;
     }
     snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, value, suffix);
     if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
         return r;
     if (r != ERR_BAD_FILE)
-        allAbsent = 0;
+        return r;
     if (popsDir != NULL) {
         snprintf(path, sizeof(path), "%s%s%c%s", devPrefix, popsDir, sep, value);
         if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
             return r;
         if (r != ERR_BAD_FILE)
-            allAbsent = 0;
+            return r;
     }
 
-    // Cache ONLY a genuine absence, so a repeat probe of a cover-less PS1 game skips the failing-open storm
-    // (the #120 win). A transient/present failure is left UN-memoized -> it re-probes next generation, when
-    // the bus may have recovered, so a real cover isn't hidden. The texcache FAILED sentinel still bounds
-    // within-generation repeats, so not memoizing here does not reopen the storm.
-    if (allAbsent) {
-        gDiag.memoMiss++;            // #120 diag: genuine full miss recorded (first probe this epoch)
-        vcdArtMissRemember(missKey); // repeat probes skip the opens until the next rescan
-    }
+    // Reached here => every probed tier returned ERR_BAD_FILE (a genuine full absence). Cache it so a repeat
+    // probe of a cover-less PS1 game skips the failing-open storm (the #120 win). The texcache FAILED sentinel
+    // still bounds within-generation repeats regardless.
+    gDiag.memoMiss++;            // #120 diag: genuine full miss recorded (first probe this epoch)
+    vcdArtMissRemember(missKey); // repeat probes skip the opens until the next rescan
     return r;
 }
 


### PR DESCRIPTION
Beta-3116 (which added #136's card-reset "recovery") **regressed**: the wedge still happened (HUD `TK:0` again = card-side) and settings-saving broke (`SE:0` → `SE:1`). Two independent source audits — a multi-agent workflow and Codex 5.6 — agree on the fix, and Codex found the reset is not just useless but unsafe.

## 1. Revert the #136 reset path (keep the launch hardening)
The mmceman RESET devctl (`0x9`) means *close all filesystem handles*. Fired from the art worker with no whole-device quiescence, it can invalidate a live settings-file handle mid-write (the art-drain guard proceeds after a 500-tick timeout), which is a credible source of the `SE:1` save failure. The pinned driver's `mmce_cmd_reset()` packet is also malformed (5 bytes allocated, only 3 initialised), and #136 promoted it from boot-time to live-session use. And whether it even *fired* is unknowable from the HUD (an `open()` failure is `ERR_BAD_FILE`, which never trips the `ERR_FILE_IO` streak), so it demonstrably did not un-stick the card.

Removes `mmceResetChannel()`, `MMCE_DEVCTL_RESET`, and the texcache streak detector. **Keeps** the `mmceLaunchGame` launch hardening (`guiWarning`+return vs `cacheEnd(1)`/`TerminateThread`) — independent, issues no card devctl or config write, cannot cause `SE:1`. The #134/#135 `ERR_FILE_IO` reclassify is untouched and preserved.

## 2. REDUCE the PS1 info-entry read burst (the real trigger)
A VCD opens up to **3× the art files per cover** a PS2 game does (disc-id tier → basename tier → POPS fallback). Two pure-redundant cuts:
- **`vcdLoadArt`**: only chase the next art tier on `ERR_BAD_FILE` (genuine absence). On a transient failure (`ERR_FILE_IO`/`ERR_LOAD_ABORTED`) the card is already choking, so stop and return immediately instead of piling up to 2 more failing opens per cover. Still un-memoized, so a real cover re-probes next generation (the #134 intent, preserved).
- **`sbPopulateConfig`**: hard-stop the ISO size stat for a `.VCD` by **extension** (not mutable view state), so a PS1 disc can never hit the CD/DVD stat path that always misses and re-probes the bus every info entry. (Andrew's own suggestion, made robust; `0 MiB` still displays.)

Neither promises to cure the desync — they cut the read volume that drives it, verifiable on the HUD (`AO` should climb less on the PS1 list). Built green (opl.elf 11390892).

🤖 Generated with [Claude Code](https://claude.com/claude-code)