### PR TITLE
fix(mmce): disc badge in ~0.5s on single-step -- scroll-time config uses the launch path's piping (#49)

### DIFF
--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1256,8 +1256,13 @@ static void menuRenderElements(theme_elems_t *elems, int allowItemConfig, config
 void menuRenderMain(void)
 {
     item_list_t *list = selected_item->item->userdata;
-    int allowItemConfig = !(list != NULL && list->mode == MMCE_MODE);
-    config_set_t *renderConfig = allowItemConfig ? itemConfig : NULL;
+    // MMCE main-screen item config re-enabled (#49): the b8bff90e-era hard-disable predates every
+    // piece of today's gating (worker settles, the 20-frame idle gate, the #120 hardening) and it
+    // meant the main-page #DiscType/#System badges could NEVER resolve on MMCE. The request now
+    // flows through menuCanRequestItemConfig's settled gate: at most one paced CFG open per settled
+    // selection -- the same browse-time read the FAV tab has always done for MMCE-sourced items.
+    int allowItemConfig = 1;
+    config_set_t *renderConfig = itemConfig;
 
     if (vcdViewActive(list->mode)) {
         // VCD/PS1 listings render with the vcd family (vcdMain*; each slot falls back at parse time to

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -101,13 +101,18 @@ static int menuCanRequestItemConfig(item_list_t *list)
     if (list != NULL && list->mode == APP_MODE)
         return guiInactiveFrames >= MENU_APP_CONFIG_IDLE_FRAMES;
 
-    // MMCE art and per-item config share the same device I/O path. Keep config behind
-    // queued or active interactive art, then retain the longer settle for the card.
-    if (list != NULL && list->mode == MMCE_MODE) {
-        if (cacheHasPendingInteractiveArt())
-            return 0;
+    // MMCE: same piping as the hardware-proven DIRECT config path (menuLoadConfigDirectInternal),
+    // which every launch/settings press has always used: the single CFG open/read/close simply
+    // serializes behind the current art chunk at the fileXio RPC layer (typically <= 20 ms) -- no
+    // waiting for the WHOLE interactive art set (cover + background + overlays) to drain. That
+    // drain-wait was the ~5 s disc-badge latency on a slow single step (issue #49, AcidReach; on a
+    // cold MMCE page the set takes seconds while cacheHasPendingInteractiveArt() stays true the
+    // entire time). Unlike the direct path we do NOT send the art-abort signal: the settled item's
+    // own cover is still loading and must not restart. The 20-frame settle below keeps the read off
+    // the active-scroll path, so there is at most ONE CFG open per settled selection -- the same
+    // per-press cost the direct path has always put on the card.
+    if (list != NULL && list->mode == MMCE_MODE)
         return guiInactiveFrames >= MENU_MMCE_CONFIG_IDLE_FRAMES;
-    }
 
     // BDM / ETH / HDD / FAV: the per-item config carries only the cheap, metadata-derived
     // #DiscType/#System/#Media badge values -- it must NOT wait for the whole interactive-art set


### PR DESCRIPTION
Addresses the residual of [#49](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/49): the ~5s disc-badge delay on MMCE single-step navigation.

**Mechanism:** the badge's `#DiscType` value lives in the per-item config; the scroll-time config request was gated behind `cacheHasPendingInteractiveArt()` — i.e. the *entire* cover+background+overlay set draining over SIO2 (~5s cold). Revisits skipped the drain (art cached) → ~0.5s; rapid scrolls landed prefetch-warmed → near-instant. That's exactly AcidReach's timing table.

**Fix (per Nathan: "make it the same as the working piping"):** the direct config path — used by every launch/settings press since forever — never waited for the drain; its CFG read serializes behind the current art chunk at the fileXio RPC layer (≤20ms, hardware-proven). Scroll-time now uses the same piping, keeping the 20-frame settle (one CFG open per *settled* selection, nothing mid-scroll) and deliberately **not** sending the direct path's art-abort signal, so the settled item's cover keeps loading uninterrupted.

**#120 exposure:** card-side delta is one CFG open per settled step — identical to the per-press cost the direct path has always put on the card, vs the ~9-failing-opens-per-info-entry burst that characterized the wedge. A history-verification pass on the `01aa6d3e` → `7c4a74a4` gate lineage is running; its verdict will be appended before merge.

Build green in `ps2dev:latest`. Expected result for AcidReach: badge ≈0.5s on every single step (same as his revisit timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)