### PR TITLE
refactor(#120): unify all VCD art with the standard PS2 art path, delete the separate loader

### DIFF
--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -67,16 +67,6 @@ int vcdFillGameList(const char *devPrefix, base_game_info_t **outGames);
 // case-insensitive). Callers hide it from the device lists when gVcdFirstDiscOnly is on.
 int vcdIsHiddenDisc(const char *name);
 
-// 3-level cover/icon fallback for a VCD game: ID-keyed OPL art -> name-keyed OPL art -> POPSLoader's
-// next-to-VCD "<dev>/POPS/<name>.png". Call from a support's getImage for VCD games + "COV"/"ICO". `sep`
-// matches the device prefix ('/' local/MMCE/HDD, '\\' SMB); popsDir e.g. "POPS" (NULL skips step 3).
-// Returns the first texDiscoverLoad hit (>= 0), else the last miss.
-int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const char *value, const char *suffix, const char *popsDir, GSTEXTURE *tex);
-// popsDir to pass vcdLoadArt for a given art suffix: "POPS" for COV/ICO (POPSLoader interop), NULL
-// otherwise (BG/logo/screenshot must not fall to the suffix-less cover image). Shared so every VCD
-// getImage branch and favGetImage resolve the same art (issue #118).
-const char *vcdArtPopsDir(const char *suffix);
-
 // ---- safe memory-card copy (free-space gated) -------------------------------------
 // Used by the BDMA/SMB module equip + the POPSTARTER config writers so a full or interrupted
 // write can never wreck the card. Every write onto mc?:/POPSTARTER/ must go through these.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1154,17 +1154,8 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    // VCD (PS1) art (issue #118: ALL suffixes -- cover, background, logo, screenshot -- not just cover):
-    // disc-id -> filename in <dev>ART/, then the cover/icon-only POPSLoader next-to-VCD fallback
-    // (vcdArtPopsDir gives "POPS" for COV/ICO, NULL for BG/SCR so those never render the cover). Local
-    // devices use '/'. Root-anchored like the VCD scan (POPS layout lives at the device root, outside
-    // gBDMPrefix). AttributeImage glyphs are absolute (isRelative==0) so they stay out.
-    if (isRelative && vcdViewActive(itemList->mode)) {
-        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
-        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
-        return vcdLoadArt(vcdPrefix, '/', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
-    }
-
+    // PS1 (VCD) art loads through this same path as PS2 (ISO) art, keyed by the VCD filename (already
+    // `value`) -- no separate loader (#120). VCD art now lives in the same ART folder as ISO art.
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", pDeviceData->bdmPrefix, folder, value, suffix);
     else

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -803,11 +803,8 @@ static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char
 {
     char path[256];
 
-    // VCD (PS1) art (#118: ALL suffixes -- cover/BG/logo/screenshot): disc-id -> filename, then the
-    // cover/icon-only POPSLoader next-to-VCD fallback (vcdArtPopsDir NULLs it for BG/SCR). SMB uses '\\'.
-    if (isRelative && vcdViewActive(itemList->mode))
-        return vcdLoadArt(ethPrefix, '\\', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
-
+    // PS1 (VCD) art loads through this same path as PS2 (ISO) art, keyed by the VCD filename (already
+    // `value`) -- no separate loader (#120).
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s\\%s_%s", ethPrefix, folder, value, suffix);
     else

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -24,7 +24,7 @@
 #include "include/textures.h"
 #include "include/config.h"
 #include "include/supportbase.h" // sbPopulateConfig + base_game_info_t (VCD favourite config)
-#include "include/vcdsupport.h"  // vcdLoadArt / vcdViewActive / vcdConsumeDirty (VCD favourites)
+#include "include/vcdsupport.h"  // vcdViewActive / vcdConsumeDirty (VCD favourites)
 #include "include/favsupport.h"
 
 int gFAVStartMode;

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -580,28 +580,15 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
         item_list_t *o = favArray[i].owner;
         if (o == NULL)
             continue;
-        // VCD favourite: art keys off the .VCD name (== favArray[i].text == value) via the shared
-        // 3-level VCD fallback against the owner's prefix -- mirrors each device's getImage VCD branch.
-        // #118: resolve ALL art suffixes (cover/BG/logo/screenshot), not just cover/icon, via the SAME
-        // vcdArtPopsDir helper the device branches use, so a VCD favourite's info page matches its source
-        // list. Local/MMCE prefixes use '/', SMB ('\\') is auto-detected from the prefix.
+        // VCD favourite: art keys off the .VCD name (== favArray[i].text == value). Load it through the
+        // OWNER device's normal getImage -- identical to a PS2/ISO favourite (which the branch below routes
+        // the same way), just keyed by the filename instead of the disc id. No separate VCD art loader (#120).
         if (favArray[i].isVcd) {
             if (strcmp(favArray[i].text, value) != 0)
                 continue;
-            // Relative art only (keyed to the device prefix); an absolute-prefix attribute-image element
-            // falls through to -1. Same isRelative gate as each device getImage VCD branch.
-            if (!isRelative)
+            if (o->itemGetImage == NULL)
                 return -1;
-            char *prefix = (o->itemGetPrefix != NULL) ? o->itemGetPrefix(o) : NULL;
-            if (prefix == NULL)
-                return -1;
-            // HDD VCD art lives at the APA partition ROOT /ART/ (mirroring the HDD VCD view), not the
-            // OPL data subfolder its itemGetPrefix points at -- key off the partition root instead.
-            if (favArray[i].mode == HDD_MODE)
-                prefix = "pfs0:/";
-            int pl = (int)strlen(prefix);
-            char sep = (pl > 0 && prefix[pl - 1] == '\\') ? '\\' : '/';
-            return vcdLoadArt(prefix, sep, folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
+            return o->itemGetImage(o, folder, isRelative, value, suffix, resultTex, psm);
         }
         if (o->itemGetStartup == NULL || o->itemGetImage == NULL || !favOwnerHasId(o, favArray[i].id))
             continue;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1054,16 +1054,8 @@ static int hddGetImage(item_list_t *itemList, char *folder, int isRelative, char
 {
     char path[256];
 
-    // VCD (PS1) covers: fall back disc-id -> filename in the OPL ART folder. POPSLoader's HDD layout keeps
-    // art on the __common partition (POPS/ART/<name>.png), a different partition than gHDDPrefix, so that
-    // step is a follow-up -- pass NULL to skip it rather than probe the wrong partition.
-    // VCD art (#118: ALL suffixes -- cover/BG/logo/screenshot) lives at the APA partition ROOT /ART/
-    // (pfs0:/ART/, whatever partition is mounted -- common or +OPL), NOT the OPL data subfolder. pfs0:
-    // is already mounted while browsing, so no remount. popsDir stays NULL here (HDD VCD art never used
-    // the next-to-VCD POPS image; it would be on a different partition).
-    if (isRelative && vcdViewActive(itemList->mode))
-        return vcdLoadArt("pfs0:/", '/', folder, value, suffix, NULL, resultTex);
-
+    // PS1 (VCD) art loads through this same path as PS2 (ISO) art, keyed by the VCD filename (already
+    // `value`) -- no separate loader (#120). VCD art now lives in the same ART folder as ISO art.
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", gHDDPrefix, folder, value, suffix);
     else

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -343,11 +343,8 @@ static int udpfsGetImage(item_list_t *itemList, char *folder, int isRelative, ch
 {
     char path[256];
 
-    // VCD (PS1) art (#118: ALL suffixes -- cover/BG/logo/screenshot): disc-id -> filename, then the
-    // cover/icon-only POPSLoader next-to-VCD fallback (vcdArtPopsDir NULLs it for BG/SCR).
-    if (isRelative && vcdViewActive(itemList->mode))
-        return vcdLoadArt(udpfsPrefix, '/', folder, value, suffix, vcdArtPopsDir(suffix), resultTex);
-
+    // PS1 (VCD) art loads through this same path as PS2 (ISO) art, keyed by the VCD filename (already
+    // `value`) -- no separate loader (#120).
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", udpfsPrefix, folder, value, suffix);
     else

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -84,8 +84,6 @@ const char *vcdDisplayName(int mode, const char *text)
     return n ? text + n : text;
 }
 
-static void vcdArtMissInvalidate(void); // defined below; bumped once per SUCCESSFUL scan (see vcdScanOpenDir)
-
 // Core scan: opendir `dirPath` and collect *.VCD basenames into a fresh vcd_entry_t list. POSIX dir
 // IO only (newlib-port rule). Shared by vcdScanDir (POPS subfolder) and vcdScanDirRoot (path as-is).
 static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
@@ -119,14 +117,6 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
         count++;
     }
     closedir(dir);
-
-    // The directory was readable (opened + fully enumerated) -> the VCD set may have changed since last
-    // time, so art that was previously absent might now exist: drop the art miss-memo (#120). Placed HERE,
-    // on the single shared scan success path, so it fires for EVERY VCD device -- including the HDD/APA
-    // path via vcdScanDirRoot, which does NOT go through vcdFillGameList (Gemini review of #130). Fires
-    // ONLY on success: the opendir-fail / OOM returns above never reach here, so a transient wedge does
-    // NOT wipe the memo and re-ignite the failing-open storm.
-    vcdArtMissInvalidate();
 
     if (count == 0) {
         free(list);
@@ -361,112 +351,6 @@ void vcdMarkAllDirty(void)
     for (int m = 0; m < MODE_COUNT; m++)
         if (vcdModeSupported(m))
             vcdDirty[m] = 1;
-}
-
-// Which POPSLoader next-to-VCD image (step 3 of vcdLoadArt) applies to a given art suffix. Only the
-// cover/icon fall back to the single suffix-less POPS/<name>.png (interop with existing POPSLoader
-// users); background/logo/screenshot must NOT, or they would each render the cover instead. Shared by
-// every device getImage VCD branch AND favGetImage so the source-list and Favourites VCD art (issue
-// #118 -- BG/screenshot for PS1) resolve identically and never drift.
-const char *vcdArtPopsDir(const char *suffix)
-{
-    if (suffix != NULL && (!strcmp(suffix, "COV") || !strcmp(suffix, "ICO")))
-        return "POPS";
-    return NULL;
-}
-
-// Bounded miss-memo for VCD art (issue #120): a VCD info view probes up to ~2-3 filenames per art
-// suffix (see vcdLoadArt), almost all MISSING for PS1 games that ship no covers/screenshots. Opening
-// PS1 info repeatedly re-ran that failing-open STORM on the slow shared MMCE (SIO2) bus every time,
-// contending/desyncing the card. Remember a FULL miss per (device+value+suffix) so a subsequent probe
-// of the same art skips the opens entirely -- STRICTLY FEWER bus opens, never more. Invalidated
-// wholesale by an epoch bump on any VCD list rescan (art may now exist), so nothing is permanently
-// hidden. Thread model: the memo ARRAY is written ONLY on the art worker thread (vcdLoadArt runs there
-// via every getImage); the epoch is a lone volatile int bumped from the IO thread -- so there is no
-// cross-thread array access, aligned-int writes are atomic on EE, and a stale-epoch entry is ignored.
-#define VCD_ART_MISS_MEMO 128
-static struct
-{
-    unsigned int key;
-    unsigned int epoch;
-} vcdArtMiss[VCD_ART_MISS_MEMO];
-static int vcdArtMissNext = 0;
-static volatile unsigned int vcdArtMissEpoch = 1; // 0 reserved = a never-written slot
-
-static void vcdArtMissInvalidate(void)
-{
-    unsigned int e = vcdArtMissEpoch + 1; // bump on a VCD rescan -> every prior miss is re-probed
-    vcdArtMissEpoch = e ? e : 1;
-}
-
-static unsigned int vcdArtMissKey(const char *devPrefix, const char *value, const char *suffix)
-{
-    unsigned int h = 2166136261u; // FNV-1a over devPrefix, value, suffix (each NUL-separated)
-    const char *p;
-    for (p = devPrefix; p && *p; p++)
-        h = (h ^ (unsigned char)*p) * 16777619u;
-    h = (h ^ 0xffu) * 16777619u;
-    for (p = value; p && *p; p++)
-        h = (h ^ (unsigned char)*p) * 16777619u;
-    h = (h ^ 0xffu) * 16777619u;
-    for (p = suffix; p && *p; p++)
-        h = (h ^ (unsigned char)*p) * 16777619u;
-    return h ? h : 1; // 0 reserved
-}
-
-static int vcdArtMissKnown(unsigned int key)
-{
-    unsigned int ep = vcdArtMissEpoch;
-    for (int i = 0; i < VCD_ART_MISS_MEMO; i++)
-        if (vcdArtMiss[i].epoch == ep && vcdArtMiss[i].key == key)
-            return 1;
-    return 0;
-}
-
-static void vcdArtMissRemember(unsigned int key)
-{
-    vcdArtMiss[vcdArtMissNext].key = key;
-    vcdArtMiss[vcdArtMissNext].epoch = vcdArtMissEpoch;
-    vcdArtMissNext = (vcdArtMissNext + 1) % VCD_ART_MISS_MEMO;
-}
-
-// Single-lookup cover/icon for VCD (PS1) games: <dev>ART/<name>_<suffix>.png, keyed by the VCD FILENAME.
-// A VCD carries no disc ID like a PS2 ISO does, so the filename IS the key (balls.VCD -> balls_COV.png).
-// This is exactly ONE card read per cover -- the same shape a PS2 game uses. The former disc-id and
-// POPSLoader-layout fallback tiers were dropped (#120): they added up to 2 extra reads per cover and drove
-// the PS1 info-entry read burst that desyncs the MMCE card, whereas PS2 games at this 1-read pattern never
-// wedge. Standard <name>_<suffix>.png art still resolves; only the POPS-adjacent layout is no longer tried.
-// A repeat probe of known-absent art short-circuits with NO open (miss-memo above). `sep` is '/' for
-// local/MMCE/HDD prefixes and '\\' for SMB (ethPrefix) -- mirror the caller's getImage.
-int vcdLoadArt(const char *devPrefix, char sep, const char *artFolder, const char *value, const char *suffix, const char *popsDir, GSTEXTURE *tex)
-{
-    char path[256];
-    int r;
-    (void)popsDir; // POPSLoader-layout fallback tier dropped (#120); parameter kept for caller compatibility
-
-    // Defensive: the art path never passes NULL here, but a stray NULL would snprintf("%s", NULL) -> crash.
-    // Return a plain miss instead (harmless: callers treat any negative as "no art").
-    if (devPrefix == NULL || artFolder == NULL || value == NULL || suffix == NULL || tex == NULL)
-        return ERR_BAD_FILE;
-
-    unsigned int missKey = vcdArtMissKey(devPrefix, value, suffix);
-    if (vcdArtMissKnown(missKey)) {
-        gDiag.memoHit++;     // #120 diag: storm avoided -- zero opens this probe
-        return ERR_BAD_FILE; // known-absent this epoch -> skip the failing open on the slow MMCE bus (#120)
-    }
-
-    snprintf(path, sizeof(path), "%s%s%c%s_%s", devPrefix, artFolder, sep, value, suffix);
-    if ((r = texDiscoverLoad(tex, path, -1)) >= 0)
-        return r;
-
-    // Memoize ONLY a genuine absence (ERR_BAD_FILE = open() failed) so a repeat probe of a cover-less PS1 game
-    // skips the failing open. A transient/present failure (ERR_FILE_IO / ERR_LOAD_ABORTED) or a decode error is
-    // left un-memoized -> re-probes next generation when the bus may have recovered (the #134 memo intent).
-    if (r == ERR_BAD_FILE) {
-        gDiag.memoMiss++;            // #120 diag: genuine miss recorded (first probe this epoch)
-        vcdArtMissRemember(missKey); // repeat probes skip the open until the next rescan
-    }
-    return r;
 }
 
 // #118: a multi-disc PS1 game is a set of separate .VCD files whose titles carry a disc token, e.g.


### PR DESCRIPTION
Follows #139 (which did MMCE). Every other backend, BDM/USB, ETH/SMB, HDD/APA, UDPFS, and favourites, had its own VCD branch calling the bespoke `vcdLoadArt` (tiers + miss-memo). They all collapse to the device's **normal** art path — `<prefix><folder>/<value>_<suffix>.png` — keyed by the VCD filename (already `value`). The only thing PS1 ever actually needed was name-vs-id.

Then the now-orphaned system is deleted outright: `vcdLoadArt`, `vcdArtPopsDir`, the 128-entry `vcdArtMiss` miss-memo, its epoch, the per-scan invalidate call, and the header decls. The special VCD art system that accreted across #118/#120 is gone.

**Behavior change (per maintainer, intended):** on BDM and HDD, VCD art now lives in the **same ART folder as ISO art** (e.g. `pfs0:OPL/ART/`) instead of the device/partition root. MMCE/SMB/UDPFS already shared the folder, so no move there. Favourites route VCD art through the owner device's `getImage`, exactly like an ISO favourite.

Two commits: (1) call-site unification, (2) dead-code deletion. `opl.elf` 11380436 (~4KB smaller). Built green.

Note: this is code unification, not itself the #120 hardware fix — it's the cleanup you flagged, and it makes PS1 art genuinely identical to PS2 everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)