### PR TITLE
fix(cheats): cap cht.tar member reads at 1 MiB (Gemini follow-up to #158)

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1317,8 +1317,13 @@ int sbLoadCheats(const char *path, const char *file)
         if (snprintf(member, sizeof(member), "%s.cht", file) < (int)sizeof(member)) {
             const TarEntryBase *entry = tarFind(TAR_KIND_CHT, member);
             // rawSize == 0 counts as a miss (wOPL parity: its size check rejects empty members) so
-            // an empty tar member never shadows a possibly-valid loose CHT/<id>.cht below.
-            if (entry != NULL && entry->rawSize > 0) {
+            // an empty tar member never shadows a possibly-valid loose CHT/<id>.cht below. The upper
+            // cap keeps a malformed/hostile member from asking for the tar engine's full 4 MiB at the
+            // launch's most heap-tight moment (Gemini review of #158): real cheat files are text that
+            // parses into at most MAX_CODES=250 cheats -- 1 MiB is already absurdly generous, and an
+            // over-cap member simply falls through to the loose file like any other miss.
+#define CHT_TAR_MEMBER_MAX (1024 * 1024)
+            if (entry != NULL && entry->rawSize > 0 && entry->rawSize <= CHT_TAR_MEMBER_MAX) {
                 // rawSize+1: tar members carry no NUL and the parser needs a terminator. wOPL feeds
                 // the raw tar buffer to its parser (a latent overread we deliberately do not copy).
                 char *tarBuf = (char *)malloc(entry->rawSize + 1);

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1300,6 +1300,12 @@ void sbCreateFolders(const char *path, int createDiscImgFolders)
         sbCreateFoldersFromList(path, discImgFolders);
 }
 
+// Upper bound on a CHT/cht.tar member read (Gemini review of #158/#159): the tar engine itself
+// allows 4 MiB, but cheat files are text parsing into at most MAX_CODES=250 cheats -- 1 MiB is
+// already absurdly generous, and a malformed/hostile over-cap member must not demand a contiguous
+// 4 MiB at the launch's most heap-tight moment. Over-cap members fall through to the loose file.
+#define CHT_TAR_MEMBER_MAX (1024 * 1024)
+
 int sbLoadCheats(const char *path, const char *file)
 {
     // 64 was too small for BDM device prefixes (up to BDM_PREFIX_MAX) plus
@@ -1317,12 +1323,8 @@ int sbLoadCheats(const char *path, const char *file)
         if (snprintf(member, sizeof(member), "%s.cht", file) < (int)sizeof(member)) {
             const TarEntryBase *entry = tarFind(TAR_KIND_CHT, member);
             // rawSize == 0 counts as a miss (wOPL parity: its size check rejects empty members) so
-            // an empty tar member never shadows a possibly-valid loose CHT/<id>.cht below. The upper
-            // cap keeps a malformed/hostile member from asking for the tar engine's full 4 MiB at the
-            // launch's most heap-tight moment (Gemini review of #158): real cheat files are text that
-            // parses into at most MAX_CODES=250 cheats -- 1 MiB is already absurdly generous, and an
-            // over-cap member simply falls through to the loose file like any other miss.
-#define CHT_TAR_MEMBER_MAX (1024 * 1024)
+            // an empty tar member never shadows a possibly-valid loose CHT/<id>.cht below; over-cap
+            // members likewise fall through (CHT_TAR_MEMBER_MAX above).
             if (entry != NULL && entry->rawSize > 0 && entry->rawSize <= CHT_TAR_MEMBER_MAX) {
                 // rawSize+1: tar members carry no NUL and the parser needs a terminator. wOPL feeds
                 // the raw tar buffer to its parser (a latent overread we deliberately do not copy).


### PR DESCRIPTION
Takes Gemini's one valid finding on #158 (posted after merge): the tar branch accepted members up to the engine's 4 MiB cap, which is a needless contiguous allocation on a 32 MB console at the launch's most heap-tight moment. Cheat files are text parsing into at most 250 cheats — 1 MiB is already absurdly generous. Over-cap members now fall through to the loose file like any other tar miss. One line + comment; build green in ps2dev:latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)