### PR TITLE
fix(vcd,pad): preserve POPStarter selectors and recover analog mode

### DIFF
--- a/docs/VCD.md
+++ b/docs/VCD.md
@@ -120,6 +120,10 @@ POPSTARTER needs extra block-device modules (the BDMAssault / "BDMA" drivers). R
 *equips* them for you from **General Settings** — you supply the module files, RiptOPL
 copies the right pair onto your memory card:
 
+RiptOPL prefers an existing `mc0:/POPSTARTER` or `mc1:/POPSTARTER` folder. On first setup it
+creates the folder on the first present card (slot 1, then slot 2). Both replacement modules are
+staged before the live pair is changed, so a failed copy leaves the previous pair available.
+
 - **VCD BDMA Apply on Launch** *(default On)* — POPSTARTER does its own IOP reset and reloads
   its block-device driver from the memory card, so the right exFAT variant must already be on
   the card or the game drops to OSDSYS. When **On**, RiptOPL equips the variant matching the

--- a/include/system.h
+++ b/include/system.h
@@ -49,9 +49,9 @@ void sysLaunchNeutrino(const char *driver, const char *path, const char *startup
 // Neutrino leg. Returns 0 = proceed; <0 = abort the launch (a toast has already been shown).
 int sysNeutrinoPreflight(const char *driver, const char *neutrinoPath);
 
-// Launch an external POPSTARTER.ELF for a PS1 VCD. selector = the argv[0] "<POPS>/<prefix><name>.ELF"
-// token; partition = "" for non-HDD. Caller deinit()s with UNMOUNT_EXCEPTION first (see system.c).
-void sysLaunchPopstarter(const char *popstarterElf, const char *selector, const char *partition);
+// Launch an external POPSTARTER.ELF for a PS1 VCD. selector = the target's argv[0]
+// "<POPS>/<prefix><name>.ELF" token. Caller deinit()s with UNMOUNT_EXCEPTION first (see system.c).
+void sysLaunchPopstarter(const char *popstarterElf, const char *selector);
 
 // ELF handoff that KEEPS the IOP (drivers + mounts) alive -- NHDDL parity: the vendored elfldr/
 // child loader SifLoadElf()s the target through OPL's live mounts and never SifIopReset()s (the

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -678,7 +678,7 @@ static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     }
 
     deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the VCD device mounted across the IOP reset
-    sysLaunchPopstarter(vcdElf, vcdSelector, "");
+    sysLaunchPopstarter(vcdElf, vcdSelector);
 }
 
 // Δ9 (NHDDL parity): Neutrino's bd backend packs the ISO and BOTH -mc VMCs into ONE shared

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -637,7 +637,7 @@ static void ethLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     }
     vcdBuildSelector(ethPrefix, VCD_PREFIX_SMB, vcdName, vcdSelector, sizeof(vcdSelector));
     deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the SMB mount alive across the IOP reset
-    sysLaunchPopstarter(vcdElf, vcdSelector, "");
+    sysLaunchPopstarter(vcdElf, vcdSelector);
 }
 
 static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -640,12 +640,12 @@ static int hddResolveHddPopstarter(char *elfOut, int elfLen)
 }
 
 // Shared POPSTARTER handoff for an HDD VCD. argv[0] differs by partition shape: PP.<name> / __.<name>
-// one-game installs boot by their literal PARTITION LABEL; a pooled __.POPS[0-9]? entry boots by its
-// VCD name. The owning partition (`part`) is passed OUT OF BAND so POPSTARTER self-mounts it after the
-// IOP reset. Everything is built on stack BEFORE deinit() frees the VCD list.
+// one-game installs boot by their literal partition label; a pooled __.POPS[0-9]? entry boots by its
+// VCD name. POPSTARTER derives the HDD route from that selector, so it must remain target argv[0].
+// Everything is built on stack before deinit() frees the VCD list.
 static void hddDoLaunchVcd(item_list_t *itemList, const char *name, const char *part)
 {
-    char vcdElf[256], vcdSelector[320], vcdPart[64];
+    char vcdElf[256], vcdSelector[320];
 
     if (name == NULL || name[0] == '\0' || part == NULL || part[0] == '\0')
         return;
@@ -654,7 +654,6 @@ static void hddDoLaunchVcd(item_list_t *itemList, const char *name, const char *
         snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", part); // literal PP.Game.ELF / __.Hidden.ELF
     else
         snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", name); // GAME.ELF (pooled-container VCD)
-    snprintf(vcdPart, sizeof(vcdPart), "hdd0:%s:", part);           // self-mount target, hdd0:PART:
 
     // Resolve + keep pfs0: on the POPSTARTER.ELF partition. Quiesce art+IO first (this remounts pfs0:).
     cacheAbortMmceImageLoadsTimed(0);
@@ -666,9 +665,9 @@ static void hddDoLaunchVcd(item_list_t *itemList, const char *name, const char *
         return;
     }
     // Success: leave IO blocked (deinit re-blocks anyway) and pfs0: on the POPSTARTER partition for the
-    // load below. sysLaunchPopstarter reboots into POPSTARTER, so there is nothing to unblock.
+    // argv-preserving load below. POPSTARTER takes over and performs its own IOP reset.
     deinit(UNMOUNT_EXCEPTION, itemList->mode);
-    sysLaunchPopstarter(vcdElf, vcdSelector, vcdPart);
+    sysLaunchPopstarter(vcdElf, vcdSelector);
 }
 
 // Launch an HDD PS1/.VCD entry BY NAME -- the Favourites tab's view-independent entry point. The

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -533,7 +533,7 @@ static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set
     // (POPSTARTER owns everything past the exec); a failed equip just toasts its diagnostic in passing.
     vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MMCE, VCD_BDMA_MMCE);
     deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the MMCE device mounted across the IOP reset
-    sysLaunchPopstarter(vcdElf, vcdSelector, "");
+    sysLaunchPopstarter(vcdElf, vcdSelector);
 }
 
 void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)

--- a/src/pad.c
+++ b/src/pad.c
@@ -39,15 +39,15 @@ struct pad_data_t
 
     char actAlign[6];
     int actuators;
-    int analogCapable;   // -1 unknown/not ready, 0 digital-only, 1 DualShock-capable
+    int analogCapable; // -1 unknown/not ready, 0 digital-only, 1 DualShock-capable
     int analogRetryDelay;
 };
 
 // Pad commands are asynchronous. Keep every wait bounded so a transient SIO2/pad error cannot hang the
 // GUI thread, then retry DualShock recovery periodically for as long as the controller remains digital.
-#define PAD_WAIT_POLLS              25
-#define PAD_WAIT_POLL_US            1000
-#define PAD_ANALOG_RETRY_DELAY      60
+#define PAD_WAIT_POLLS         25
+#define PAD_WAIT_POLL_US       1000
+#define PAD_ANALOG_RETRY_DELAY 60
 
 #define PAD_INIT_RETRY       -1
 #define PAD_INIT_UNSUPPORTED 0

--- a/src/pad.c
+++ b/src/pad.c
@@ -7,6 +7,7 @@
 #include "include/opl.h"
 #include "include/pad.h"
 #include "include/ioman.h"
+#include <delaythread.h>
 #include <libpad.h>
 #include <timer.h>
 #include <time.h>
@@ -38,15 +39,19 @@ struct pad_data_t
 
     char actAlign[6];
     int actuators;
-    int analogRetries; // bounded self-heal budget (frames): re-init a connected DualShock stuck in digital
+    int analogCapable;   // -1 unknown/not ready, 0 digital-only, 1 DualShock-capable
+    int analogRetryDelay;
 };
 
-// Cold-boot analog self-heal: if a controller's mode table isn't ready when initializePad first runs, it's
-// misread as digital and analog is never enabled -- and the only other re-init path is a physical
-// disconnect, which a slow-to-init (never-disconnected) pad never hits, so analog stays dead all session.
-// Re-run initializePad for up to this many frames while a connected pad reads as non-analog. A genuinely
-// digital controller just exhausts the budget harmlessly (initializePad bails before touching the mode).
-#define PAD_ANALOG_SELFHEAL_FRAMES 120
+// Pad commands are asynchronous. Keep every wait bounded so a transient SIO2/pad error cannot hang the
+// GUI thread, then retry DualShock recovery periodically for as long as the controller remains digital.
+#define PAD_WAIT_POLLS              25
+#define PAD_WAIT_POLL_US            1000
+#define PAD_ANALOG_RETRY_DELAY      60
+
+#define PAD_INIT_RETRY       -1
+#define PAD_INIT_UNSUPPORTED 0
+#define PAD_INIT_OK          1
 
 /// current time in miliseconds (last update time)
 static u32 curtime = 0;
@@ -82,34 +87,64 @@ static const int keyToPad[17] = {
     PAD_R2,
     PAD_L2};
 
+static int isPadReadyState(int state)
+{
+    return (state == PAD_STATE_STABLE) || (state == PAD_STATE_FINDCTP1);
+}
+
 /*
  * waitPadReady()
  */
 static int waitPadReady(struct pad_data_t *pad)
 {
-    int state;
+    int state = PAD_STATE_DISCONN;
+    int polls;
 
-    // busy wait for the pad to get ready
-    do {
+    for (polls = 0; polls < PAD_WAIT_POLLS; polls++) {
         state = padGetState(pad->port, pad->slot);
-    } while ((state != PAD_STATE_STABLE) && (state != PAD_STATE_FINDCTP1) && (state != PAD_STATE_DISCONN));
+        if (isPadReadyState(state) || (state == PAD_STATE_DISCONN))
+            return state;
+        DelayThread(PAD_WAIT_POLL_US);
+    }
+
+    LOG("PAD pad %d,%d ready wait timed out in state %d\n", pad->port, pad->slot, state);
 
     return state;
-};
+}
 
-static void initializePad(struct pad_data_t *pad)
+static int waitPadRequestComplete(struct pad_data_t *pad)
+{
+    int reqState = PAD_RSTAT_BUSY;
+    int polls;
+
+    for (polls = 0; polls < PAD_WAIT_POLLS; polls++) {
+        reqState = padGetReqState(pad->port, pad->slot);
+        if (reqState != PAD_RSTAT_BUSY)
+            return reqState == PAD_RSTAT_COMPLETE;
+        DelayThread(PAD_WAIT_POLL_US);
+    }
+
+    LOG("PAD pad %d,%d request timed out\n", pad->port, pad->slot);
+    return 0;
+}
+
+static int initializePad(struct pad_data_t *pad)
 {
     int tmp;
     int modes;
     int i;
+    int state;
 
     LOG("PAD initializing pad %d,%d\n", pad->port, pad->slot);
 
     // is there any device connected to that port?
-    if (waitPadReady(pad) == PAD_STATE_DISCONN) {
+    state = waitPadReady(pad);
+    if (state == PAD_STATE_DISCONN) {
         LOG("PAD pad %d,%d not connected.\n", pad->port, pad->slot);
-        return; // nope, don't waste your time here!
+        return PAD_INIT_RETRY;
     }
+    if (!isPadReadyState(state))
+        return PAD_INIT_RETRY;
 
     // How many different modes can this device operate in?
     // i.e. get # entrys in the modetable
@@ -130,11 +165,11 @@ static void initializePad(struct pad_data_t *pad)
     tmp = padInfoMode(pad->port, pad->slot, PAD_MODECURID, 0);
     LOG("PAD It is currently using mode %d\n", tmp);
 
-    // If modes == 0, this is not a Dual shock controller
-    // (it has no actuator engines)
-    if (modes == 0) {
-        LOG("PAD This is a digital controller?\n");
-        return;
+    // A not-yet-ready DualShock also reports an empty mode table, so keep it retryable. Once a
+    // non-empty table proves that DualShock mode is absent, mark the controller unsupported.
+    if (modes <= 0) {
+        LOG("PAD mode table is not ready (or controller is digital-only)\n");
+        return PAD_INIT_RETRY;
     }
 
     // Verify that the controller has a DUAL SHOCK mode
@@ -147,31 +182,42 @@ static void initializePad(struct pad_data_t *pad)
 
     if (i >= modes) {
         LOG("PAD This is no Dual Shock controller\n");
-        return;
+        pad->analogCapable = 0;
+        return PAD_INIT_UNSUPPORTED;
     }
+    pad->analogCapable = 1;
 
     // If ExId != 0x0 => This controller has actuator engines
     // This check should always pass if the Dual Shock test above passed
     tmp = padInfoMode(pad->port, pad->slot, PAD_MODECUREXID, 0);
     if (tmp == 0) {
         LOG("PAD This is no Dual Shock controller??\n");
-        return;
+        return PAD_INIT_RETRY;
     }
 
     LOG("PAD Enabling dual shock functions\n");
 
     // When using MMODE_LOCK, user cant change mode with Select button
-    padSetMainMode(pad->port, pad->slot, PAD_MMODE_DUALSHOCK, PAD_MMODE_LOCK);
+    tmp = padSetMainMode(pad->port, pad->slot, PAD_MMODE_DUALSHOCK, PAD_MMODE_LOCK);
+    if (tmp != 1 || !waitPadRequestComplete(pad)) {
+        LOG("PAD padSetMainMode failed: accepted=%d req=%d\n", tmp, padGetReqState(pad->port, pad->slot));
+        return PAD_INIT_RETRY;
+    }
 
-    waitPadReady(pad);
+    if (!isPadReadyState(waitPadReady(pad)))
+        return PAD_INIT_RETRY;
     tmp = padInfoPressMode(pad->port, pad->slot);
     LOG("PAD infoPressMode: %d\n", tmp);
 
-    waitPadReady(pad);
+    if (!isPadReadyState(waitPadReady(pad)))
+        return PAD_INIT_RETRY;
     tmp = padEnterPressMode(pad->port, pad->slot);
     LOG("PAD enterPressMode: %d\n", tmp);
+    if (tmp == 1 && !waitPadRequestComplete(pad))
+        LOG("PAD enterPressMode request failed\n");
 
-    waitPadReady(pad);
+    if (!isPadReadyState(waitPadReady(pad)))
+        return PAD_INIT_OK; // analog mode is restored; pressure/rumble setup can wait for reconnect
     pad->actuators = padInfoAct(pad->port, pad->slot, -1, 0);
     LOG("PAD # of actuators: %d\n", pad->actuators);
 
@@ -183,14 +229,18 @@ static void initializePad(struct pad_data_t *pad)
         pad->actAlign[4] = 0xff;
         pad->actAlign[5] = 0xff;
 
-        waitPadReady(pad);
+        if (!isPadReadyState(waitPadReady(pad)))
+            return PAD_INIT_OK;
         tmp = padSetActAlign(pad->port, pad->slot, pad->actAlign);
         LOG("PAD padSetActAlign: %d\n", tmp);
+        if (tmp == 1 && !waitPadRequestComplete(pad))
+            LOG("PAD padSetActAlign request failed\n");
     } else {
         LOG("PAD Did not find any actuators.\n");
     }
 
     waitPadReady(pad);
+    return PAD_INIT_OK;
 }
 
 static void updatePadState(struct pad_data_t *pad, int state)
@@ -259,12 +309,15 @@ static int readPad(struct pad_data_t *pad)
     if ((oldState == PAD_STATE_DISCONN) && ((pad->state == PAD_STATE_STABLE) || (pad->state == PAD_STATE_FINDCTP1))) {
         // Pad just connected.
         LOG("PAD pad %d,%d connected\n", pad->port, pad->slot);
+        pad->analogCapable = -1;
+        pad->analogRetryDelay = 0;
         initializePad(pad);
-        pad->analogRetries = PAD_ANALOG_SELFHEAL_FRAMES; // arm the self-heal below in case the mode table wasn't ready yet
     }
     // The pad may transit from any state to disconnected. So check only for the disconnected state.
     else if ((oldState != PAD_STATE_DISCONN) && (pad->state == PAD_STATE_DISCONN)) {
         LOG("PAD pad %d,%d disconnected\n", pad->port, pad->slot);
+        pad->analogCapable = -1;
+        pad->analogRetryDelay = 0;
     }
 
     if ((pad->state == PAD_STATE_STABLE) || (pad->state == PAD_STATE_FINDCTP1)) {
@@ -275,13 +328,19 @@ static int readPad(struct pad_data_t *pad)
             newpdata = 0xffff ^ pad->buttons.btns;
             padsRead++;
 
-            // Self-heal a DualShock that missed the cold-boot analog-mode set: while a connected pad reads as
-            // non-analog (mode high-nibble != 0x7 = not DualShock/analog) and the budget isn't spent, re-run
-            // initializePad. It succeeds once the mode table is ready (mode flips to analog, stopping this); a
-            // real digital controller just burns the budget with fast no-op inits (see PAD_ANALOG_SELFHEAL_FRAMES).
-            if ((pad->buttons.mode >> 4) != 0x07 && pad->analogRetries > 0) {
-                pad->analogRetries--;
-                initializePad(pad);
+            if ((pad->buttons.mode >> 4) == 0x07) {
+                pad->analogCapable = 1;
+                pad->analogRetryDelay = 0;
+            } else if (pad->analogCapable != 0) {
+                // freepad can temporarily return a pad to digital mode while recovering from a read error.
+                // Retry forever with a backoff; a real digital-only controller is disabled once its non-empty
+                // mode table proves that DualShock mode is absent.
+                if (pad->analogRetryDelay > 0) {
+                    pad->analogRetryDelay--;
+                } else {
+                    int initResult = initializePad(pad);
+                    pad->analogRetryDelay = (initResult == PAD_INIT_OK) ? 1 : PAD_ANALOG_RETRY_DELAY;
+                }
             }
         }
     }
@@ -494,12 +553,9 @@ static int startPad(struct pad_data_t *pad)
         return 0;
     }
 
+    pad->analogCapable = -1;
+    pad->analogRetryDelay = 0;
     initializePad(pad);
-    // Arm the self-heal for pads present at cold boot: startPads() drives them straight to
-    // STABLE/FINDCTP1 here, so readPad's connect block (which arms on DISCONN->connected) never
-    // fires for them. Without this the budget stays 0 and the self-heal is inert at boot -- the
-    // exact case it exists for.
-    pad->analogRetries = PAD_ANALOG_SELFHEAL_FRAMES;
 
     newState = waitPadReady(pad);
     updatePadState(pad, newState);

--- a/src/pad.c
+++ b/src/pad.c
@@ -338,8 +338,8 @@ static int readPad(struct pad_data_t *pad)
                 if (pad->analogRetryDelay > 0) {
                     pad->analogRetryDelay--;
                 } else {
-                    int initResult = initializePad(pad);
-                    pad->analogRetryDelay = (initResult == PAD_INIT_OK) ? 1 : PAD_ANALOG_RETRY_DELAY;
+                    initializePad(pad);
+                    pad->analogRetryDelay = PAD_ANALOG_RETRY_DELAY;
                 }
             }
         }

--- a/src/system.c
+++ b/src/system.c
@@ -1433,7 +1433,7 @@ void sysLaunchNeutrino(const char *driver, const char *path, const char *startup
 // POPSTARTER itself re-derives the matching .VCD from), copies both to stack buffers, and
 // deinit()s the owning device with UNMOUNT_EXCEPTION BEFORE calling this -- the same contract as
 // sysLaunchNeutrino (so the VCD-holding device stays mounted across the IOP reset).
-void sysLaunchPopstarter(const char *popstarterElf, const char *selector, const char *partition)
+void sysLaunchPopstarter(const char *popstarterElf, const char *selector)
 {
     if (popstarterElf == NULL || selector == NULL) {
         LOG("[POPS] null arg, abort\n");
@@ -1442,23 +1442,13 @@ void sysLaunchPopstarter(const char *popstarterElf, const char *selector, const 
 
     char *argv[1];
     argv[0] = (char *)selector;
-    LOG("[POPS] elf=%s argv0=%s part=%s\n", popstarterElf, selector, partition ? partition : "");
+    LOG("[POPS] elf=%s argv0=%s\n", popstarterElf, selector);
 
-    if (partition != NULL && partition[0] != '\0') {
-        // HDD/APA launches keep the classic resetting loader: the partition-context handoff is
-        // the hardware-proven PP. path, and POPSTARTER's HDD route is the CORRECT one there.
-        LoadELFFromFileWithPartition(popstarterElf, partition, 1, argv);
-        return;
-    }
-
-    // BDMA/SMB: POPSTARTER string-parses ARGV[0] for the XX./SB. selector prefix to pick its
-    // backend. The stock SDK loader CLOBBERS the target's argv[0] with "<partition><filename>"
-    // and shifts the selector to argv[1] -- POPSTARTER then saw a prefixless "POPSTARTER.ELF"
-    // basename, took its HDD route, and died on "__common" (issues #56/#69: PS1 launch failing
-    // on every non-HDD device, regardless of the selector STRING, which PR #66 already fixed).
-    // Hand off via the argv-preserving no-reset loader instead -- POPSLoader parity: its loader
-    // "preserves caller args" and defaults REBOOT_IOP_WHILE_LOADING_POPSTARTER=0; POPSTARTER
-    // does its own IOP reset and reloads its drivers from the MC regardless.
+    // Every POPSTARTER route, including APA HDD, depends on the selector remaining target argv[0].
+    // The stock SDK partition loader replaces it with the ELF load path and shifts the selector to
+    // argv[1]; pooled __.POPS installs then lose their only selected-game identity. The caller has
+    // already kept the POPSTARTER device mounted, so use the argv-preserving loader uniformly.
+    // POPSTARTER performs its own IOP reset and device/partition discovery from the selector.
     if (sysLoadELFKeepIOP(popstarterElf, "", 1, argv) < 0)
         LOG("[POPS] keep-IOP handoff failed for %s\n", popstarterElf);
 }

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -585,11 +585,18 @@ static const char *vcdBdmaModule[2] = {"usbd.irx", "usbhdfsd.irx"};
 
 #define VCD_BDMA_MARKER "bdma_config.txt"
 
-// Resolve the memory-card POPSTARTER folder (where the modules live). Prefer an existing
-// mc?:/POPSTARTER; if neither card has one, default to mc0 and create it. Always returns 1.
+// Resolve the memory-card POPSTARTER folder (where the modules live). Prefer an existing folder;
+// otherwise create it on the first present card. A slot-2-only first-time setup must not silently
+// select absent mc0:, and mkdir/probe failure must reach the caller.
 static int vcdResolvePopstarterMc(char *out, int outSize)
 {
     static const char *cards[2] = {"mc0:/POPSTARTER", "mc1:/POPSTARTER"};
+    static const char *roots[2] = {"mc0:/", "mc1:/"};
+
+    if (out == NULL || outSize <= 0)
+        return 0;
+    out[0] = '\0';
+
     for (int i = 0; i < 2; i++) {
         DIR *d = opendir(cards[i]);
         if (d != NULL) {
@@ -598,9 +605,24 @@ static int vcdResolvePopstarterMc(char *out, int outSize)
             return 1;
         }
     }
-    snprintf(out, outSize, "%s", cards[0]);
-    mkdir(out, 0777); // first-time setup: create mc0:/POPSTARTER
-    return 1;
+
+    for (int i = 0; i < 2; i++) {
+        DIR *root = opendir(roots[i]);
+        if (root == NULL)
+            continue;
+        closedir(root);
+
+        snprintf(out, outSize, "%s", cards[i]);
+        mkdir(out, 0777);
+        DIR *created = opendir(out);
+        if (created != NULL) {
+            closedir(created);
+            return 1;
+        }
+    }
+
+    out[0] = '\0';
+    return 0;
 }
 
 // Write the equipped-state marker mc?:/POPSTARTER/bdma_config.txt = the variant token.
@@ -618,7 +640,8 @@ static int vcdWriteBdmaMarker(const char *mcDir, int mode)
 int vcdReadBdmaMode(void)
 {
     char mcDir[64];
-    vcdResolvePopstarterMc(mcDir, sizeof(mcDir));
+    if (!vcdResolvePopstarterMc(mcDir, sizeof(mcDir)))
+        return VCD_BDMA_FAT32;
     char path[96];
     snprintf(path, sizeof(path), "%s/%s", mcDir, VCD_BDMA_MARKER);
     int fd = open(path, O_RDONLY);
@@ -648,7 +671,11 @@ int vcdEquipBdma(int source, int mode, char *diag, int diagSize)
         return -1;
 
     char mcDir[64];
-    vcdResolvePopstarterMc(mcDir, sizeof(mcDir));
+    if (!vcdResolvePopstarterMc(mcDir, sizeof(mcDir))) {
+        if (diag != NULL && diagSize > 0)
+            snprintf(diag, diagSize, "No writable PS2 memory card is available.");
+        return -3;
+    }
 
     char dst0[96], dst1[96];
     snprintf(dst0, sizeof(dst0), "%s/%s", mcDir, vcdBdmaModule[0]);
@@ -735,21 +762,74 @@ int vcdEquipBdma(int source, int mode, char *diag, int diagSize)
         return -4; // the matched SOURCE device had no variant files in its POPS/ (or none matched)
     }
 
-    // Copy both through the free-space-gated safe-copy (each write is space-gated + truncation-safe, so
-    // a failure never corrupts an individual file).
-    int r = vcdSafeCopyFile(src0, dst0);
-    if (r != 0)
-        return r; // -2 (no space) / -3 (IO); dst0 not yet replaced
-    r = vcdSafeCopyFile(src1, dst1);
+    // Stage BOTH replacements and backups before touching either live module. vcdSafeCopyFile removes
+    // a partial destination on failure, which is safe for these private staging names but not for a live
+    // driver. If either commit fails, restore the complete old pair (or the old absence) and still let the
+    // caller follow the established best-effort POPSTARTER handoff policy.
+    char tmp0[96], tmp1[96], bak0[96], bak1[96];
+    snprintf(tmp0, sizeof(tmp0), "%s/%s.new", mcDir, vcdBdmaModule[0]);
+    snprintf(tmp1, sizeof(tmp1), "%s/%s.new", mcDir, vcdBdmaModule[1]);
+    snprintf(bak0, sizeof(bak0), "%s/%s.bak", mcDir, vcdBdmaModule[0]);
+    snprintf(bak1, sizeof(bak1), "%s/%s.bak", mcDir, vcdBdmaModule[1]);
+    unlink(tmp0);
+    unlink(tmp1);
+    unlink(bak0);
+    unlink(bak1);
+
+    int r = vcdSafeCopyFile(src0, tmp0);
+    if (r == 0)
+        r = vcdSafeCopyFile(src1, tmp1);
     if (r != 0) {
-        // First module is now the NEW variant but the second failed -> the card holds a mismatched,
-        // half-equipped pair. Roll back to a clean FAT32/no-modules state (drop the lone new module +
-        // write the FAT32 marker) so the marker readback (vcdReadBdmaMode) stays truthful and POPSTARTER
-        // falls back to its built-in driver instead of loading a mismatched pair.
-        unlink(dst0);
-        vcdWriteBdmaMarker(mcDir, VCD_BDMA_FAT32);
+        unlink(tmp0);
+        unlink(tmp1);
         return r;
     }
+
+    int old0 = open(dst0, O_RDONLY);
+    int old1 = open(dst1, O_RDONLY);
+    int had0 = old0 >= 0;
+    int had1 = old1 >= 0;
+    if (old0 >= 0)
+        close(old0);
+    if (old1 >= 0)
+        close(old1);
+
+    // Same-directory renames avoid a second full copy of every module. Move the old pair aside,
+    // install both staged files, and restore both old names if any step fails.
+    if (had0 && rename(dst0, bak0) != 0)
+        r = -3;
+    if (r == 0 && had1 && rename(dst1, bak1) != 0) {
+        if (had0)
+            rename(bak0, dst0);
+        r = -3;
+    }
+    if (r == 0 && rename(tmp0, dst0) != 0) {
+        if (had0)
+            rename(bak0, dst0);
+        if (had1)
+            rename(bak1, dst1);
+        r = -3;
+    }
+    if (r == 0 && rename(tmp1, dst1) != 0) {
+        unlink(dst0);
+        if (had0)
+            rename(bak0, dst0);
+        if (had1)
+            rename(bak1, dst1);
+        r = -3;
+    }
+    if (r != 0) {
+        unlink(tmp0);
+        unlink(tmp1);
+        unlink(bak0);
+        unlink(bak1);
+        return r;
+    }
+
+    unlink(tmp0);
+    unlink(tmp1);
+    unlink(bak0);
+    unlink(bak1);
 
     int mr = vcdWriteBdmaMarker(mcDir, mode);
     return (mr != 0) ? mr : 0;
@@ -824,7 +904,8 @@ int vcdSmbModulesPresent(void)
 int vcdWritePopstarterNet(const char *ipconfig, const char *smbconfig)
 {
     char mcDir[64];
-    vcdResolvePopstarterMc(mcDir, sizeof(mcDir)); // creates mc0:/POPSTARTER if neither card has it
+    if (!vcdResolvePopstarterMc(mcDir, sizeof(mcDir)))
+        return -3;
     char path[96];
     int r1 = 0, r2 = 0;
     if (ipconfig != NULL) {


### PR DESCRIPTION
## Summary

- make wired DualShock analog recovery bounded, result-aware, and repeatable
- preserve POPStarter's selector as target `argv[0]` for APA HDD as well as BDM/MMCE/SMB
- choose slot 2 correctly for first-time POPStarter memory-card setup
- stage and roll back BDMA driver-pair replacement instead of truncating a live module
- document memory-card selection and pair staging

## Root cause

The pad self-heal used a one-shot retry budget, ignored asynchronous request completion, and could wait forever in the GUI thread. After freepad returned a controller to digital mode during recovery, RiptOPL could permanently stop trying until unplug/replug.

APA VCD launch used the stock partition loader, which replaces target `argv[0]` with the ELF load path and shifts the selected `GAME.ELF` selector to `argv[1]`. Pooled `__.POPS*` installs then lost their selected-game identity.

First-time POPStarter setup always chose `mc0:` when neither POPSTARTER folder existed. BDMA replacement also opened live modules with `O_TRUNC`, allowing a mid-copy failure to leave a broken pair.

## Fix

- bound pad state/request waits and inspect final libpad request status
- retry DualShock analog recovery with backoff instead of a permanent lifetime budget
- route every POPStarter launch through the existing argv-preserving keep-IOP loader
- probe both memory-card roots before creating `POPSTARTER`
- stage both BDMA modules, move the previous pair aside, and roll it back on commit failure
- retain the intentional DEBUG POPStarter used for SMB
- retain best-effort POPStarter handoff when BDMA preparation fails
- do not seek or validate Sony POPS payloads; those remain user-provided and POPStarter-managed

## Validation

- `git diff --check`
- `clang-format --dry-run --Werror` on all changed C/header files
- clean Docker build and link of `opl.elf` with `ps2dev/ps2dev:latest`

Follow-up to #149. Hardware confirmation remains appropriate for the intermittent controller recovery and pooled APA launch paths.