### PR TITLE
fix(hdd): list APA one-game VCD installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ This build layers several features on top of upstream OPL:
   A **Default game view** setting (**Both** / **ISO** / **VCD**, default **Both**) can lock a page
   to one type, and Favourites follow the active view. PS1 titles boot through **POPSTARTER** only
   (never OPL's core, never Neutrino — the Loader Core selector is inert for them). Works on USB /
-  MMCE / MX4SIO / iLink / SMB **and the internal HDD** — both APA (`__.POPS*` partitions) and
+  MMCE / MX4SIO / iLink / SMB **and the internal HDD** — both APA (exact `__.POPS[0-9]?`
+  containers plus `PP.<name>` / `__.<name>` one-game partitions containing `IMAGE0.VCD`) and
   **exFAT** (BDMA; PS1 games in `massN:/POPS/`). See
   **[docs/VCD.md](docs/VCD.md)**.
 - **Core-aware per-game settings:** the per-game screen adapts to the selected **Loader Core** —

--- a/docs/VCD.md
+++ b/docs/VCD.md
@@ -55,8 +55,10 @@ VCD titles always boot through **`POPSTARTER.ELF`**. They never use OPL's built-
 or Neutrino, so on a VCD game the per-game **Loader Core** selector is locked to an
 inert label — choosing a core there has no effect on a PS1 game.
 
-POPSTARTER only needs the VCD's *name* to do its job; RiptOPL hands it the selected
-title and POPSTARTER finds the matching `*.VCD`.
+For ordinary VCD files, POPSTARTER needs the VCD's *name*; RiptOPL hands it the selected
+title and POPSTARTER finds the matching `*.VCD`. An APA one-game install instead launches
+with its literal, case-sensitive `PP.<name>` / `__.<name>` partition label so POPSTARTER can
+mount that partition and boot its fixed `IMAGE0.VCD`.
 
 Where `POPSTARTER.ELF` is loaded from is set by **Settings → General Settings →
 POPSTARTER.ELF Device** — a driver-accurate picker (matching the Neutrino Device picker):
@@ -86,7 +88,7 @@ characters; for a longer path set `popstarter_path` in `settings_riptopl.cfg` di
 | Device | Location |
 | --- | --- |
 | USB / MMCE / MX4SIO / iLink / SMB | a **`POPS`** folder at the device root, holding `POPSTARTER.ELF` + your `*.VCD` files |
-| Internal HDD (APA/PFS) | two layouts, both listed: a **`__.POPS`, `__.POPS0` … `__.POPS9`** store partition (many `*.VCD` on its root, named per file), and/or **`PP.<name>`** single-game install partitions (one `IMAGE0.VCD` each; shown as `<name>`). `POPSTARTER.ELF` is loaded from a **`POPS`** folder on the **`__common`** partition (then **`+OPL`** as a fallback). |
+| Internal HDD (APA/PFS) | two layouts, both listed: an exact **`__.POPS`, `__.POPS0` … `__.POPS9`** store partition (many `*.VCD` on its root, named per file), and/or **`PP.<name>`** (visible) / **`__.<name>`** (hidden-label) one-game partitions. A one-game candidate is listed only when its root contains the exact file **`IMAGE0.VCD`**, which prevents similarly named HDD apps from appearing as games; it is shown as `<name>`. `POPSTARTER.ELF` is loaded from a **`POPS`** folder on the **`__common`** partition (then **`+OPL`** as a fallback). |
 
 > The HDD's `XX.*` (BDMA/exFAT) and `SB.*` (SMBv1) launcher partitions point at VCDs that live on
 > an exFAT device or an SMB share — those games appear under the **USB/MX4SIO/MMCE** or **SMB** VCD
@@ -99,7 +101,8 @@ won't auto-match art by ID.
 
 > **Internal HDD covers:** VCD covers on the APA HDD load from an **`ART`** folder at the
 > **partition root** (`pfs:/ART/` — i.e. `<your OPL partition>:/ART/`), not the `OPL/ART/`
-> subfolder PS2-HDD covers use. (`PP.*` installs key off the displayed name, e.g. `GAME_COV.png`.)
+> subfolder PS2-HDD covers use. (`PP.*` / `__.*` one-game installs key off the displayed
+> name without the three-character prefix, e.g. `GAME_COV.png`.)
 
 ## 5. exFAT PS1 support — the BDMA equip
 

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -32,13 +32,13 @@ typedef struct
     hdl_game_info_t *games;
 } hdl_games_list_t;
 
-// HDD PS1/VCD store: PS1 .VCD games live on dedicated APA partitions __.POPS / __.POPS0..9 (each a
-// PFS filesystem with GameName.VCD at its root). This is the sorted, deduped list of which __.POPS*
-// partitions are present, enumerated from the APA partition table.
+// HDD PS1/VCD sources: exact __.POPS / __.POPS0..9 containers (many named .VCD files) plus
+// partition-installed PP.<name> / __.<name> games (one root IMAGE0.VCD). This is the sorted,
+// deduped list of matching main PFS partitions enumerated from the APA partition table.
 typedef struct
 {
     int count;
-    char (*names)[APA_IDMAX + 1]; // malloc'd array of partition labels, e.g. "__.POPS", "__.POPS3"
+    char (*names)[APA_IDMAX + 1]; // malloc'd labels, e.g. "__.POPS3", "PP.Game", "__.Hidden"
 } hdd_pops_list_t;
 
 typedef struct
@@ -74,8 +74,11 @@ void hddSetIdleTimeout(int timeout);
 void hddSetIdleImmediate(void);
 int hddGetHDLGamelist(hdl_games_list_t *game_list);
 void hddFreeHDLGamelist(hdl_games_list_t *game_list);
-// Enumerate the present __.POPS / __.POPS0..9 APA partitions (HDD PS1/VCD store). Fills a sorted,
-// deduped list; returns the count (0 on none/error). Free via hddFreePopsPartitionList.
+// True for a one-game PP.<name> / __.<name> partition label, excluding the exact __.POPS[0-9]?
+// container names. Matching is case-sensitive, like POPSTARTER's partition selector.
+int hddIsPopsPartitionGame(const char *name);
+// Enumerate the present classic-container and one-game APA/PFS partitions. Fills a sorted, deduped
+// list; returns the count (0 on none/error). Free via hddFreePopsPartitionList.
 int hddGetPopsPartitionList(hdd_pops_list_t *list);
 void hddFreePopsPartitionList(hdd_pops_list_t *list);
 int hddSetHDLGameInfo(hdl_game_info_t *ginfo);

--- a/include/opl.h
+++ b/include/opl.h
@@ -77,6 +77,10 @@ int loadConfig(int types);
 int saveConfig(int types, int showUI);
 void applyConfig(int themeID, int langID, int skipDeviceRefresh);
 void menuDeferredUpdate(void *data);
+// Queue an immediate list rebuild for every enabled VCD-capable device page. Runtime settings that
+// call vcdMarkAllDirty() need this because no-auto-refresh modes (notably HDD) will not consume the
+// dirty flag on their own. Favourites are rebuilt separately through loadFavourites().
+void oplQueueVcdDeviceUpdates(void);
 void moduleUpdateMenu(int mode, int themeChanged, int langChanged);
 void handleLwnbdSrv();
 void deinit(int exception, int modeSelected);

--- a/src/gui.c
+++ b/src/gui.c
@@ -631,6 +631,7 @@ void guiShowVcdConfig(void)
     diaSetVisible(diaVcdConfig, CFG_LBL_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
     diaSetVisible(diaVcdConfig, CFG_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
 
+    int rebuildVcdLists = 0;
     int ret = diaExecuteDialog(diaVcdConfig, -1, 1, &guiVcdUpdater);
     if (ret) {
         diaGetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, &gPopstarterDevice);
@@ -650,8 +651,10 @@ void guiShowVcdConfig(void)
             // lists only -- Favourites are intentionally left unfiltered (an explicit user pick).
             int previousFirstDiscOnly = gVcdFirstDiscOnly;
             diaGetInt(diaVcdConfig, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
-            if (gVcdFirstDiscOnly != previousFirstDiscOnly)
+            if (gVcdFirstDiscOnly != previousFirstDiscOnly) {
                 vcdMarkAllDirty();
+                rebuildVcdLists = 1;
+            }
         }
         {
             // Equip BDMA modules only when SOURCE or MODE actually changed (the equip copies files to
@@ -680,6 +683,10 @@ void guiShowVcdConfig(void)
         }
         applyConfig(-1, -1, 0);
         menuReinitMainMenu();
+        // Queue after applyConfig/menu reinit so the IO worker cannot rebuild a submenu concurrently
+        // with their support/menu bookkeeping on the GUI thread.
+        if (rebuildVcdLists)
+            oplQueueVcdDeviceUpdates();
     }
 }
 
@@ -866,9 +873,9 @@ reselect_video_mode:
         diaGetInt(diaUIConfig, UICFG_OVERSCAN, &gOverscan);
         int previousGameView = gDefaultGameView;
         diaGetInt(diaUIConfig, UICFG_GAMEVIEW, &gDefaultGameView);
-        if (gDefaultGameView != previousGameView) {
+        int gameViewChanged = gDefaultGameView != previousGameView;
+        if (gameViewChanged) {
             vcdMarkAllDirty(); // rebuild every VCD-capable page so the new default view takes effect
-            loadFavourites();  // re-resolve the Favourites tab against the now-locked source lists
         }
 
         if (ret == UICFG_RESETCOL)
@@ -878,6 +885,13 @@ reselect_video_mode:
             bgmStop();
 
         applyConfig(themeID, langID, 1);
+        if (gameViewChanged) {
+            // applyConfig(..., skipDeviceRefresh=1) deliberately avoids device scans. Queue after it
+            // returns so HDD (which has no automatic refresh) cannot retain PS2 rows while rendering
+            // uses the new VCD view, without racing the theme/menu bookkeeping above.
+            oplQueueVcdDeviceUpdates();
+            loadFavourites(); // queued after source pages so the FAV resolver sees their rebuilt rows
+        }
         sfxInit(0);
 
         if (gEnableBGM && !isBgmPlaying())

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -280,11 +280,34 @@ static int hddPopsNameCompare(const void *a, const void *b)
     return strcmp((const char *)a, (const char *)b);
 }
 
-// Enumerate the HDD's PS1/VCD APA partitions: the "__.POPS"/"__.POPS0..9" multi-VCD store partitions AND
-// the "PP."* single-game installs (one IMAGE0.VCD per partition). Walks the APA partition table with the
-// same fileXioDopen("hdd0:")/fileXioDread primitive as hddGetHDLGamelist, keeping each distinct MAIN
-// partition with either prefix. The result is qsort'd by label for a deterministic order (APA on-disk
-// order is not relied on). The caller (hddBuildVcdGameList) branches on the label prefix.
+#define HDD_APA_ATTR_MAIN_PARTITION 0x0000
+#define HDD_APA_FS_TYPE_PFS         0x0100
+
+// POPS' pooled HDD layout recognizes exactly eleven container labels: __.POPS and __.POPS0..9.
+// A looser prefix match misclassifies labels such as __.POPS12, which POPSLoader treats as a possible
+// one-game hidden partition and accepts only after finding IMAGE0.VCD at its root.
+static int hddIsPopsContainerName(const char *name)
+{
+    if (name == NULL || strncmp(name, "__.POPS", 7) != 0)
+        return 0;
+    return name[7] == '\0' || (name[7] >= '0' && name[7] <= '9' && name[8] == '\0');
+}
+
+int hddIsPopsPartitionGame(const char *name)
+{
+    if (name == NULL)
+        return 0;
+    if (strncmp(name, "PP.", 3) != 0 && strncmp(name, "__.", 3) != 0)
+        return 0;
+    if (name[3] == '\0')
+        return 0; // require a non-empty tail after PP. / __.
+    return !hddIsPopsContainerName(name);
+}
+
+// Enumerate the HDD's PS1/VCD APA partitions: exact __.POPS / __.POPS0..9 multi-VCD containers and
+// PP.<name> / __.<name> one-game installs. Mirror POPSLoader's APA-table filter: only main PFS records
+// can be mounted and scanned. In particular, ordinary HDL games also commonly use PP.* labels but have
+// mode 0x1337; filtering them here avoids a failed PFS mount for every PS2 game during a VCD refresh.
 int hddGetPopsPartitionList(hdd_pops_list_t *list)
 {
     iox_dirent_t dirent;
@@ -298,13 +321,10 @@ int hddGetPopsPartitionList(hdd_pops_list_t *list)
         return 0;
 
     while (fileXioDread(fd, &dirent) > 0) {
-        // Two HDD-resident PS1/VCD partition shapes: the "__.POPS"* multi-VCD store, and "PP."* single-game
-        // installs (one IMAGE0.VCD per partition, named by the partition label). XX.* (BDMA) / SB.* (SMBv1)
-        // launchers source their VCD off-HDD and are intentionally excluded here.
-        if (strncmp(dirent.name, "__.POPS", 7) != 0 && strncmp(dirent.name, "PP.", 3) != 0)
-            continue; // not an HDD-resident PS1/VCD partition
-        if (dirent.stat.attr & APA_FLAG_SUB)
-            continue; // main partition only (skip sub-partitions)
+        if (dirent.stat.attr != HDD_APA_ATTR_MAIN_PARTITION || dirent.stat.mode != HDD_APA_FS_TYPE_PFS)
+            continue; // skip APA sub-partitions and HDL/raw/system formats
+        if (!hddIsPopsContainerName(dirent.name) && !hddIsPopsPartitionGame(dirent.name))
+            continue; // not an HDD-resident PS1/VCD source
 
         int dup = 0;
         for (i = 0; i < count; i++) {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -39,8 +39,9 @@ static unsigned char hddSupportModulesLoaded = 0;
 static char *hddPrefix = "pfs0:";
 static hdl_games_list_t hddGames;
 
-// HDD VCD view: PS1 .VCD games gathered from the __.POPS* APA partitions. hddVcdParts is index-
-// parallel to hddVcdGames -- it records which partition each VCD lives on (for the launch handoff).
+// HDD VCD view: PS1 games gathered from pooled __.POPS[0-9]? partitions and one-game PP. / __.
+// partitions. hddVcdParts is index-parallel to hddVcdGames -- it records the full owning partition
+// label for the launch handoff.
 static base_game_info_t *hddVcdGames = NULL;
 static int hddVcdGameCount = 0;
 static char (*hddVcdParts)[APA_IDMAX + 1] = NULL;
@@ -373,7 +374,7 @@ item_list_t *hddGetObject(int initOnly)
     return &hddGameList;
 }
 
-// ---- HDD VCD view (PS1 .VCD on the __.POPS* APA partitions) -------------------------------
+// ---- HDD VCD view (PS1 games on APA/PFS partitions) ---------------------------------------
 
 static void hddFreeVcdGameList(void)
 {
@@ -384,11 +385,11 @@ static void hddFreeVcdGameList(void)
     hddVcdGameCount = 0;
 }
 
-// Build the HDD VCD game list by scanning every present __.POPS* APA partition. Each is mounted
-// read-only on pfs0:, its root scanned for *.VCD, and the results appended to hddVcdGames, with the
-// owning partition label kept index-parallel in hddVcdParts (so the launch path knows which partition
-// to hand POPSTARTER). The default OPL data-partition mount is restored at the end -- pfs0: is the
-// single shared slot, so the rest of HDD mode breaks if we leave it pointed elsewhere. Returns the count.
+// Build the HDD VCD game list from both supported APA/PFS shapes. Exact __.POPS / __.POPS0..9
+// containers contribute every root *.VCD; PP.<name> / __.<name> candidates contribute one entry only
+// after a root IMAGE0.VCD probe succeeds. Each partition is mounted read-only on pfs0:, and its full
+// label is kept index-parallel in hddVcdParts for POPSTARTER. The default OPL data-partition mount is
+// restored at the end -- pfs0: is the single shared slot, so HDD mode breaks if it is left elsewhere.
 // Bounded wait (ticks, ~1ms each) for the art worker to drain before we remount pfs0:. Matches the
 // MMCE art-abort budget; long enough for an in-flight pfs cover read to abort at its next row
 // boundary, short enough that a truly-wedged read can't hang the view switch forever.
@@ -402,7 +403,7 @@ static int hddBuildVcdGameList(void)
     hddFreeVcdGameList();
 
     if (hddGetPopsPartitionList(&parts) <= 0)
-        return 0; // no __.POPS* partitions; pfs0: was not touched here
+        return 0; // no matching PFS partitions; pfs0: was not touched here
 
     // pfs0: is the single shared ps2fs slot; umounting it in the loop below while the cache art
     // worker still holds an open pfs0: cover fd is the documented HDD-freeze hazard (see hddLaunchVcd).
@@ -422,15 +423,16 @@ static int hddBuildVcdGameList(void)
         if (fileXioMount(hddPrefix, mountSrc, FIO_MT_RDONLY) < 0)
             continue; // can't mount this partition -> skip it
 
-        // PP.* single-game install: ONE IMAGE0.VCD on the partition root, displayed by the partition
-        // label minus "PP." (the launch keys off the FULL label -- see hddDoLaunchVcd). __.POPS* stores
-        // (handled below) hold MANY .VCD files named per game.
-        if (strncmp(parts.names[p], "PP.", 3) == 0) {
+        // PP.<name> / __.<name> one-game install: require ONE exact IMAGE0.VCD at the partition root,
+        // display the label without its three-character prefix, and retain the FULL label for launch.
+        // The name predicate excludes the exact __.POPS[0-9]? pooled containers handled below.
+        if (hddIsPopsPartitionGame(parts.names[p])) {
             int imgfd = open("pfs0:/IMAGE0.VCD", O_RDONLY);
+            if (imgfd >= 0)
+                close(imgfd); // close before unmount; ps2fs may reject an unmount with a live fd
             fileXioUmount(hddPrefix);
             if (imgfd < 0)
-                continue; // no IMAGE0.VCD here -> not a usable PP. install
-            close(imgfd);
+                continue; // candidate name alone is insufficient (PP.* HDDOSD apps are common)
 
             base_game_info_t *grownGames = realloc(hddVcdGames, (total + 1) * sizeof(base_game_info_t));
             if (grownGames == NULL)
@@ -443,11 +445,11 @@ static int hddBuildVcdGameList(void)
 
             base_game_info_t *g = &hddVcdGames[total];
             memset(g, 0, sizeof(base_game_info_t));
-            snprintf(g->name, sizeof(g->name), "%s", parts.names[p] + 3); // strip "PP." -> display name
+            snprintf(g->name, sizeof(g->name), "%s", parts.names[p] + 3); // strip PP. / __. for display
             snprintf(g->extension, sizeof(g->extension), ".VCD");
             g->parts = 1;
             g->format = GAME_FORMAT_ISO;                                       // harmless; VCD flag gates the launch
-            snprintf(hddVcdParts[total], APA_IDMAX + 1, "%s", parts.names[p]); // FULL label, e.g. PP.GAME
+            snprintf(hddVcdParts[total], APA_IDMAX + 1, "%s", parts.names[p]); // case-preserved full label
             total += 1;
             continue;
         }
@@ -646,11 +648,10 @@ static int hddResolveHddPopstarter(char *elfOut, int elfLen)
     return 0;
 }
 
-// Shared POPSTARTER handoff for an HDD VCD. argv[0] differs by partition shape: a PP.* single-game
-// install boots by its PARTITION LABEL (e.g. PP.GAME.ELF), a __.POPS* store entry boots by the VCD name
-// (e.g. GAME.ELF). The owning partition (`part`) is passed OUT OF BAND so POPSTARTER self-mounts it after
-// the IOP reset. Everything is built on stack BEFORE deinit() frees the VCD list. Used by both the
-// in-view menu launch and the Favourites tab (hddLaunchVcd).
+// Shared POPSTARTER handoff for an HDD VCD. argv[0] differs by partition shape: PP.<name> / __.<name>
+// one-game installs boot by their literal PARTITION LABEL; a pooled __.POPS[0-9]? entry boots by its
+// VCD name. The owning partition (`part`) is passed OUT OF BAND so POPSTARTER self-mounts it after the
+// IOP reset. Everything is built on stack BEFORE deinit() frees the VCD list.
 static void hddDoLaunchVcd(item_list_t *itemList, const char *name, const char *part)
 {
     char vcdElf[256], vcdSelector[320], vcdPart[64];
@@ -658,10 +659,10 @@ static void hddDoLaunchVcd(item_list_t *itemList, const char *name, const char *
     if (name == NULL || name[0] == '\0' || part == NULL || part[0] == '\0')
         return;
 
-    if (strncmp(part, "PP.", 3) == 0)
-        snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", part); // PP.GAME.ELF (the partition label)
+    if (hddIsPopsPartitionGame(part))
+        snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", part); // literal PP.Game.ELF / __.Hidden.ELF
     else
-        snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", name); // GAME.ELF (the __.POPS* VCD name)
+        snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", name); // GAME.ELF (pooled-container VCD)
     snprintf(vcdPart, sizeof(vcdPart), "hdd0:%s:", part);           // self-mount target, hdd0:PART:
 
     // Resolve + keep pfs0: on the POPSTARTER.ELF partition. Quiesce art+IO first (this remounts pfs0:).

--- a/src/opl.c
+++ b/src/opl.c
@@ -551,6 +551,19 @@ opl_io_module_t *oplGetModule(int mode)
     return &list_support[mode];
 }
 
+void oplQueueVcdDeviceUpdates(void)
+{
+    // vcdMarkAllDirty() is intentionally side-effect-free because it also runs during early config
+    // loading, before the IO worker and device modules are ready. Runtime callers must explicitly
+    // enqueue the enabled pages. This matters most for HDD, whose updateDelay=-1 means a dirty view
+    // otherwise keeps displaying the old submenu indefinitely while rendering uses the new view.
+    for (int i = 0; i < MODE_COUNT; i++) {
+        item_list_t *support = list_support[i].support;
+        if (support != NULL && support->enabled && support->mode != FAV_MODE && vcdModeSupported(support->mode))
+            ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
+    }
+}
+
 void initSupport(item_list_t *itemList, int mode, int force_reinit)
 {
     opl_io_module_t *mod = &list_support[mode];


### PR DESCRIPTION
## Summary

- queue VCD-capable page rebuilds when runtime VCD view settings change, so HDD cannot keep stale PS2 rows while rendering VCD art
- scan HDD APA/PFS VCD sources with POPSLoader-compatible rules: exact `__.POPS` / `__.POPS0`..`__.POPS9` containers, `PP.<name>` and hidden `__.<name>` one-game partitions, main PFS records only, and an exact `IMAGE0.VCD` probe before listing a one-game candidate
- launch partition-installed HDD VCD games with their full case-preserved partition label, and update README / VCD docs for the supported APA layouts

## Root Cause

The VCD art path switched immediately, but some runtime settings only marked VCD lists dirty. HDD mode does not auto-consume that dirty flag, so the page could keep the old PS2 submenu while rendering in VCD mode.

The HDD VCD scanner also only handled the older loose `__.POPS*` / `PP.*` shape. POPSLoader supports exact pooled `__.POPS` containers plus both visible `PP.<name>` and hidden `__.<name>` one-game partitions, gated by `IMAGE0.VCD`.

## Validation

- `git diff --check`
- throwaway PS2 SDK Docker build: `make clean release`

Hardware validation still recommended on real APA HDD media for L3/default-view switching, pooled `__.POPS*`, visible `PP.*`, and hidden `__.*` one-game installs.