### PR TITLE
feat(cheats): CHT/cht.tar support (wOPL parity) + honest missing-file toast (#154)

### DIFF
--- a/include/cheatman.h
+++ b/include/cheatman.h
@@ -76,6 +76,7 @@ void InitCheatsConfig(config_set_t *configSet);
 int GetCheatsEnabled(void);
 const u32 *GetCheatsList(void);
 int load_cheats(const char *cheatfile);
+int load_cheats_buf(const char *buf); // buf must be NUL-terminated (tar members carry no NUL)
 void set_cheats_list(void);
 
 // Prebuilt PS2RD cheat image (.img): a binary patch list applied directly at boot, parallel to the

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -298,7 +298,11 @@ static int parse_buf(const char *buf)
         int len = lfIdx;
         if (len < 0)
             len = strlen(buf);
-        else if (len > CHEAT_LINE_MAX)
+        // Cap BOTH branches: a final line with no trailing LF longer than CHEAT_LINE_MAX used to
+        // strncpy past line[256] -- a stack smash on the launch thread. Loose .cht files always
+        // carried this; community-distributed cht.tar packs make malformed input a first-class
+        // vector, so it lands with the tar support (adversarial review of #154).
+        if (len > CHEAT_LINE_MAX)
             len = CHEAT_LINE_MAX;
 
         if (!is_empty_substr(buf, len)) {
@@ -407,16 +411,14 @@ static inline char *read_text_file(const char *filename, int maxsize)
 /*
  * Load cheats from text file.
  */
-int load_cheats(const char *cheatfile)
+// Lazy cheat table: MAX_CODES x sizeof(cheat_entry_t) (~1.03 MB) that used to sit in BSS
+// permanently, held even with cheats off (the default). Allocated on the first cheat load and
+// kept for the session (a successful launch hands off to ExecPS2 anyway; a failed one reuses
+// the buffer on retry). An allocation failure degrades exactly like an unreadable cheat file --
+// the launch legs already toast _STR_ERR_CHEATS_LOAD_FAILED for ret < 0. Shared by the loose-
+// file loader below and the CHT/cht.tar member loader (load_cheats_buf).
+static int ensureCheatTable(void)
 {
-    char *buf = NULL;
-    int ret;
-
-    // Lazy cheat table: MAX_CODES x sizeof(cheat_entry_t) (~1.03 MB) that used to sit in BSS
-    // permanently, held even with cheats off (the default). Allocated on the first cheat-file
-    // load and kept for the session (a successful launch hands off to ExecPS2 anyway; a failed
-    // one reuses the buffer on retry). An allocation failure degrades exactly like an unreadable
-    // cheat file -- the launch legs already toast _STR_ERR_CHEATS_LOAD_FAILED for ret < 0.
     if (gCheats == NULL) {
         gCheats = (cheat_entry_t *)malloc(MAX_CODES * sizeof(cheat_entry_t));
         if (gCheats == NULL) {
@@ -425,6 +427,16 @@ int load_cheats(const char *cheatfile)
         }
     }
     memset(gCheats, 0, MAX_CODES * sizeof(cheat_entry_t));
+    return 0;
+}
+
+int load_cheats(const char *cheatfile)
+{
+    char *buf = NULL;
+    int ret;
+
+    if (ensureCheatTable() < 0)
+        return -1;
 
     LOG("%s: Reading cheat file '%s'...\n", __FUNCTION__, cheatfile);
     buf = read_text_file(cheatfile, 0);
@@ -436,6 +448,24 @@ int load_cheats(const char *cheatfile)
     ret = parse_buf(buf);
     free(buf);
 
+    if (ret < 0)
+        return ret;
+
+    return (gCheatMode == 0) ? 0 : 1;
+}
+
+// Parse cheats from an in-memory buffer (a CHT/cht.tar member). buf MUST be NUL-terminated --
+// tar members carry no terminator, so the caller allocates rawSize+1 and terminates. wOPL's
+// variant takes an unused size parameter and feeds the raw tar buffer to the parser (a latent
+// overread); the explicit contract here avoids porting that.
+int load_cheats_buf(const char *buf)
+{
+    int ret;
+
+    if (buf == NULL || ensureCheatTable() < 0)
+        return -1;
+
+    ret = parse_buf(buf);
     if (ret < 0)
         return ret;
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -10,6 +10,7 @@
 #include "include/ioman.h"
 #include "modules/iopcore/common/cdvd_config.h"
 #include "include/cheatman.h"
+#include "include/tar.h" // CHT/cht.tar cheat archive (#154, wOPL 1.2 parity)
 #include "include/pggsm.h"
 #include "include/ps2cnf.h"
 #include "include/gui.h"
@@ -1308,12 +1309,52 @@ int sbLoadCheats(const char *path, const char *file)
     int cheatMode = 0;
 
     if (GetCheatsEnabled()) {
+        // wOPL 1.2 parity (#154, Blade1984000's widescreen packs): CHT/cht.tar -- a flat ustar of
+        // <startup>.cht members at a device root -- is probed FIRST, cross-device (the tar engine's
+        // gDevices order; the CHT kind's tables have shipped inert in src/tar.c since the art port).
+        // The loose CHT/<startup>.cht below stays the untouched fallback for any tar miss/failure.
+        char member[64];
+        if (snprintf(member, sizeof(member), "%s.cht", file) < (int)sizeof(member)) {
+            const TarEntryBase *entry = tarFind(TAR_KIND_CHT, member);
+            // rawSize == 0 counts as a miss (wOPL parity: its size check rejects empty members) so
+            // an empty tar member never shadows a possibly-valid loose CHT/<id>.cht below.
+            if (entry != NULL && entry->rawSize > 0) {
+                // rawSize+1: tar members carry no NUL and the parser needs a terminator. wOPL feeds
+                // the raw tar buffer to its parser (a latent overread we deliberately do not copy).
+                char *tarBuf = (char *)malloc(entry->rawSize + 1);
+                if (tarBuf != NULL) {
+                    if (tarRead(TAR_KIND_CHT, entry, tarBuf, entry->rawSize) == entry->rawSize) {
+                        tarBuf[entry->rawSize] = '\0';
+                        cheatMode = load_cheats_buf(tarBuf);
+                    } else
+                        cheatMode = -1;
+                    free(tarBuf);
+                    if (cheatMode >= 0) {
+                        LOG("Cheats found in CHT/cht.tar (%s)\n", tarGetDevicePrefix(TAR_KIND_CHT));
+                        if ((gAutoLaunchGame == NULL) && (gAutoLaunchBDMGame == NULL) && (cheatMode == 1))
+                            guiManageCheats();
+                        return cheatMode;
+                    }
+                    LOG("Error: cht.tar member failed to load; trying the loose file\n");
+                }
+            }
+        }
+
         snprintf(cheatfile, sizeof(cheatfile), "%sCHT/%s.cht", path, file);
         LOG("Loading Cheat File %s\n", cheatfile);
 
-        if ((cheatMode = load_cheats(cheatfile)) < 0)
+        if ((cheatMode = load_cheats(cheatfile)) < 0) {
+            // Distinguish absent from unreadable so the launch legs' 'No cheats found' branch --
+            // dead code until now (load_cheats never returned -ENOENT; an upstream errno-propagation
+            // attempt wrote to the pointer and was reverted) -- fires for a merely-missing file
+            // instead of the scary 'failed to load cheats' toast.
+            int probe = open(cheatfile, O_RDONLY);
+            if (probe < 0)
+                cheatMode = -ENOENT;
+            else
+                close(probe);
             LOG("Error: failed to load cheats\n");
-        else {
+        } else {
             LOG("Cheats found\n");
             if ((gAutoLaunchGame == NULL) && (gAutoLaunchBDMGame == NULL) && (cheatMode == 1))
                 guiManageCheats();


### PR DESCRIPTION
Addresses Blade1984000's report in #154: widescreen cheat packs (`cht.tar`) never load, and his loose-file attempt also failed.

## What was wrong
1. **`cht.tar` was a feature gap** — wOPL 1.2 probes `CHT/cht.tar` before the loose file; our tar engine has carried the CHT plumbing **inert since the art port** (the header says "kept intact so they can be wired later"). Now wired: tar-first, cross-device, case-insensitive member match, loose `CHT/<startup>.cht` untouched as fallback. Improvements over wOPL kept deliberately: our parser gets a NUL-terminated copy (wOPL feeds the raw tar buffer — a latent overread), and empty members fall through to the loose file.
2. **The "No cheats found" mild toast was dead code at all five launch legs** — `load_cheats` never returned `-ENOENT` (upstream errno bug, attempted + reverted), so a merely-missing file always toasted the scary "failed to load cheats". Revived: absent → mild, unreadable/alloc-fail → scary.
3. **Bonus (adversarial review): pre-existing stack smash fixed** — `parse_buf` didn't cap the final line's length when it lacked a trailing LF; >255 chars overran a stack buffer on the launch thread. Community tar packs make malformed input a first-class vector, so it lands with the feature.

## For Blade's loose-file mystery
HDD-launched games read cheats from `pfs0:CHT/` **inside the +OPL partition** (not visible from Windows; not the USB root) — the most likely reason his extracted files also failed. With this port his `cht.tar` works from any device root, same as wOPL. Discriminator if anything still fails: one loose `<GAMEID>.cht` (lowercase extension) in `USB:\CHT\`, launch that game **from USB**.

Verified: compile-checked green by the reviewer itself; CHT tar state fully disjoint from the art worker's; member names can't exceed the index cap (`GAME_STARTUP_MAX=12` vs 19); `tarRead` returns exact-or-zero; read-only devices skip the cache sidecar harmlessly; 4 MiB member cap bounds allocations. Known (inherited, same as art-tar): a `cht.tar` added after the first cheat-enabled launch isn't seen until reboot.

HW test: Blade's widescreen `cht.tar` at `USB:\CHT\cht.tar` (or on the +OPL partition), cheats enabled per game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)