### PR TITLE
feat(settings): move BDM/ETH/MMCE Prefix Paths to General Settings

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -187,6 +187,25 @@ struct UIItem diaConfig[] = {
     {UI_INT, CFG_AUTOSTARTLAST, 1, 1, _STR_HINT_AUTOSTARTLAST, 0, 0, {.intvalue = {0, 0, 0, 9}}},
     {UI_BREAK},
 
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Prefix Paths", -1}}},
+    {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDM_PREFIX}}},
+    {UI_SPACER},
+    {UI_STRING, CFG_BDMPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ETH_PREFIX}}},
+    {UI_SPACER},
+    {UI_STRING, CFG_ETHPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_MMCE_PREFIX}}},
+    {UI_SPACER},
+    {UI_STRING, CFG_MMCEPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
+    {UI_BREAK},
+
     // buttons
     {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
     {UI_BREAK},
@@ -263,25 +282,6 @@ struct UIItem diaDeviceConfig[] = {
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_MMCEMODE}}},
     {UI_SPACER},
     {UI_ENUM, CFG_MMCEMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Prefix Paths", -1}}},
-    {UI_SPLITTER},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDM_PREFIX}}},
-    {UI_SPACER},
-    {UI_STRING, CFG_BDMPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ETH_PREFIX}}},
-    {UI_SPACER},
-    {UI_STRING, CFG_ETHPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_MMCE_PREFIX}}},
-    {UI_SPACER},
-    {UI_STRING, CFG_MMCEPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
     {UI_BREAK},
 
     {UI_BREAK},

--- a/src/gui.c
+++ b/src/gui.c
@@ -566,6 +566,11 @@ void guiShowConfig()
     diaSetVisible(diaConfig, CFG_AUTOSTARTLAST, gRememberLastPlayed);
     diaSetVisible(diaConfig, CFG_LBL_AUTOSTARTLAST, gRememberLastPlayed);
 
+    // Device prefix paths (moved from Device Settings to General Settings)
+    diaSetString(diaConfig, CFG_BDMPREFIX, gBDMPrefix);
+    diaSetString(diaConfig, CFG_ETHPREFIX, gETHPrefix);
+    diaSetString(diaConfig, CFG_MMCEPREFIX, gMMCEPrefix);
+
     int ret;
 reshow_config:
     ret = diaExecuteDialog(diaConfig, -1, 1, &guiUpdater);
@@ -583,6 +588,9 @@ reshow_config:
         diaGetInt(diaConfig, CFG_ENWRITEOP, &gEnableWrite);
         diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
         diaGetInt(diaConfig, CFG_AUTOSTARTLAST, &gAutoStartLastPlayed);
+        diaGetString(diaConfig, CFG_BDMPREFIX, gBDMPrefix, sizeof(gBDMPrefix));
+        diaGetString(diaConfig, CFG_ETHPREFIX, gETHPrefix, sizeof(gETHPrefix));
+        diaGetString(diaConfig, CFG_MMCEPREFIX, gMMCEPrefix, sizeof(gMMCEPrefix));
         DisableCron = 1; // Disable Auto Start Last Played counter (we don't want to call it right after enable it on GUI)
 
         applyConfig(-1, -1, 0);
@@ -1115,11 +1123,6 @@ void guiShowDeviceConfig(void)
     diaSetInt(diaDeviceConfig, CFG_UDPFSMODE, udpfsModeVal);
     diaSetVisible(diaDeviceConfig, CFG_UDPFSMODE, netPickerVal == 2); // Files/Image only meaningful for UDPFS
 
-    // Prefix paths
-    diaSetString(diaDeviceConfig, CFG_BDMPREFIX, gBDMPrefix);
-    diaSetString(diaDeviceConfig, CFG_ETHPREFIX, gETHPrefix);
-    diaSetString(diaDeviceConfig, CFG_MMCEPREFIX, gMMCEPrefix);
-
     // Cache & storage
     diaSetInt(diaDeviceConfig, CFG_HDDSPINDOWN, gHDDSpindown);
     diaSetInt(diaDeviceConfig, CFG_HDDGAMELISTCACHE, gHDDGameListCache);
@@ -1166,10 +1169,6 @@ void guiShowDeviceConfig(void)
         } else {
             gETHStartMode = START_MODE_DISABLED;
         }
-
-        diaGetString(diaDeviceConfig, CFG_BDMPREFIX, gBDMPrefix, sizeof(gBDMPrefix));
-        diaGetString(diaDeviceConfig, CFG_ETHPREFIX, gETHPrefix, sizeof(gETHPrefix));
-        diaGetString(diaDeviceConfig, CFG_MMCEPREFIX, gMMCEPrefix, sizeof(gMMCEPrefix));
 
         diaGetInt(diaDeviceConfig, CFG_HDDSPINDOWN, &gHDDSpindown);
         diaGetInt(diaDeviceConfig, CFG_HDDGAMELISTCACHE, &gHDDGameListCache);


### PR DESCRIPTION
Moves the three **Prefix Path** settings (BDM, ETH, MMCE) from **Device Settings** to **General Settings**, as requested.

Pure relocation, no behavior change:
- The `Prefix Paths` UI block moves from `diaDeviceConfig` to `diaConfig` (dialogs.c).
- The `diaSetString`/`diaGetString` binding calls for `CFG_BDMPREFIX`/`CFG_ETHPREFIX`/`CFG_MMCEPREFIX` move from the device-config handler to `guiShowConfig` (gui.c).
- CFG ids and the `g*Prefix` globals are unchanged, so previously-saved values load and apply exactly as before; only the page they appear on changes.

Emulator-verifiable: open General Settings, the three Prefix Path fields are there (and gone from Device Settings). Built green (opl.elf 11380452).

🤖 Generated with [Claude Code](https://claude.com/claude-code)