### PR TITLE
refactor(#120): PS1 (VCD) art loads through the same path as PS2, keyed by filename

### DIFF
--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -874,12 +874,11 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
-    // VCD (PS1) covers: fall back disc-id -> filename -> POPSLoader's next-to-VCD <dev>/POPS/<name>.png.
-    // #118: route ALL VCD art suffixes (cover/BG/logo/screenshot), not just cover; popsDir guard keeps
-    // BG/SCR off the cover-only POPSLoader fallback.
-    if (isRelative && mmceArtPrimary[0] != '\0' && vcdViewActive(itemList->mode))
-        return vcdLoadArt(mmceArtPrimary, '/', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
-
+    // PS1 (VCD) art loads through the EXACT same path as PS2 (ISO) art: one lookup of
+    // <dev>ART/<value>_<suffix>.png. The ONLY difference is the key -- PS2 uses the disc ID, PS1 uses the
+    // VCD filename (already the item's `value`). No separate VCD art loader, no tiers, no miss-memo: whatever
+    // PS2 art does (and PS2 info never wedges the card), PS1 now does identically (#120). This deletes the
+    // vcdLoadArt detour that was the only thing different about PS1 art.
     return mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
 }
 


### PR DESCRIPTION
Per Andrew's hardware findings and NathanNeurotic's call: PS1 art should work exactly like PS2 art, differing only in the key (VCD filename vs disc ID).

**The one real difference:** PS2 (ISO) art went straight through `mmceTryLoadImage`; PS1 (VCD) art detoured through a bespoke `vcdLoadArt` (multi-tier + miss-memo). Both bottom out at the *identical* `texDiscoverLoad("<dev>ART/<value>_<suffix>.png")`.

**This change** deletes the detour — `mmceGetImage` now calls `mmceTryLoadImage` for VCD art too. PS1 art loads byte-for-byte like PS2, differing only in the key (the VCD filename, already the item's `value`). Whatever PS2 does on a missing file (and PS2 info never wedges the Bitfunx card), PS1 now does identically.

Confirmed context: Cover Art OFF stops the wedge; PS1 covers/backgrounds load fine, only screenshots/info misbehave. `vcdLoadArt`/`vcdArtPopsDir` stay for the other device backends for now; this targets the confirmed MMCE wedge.

Built green (opl.elf 11388720). Not calling this a fix until Andrew's hardware confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)