### PR TITLE
fix(mmce): theme discovery on MMCE -- unreachable registration + untrustworthy d_type (#152)

### DIFF
--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -344,6 +344,12 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     if (mmcePrefix[0] == '\0') {
         mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
         mmceFoldersCreatedFor[0] = '\0'; // card gone: recreate folders on the next (possibly different) card
+        // Card gone: re-arm THM/LNG registration so a swapped-in card's assets get discovered
+        // (Gemini review of #153). The old card's already-registered entries stay in the pickers --
+        // eviction infrastructure doesn't exist -- but picking a stale one fails gracefully
+        // (thmLoad abandons and keeps the current theme), and thmAddElements caps at THM_MAX_FILES.
+        ThemesLoaded = 0;
+        LanguagesLoaded = 0;
         return (mmceGameCount > 0 || mmceVcdGameCount > 0);
     }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -349,6 +349,24 @@ static int mmceNeedsUpdate(item_list_t *itemList)
 
     mmceGameList.updateDelay = MENU_UPD_DELAY_NOUPDATE;
 
+    // Register the card's THM/LNG dirs BEFORE the VCD-view early returns (#152, AndrewBento). These
+    // used to sit below them, giving one realistic shot at boot: once the first list scan latches
+    // NOUPDATE above, the only future passes are L3-toggle / VCD-view ones, which returned before
+    // reaching the registration -- so if the boot-time attempt lost a race against the contended
+    // MMCE SIO2 bus (config + list + art traffic), themes on the card stayed invisible for the whole
+    // session while USB's fast first try succeeded. Here every pass retries until each succeeds; the
+    // cost is one dir-open per pass until then (identical to the old ISO-view retry behavior).
+    if (!ThemesLoaded) {
+        sprintf(path, "%sTHM", mmcePrefix);
+        if (thmAddElements(path, "/", 1) > 0)
+            ThemesLoaded = 1;
+    }
+    if (!LanguagesLoaded) {
+        sprintf(path, "%sLNG", mmcePrefix);
+        if (lngAddLanguages(path, "/", mmceGameList.mode) > 0)
+            LanguagesLoaded = 1;
+    }
+
     // VCD view: force a rescan once on toggle, then skip the disc heuristics while showing VCDs.
     if (vcdConsumeDirty(itemList->mode))
         return 1;
@@ -386,19 +404,8 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     if (!sbIsSameSize(mmcePrefix, mmceULSizePrev))
         result = 1;
 
-    // update Themes
-    if (!ThemesLoaded) {
-        sprintf(path, "%sTHM", mmcePrefix);
-        if (thmAddElements(path, "/", 1) > 0)
-            ThemesLoaded = 1;
-    }
-
-    // update Languages
-    if (!LanguagesLoaded) {
-        sprintf(path, "%sLNG", mmcePrefix);
-        if (lngAddLanguages(path, "/", mmceGameList.mode) > 0)
-            LanguagesLoaded = 1;
-    }
+    // Themes/Languages registration moved ABOVE the VCD-view early returns (#152) -- see the block
+    // after the NOUPDATE latch near the top of this function.
 
     // Create the library folders once per card/slot, not on every refresh (each is an SIO2 mkdir).
     if (strcmp(mmceFoldersCreatedFor, mmcePrefix) != 0) {

--- a/src/themes.c
+++ b/src/themes.c
@@ -1943,7 +1943,7 @@ static int thmReadEntry(int index, const char *path, const char *separator, cons
     // is not positively DT_DIR, confirm with an opendir() probe: it succeeds only for directories
     // on every driver regardless of mode-bit dialect, and runs only for THM-folder candidates.
     int isDir = (d_type == DT_DIR);
-    if (!isDir && strstr(name, "thm_")) {
+    if (!isDir && strncmp(name, "thm_", 4) == 0) {
         char probe[256];
         snprintf(probe, sizeof(probe), "%s%s%s", path, separator, name);
         DIR *pd = opendir(probe);
@@ -1953,7 +1953,9 @@ static int thmReadEntry(int index, const char *path, const char *separator, cons
         }
     }
 
-    if (isDir && strstr(name, "thm_")) {
+    // strncmp, not upstream's strstr: the name parse below assumes the prefix is at the START
+    // (name + 4), so a mid-string "thm_" match always produced a garbage theme name anyway.
+    if (isDir && strncmp(name, "thm_", 4) == 0) {
         theme_file_t *currTheme = &themes[nThemes + index];
 
         int length = strlen(name) - 4 + 1;

--- a/src/themes.c
+++ b/src/themes.c
@@ -1935,7 +1935,25 @@ static void thmFree(theme_t *theme)
 
 static int thmReadEntry(int index, const char *path, const char *separator, const char *name, unsigned char d_type)
 {
-    if (d_type == DT_DIR && strstr(name, "thm_")) {
+    // #152: don't trust d_type alone. It is derived from iomanX FIO_S_IFDIR mode bits, but MMCE
+    // card FIRMWARE fills stat.mode verbatim over the wire (mmceman copies it through), and clone
+    // firmwares (e.g. Bitfunx PSxMemCard) may not speak the FIO_S_* dialect -- every entry then
+    // degrades to DT_UNKNOWN. That is why languages still listed (lngReadEntry accepts != DT_DIR)
+    // while themes vanished (this required == DT_DIR exactly). For a thm_-prefixed candidate that
+    // is not positively DT_DIR, confirm with an opendir() probe: it succeeds only for directories
+    // on every driver regardless of mode-bit dialect, and runs only for THM-folder candidates.
+    int isDir = (d_type == DT_DIR);
+    if (!isDir && strstr(name, "thm_")) {
+        char probe[256];
+        snprintf(probe, sizeof(probe), "%s%s%s", path, separator, name);
+        DIR *pd = opendir(probe);
+        if (pd != NULL) {
+            closedir(pd);
+            isDir = 1;
+        }
+    }
+
+    if (isDir && strstr(name, "thm_")) {
         theme_file_t *currTheme = &themes[nThemes + index];
 
         int length = strlen(name) - 4 + 1;


### PR DESCRIPTION
Root-causes [#152](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/152) (Andrew: themes on MMCE never found, USB fine). Two stacked causes, both fixed:

**1. The registration was starved.** `mmceNeedsUpdate`'s THM/LNG registration sat *below* the VCD-view early returns; after the first list scan latches `NOUPDATE`, the only passes that ever run again are L3-toggle/VCD ones — which return before reaching it. Net effect: one shot at boot, racing the contended MMCE bus. Lost the race → no themes all session. Now hoisted above the early returns so every pass retries until success (manual refresh in VCD view retries too).

**2. `d_type == DT_DIR` can't be trusted on MMCE.** The readdir glue derives `DT_DIR` from iomanX `FIO_S_IFDIR` bits, but mmceman copies `stat.mode` **verbatim from the card firmware** (verified in `mmce_fs_dread` at the pin; the protocol doc doesn't pin semantics) — a clone firmware like the Bitfunx PSxMemCard can degrade every entry to `DT_UNKNOWN`. The smoking-gun asymmetry: the language loader accepts `!= DT_DIR` (tolerates UNKNOWN → languages kept working), the theme loader demanded `== DT_DIR` (→ only themes vanished). Non-`DT_DIR` `thm_*` candidates now get one `opendir()` probe — directory-detection that works on every driver regardless of mode-bit dialect, bounded to THM-folder entries, `DT_DIR` fast path unchanged.

Addresses #152 — leaving the issue open pending Andrew's hardware confirmation (PCSX2 has no mmceman). Test: themes in `mmce0:/THM/thm_<name>/` should appear in the theme picker; if not at boot, an L3 toggle or refresh should pull them in.

Build green in `ps2dev:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)