### PR TITLE
fix: make the pfs1: APA-VCD scan and the BDMA equip actually function + storage control-plane hardening (#120 audit triage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It supports six categories of devices:
 6. ATA/IDE HDDs, including internal exFAT configurations (MBR/GPT).
 
 Plus an optional **network-block-device boot** (UDPBD / UDPFS, via Neutrino) that streams games
-from a PC over the LAN as their own game list — UDPBD is the pre-selected network protocol (an
+from a PC over the LAN as their own game list — UDPFS is the pre-selected network protocol (an
 inert no-op until a network adapter and PC server are present) and is mutually exclusive with SMB.
 See [This Fork's Additions](#this-forks-additions).
 
@@ -122,9 +122,9 @@ This build layers several features on top of upstream OPL:
   globally and per-game. See **[docs/NEUTRINO.md](docs/NEUTRINO.md)**.
 - **UDPBD network boot (Neutrino):** stream games from a PC over the LAN as a network block
   device — they show up as a **UDPBD Games** list with full covers and per-game settings, just
-  like a local drive. UDPBD launches via Neutrino, is the **pre-selected network protocol**
-  (inert until a NIC + PC server are present), is mutually exclusive with SMB (they share the
-  one network adapter), and needs a static PS2 IP (the default is `192.168.1.10`). Run it from the
+  like a local drive. UDPBD launches via Neutrino, is mutually exclusive with SMB (they share
+  the one network adapter), and needs a static PS2 IP (the default is `192.168.1.10`); the
+  fork's **pre-selected network protocol is UDPFS** (switch to UDPBD in Device Settings). Run it from the
   **[PS2 Servers](https://github.com/NathanNeurotic/PS2-Servers)** all-in-one PC launcher. See the
   network-boot section of **[docs/NEUTRINO.md](docs/NEUTRINO.md#4-network-boot--udpbd--udpfs-neutrino-only)**.
 - **UDPFS network boot (Neutrino):** a newer network transport (Neutrino's UDPRDMA) offered
@@ -320,7 +320,7 @@ on the host machine or NAS device and make sure that it has full read and
 write permissions. USB Advance/Extreme format is optional - \*.ISO images
 are supported using the folder structure above.
 
-> **RiptOPL network defaults:** the network protocol selector defaults to **UDPBD** — switch
+> **RiptOPL network defaults:** the network protocol selector defaults to **UDPFS** — switch
 > it to **SMB** under **Device Settings** before the **NET Games** tab appears. Network Config
 > ships static defaults (PS2 `192.168.1.10`, PC `192.168.1.100`, share `games`, user `guest`);
 > adjust them to your LAN. The default **SMB Port is `1111`** — a non-privileged port (>1024), so a server

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ It supports six categories of devices:
 6. ATA/IDE HDDs, including internal exFAT configurations (MBR/GPT).
 
 Plus an optional **network-block-device boot** (UDPBD / UDPFS, via Neutrino) that streams games
-from a PC over the LAN as their own game list — off by default and mutually exclusive with SMB.
+from a PC over the LAN as their own game list — UDPBD is the pre-selected network protocol (an
+inert no-op until a network adapter and PC server are present) and is mutually exclusive with SMB.
 See [This Fork's Additions](#this-forks-additions).
 
 All of the devices mentioned above support multiple file formats, including:
@@ -121,8 +122,9 @@ This build layers several features on top of upstream OPL:
   globally and per-game. See **[docs/NEUTRINO.md](docs/NEUTRINO.md)**.
 - **UDPBD network boot (Neutrino):** stream games from a PC over the LAN as a network block
   device — they show up as a **UDPBD Games** list with full covers and per-game settings, just
-  like a local drive. UDPBD launches via Neutrino, is **off by default**, is mutually exclusive
-  with SMB (they share the one network adapter), and needs a static PS2 IP. Run it from the
+  like a local drive. UDPBD launches via Neutrino, is the **pre-selected network protocol**
+  (inert until a NIC + PC server are present), is mutually exclusive with SMB (they share the
+  one network adapter), and needs a static PS2 IP (the default is `192.168.1.10`). Run it from the
   **[PS2 Servers](https://github.com/NathanNeurotic/PS2-Servers)** all-in-one PC launcher. See the
   network-boot section of **[docs/NEUTRINO.md](docs/NEUTRINO.md#4-network-boot--udpbd--udpfs-neutrino-only)**.
 - **UDPFS network boot (Neutrino):** a newer network transport (Neutrino's UDPRDMA) offered
@@ -318,9 +320,10 @@ on the host machine or NAS device and make sure that it has full read and
 write permissions. USB Advance/Extreme format is optional - \*.ISO images
 are supported using the folder structure above.
 
-> **RiptOPL network defaults:** Network/SMB is **off by default** — turn it on under
-> **Device Settings** (and set your IP in **Network Config**) before the **NET Games** tab
-> appears. The default **SMB Port is `1111`** — a non-privileged port (>1024), so a server
+> **RiptOPL network defaults:** the network protocol selector defaults to **UDPBD** — switch
+> it to **SMB** under **Device Settings** before the **NET Games** tab appears. Network Config
+> ships static defaults (PS2 `192.168.1.10`, PC `192.168.1.100`, share `games`, user `guest`);
+> adjust them to your LAN. The default **SMB Port is `1111`** — a non-privileged port (>1024), so a server
 > binds it without admin/root. **Network Config** now opens with **advanced options on**, so
 > the **Port** field (and ETH link mode) are editable immediately. If Windows 10/11 has
 > disabled SMB1/NTLMv1, use the **[PS2 Servers](https://github.com/NathanNeurotic/PS2-Servers)**

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -93,6 +93,9 @@ int bdmSupportIsUDPBD(item_list_t *support); // 1 if this support is the UDPBD b
 // Re-evaluate every BDM device's presence + page visibility on the next refresh (bumps the latch
 // generation). Call after a device-enable toggle so a latched-hidden tab re-shows without a replug.
 void bdmForceDeviceRefresh(void);
+// Effective BDM start mode: floors to AUTO while a BDM network transport (UDPBD/UDPFSBD) is the
+// selected protocol so its hotplug tab can exist; never modifies/persists the saved gBDMStartMode.
+int bdmEffectiveStartMode(void);
 // Current BDM device-change generation (bumped on hotplug / Device-Settings apply). The menu hook
 // reads this to bypass its background SIO2 rescan throttle when a real device change occurs.
 unsigned int bdmGetGeneration(void);

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -84,6 +84,10 @@ void hddFreePopsPartitionList(hdd_pops_list_t *list);
 int hddSetHDLGameInfo(hdl_game_info_t *ginfo);
 int hddDeleteHDLGame(hdl_game_info_t *ginfo);
 
+// Drop the once-per-session HDD VCD list cache so the next VCD-view update re-walks the partitions.
+// Needed only when a SCAN-TIME filter changes (gVcdFirstDiscOnly); view flips reuse the built list.
+void hddVcdInvalidateCache(void);
+
 void hddInit(item_list_t *itemList);
 item_list_t *hddGetObject(int initOnly);
 int hddLoadModules(void);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -427,6 +427,26 @@ static void bdmInit(item_list_t *itemList)
     itemList->enabled = 1;
 }
 
+// Per-transport enable flag for a classified BDM device type.
+// Returns 1 = enabled, 0 = disabled, -1 = unclassifiable (generic/unknown driver: never force-hidden).
+static int bdmTransportEnabled(int bdmDeviceType)
+{
+    switch (bdmDeviceType) {
+        case BDM_TYPE_USB:
+            return gEnableUSB ? 1 : 0;
+        case BDM_TYPE_ILINK:
+            return gEnableILK ? 1 : 0;
+        case BDM_TYPE_SDC:
+            return gEnableMX4SIO ? 1 : 0;
+        case BDM_TYPE_ATA:
+            return gEnableBdmHDD ? 1 : 0;
+        case BDM_TYPE_UDPBD:
+            return gEnableUDPBD ? 1 : 0;
+        default:
+            return -1;
+    }
+}
+
 static int bdmNeedsUpdate(item_list_t *itemList)
 {
     char path[256];
@@ -452,31 +472,8 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     // to off for a bdm device we want to hide the menu even though the drivers are still loaded and the device is being detected by bdm.
     opl_io_module_t *pOwner = (opl_io_module_t *)itemList->owner;
     if (pOwner != NULL && pOwner->menuItem.visible == 1) {
-        int deviceEnabled = 0;
-        int shouldApplyVisibility = 1;
-        switch (pDeviceData->bdmDeviceType) {
-            case BDM_TYPE_USB:
-                deviceEnabled = gEnableUSB;
-                break;
-            case BDM_TYPE_ILINK:
-                deviceEnabled = gEnableILK;
-                break;
-            case BDM_TYPE_SDC:
-                deviceEnabled = gEnableMX4SIO;
-                break;
-            case BDM_TYPE_ATA:
-                deviceEnabled = gEnableBdmHDD;
-                break;
-            case BDM_TYPE_UDPBD:
-                deviceEnabled = gEnableUDPBD;
-                break;
-            default:
-                shouldApplyVisibility = 0;
-                break;
-        }
-
         // If the device page is visible but the device support is not enabled, hide the device page.
-        if (shouldApplyVisibility && deviceEnabled == 0)
+        if (bdmTransportEnabled(pDeviceData->bdmDeviceType) == 0)
             pOwner->menuItem.visible = 0;
     }
 
@@ -1421,6 +1418,20 @@ int bdmUpdateDeviceData(item_list_t *itemList)
             LOG("Mass device: %d (%d) %s -> %s (compat root %s)\n", itemList->mode, pDeviceData->massDeviceIndex, pDeviceData->bdmPrefix, pDeviceData->bdmDriver, pDeviceData->bdmDeviceRoot);
         else
             LOG("Mass device: %d using generic BDM path %s\n", itemList->mode, pDeviceData->bdmPrefix);
+
+        // Publish-time enable gate (#120 audit F-13): the visible-page filter in bdmNeedsUpdate only
+        // hides a page that is ALREADY showing, i.e. one refresh pass too late. Without this gate a
+        // mounted slot on a DISABLED transport (e.g. an ATA-backed mass slot left over from the
+        // boot-resolver escalation or a BDMA-equip force-load, with BDM HDD OFF) flashes its tab,
+        // plays the connect sound and folder-writes the device on every BdmGeneration bump. Identity
+        // stays populated above: the BDMA equip and the device pickers read it through
+        // bdmGetDeviceSlotsByType/bdmReadDeviceIdentity independent of page visibility.
+        if (bdmTransportEnabled(pDeviceData->bdmDeviceType) == 0) {
+            LOG("bdmUpdateDeviceData: device %d is %s-backed but that transport is disabled; not publishing\n",
+                itemList->mode, pDeviceData->bdmDriver);
+            fileXioDclose(dir);
+            return 0;
+        }
 
         // Make the menu item visible.
         if (itemList->owner != NULL) {

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -427,6 +427,21 @@ static void bdmInit(item_list_t *itemList)
     itemList->enabled = 1;
 }
 
+// Effective BDM device start mode. The UDPBD tab is not a mode-level tab like SMB -- it is a
+// hotplug-published BDM mass page, which needs the BDM pages initialized, polled, and the bdm core
+// modules loaded before smap_udpbd can even LINK. The unified network-protocol picker couples SMB to
+// gETHStartMode and UDPFS to its own derived start mode, but selecting UDPBD/UDPFSBD wrote NOTHING to
+// gBDMStartMode -- with the shipped Manual default (or Off), the UDPBD tab could NEVER appear unless
+// the user happened to enter the generic BDM placeholder tab first ("UDPBD tab never shows", 2026-07-13).
+// Floor the EFFECTIVE mode at AUTO while a BDM network transport is the selected protocol, mirroring
+// the UDPFS_MODE derivation; the user's saved gBDMStartMode is never modified or persisted.
+int bdmEffectiveStartMode(void)
+{
+    if (gEnableUDPBD && gBDMStartMode != START_MODE_AUTO)
+        return START_MODE_AUTO;
+    return gBDMStartMode;
+}
+
 // Per-transport enable flag for a classified BDM device type.
 // Returns 1 = enabled, 0 = disabled, -1 = unclassifiable (generic/unknown driver: never force-hidden).
 static int bdmTransportEnabled(int bdmDeviceType)
@@ -457,7 +472,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     bdmDeviceModeStarted = 1;
 
     // If bdm mode is disabled bail out as we don't want to update the visibility state of the device pages.
-    if (gBDMStartMode == START_MODE_DISABLED)
+    if (bdmEffectiveStartMode() == START_MODE_DISABLED)
         return 0;
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
@@ -1297,9 +1312,10 @@ void bdmInitDevicesData()
         if (bdmDeviceList[i].owner != NULL) {
             opl_io_module_t *pOwner = (opl_io_module_t *)bdmDeviceList[i].owner;
 
-            if (gBDMStartMode == START_MODE_DISABLED) {
+            int effectiveMode = bdmEffectiveStartMode();
+            if (effectiveMode == START_MODE_DISABLED) {
                 pOwner->menuItem.visible = 0;
-            } else if (gBDMStartMode == START_MODE_MANUAL) {
+            } else if (effectiveMode == START_MODE_MANUAL) {
                 // If BDM has already been started then make the page invisible and reset the bdm tick counter so visibility status is refreshed
                 // according to device state.
                 if (bdmDeviceModeStarted == 1) {
@@ -1307,7 +1323,7 @@ void bdmInitDevicesData()
                     ((bdm_device_data_t *)bdmDeviceList[i].priv)->bdmDeviceTick = -1;
                 } else
                     pOwner->menuItem.visible = (i == 0 ? 1 : 0);
-            } else if (gBDMStartMode == START_MODE_AUTO) {
+            } else if (effectiveMode == START_MODE_AUTO) {
                 pOwner->menuItem.visible = 0;
                 ((bdm_device_data_t *)bdmDeviceList[i].priv)->bdmDeviceTick = -1;
             }
@@ -1360,7 +1376,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     int driverResult, deviceResult;
 
     // If bdm mode is disabled bail out as we don't want to update the visibility state of the device pages.
-    if (gBDMStartMode == START_MODE_DISABLED)
+    if (bdmEffectiveStartMode() == START_MODE_DISABLED)
         return 0;
 
     // LOG("bdmUpdateDeviceData: %d\n", itemList->mode);
@@ -1429,6 +1445,17 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         if (bdmTransportEnabled(pDeviceData->bdmDeviceType) == 0) {
             LOG("bdmUpdateDeviceData: device %d is %s-backed but that transport is disabled; not publishing\n",
                 itemList->mode, pDeviceData->bdmDriver);
+            fileXioDclose(dir);
+            return 0;
+        }
+
+        // An EXPLICIT BDM = Off is only overridden by the UDPBD floor (bdmEffectiveStartMode) so
+        // the selected UDPBD protocol can publish ITS tab -- every other transport's page stays
+        // hidden exactly as the user asked (their sticks would otherwise resurface with the dialog
+        // still showing "Off").
+        if (gBDMStartMode == START_MODE_DISABLED && pDeviceData->bdmDeviceType != BDM_TYPE_UDPBD) {
+            LOG("bdmUpdateDeviceData: device %d withheld -- BDM is explicitly Off (UDPBD floor active)\n",
+                itemList->mode);
             fileXioDclose(dir);
             return 0;
         }

--- a/src/gui.c
+++ b/src/gui.c
@@ -2105,6 +2105,12 @@ static void guiDrawOverlays()
                  gDiag.artOpens, gDiag.memoHit, gDiag.memoMiss, gDiag.artTerminate,
                  gDiag.vcdRescanPreserved, gDiag.isoScanPreserved, gDiag.lastSaveErrno);
         fntRenderString(gTheme->fonts[0], 0, screenHeight - 24, ALIGN_NONE, 0, 0, diag, GS_SETREG_RGBA(255, 255, 0, 128));
+        // PAD dead-analog diagnostic line (see include/diag.h): md:2 with a zero t-entry = freepad
+        // published a half-built mode table; AC:0 = digital-only latched (the dead-analog state).
+        snprintf(diag, sizeof(diag), "PAD md:%d t0:%d t1:%d AC:%d SH:%u UN:%u SM:%u TO:%u",
+                 gDiag.padModes, gDiag.padMode0, gDiag.padMode1, gDiag.padAnalogCapable,
+                 gDiag.padSelfHeal, gDiag.padUnsupported, gDiag.padSetMainModeOk, gDiag.padReqTimeout);
+        fntRenderString(gTheme->fonts[0], 0, screenHeight - 40, ALIGN_NONE, 0, 0, diag, GS_SETREG_RGBA(255, 255, 0, 128));
     }
 }
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -21,6 +21,7 @@
 #include "include/ethsupport.h"
 #include "include/udpfssupport.h" // udpfsGetModulesLoaded() -- network-protocol restart-notice check
 #include "include/bdmsupport.h"   // bdmForceDeviceRefresh() -- re-show a latched-hidden BDM tab after a device-enable toggle
+#include "include/hddsupport.h"   // hddVcdInvalidateCache() -- first-disc-only is a scan-time filter
 #include "include/favsupport.h"
 #include "include/compatupd.h"
 #include "include/pggsm.h"
@@ -653,6 +654,7 @@ void guiShowVcdConfig(void)
             diaGetInt(diaVcdConfig, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
             if (gVcdFirstDiscOnly != previousFirstDiscOnly) {
                 vcdMarkAllDirty();
+                hddVcdInvalidateCache(); // scan-time filter changed -> the cached HDD VCD list is stale
                 rebuildVcdLists = 1;
             }
         }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -383,6 +383,26 @@ item_list_t *hddGetObject(int initOnly)
 
 // ---- HDD VCD view (PS1 games on APA/PFS partitions) ---------------------------------------
 
+// Once-per-session latch (POPSLoader's HAS_CHECKED parity: "HDD is checked only once since it cannot
+// be removed/replaced without damaging the console"). While set, hddUpdateGameList's VCD branch reuses
+// the built arrays so an L3 toggle rebuilds only the submenu, never re-walks the partitions. A latch
+// (not hddVcdGames != NULL) so a drive whose candidates scanned to ZERO VCDs is also remembered. The
+// no-candidates early return deliberately does NOT latch: hddGetPopsPartitionList returns 0 for a
+// transient hdd0: dopen failure too, and that walk is one mount-free APA pass -- cheap to repeat.
+// Cleared by hddFreeVcdGameList (covers rebuilds + hddCleanUp/hddShutdown teardown) and by
+// hddVcdInvalidateCache (the first-disc-only setting filters at scan time, so its change must rescan).
+// The generation counter keeps an invalidation from being SWALLOWED by a build already in flight on
+// the IO worker (GUI-thread dialog save during a cold scan): the build re-latches only if no
+// invalidation arrived since it started.
+static unsigned char hddVcdListBuilt = 0;
+static volatile unsigned int hddVcdCacheGen = 0;
+
+void hddVcdInvalidateCache(void)
+{
+    hddVcdCacheGen++;
+    hddVcdListBuilt = 0;
+}
+
 static void hddFreeVcdGameList(void)
 {
     free(hddVcdGames);
@@ -390,18 +410,25 @@ static void hddFreeVcdGameList(void)
     free(hddVcdParts);
     hddVcdParts = NULL;
     hddVcdGameCount = 0;
+    hddVcdListBuilt = 0;
 }
 
 // Build the HDD VCD game list from both supported APA/PFS shapes. Exact __.POPS / __.POPS0..9
-// containers contribute every root *.VCD; PP.<name> / __.<name> candidates contribute one entry only
-// after a root IMAGE0.VCD probe succeeds. Each partition is mounted read-only on the dedicated pfs1:
-// scan slot, and its full label is kept index-parallel in hddVcdParts for POPSTARTER. pfs0: stays on
-// the OPL data partition throughout, so CFG and ART reads keep their live mount during the scan.
+// containers contribute every root *.VCD; PP.<name> / __.<name> candidates contribute one entry each.
+// A one-game candidate whose label carries a STRICT PS1 disc-ID (PP.SLUS_005.51.Name -- the
+// POPStarter/BatchKitManager convention) is accepted from the APA table alone, ZERO mounts: every
+// documented PP.* false-positive family fails that pattern (HDDOSD apps like CodeBreaker have no
+// '_' at [4]; HDL games are mode-0x1337-filtered upstream), and the launch never needs the probe
+// (POPSTARTER boots by literal partition label). Only ID-less labels (PP.CASTLEVANIA) pay the
+// mount + IMAGE0.VCD probe that filters HDDOSD apps. This is what makes a 40-partition drive load
+// in one APA pass instead of 40 PFS mount/probe/umount cycles (~35 s on a mechanical drive).
+// Mounts use the dedicated pfs1: scan slot; pfs0: stays on the OPL data partition throughout.
 
 static int hddBuildVcdGameList(void)
 {
     hdd_pops_list_t parts;
     int total = 0;
+    unsigned int genAtEntry = hddVcdCacheGen; // re-latch below only if no invalidation raced this build
 
     hddFreeVcdGameList();
 
@@ -410,25 +437,30 @@ static int hddBuildVcdGameList(void)
     fileXioUmount("pfs1:");
 
     if (hddGetPopsPartitionList(&parts) <= 0)
-        return 0; // no matching PFS partitions; the live pfs0: mount was not touched
+        return 0; // no candidates OR a transient dopen failure -- deliberately NOT latched (see above)
 
     for (int p = 0; p < parts.count; p++) {
         char mountSrc[64];
         snprintf(mountSrc, sizeof(mountSrc), "hdd0:%s", parts.names[p]);
 
-        if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0)
-            continue; // can't mount this partition -> skip it
-
-        // PP.<name> / __.<name> one-game install: require ONE exact IMAGE0.VCD at the partition root,
-        // display the label without its three-character prefix, and retain the FULL label for launch.
-        // The name predicate excludes the exact __.POPS[0-9]? pooled containers handled below.
+        // PP.<name> / __.<name> one-game install: display the label without its three-character
+        // prefix and retain the FULL label for launch. The name predicate excludes the exact
+        // __.POPS[0-9]? pooled containers handled below.
         if (hddIsPopsPartitionGame(parts.names[p])) {
-            int imgfd = open("pfs1:/IMAGE0.VCD", O_RDONLY);
-            if (imgfd >= 0)
-                close(imgfd); // close before unmount; ps2fs may reject an unmount with a live fd
-            fileXioUmount("pfs1:");
-            if (imgfd < 0)
-                continue; // candidate name alone is insufficient (PP.* HDDOSD apps are common)
+            char discId[12]; // validation only -- the entry keys off the full label, never the ID
+            if (!vcdExtractGameId(parts.names[p] + 3, discId, sizeof(discId))) {
+                // ID-less label (e.g. PP.CASTLEVANIA): require ONE exact IMAGE0.VCD at the partition
+                // root. This probe is what keeps PP.* HDDOSD apps off the PS1 list; ID-shaped labels
+                // above skip it because no documented app family matches the strict ID pattern.
+                if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0)
+                    continue; // can't mount this partition -> skip it
+                int imgfd = open("pfs1:/IMAGE0.VCD", O_RDONLY);
+                if (imgfd >= 0)
+                    close(imgfd); // close before unmount; ps2fs may reject an unmount with a live fd
+                fileXioUmount("pfs1:");
+                if (imgfd < 0)
+                    continue; // candidate name alone is insufficient (PP.* HDDOSD apps are common)
+            }
 
             base_game_info_t *grownGames = realloc(hddVcdGames, (total + 1) * sizeof(base_game_info_t));
             if (grownGames == NULL)
@@ -450,6 +482,10 @@ static int hddBuildVcdGameList(void)
             total += 1;
             continue;
         }
+
+        // __.POPS[0-9]? pooled container: mount and scan its root for *.VCD entries.
+        if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0)
+            continue; // can't mount this partition -> skip it
 
         vcd_entry_t *vcds = NULL;
         int n = vcdScanDirRoot("pfs1:/", &vcds);
@@ -495,6 +531,9 @@ static int hddBuildVcdGameList(void)
     fileXioUmount("pfs1:");
 
     hddVcdGameCount = total;
+    // Remember a scanned-to-zero result too (candidates existed, none were VCDs) so toggles don't
+    // re-probe them. Skip the latch if an invalidation arrived while this build was running.
+    hddVcdListBuilt = (genAtEntry == hddVcdCacheGen);
     return total;
 }
 
@@ -502,7 +541,7 @@ static int hddNeedsUpdate(item_list_t *itemList)
 { /* Auto refresh is disabled by setting HDD_MODE_UPDATE_DELAY to MENU_UPD_DELAY_NOUPDATE, within hddsupport.h.
        Hence any update request would be issued by the user, which should be taken as an explicit request to re-scan the HDD. */
     if (vcdConsumeDirty(itemList->mode))
-        return 1; // L3 toggle / default-view change -> force one rescan
+        return 1; // L3 toggle / default-view change -> rebuild the submenu (the ARRAY may be cached)
     if (vcdViewActive(itemList->mode))
         return 0; // in VCD view: skip the HDL re-scan churn
     return 1;
@@ -511,7 +550,9 @@ static int hddNeedsUpdate(item_list_t *itemList)
 static int hddUpdateGameList(item_list_t *itemList)
 {
     if (vcdViewActive(itemList->mode))
-        return hddBuildVcdGameList();
+        // Reuse the session's built list on view flips; hddBuildVcdGameList runs only when never
+        // built, invalidated (first-disc-only change), or freed by teardown (hddFreeVcdGameList).
+        return hddVcdListBuilt ? hddVcdGameCount : hddBuildVcdGameList();
 
     hdl_games_list_t hddGamesNew;
     int ret;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -293,8 +293,11 @@ void hddLoadSupportModules(void)
                            "-n"
                            "\0"
                            "20";
-    static char pfsarg[] = "\0"
-                           "-m" // max mounts: keep pfs0: on OPL data while pfs1: scans POPS partitions
+    // No leading "\0": LOADFILE already supplies argv[0] ("LBbyEE") for buffer loads, so the first
+    // string here is argv[1]. PFS stops parsing at the first token that doesn't start with '-', so a
+    // leading empty string silently discarded EVERY option below (upstream OPL carries the same dead
+    // byte) -- leaving PFS at its defaults (-m 1, -o 2, -n 8) and making the pfs1: scan mount fail.
+    static char pfsarg[] = "-m" // max mounts: keep pfs0: on OPL data while pfs1: scans POPS partitions
                            "\0"
                            "2"
                            "\0"
@@ -439,6 +442,7 @@ static int hddBuildVcdGameList(void)
             base_game_info_t *g = &hddVcdGames[total];
             memset(g, 0, sizeof(base_game_info_t));
             snprintf(g->name, sizeof(g->name), "%s", parts.names[p] + 3); // strip PP. / __. for display
+            snprintf(g->startup, sizeof(g->startup), "%s", g->name);      // keep VCD identity = name (pooled entries do the same)
             snprintf(g->extension, sizeof(g->extension), ".VCD");
             g->parts = 1;
             g->format = GAME_FORMAT_ISO;                                       // harmless; VCD flag gates the launch

--- a/src/include/diag.h
+++ b/src/include/diag.h
@@ -52,6 +52,23 @@ typedef struct
     volatile unsigned int vcdRescanPreserved;
     volatile unsigned int isoScanPreserved;
     volatile int lastSaveErrno;
+    // PAD line (intermittent dead-analog investigation, 2026-07-13; all writers on the EE main
+    // thread via readPads/initializePad). Read when analog is dead:
+    //   md/t0/t1 - last MODETABLE count + entries [0]/[1] seen by initializePad. md:2 with a zero
+    //              t-entry = freepad published a HALF-BUILT table (the latch bug's trigger).
+    //   AC       - last latched analogCapable verdict (0 = digital-only latched = dead analog).
+    //   SH       - analog self-heal re-init attempts (climbing = retry loop alive).
+    //   UN       - genuine fully-published digital-only verdicts (stays 0 for a real DualShock).
+    //   SM       - padSetMainMode accepted AND observed complete (0 while SH climbs = IOP reject).
+    //   TO       - request-completion waits that timed out (persistent TO = command-side contention).
+    volatile int padModes;
+    volatile int padMode0;
+    volatile int padMode1;
+    volatile int padAnalogCapable;
+    volatile unsigned int padSelfHeal;
+    volatile unsigned int padUnsupported;
+    volatile unsigned int padSetMainModeOk;
+    volatile unsigned int padReqTimeout;
 } opl_diag_t;
 
 extern opl_diag_t gDiag;

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1212,8 +1212,9 @@ void menuHandleInputMenu()
     }
 
     if (getKeyOn(KEY_START) || getKeyOn(gSelectButton == KEY_CIRCLE ? KEY_CROSS : KEY_CIRCLE)) {
-        // Check if there is anything to show the user, at all.
-        if (gAPPStartMode || gETHStartMode || gBDMStartMode || gHDDStartMode || gMMCEStartMode || gFAVStartMode) {
+        // Check if there is anything to show the user, at all. BDM uses the EFFECTIVE mode: a
+        // selected UDPBD protocol floors it to Auto (its tab can exist even with raw BDM = Off).
+        if (gAPPStartMode || gETHStartMode || bdmEffectiveStartMode() || gHDDStartMode || gMMCEStartMode || gFAVStartMode) {
             guiSwitchScreen(GUI_SCREEN_MAIN);
             refreshMenuPosition();
         }

--- a/src/opl.c
+++ b/src/opl.c
@@ -1582,20 +1582,22 @@ static void _loadConfig()
                 configSetInt(configOPL, CONFIG_OPL_HDD_MODE, gHDDStartMode);
                 configSetInt(configOPL, CONFIG_OPL_ENABLE_BDMHDD, gEnableBdmHDD);
             }
-            configGetInt(configOPL, CONFIG_OPL_ENABLE_UDPBD, &gEnableUDPBD);
+            int udpbdKeyPresent = configGetInt(configOPL, CONFIG_OPL_ENABLE_UDPBD, &gEnableUDPBD);
             configGetInt(configOPL, CONFIG_OPL_NET_BOOT_PROTOCOL, &gNetBootProtocol);
             // Unified network-protocol selector (single SMAP NIC -> at most one transport per session).
             // Read the new key if present (authoritative); otherwise DERIVE it from the three legacy keys,
             // preserving the historical "network BDM wins over SMB" precedence (imported/hand-edited configs
             // could set both; at boot UDPBD loaded first, so it won). NET_PROTO_UDPFS (filesystem) has no
             // legacy encoding, so it is only ever reached by an explicit new-format value -- backward-safe.
+            // Since UDPBD became the shipped DEFAULT (2026-07-13), the legacy branch must key off the
+            // FILE's enable_udpbd, not the defaulted global -- otherwise a pre-UDPBD-era SMB config
+            // (has eth_mode, lacks enable_udpbd) would inherit the default 1 and silently flip to UDPBD.
             if (!configGetInt(configOPL, CONFIG_OPL_NETWORK_PROTOCOL, &gNetworkProtocol)) {
-                if (gEnableUDPBD)
-                    gNetworkProtocol = (gNetBootProtocol == NET_BOOT_UDPFS) ? NET_PROTO_UDPFSBD : NET_PROTO_UDPBD;
+                if (udpbdKeyPresent)
+                    gNetworkProtocol = gEnableUDPBD ? ((gNetBootProtocol == NET_BOOT_UDPFS) ? NET_PROTO_UDPFSBD : NET_PROTO_UDPBD) : ((gETHStartMode != START_MODE_DISABLED) ? NET_PROTO_SMB : NET_PROTO_OFF);
                 else if (gETHStartMode != START_MODE_DISABLED)
                     gNetworkProtocol = NET_PROTO_SMB;
-                else
-                    gNetworkProtocol = NET_PROTO_OFF;
+                // else: the file never expressed ANY network choice -> the shipped default stands (UDPBD)
             }
             // UDPBD (SUDPBDv2) is a first-class protocol, NOT folded away: it is wire-incompatible with
             // UDPRDMA (SUDPBDv2 on 0xBDBD vs UDPFS on 0xF5F6), so users still on the older udpbd-server
@@ -2574,13 +2576,16 @@ static void setDefaults(void)
     hddCacheSize = 8;
     smbCacheSize = 16;
 
-    ps2_ip_use_dhcp = 1;
+    // RiptOPL network defaults (2026-07-13, Nathan's reference config): static addressing on the
+    // common 192.168.1.x home subnet with a ready-to-edit SMB target, so a first-time user sees a
+    // working-shaped setup instead of blanks. DHCP stays available one toggle away.
+    ps2_ip_use_dhcp = 0;
     gETHOpMode = ETH_OP_MODE_AUTO;
-    gPCShareAddressIsNetBIOS = 1;
+    gPCShareAddressIsNetBIOS = 0; // raw-IP SMB addressing by default (matches the static defaults below)
     gPCShareNBAddress[0] = '\0';
     ps2_ip[0] = 192;
     ps2_ip[1] = 168;
-    ps2_ip[2] = 0;
+    ps2_ip[2] = 1;
     ps2_ip[3] = 10;
     ps2_netmask[0] = 255;
     ps2_netmask[1] = 255;
@@ -2588,19 +2593,19 @@ static void setDefaults(void)
     ps2_netmask[3] = 0;
     ps2_gateway[0] = 192;
     ps2_gateway[1] = 168;
-    ps2_gateway[2] = 0;
+    ps2_gateway[2] = 1;
     ps2_gateway[3] = 1;
     pc_ip[0] = 192;
     pc_ip[1] = 168;
-    pc_ip[2] = 0;
-    pc_ip[3] = 2;
+    pc_ip[2] = 1;
+    pc_ip[3] = 100;
     ps2_dns[0] = 192;
     ps2_dns[1] = 168;
-    ps2_dns[2] = 0;
+    ps2_dns[2] = 1;
     ps2_dns[3] = 1;
     gPCPort = 1111; // RiptOPL default SMB port (was 445): non-privileged and freely editable through the always-visible advanced network options; match it to the PC server's displayed port
-    gPCShareName[0] = '\0';
-    gPCUserName[0] = '\0';
+    strcpy(gPCShareName, "games");
+    strcpy(gPCUserName, "guest");
     gPCPassword[0] = '\0';
     gNetworkStartup = ERROR_ETH_NOT_STARTED;
     gHDDSpindown = 20;
@@ -2616,9 +2621,9 @@ static void setDefaults(void)
     gBdmaSource = VCD_BDMA_SRC_USB;
     gBdmaMode = VCD_BDMA_FAT32;
     gBdmaApplyOnLaunch = 1; // auto-equip on launch by default (the MX4SIO->OSDSYS fix)
-    gVcdHideGameId = 0;     // show the raw filename by default; opt-in cosmetic prefix hide
-    gVcdFirstDiscOnly = 0;  // #118: show every disc by default; opt-in first-disc-only hide
-    gWritePopstarterNet = 0;
+    gVcdHideGameId = 1;     // hide the PS1 game-ID prefix by default (display-only; raw names one toggle away)
+    gVcdFirstDiscOnly = 1;  // #118: hide discs 2+ of multi-disc PS1 sets by default (POPSLoader parity)
+    gWritePopstarterNet = 1;
     gDefaultDevice = APP_MODE;
     gAutosort = 1;
     gAutoRefresh = 0;
@@ -2628,7 +2633,7 @@ static void setDefaults(void)
     gEnableWrite = 1;
     gRememberLastPlayed = 0;
     gAutoStartLastPlayed = 9;
-    gSelectButton = KEY_CIRCLE; // Default to Japan.
+    gSelectButton = KEY_CROSS; // Default to Cross-select (western layout); swap_select_btn=0 restores Circle
     gMMCEPrefix[0] = '\0';
     gBDMPrefix[0] = '\0';
     gETHPrefix[0] = '\0';
@@ -2639,7 +2644,7 @@ static void setDefaults(void)
     gDefaultGameView = GAME_VIEW_BOTH;
     gEnableSFX = 1;
     gEnableBootSND = 1;
-    gEnableBGM = 0;
+    gEnableBGM = 1;
     gSFXVolume = 80;
     gBootSndVolume = 80;
     gBGMVolume = 70;
@@ -2657,7 +2662,7 @@ static void setDefaults(void)
     gMMCESlot = 2; //Default to first Auto slot
     gMMCEIGRSlot = 3;
     gMMCEEnableGameID = 1;
-    gApplyGameID = 0; // visual GameID barcode OFF by default (only meaningful to Pixel FX/RetroGEM HDMI displays)
+    gApplyGameID = 1; // visual GameID barcode ON by default (Pixel FX/RetroGEM HDMI displays; imperceptible otherwise)
     // Restore the fork's long-standing known-good MMCE SIO2 pacing (was flipped to 0/0 in 519f520d,
     // mislabeled "safer" -- 0 cycles + alarms OFF is the aggressive/perf extreme the in-app hints warn
     // about: lower cycles = "instabilities", alarms OFF = "can cause MMCE timeouts to result in freezes").
@@ -2670,10 +2675,11 @@ static void setDefaults(void)
     gEnableUSB = 1;
     gEnableILK = 0;
     gEnableMX4SIO = 0;
-    gEnableBdmHDD = 0;                 // exFAT BDM HDD OFF by default (the other "HDD type"; APA/PFS is gHDDStartMode above)
-    gEnableUDPBD = 0;                  // OFF by default: needs a PC-side UDPBD server, and is NIC-exclusive with SMB
-    gNetBootProtocol = NET_BOOT_UDPBD; // default transport when network boot is enabled (back-compat)
-    gNetworkProtocol = NET_PROTO_OFF;  // unified selector: no network device by default (matches the shadows above)
+    gEnableBdmHDD = 0;                  // exFAT BDM HDD OFF by default (the other "HDD type"; APA/PFS is gHDDStartMode above)
+    gEnableUDPBD = 1;                   // RiptOPL 2026-07-13: UDPBD is the default network protocol (below)
+    gNetBootProtocol = NET_BOOT_UDPBD;  // default transport when network boot is enabled (back-compat)
+    gNetworkProtocol = NET_PROTO_UDPBD; // unified selector: UDPBD by default (no NIC/DEV9 = graceful no-op;
+                                        // NIC-exclusive with SMB -- picking SMB in the selector flips both shadows)
 
     frameCounter = 0;
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1589,15 +1589,15 @@ static void _loadConfig()
             // preserving the historical "network BDM wins over SMB" precedence (imported/hand-edited configs
             // could set both; at boot UDPBD loaded first, so it won). NET_PROTO_UDPFS (filesystem) has no
             // legacy encoding, so it is only ever reached by an explicit new-format value -- backward-safe.
-            // Since UDPBD became the shipped DEFAULT (2026-07-13), the legacy branch must key off the
-            // FILE's enable_udpbd, not the defaulted global -- otherwise a pre-UDPBD-era SMB config
-            // (has eth_mode, lacks enable_udpbd) would inherit the default 1 and silently flip to UDPBD.
+            // Since a NETWORK protocol became the shipped DEFAULT (UDPFS, 2026-07-13), the legacy branch
+            // must key off the FILE's enable_udpbd, not the defaulted global -- a legacy config must only
+            // ever derive from what IT expressed, never inherit a defaulted enable flag.
             if (!configGetInt(configOPL, CONFIG_OPL_NETWORK_PROTOCOL, &gNetworkProtocol)) {
                 if (udpbdKeyPresent)
                     gNetworkProtocol = gEnableUDPBD ? ((gNetBootProtocol == NET_BOOT_UDPFS) ? NET_PROTO_UDPFSBD : NET_PROTO_UDPBD) : ((gETHStartMode != START_MODE_DISABLED) ? NET_PROTO_SMB : NET_PROTO_OFF);
                 else if (gETHStartMode != START_MODE_DISABLED)
                     gNetworkProtocol = NET_PROTO_SMB;
-                // else: the file never expressed ANY network choice -> the shipped default stands (UDPBD)
+                // else: the file never expressed ANY network choice -> the shipped default stands (UDPFS)
             }
             // UDPBD (SUDPBDv2) is a first-class protocol, NOT folded away: it is wire-incompatible with
             // UDPRDMA (SUDPBDv2 on 0xBDBD vs UDPFS on 0xF5F6), so users still on the older udpbd-server
@@ -2676,10 +2676,10 @@ static void setDefaults(void)
     gEnableILK = 0;
     gEnableMX4SIO = 0;
     gEnableBdmHDD = 0;                  // exFAT BDM HDD OFF by default (the other "HDD type"; APA/PFS is gHDDStartMode above)
-    gEnableUDPBD = 1;                   // RiptOPL 2026-07-13: UDPBD is the default network protocol (below)
+    gEnableUDPBD = 0;                   // the UDPBD BLOCK device stays opt-in; the default protocol below is UDPFS
     gNetBootProtocol = NET_BOOT_UDPBD;  // default transport when network boot is enabled (back-compat)
-    gNetworkProtocol = NET_PROTO_UDPBD; // unified selector: UDPBD by default (no NIC/DEV9 = graceful no-op;
-                                        // NIC-exclusive with SMB -- picking SMB in the selector flips both shadows)
+    gNetworkProtocol = NET_PROTO_UDPFS; // unified selector: UDPFS (UDPRDMA filesystem) by default -- inert
+                                        // without a NIC + PC server; NIC-exclusive with SMB as before
 
     frameCounter = 0;
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -571,7 +571,9 @@ void initSupport(item_list_t *itemList, int mode, int force_reinit)
     // Set the start mode flag based on device type.
     int startMode = 0;
     if (mode >= BDM_MODE && mode < ETH_MODE)
-        startMode = gBDMStartMode;
+        // Effective, not raw: a selected UDPBD/UDPFSBD network protocol floors BDM to Auto so its
+        // hotplug tab can exist (see bdmEffectiveStartMode) -- the saved setting is untouched.
+        startMode = bdmEffectiveStartMode();
     else if (mode == ETH_MODE)
         startMode = gETHStartMode;
     else if (mode == HDD_MODE)

--- a/src/opl.c
+++ b/src/opl.c
@@ -1568,6 +1568,20 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_ENABLE_ILINK, &gEnableILK);
             configGetInt(configOPL, CONFIG_OPL_ENABLE_MX4SIO, &gEnableMX4SIO);
             configGetInt(configOPL, CONFIG_OPL_ENABLE_BDMHDD, &gEnableBdmHDD);
+            // #120 audit F-12: APA (gHDDStartMode) and BDM-ATA (gEnableBdmHDD) are mutually exclusive by
+            // design, but the Device-Settings interlock only guards values changed THROUGH the dialog. A
+            // legacy, hand-edited or cross-version config can load both, and then BOTH internal-HDD
+            // stacks initialize against the one drive. Normalize at load: the backend matching the boot
+            // device wins; otherwise the APA start mode (the older, more deliberate setting) is kept.
+            // configSetInt the loser so the next save persists the reconciled pair.
+            if (gEnableBdmHDD && gHDDStartMode != START_MODE_DISABLED) {
+                if (gBootDirBdmType == BDM_TYPE_ATA)
+                    gHDDStartMode = START_MODE_DISABLED;
+                else
+                    gEnableBdmHDD = 0;
+                configSetInt(configOPL, CONFIG_OPL_HDD_MODE, gHDDStartMode);
+                configSetInt(configOPL, CONFIG_OPL_ENABLE_BDMHDD, gEnableBdmHDD);
+            }
             configGetInt(configOPL, CONFIG_OPL_ENABLE_UDPBD, &gEnableUDPBD);
             configGetInt(configOPL, CONFIG_OPL_NET_BOOT_PROTOCOL, &gNetBootProtocol);
             // Unified network-protocol selector (single SMAP NIC -> at most one transport per session).
@@ -1626,6 +1640,12 @@ static void _loadConfig()
         if (gBootDirBdmType == BDM_TYPE_ATA && !gEnableBdmHDD) {
             gEnableBdmHDD = 1;
             configSetInt(configGetByType(CONFIG_OPL), CONFIG_OPL_ENABLE_BDMHDD, gEnableBdmHDD);
+            // #120 audit F-12: don't leave a loaded APA start mode fighting the just-enabled BDM-ATA
+            // backend (the drive we booted from is exFAT, so APA is definitionally wrong for it).
+            if (gHDDStartMode != START_MODE_DISABLED) {
+                gHDDStartMode = START_MODE_DISABLED;
+                configSetInt(configGetByType(CONFIG_OPL), CONFIG_OPL_HDD_MODE, gHDDStartMode);
+            }
         }
     }
 

--- a/src/pad.c
+++ b/src/pad.c
@@ -6,6 +6,7 @@
 
 #include "include/opl.h"
 #include "include/pad.h"
+#include "include/diag.h"
 #include "include/ioman.h"
 #include <delaythread.h>
 #include <libpad.h>
@@ -48,6 +49,13 @@ struct pad_data_t
 #define PAD_WAIT_POLLS         25
 #define PAD_WAIT_POLL_US       1000
 #define PAD_ANALOG_RETRY_DELAY 60
+// A padSetMainMode round-trip can NEVER finish under freepad's own minimum latency: the IOP main
+// thread dispatches the task on the next vblank, SetMainModeThread needs three vblank-gated SIO2
+// transfers, and the request only flips COMPLETE after the next good ReadData -- >= 5 vblanks,
+// ~83-100 ms. The generic 25 ms budget above therefore ALWAYS timed out on this leg, so analog
+// arming worked only when the IOP happened to finish in the background and the pressure/rumble
+// setup below it was unreachable. Give request-completion waits a budget above the happy path.
+#define PAD_REQ_WAIT_POLLS     150
 
 #define PAD_INIT_RETRY       -1
 #define PAD_INIT_UNSUPPORTED 0
@@ -117,13 +125,14 @@ static int waitPadRequestComplete(struct pad_data_t *pad)
     int reqState = PAD_RSTAT_BUSY;
     int polls;
 
-    for (polls = 0; polls < PAD_WAIT_POLLS; polls++) {
+    for (polls = 0; polls < PAD_REQ_WAIT_POLLS; polls++) {
         reqState = padGetReqState(pad->port, pad->slot);
         if (reqState != PAD_RSTAT_BUSY)
             return reqState == PAD_RSTAT_COMPLETE;
         DelayThread(PAD_WAIT_POLL_US);
     }
 
+    gDiag.padReqTimeout++; // PAD HUD TO: request never left BUSY within the budget
     LOG("PAD pad %d,%d request timed out\n", pad->port, pad->slot);
     return 0;
 }
@@ -168,24 +177,50 @@ static int initializePad(struct pad_data_t *pad)
     // A not-yet-ready DualShock also reports an empty mode table, so keep it retryable. Once a
     // non-empty table proves that DualShock mode is absent, mark the controller unsupported.
     if (modes <= 0) {
+        // Snapshot BEFORE bailing so a PERSISTENT empty-table failure shows md:0 on the PAD HUD
+        // instead of a stale last-good snapshot masking exactly the state under investigation.
+        gDiag.padModes = modes;
+        gDiag.padMode0 = -1;
+        gDiag.padMode1 = -1;
         LOG("PAD mode table is not ready (or controller is digital-only)\n");
         return PAD_INIT_RETRY;
     }
 
-    // Verify that the controller has a DUAL SHOCK mode
-    i = 0;
-    do {
-        if (padInfoMode(pad->port, pad->slot, PAD_MODETABLE, i) == PAD_TYPE_DUALSHOCK)
-            break;
-        i++;
-    } while (i < modes);
+    // Verify that the controller has a DUAL SHOCK mode. CRITICAL: freepad's query threads have a
+    // 10-attempt budget per stage, and under sustained SIO2 contention (MMCE/MX4SIO boot traffic)
+    // they can publish numModes > 0 while the mode TABLE entries were never written (BSS zero).
+    // Legal CTP mode types are 2..7 and freepad only writes an entry on a validated controller
+    // response, so a 0/invalid entry PROVES the table is half-built -- that must stay RETRYABLE.
+    // The old code latched analogCapable=0 ("digital-only") off exactly that half-built table,
+    // permanently disarming the self-heal (its gate is analogCapable != 0) until a physical
+    // unplug/replug reset it via the DISCONN edge: the intermittent dead-analog bug (Nathan +
+    // FifthFox + 2 testers). Only a FULLY-published table lacking DUALSHOCK may latch digital-only.
+    int sawInvalid = 0;
+    int hasDualshock = 0;
+    for (i = 0; i < modes; i++) {
+        tmp = padInfoMode(pad->port, pad->slot, PAD_MODETABLE, i);
+        if (tmp == PAD_TYPE_DUALSHOCK)
+            hasDualshock = 1;
+        else if (tmp == 0)
+            sawInvalid = 1; // freepad writes entries only from validated responses -> 0 = unwritten slot
+    }
+    gDiag.padModes = modes; // PAD HUD md/t0/t1: last mode-table snapshot
+    gDiag.padMode0 = (modes > 0) ? padInfoMode(pad->port, pad->slot, PAD_MODETABLE, 0) : -1;
+    gDiag.padMode1 = (modes > 1) ? padInfoMode(pad->port, pad->slot, PAD_MODETABLE, 1) : -1;
 
-    if (i >= modes) {
+    if (!hasDualshock) {
+        if (sawInvalid) {
+            LOG("PAD mode table half-built (contention?) -- retrying, NOT latching digital-only\n");
+            return PAD_INIT_RETRY; // analogCapable stays -1/previous: the self-heal keeps trying
+        }
         LOG("PAD This is no Dual Shock controller\n");
+        gDiag.padUnsupported++; // PAD HUD UN: genuine fully-published digital-only verdicts
         pad->analogCapable = 0;
+        gDiag.padAnalogCapable = 0; // PAD HUD AC
         return PAD_INIT_UNSUPPORTED;
     }
     pad->analogCapable = 1;
+    gDiag.padAnalogCapable = 1; // PAD HUD AC
 
     // If ExId != 0x0 => This controller has actuator engines
     // This check should always pass if the Dual Shock test above passed
@@ -203,6 +238,7 @@ static int initializePad(struct pad_data_t *pad)
         LOG("PAD padSetMainMode failed: accepted=%d req=%d\n", tmp, padGetReqState(pad->port, pad->slot));
         return PAD_INIT_RETRY;
     }
+    gDiag.padSetMainModeOk++; // PAD HUD SM: padSetMainMode accepted AND observed complete
 
     if (!isPadReadyState(waitPadReady(pad)))
         return PAD_INIT_RETRY;
@@ -338,6 +374,7 @@ static int readPad(struct pad_data_t *pad)
                 if (pad->analogRetryDelay > 0) {
                     pad->analogRetryDelay--;
                 } else {
+                    gDiag.padSelfHeal++; // PAD HUD SH: analog self-heal re-init attempts
                     initializePad(pad);
                     pad->analogRetryDelay = PAD_ANALOG_RETRY_DELAY;
                 }
@@ -555,6 +592,12 @@ static int startPad(struct pad_data_t *pad)
 
     pad->analogCapable = -1;
     pad->analogRetryDelay = 0;
+    // Seed the PAD HUD fields to "unknown" so a pre-init read of the diag line can't be mistaken
+    // for a latched digital-only verdict (AC:0) or an empty mode table (md:0).
+    gDiag.padAnalogCapable = -1;
+    gDiag.padModes = -1;
+    gDiag.padMode0 = -1;
+    gDiag.padMode1 = -1;
     initializePad(pad);
 
     newState = waitPadReady(pad);

--- a/src/themes.c
+++ b/src/themes.c
@@ -2021,9 +2021,10 @@ static void thmLoadFonts(config_set_t *themeConfig, const char *themePath, theme
     }
 }
 
-// #120: how long a theme (re)load waits for MMCE-backed art to abort before force-resetting the art
-// worker (mirrors mmcesupport.c's MMCE_ART_ABORT_WAIT_TICKS). A wedged MMCE read that never returns is
-// broken out of via cacheEnd(1)/cacheInit() after this bound, so a theme swap can never hang.
+// #120: how long a theme (re)load waits for MMCE-backed art to abort before giving up (mirrors
+// mmcesupport.c's MMCE_ART_ABORT_WAIT_TICKS). A wedged MMCE read that never returns makes thmLoad
+// ABANDON the swap and keep the current theme (never cacheEnd(1): its TerminateThread would kill the
+// worker mid-fileXio and orphan the shared RPC channel), so a theme swap can never hang.
 #define THM_MMCE_ART_ABORT_WAIT_TICKS 500
 
 // Returns 0 on success, -1 when the load was ABANDONED because the art worker would not drain (a

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -762,19 +762,15 @@ int vcdEquipBdma(int source, int mode, char *diag, int diagSize)
         return -4; // the matched SOURCE device had no variant files in its POPS/ (or none matched)
     }
 
-    // Stage BOTH replacements and backups before touching either live module. vcdSafeCopyFile removes
-    // a partial destination on failure, which is safe for these private staging names but not for a live
-    // driver. If either commit fails, restore the complete old pair (or the old absence) and still let the
-    // caller follow the established best-effort POPSTARTER handoff policy.
-    char tmp0[96], tmp1[96], bak0[96], bak1[96];
+    // Stage BOTH replacements before touching either live module. vcdSafeCopyFile removes a partial
+    // destination on failure, which is safe for these private staging names but not for a live driver.
+    // Staging guarantees both variant files were fully READ off the source device (the realistic torn-
+    // pair cause is a flaky USB/MMCE source dying between file 1 and file 2) before the live pair moves.
+    char tmp0[96], tmp1[96];
     snprintf(tmp0, sizeof(tmp0), "%s/%s.new", mcDir, vcdBdmaModule[0]);
     snprintf(tmp1, sizeof(tmp1), "%s/%s.new", mcDir, vcdBdmaModule[1]);
-    snprintf(bak0, sizeof(bak0), "%s/%s.bak", mcDir, vcdBdmaModule[0]);
-    snprintf(bak1, sizeof(bak1), "%s/%s.bak", mcDir, vcdBdmaModule[1]);
     unlink(tmp0);
     unlink(tmp1);
-    unlink(bak0);
-    unlink(bak1);
 
     int r = vcdSafeCopyFile(src0, tmp0);
     if (r == 0)
@@ -785,51 +781,25 @@ int vcdEquipBdma(int source, int mode, char *diag, int diagSize)
         return r;
     }
 
-    int old0 = open(dst0, O_RDONLY);
-    int old1 = open(dst1, O_RDONLY);
-    int had0 = old0 >= 0;
-    int had1 = old1 >= 0;
-    if (old0 >= 0)
-        close(old0);
-    if (old1 >= 0)
-        close(old1);
-
-    // Same-directory renames avoid a second full copy of every module. Move the old pair aside,
-    // install both staged files, and restore both old names if any step fails.
-    if (had0 && rename(dst0, bak0) != 0)
-        r = -3;
-    if (r == 0 && had1 && rename(dst1, bak1) != 0) {
-        if (had0)
-            rename(bak0, dst0);
-        r = -3;
+    // Commit by COPY, not rename(): this dir is always on mc0:/mc1:, and the stock mcman.irx OPL embeds
+    // registers the legacy ioman 'mc' device with NO rename op -- iomanX returns -EUNSUP for every mc
+    // rename(), so a rename-based swap can never succeed here. If a commit write fails, the CARD is
+    // refusing IO: normalize to the consistent no-pair state (POPStarter falls back to its built-in
+    // FAT32 driver, same as the VCD_BDMA_FAT32 path) rather than leave a torn mixed-variant pair.
+    unlink(dst0); // free the old module's space first; tmp + old + new pairs may not fit a real MC
+    r = vcdSafeCopyFile(tmp0, dst0);
+    if (r == 0) {
+        unlink(dst1);
+        r = vcdSafeCopyFile(tmp1, dst1);
     }
-    if (r == 0 && rename(tmp0, dst0) != 0) {
-        if (had0)
-            rename(bak0, dst0);
-        if (had1)
-            rename(bak1, dst1);
-        r = -3;
-    }
-    if (r == 0 && rename(tmp1, dst1) != 0) {
-        unlink(dst0);
-        if (had0)
-            rename(bak0, dst0);
-        if (had1)
-            rename(bak1, dst1);
-        r = -3;
-    }
-    if (r != 0) {
-        unlink(tmp0);
-        unlink(tmp1);
-        unlink(bak0);
-        unlink(bak1);
-        return r;
-    }
-
     unlink(tmp0);
     unlink(tmp1);
-    unlink(bak0);
-    unlink(bak1);
+    if (r != 0) {
+        unlink(dst0); // drop the half-installed pair; vcdSafeCopyFile already removed its partial write
+        unlink(dst1);
+        vcdWriteBdmaMarker(mcDir, VCD_BDMA_FAT32);
+        return r;
+    }
 
     int mr = vcdWriteBdmaMarker(mcDir, mode);
     return (mr != 0) ? mr : 0;


### PR DESCRIPTION
Outcome of a full adversarial triage of the three third-party #120 audits (Gemini / Codex / Copilot) against current master — 17 verification agents, every claim checked against real code. Most audit claims were already-shipped fixes or invented mechanics, but the triage surfaced **two live regressions in PRs #148–#150 that none of the audits caught**, plus two confirmed low/medium control-plane gaps they half-saw.

## 1. `fix(hdd)`: PFS never received its arguments — the entire `pfs1:` APA-VCD scan was inert
`pfsarg` began with a leading `"\0"`. LOADFILE supplies `argv[0]` (`"LBbyEE"`) for buffer loads, so that empty string was `argv[1]` — and ps2fs stops parsing options at the first token that doesn't start with `-`. **Every option (`-m 2 -o 10 -n 40`) was silently discarded**; PFS ran at defaults (`maxMount=1, maxOpen=2, numBuf=8`). Upstream OPL carries the same dead byte (harmless there — it only mounts `pfs0:`). It became load-bearing when #149 appended `-m 2` behind it: with one mount slot held by `pfs0:`, every `fileXioMount("pfs1:")` failed and the HDD (APA) PS1 list silently stayed **empty** — the exact thing Blade1984000 is HW-testing right now. Verified against ps2sdk modload/loadfile/pfs sources. Side effect worth knowing: `-o 10 -n 40` now apply for the first time ever (more concurrent pfs opens + 5× buffers).

## 2. `fix(vcd)`: BDMA equip could never succeed — `rename()` is unsupported on `mc`
#150's staged-swap commits via same-dir `rename()` on `mc0:/mc1:` paths, but stock `mcman.irx` registers the legacy ioman `mc` device with **no rename op** (iomanX → `-EUNSUP`). Every equip failed with "IO error" after wasting two staged copies; the equip + Apply-on-Launch feature was functionally dead (launches still proceeded — the dumb-handoff contract held). Now commits by copy, keeps the staging (both files fully read off the source before the live pair moves), and normalizes to the consistent no-pair + FAT32-marker state on a commit-write failure instead of a torn mixed-variant pair.

## 3. `fix(bdm)`: publish-time transport-enable gate (audit F-13 — the one real "USB kicks on the HDD" mechanism)
The per-type `gEnable*` filter only hid pages **already visible** — one refresh pass late. A mounted ATA-backed slot with BDM HDD OFF (left over from the boot-resolver escalation or a BDMA-equip force-load) flashed its tab, played the connect sound, and folder-wrote the device on every `BdmGeneration` bump. Now filtered at publish time; generic/unknown drivers keep the never-force-hidden behavior; device identity stays populated for the equip/pickers.

## 4. `fix(cfg)`: APA vs BDM-ATA exclusivity is now a load-time invariant (audit F-12)
Both flags could survive a legacy/hand-edited config load and both stacks would initialize; the ATA-boot reconcile even force-enabled BDM-ATA without clearing a loaded APA mode. Normalized at `_loadConfig` (boot-device backend wins) and the reconcile now clears APA.

## Verified-NOT-issues from the audits (no code changed, for the record)
- `xhdd -nobdm` / `IOP_DT_CHAR` proposal: **invented mechanics** — bdmfs_fatfs never scans iomanX device types; xhdd never registers with BDM (the registrant is `ata_bd` and it ignores argv). Do not apply it.
- "No async IO worker exists" (Copilot): texcache **is** that worker; all its proposed throttles already ship, more granular than proposed.
- mmceResetChannel 3-strike recovery (Codex 1.7): landed in #136, **failed on hardware, reverted** in `bee3c358` — don't re-land as described.
- `cacheEnd(1)`/TerminateThread: reachable only on poweroff/exit/disc-boot teardown, after bounded aborts — safe-by-construction; only a stale comment referenced the old behavior (fixed here).
- mmceman FD leak: already patched in the primary flavour; WOPLSDK/PS2MAXSDK stay stock **by design** (provenance discriminator).
- IGR on MMCE: `mmceigr.irx` + `gMMCEIGRSlot` (default BOTH) already ship, and the `mc0:` hint already shipped in `98240feb` — the audits' "workaround" is the current documented behavior.

## Build & test
- Full build green in `ps2dev/ps2dev:latest` (only the pre-existing `system.c` const warning).
- HW validation wanted: **APA VCD list on internal HDD** (Blade's exact scenario — with this fix `pfs1:` mounts for the first time on real HW), BDMA equip from Settings (should stop erroring), and a boot from ATA-backed BDM with a legacy config carrying both HDD flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)