### PR TITLE
feat(themes): per-device element placement (devices= on MenuIcon/ItemsList/HintText)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ This build layers several features on top of upstream OPL:
   cover count, and aspect-correct covers in both 4:3 and widescreen. Tune it live under
   **Coverflow Settings** (shown while the Coverflow theme is active). Authoring details
   and every theme value live in the **[Theme Engine reference](docs/THEME_ENGINE.md)**.
+- **Per-device theme placement (`devices=`):** themes can position the device icon, the games
+  list and the button hints **differently per device page** (e.g. pin the MMCE icon top-right
+  while every other page keeps the shared spot). Add `devices=usb,hdd,…` to a `MenuIcon`,
+  `ItemsList` or `HintText` block; the unfiltered element automatically stands down on the pages
+  a filtered one covers. Existing themes are untouched. See
+  **[Theme Engine reference §5](docs/THEME_ENGINE.md#per-device-placement-devices--this-fork)**.
 - **Cover-art `.tar` archive (opt-in):** keep all of a device's covers in a single uncompressed
   **`ART/art.tar`** (entries named `<GAMEID>_<suffix>.png`; VCD entries first use the filename without
   `.VCD`, or the displayed `PP.<name>` / `__.<name>` install name, then fall back to a parsed PS1 ID)

--- a/docs/THEME_ENGINE.md
+++ b/docs/THEME_ENGINE.md
@@ -126,6 +126,7 @@ Every element block starts with `type=<ElementType>` (see §5). Most also accept
 | `font` | `0`…`15` | `0` | Font index (see §2). |
 | `reflection` | `0` / `1` | `0` | Draw a mirrored reflection beneath the element (used by `Coverflow`). |
 | `enabled` | `0` / `1` | `1` | Set `0` to skip the element without deleting the block. |
+| `devices` | name list | *(none)* | **This fork.** Show the element only on the listed device pages — honored by `MenuIcon`, `ItemsList` and `HintText` (ignored elsewhere). See §5 “Per-device placement”. |
 
 **Value tokens:** `POS_MID`, `DIM_INF` (above), and `#RRGGBB` for colors. `x`/`y` accept
 negative numbers for right/bottom-relative placement.
@@ -201,6 +202,63 @@ Set with `type=`. Elements marked **item** redraw when you move the selection.
 | Property | Used by | Notes |
 |---|---|---|
 | `decorator` | `ItemsList` | A `GameImage` pattern name to draw as per-row icons. |
+
+### Per-device placement (`devices=`) — *this fork*
+
+Normally one `MenuIcon`, one `ItemsList` and one `HintText` serve **every** device page, so they
+share a single position. `devices=` lets a theme place them differently per device: an element
+with the key draws **only** on the listed pages, and an unfiltered element of the same type
+automatically stands down there (no key needed on it), staying the default everywhere else.
+
+```ini
+# The shared icon spot, used by every page not claimed below.
+main3:
+type=MenuIcon
+x=POS_MID
+y=400
+
+# On the MMCE and APA-HDD pages, pin the icon top-right instead.
+main4:
+type=MenuIcon
+devices=mmce,hdd
+x=-40
+y=24
+```
+
+**Device names** (comma-separated, case-insensitive):
+
+| Name | Page |
+|---|---|
+| `usb` | USB mass storage (any slot) |
+| `ilink` | iLink / FireWire |
+| `mx4sio` | MX4SIO |
+| `hdd_bd` | Internal HDD, exFAT (BDM) |
+| `hdd` | Internal HDD, APA/PFS |
+| `eth` | Network (SMB) |
+| `smb` | Alias of `eth` |
+| `mmce` | MMCE / memory-card emulator |
+| `udpbd` | UDPBD network boot |
+| `udpfs` | UDPFS network boot |
+| `app` | The Apps tab |
+| `fav` | The Favourites tab |
+| `bdm` | The generic BDM page before its driver is identified (auto/manual start) |
+
+Rules worth knowing:
+
+- **Only `MenuIcon`, `ItemsList` and `HintText`** honor the key; on other element types it parses
+  but has no effect.
+- Matching follows the page's **visible device icon**, so a BDM page counts as `usb`/`mx4sio`/…
+  once its driver is identified, and as `bdm` before that. In the PS1/VCD (L3) view the page keeps
+  the device's identity — filters keep working there via the `vcdMain*` family.
+- A filtered `ItemsList` is an **override**: it does not consume one of the theme's ItemsList
+  slots (games/apps/favs/VCD, claimed in file order — see §1), and navigation/paging automatically
+  follows whichever list is drawn. Give it its own `x`/`y`/`height` (its row count comes from
+  `height`); `decorator=` works as usual.
+- Unknown device names are logged and skipped; if nothing valid remains, the element behaves as if
+  the key were absent (shared placement) rather than disappearing.
+- Two filtered elements of the same type may list different devices; listing the **same** device
+  twice draws both — that's an authoring error, not a picker.
+- Themes without the key are untouched — the filter only activates when `devices=` appears.
 
 ---
 

--- a/docs/THEME_ENGINE.md
+++ b/docs/THEME_ENGINE.md
@@ -254,6 +254,9 @@ Rules worth knowing:
   slots (games/apps/favs/VCD, claimed in file order — see §1), and navigation/paging automatically
   follows whichever list is drawn. Give it its own `x`/`y`/`height` (its row count comes from
   `height`); `decorator=` works as usual.
+- **Keep one unfiltered `ItemsList`.** If *every* list in the theme carries `devices=`, OPL adds a
+  plain default list (373×316 at 42,42) on the pages nothing covers — navigation always needs a
+  list — and it won't match your layout.
 - Unknown device names are logged and skipped; if nothing valid remains, the element behaves as if
   the key were absent (shared placement) rather than disappearing.
 - Two filtered elements of the same type may list different devices; listing the **same** device

--- a/include/themes.h
+++ b/include/themes.h
@@ -88,6 +88,13 @@ typedef struct theme_element
     int font;
     int reflection;
     int reflectionOffset; // Coverflow: vertical px shift of the mirror (theme key reflection_offset; -up / +down)
+    // Per-device element filter (theme key devices=usb,hdd,...): bitmask over the thmDeviceVocab
+    // table indices in themes.c. 0 = unfiltered (the pre-existing behavior). deviceCoverage is
+    // filled at theme-load validation for UNFILTERED MenuIcon/ItemsList/HintText elements: the
+    // union of their family's filtered same-type masks, so an unfiltered element can skip the
+    // devices a filtered sibling covers without needing to know its family at draw time.
+    int deviceFilter;
+    int deviceCoverage;
 
     void *extended;
 
@@ -171,6 +178,11 @@ int thmAddElements(char *path, const char *separator, int forceRefresh);
 const char *thmGetValue(void);
 GSTEXTURE *thmGetTexture(unsigned int id);
 void thmEnd(void);
+
+// Per-device ItemsList resolution (theme key devices=): returns the first ItemsList element in the
+// family whose device filter matches iconId, else the given fallback -- so navigation math and the
+// drawn rows always agree. fallback must follow the existing never-NULL slot chain.
+theme_element_t *thmResolveItemsList(theme_elems_t *family, theme_element_t *fallback, int iconId);
 
 // Indices are shifted in GUI, as we add the internal default theme at 0
 int thmSetGuiValue(int themeID, int reload);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1272,7 +1272,7 @@ void menuRenderMain(void)
         // when the theme defines no 4th ItemsList (never NULL). This also covers the Favourites tab's
         // own VCD view (its L3 toggle): VCD favourites render with the PS1 family, not the favs family.
         menuRenderElements(&gTheme->vcdMainElems, allowItemConfig, renderConfig);
-        gTheme->itemsList = gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->vcdMainElems, gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else if (list->mode == FAV_MODE) {
         // Favourites (ISO view) render with the theme's favs family (favsMain*); falls back to the game
         // elements when the theme defines no favsMain override.
@@ -1280,13 +1280,15 @@ void menuRenderMain(void)
         // Fall back to the games list (the slot every real theme populates -- the 1st/only ItemsList)
         // when the theme defines no favs/apps/vcd ItemsList, so gTheme->itemsList stays set: the
         // scroll/paging code (menuNextV/PrevV/Page) derefs gTheme->itemsList->extended without a NULL check.
-        gTheme->itemsList = gTheme->favsItemsList ? gTheme->favsItemsList : gTheme->gamesItemsList;
+        // thmResolveItemsList overrides the slot with a devices=-filtered ItemsList when one covers this
+        // page's device icon -- the same rule drawItemsList gates on, so paging math matches the drawn rows.
+        gTheme->itemsList = thmResolveItemsList(&gTheme->favsMainElems, gTheme->favsItemsList ? gTheme->favsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else if (list->mode == APP_MODE) {
         menuRenderElements(&gTheme->appsMainElems, allowItemConfig, renderConfig);
-        gTheme->itemsList = gTheme->appsItemsList ? gTheme->appsItemsList : gTheme->gamesItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->appsMainElems, gTheme->appsItemsList ? gTheme->appsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else {
         menuRenderElements(&gTheme->mainElems, allowItemConfig, renderConfig);
-        gTheme->itemsList = gTheme->gamesItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->mainElems, gTheme->gamesItemsList, selected_item->item->icon_id);
     }
 }
 
@@ -1398,13 +1400,15 @@ void menuRenderInfo(void)
     if (vcdViewActive(list->mode)) {
         // The VCD list uses vcdItemsList (its own cover cache); falls back to the games list when
         // absent so itemsList is never NULL. Also covers the Favourites tab's VCD view (L3 toggle).
-        gTheme->itemsList = gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList;
+        // Resolution goes through thmResolveItemsList against the MAIN family (info families define
+        // no lists): paging on the info screen must count the rows of the list the MAIN screen drew.
+        gTheme->itemsList = thmResolveItemsList(&gTheme->vcdMainElems, gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else if (list->mode == FAV_MODE) {
-        gTheme->itemsList = gTheme->favsItemsList ? gTheme->favsItemsList : gTheme->gamesItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->favsMainElems, gTheme->favsItemsList ? gTheme->favsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else if (list->mode == APP_MODE) {
-        gTheme->itemsList = gTheme->appsItemsList ? gTheme->appsItemsList : gTheme->gamesItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->appsMainElems, gTheme->appsItemsList ? gTheme->appsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else {
-        gTheme->itemsList = gTheme->gamesItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->mainElems, gTheme->gamesItemsList, selected_item->item->icon_id);
     }
 }
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -134,19 +134,27 @@ static const struct
 #define THM_DEVICE_VOCAB_COUNT ((int)(sizeof(thmDeviceVocab) / sizeof(thmDeviceVocab[0])))
 
 // Parse a comma-separated devices= value into a vocab-index bitmask. Unknown names LOG and are
-// ignored; an empty/unparseable value yields 0 = unfiltered, so a typo degrades to the
-// pre-existing shared-element behavior instead of hiding the element everywhere.
-static int thmParseDeviceList(const char *value)
+// ignored (quiet suppresses that -- addGUIElem pre-checks the same value initBasic then parses
+// for real, and the warning should print once); an empty/unparseable value yields 0 = unfiltered,
+// so a typo degrades to the pre-existing shared-element behavior instead of hiding the element
+// everywhere. strtok_r, NOT strtok: theme loads run on the IO worker too (device NeedsUpdate ->
+// thmAddElements) and could interleave with a GUI-thread strtok (e.g. neutrinoArgsParse).
+static int thmParseDeviceList(const char *value, int quiet)
 {
     int mask = 0;
-    char buf[128];
+    char *buf;
     char *tok;
+    char *saveptr;
 
     if (value == NULL)
         return 0;
-    snprintf(buf, sizeof(buf), "%s", value);
-    // plain strtok: theme parsing is single-threaded at load time (matches supportbase/system usage)
-    for (tok = strtok(buf, ", \t"); tok != NULL; tok = strtok(NULL, ", \t")) {
+
+    buf = malloc(strlen(value) + 1);
+    if (buf == NULL)
+        return 0;
+    strcpy(buf, value);
+
+    for (tok = strtok_r(buf, ", \t", &saveptr); tok != NULL; tok = strtok_r(NULL, ", \t", &saveptr)) {
         int i, hit = 0;
         for (i = 0; i < THM_DEVICE_VOCAB_COUNT; i++) {
             if (strcasecmp(tok, thmDeviceVocab[i].name) == 0) {
@@ -155,9 +163,10 @@ static int thmParseDeviceList(const char *value)
                 break;
             }
         }
-        if (!hit)
+        if (!hit && !quiet)
             LOG("THEMES devices=: unknown device name '%s' ignored\n", tok);
     }
+    free(buf);
     return mask;
 }
 
@@ -1364,7 +1373,7 @@ static theme_element_t *initBasic(const char *themePath, config_set_t *themeConf
     // Optional per-device filter (MenuIcon/ItemsList/HintText consume it; harmless elsewhere).
     snprintf(elemProp, sizeof(elemProp), "%s_devices", name);
     if (configGetStr(themeConfig, elemProp, &temp))
-        elem->deviceFilter = thmParseDeviceList(temp);
+        elem->deviceFilter = thmParseDeviceList(temp, 0);
 
     return elem;
 }
@@ -1906,11 +1915,19 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
     theme->vcdItemsList = validateItemsList(themePath, themeConfig, theme, theme->vcdItemsList, &theme->vcdMainElems);
 
     // devices=-filtered ItemsList overrides: link their decorators (they own no slot, so the pass
-    // above never reaches them)...
+    // above never reaches them). Info families too -- a filtered ItemsList can be declared there
+    // and its decorator string must not be left pointing into themeConfig (freed at end of load).
+    // NOTE: filtered decorators are NOT cache-split/exempted below (splitDecoratorCoverCache /
+    // clampSelectedCoverCaches walk the four slot lists only); a filtered list with its own COV
+    // decorator just loses idle-time priming (pop-in), nothing worse.
     validateFilteredItemsLists(themePath, themeConfig, theme, &theme->mainElems);
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->infoElems);
     validateFilteredItemsLists(themePath, themeConfig, theme, &theme->appsMainElems);
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->appsInfoElems);
     validateFilteredItemsLists(themePath, themeConfig, theme, &theme->favsMainElems);
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->favsInfoElems);
     validateFilteredItemsLists(themePath, themeConfig, theme, &theme->vcdMainElems);
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->vcdInfoElems);
 
     // ...then precompute the unfiltered elements' coverage so an unfiltered MenuIcon/ItemsList/
     // HintText yields to filtered same-type siblings on the devices those cover. Must run AFTER the
@@ -1999,9 +2016,13 @@ static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t 
                 char devProp[64];
                 const char *devValue;
                 snprintf(devProp, sizeof(devProp), "%s_devices", name);
-                if (configGetStr(themeConfig, devProp, &devValue) && thmParseDeviceList(devValue) != 0) {
+                if (configGetStr(themeConfig, devProp, &devValue) && thmParseDeviceList(devValue, 1 /* initBasic re-parses and logs */) != 0) {
                     elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 42, 42, ALIGN_NONE, 400, 360, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
+                    // Pre-existing quirk kept as-is: an UNFILTERED ItemsList parsed for an INFO
+                    // family still claims the next nav slot below (thmLoad's info loops run after
+                    // the main ones). Refusing info-family claims here would change behavior for
+                    // themes that rely on it.
                 } else if (!theme->gamesItemsList) {
                     elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 0, 0, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);

--- a/src/themes.c
+++ b/src/themes.c
@@ -102,6 +102,134 @@ static const char *elementsType[ELEM_TYPE_COUNT] = {
     "GameCountText",
     "Coverflow"};
 
+// Per-device element filter (theme key devices=usb,hdd,... on MenuIcon/ItemsList/HintText) /////////////////////////////////
+//
+// Themer-facing device vocabulary, keyed to the SAME icon identity the MenuIcon renders
+// (menu->item->icon_id): BDM pages re-resolve it per detected driver at mount time (opl.c's
+// updateMenuFromGameList re-reads itemIconId), so a filter can never disagree with the visible
+// icon, and one 'usb' filter naturally covers every USB slot. 'bdm' names the generic
+// pre-mount/manual-start BDM page -- whose legacy TEXTURE name is literally "usb" (textures.c),
+// which is why this table must never be derived from texture names. 'vcd' is deliberately
+// absent: the L3 VCD view is an element FAMILY (vcdMain*), not a device; device filters keep
+// working inside the vcd family, where icon_id remains the device's.
+static const struct
+{
+    const char *name;
+    int iconId;
+} thmDeviceVocab[] = {
+    {"usb", USB_ICON},
+    {"ilink", ILINK_ICON},
+    {"mx4sio", MX4SIO_ICON},
+    {"hdd_bd", HDD_BD_ICON}, // internal exFAT (GPT/MBR) HDD via BDM
+    {"hdd", HDD_ICON},       // internal APA/PFS HDD
+    {"eth", ETH_ICON},
+    {"smb", ETH_ICON}, // alias: same page/icon as eth
+    {"mmce", MMCE_ICON},
+    {"udpbd", UDP_ICON},
+    {"udpfs", UDPFS_ICON},
+    {"app", APP_ICON},
+    {"fav", FAV_ICON},
+    {"bdm", BDM_ICON}, // generic/unidentified BDM page (pre-mount or manual-start)
+};
+#define THM_DEVICE_VOCAB_COUNT ((int)(sizeof(thmDeviceVocab) / sizeof(thmDeviceVocab[0])))
+
+// Parse a comma-separated devices= value into a vocab-index bitmask. Unknown names LOG and are
+// ignored; an empty/unparseable value yields 0 = unfiltered, so a typo degrades to the
+// pre-existing shared-element behavior instead of hiding the element everywhere.
+static int thmParseDeviceList(const char *value)
+{
+    int mask = 0;
+    char buf[128];
+    char *tok;
+
+    if (value == NULL)
+        return 0;
+    snprintf(buf, sizeof(buf), "%s", value);
+    // plain strtok: theme parsing is single-threaded at load time (matches supportbase/system usage)
+    for (tok = strtok(buf, ", \t"); tok != NULL; tok = strtok(NULL, ", \t")) {
+        int i, hit = 0;
+        for (i = 0; i < THM_DEVICE_VOCAB_COUNT; i++) {
+            if (strcasecmp(tok, thmDeviceVocab[i].name) == 0) {
+                mask |= (1 << i);
+                hit = 1;
+                break;
+            }
+        }
+        if (!hit)
+            LOG("THEMES devices=: unknown device name '%s' ignored\n", tok);
+    }
+    return mask;
+}
+
+// Does a vocab-index bitmask cover the given page icon? Matching is by icon id, so aliases
+// (smb/eth) and any future same-icon entries are free.
+static int thmDeviceMaskMatches(int mask, int iconId)
+{
+    int i;
+    if (mask == 0)
+        return 0;
+    for (i = 0; i < THM_DEVICE_VOCAB_COUNT; i++) {
+        if ((mask & (1 << i)) && thmDeviceVocab[i].iconId == iconId)
+            return 1;
+    }
+    return 0;
+}
+
+// Shared draw gate for MenuIcon/ItemsList/HintText: a FILTERED element draws only on its devices;
+// an UNFILTERED element skips the devices a filtered same-type sibling covers (deviceCoverage,
+// precomputed at theme load). Both fields zero -- every theme without the devices= key -- makes
+// this a no-op, preserving byte-identical behavior.
+static int thmElemSkipsDevice(const theme_element_t *elem, int iconId)
+{
+    if (elem->deviceFilter)
+        return !thmDeviceMaskMatches(elem->deviceFilter, iconId);
+    if (elem->deviceCoverage)
+        return thmDeviceMaskMatches(elem->deviceCoverage, iconId);
+    return 0;
+}
+
+// Nav-side twin of drawItemsList's gate: pick the FILTERED ItemsList that covers this page, else
+// the family's slot element (fallback). menusys assigns gTheme->itemsList through this so paging
+// math (displayedItems) always reads the exact element whose rows are on screen.
+theme_element_t *thmResolveItemsList(theme_elems_t *family, theme_element_t *fallback, int iconId)
+{
+    theme_element_t *elem;
+
+    if (family != NULL) {
+        for (elem = family->first; elem != NULL; elem = elem->next) {
+            if (elem->type == ELEM_TYPE_ITEMS_LIST && elem->deviceFilter && thmDeviceMaskMatches(elem->deviceFilter, iconId))
+                return elem;
+        }
+    }
+    return fallback;
+}
+
+// Precompute deviceCoverage per family: an UNFILTERED MenuIcon/ItemsList/HintText yields to
+// filtered same-type siblings on the devices they cover (the themer's per-device override wins
+// there; the unfiltered element stays the everywhere-else default). Runs once at theme load so the
+// per-frame gate never walks the family. Families with no devices= keys leave everything 0.
+static void thmComputeDeviceCoverage(theme_elems_t *elems)
+{
+    static const int filteredTypes[] = {ELEM_TYPE_MENU_ICON, ELEM_TYPE_ITEMS_LIST, ELEM_TYPE_HINT_TEXT};
+    unsigned int t;
+
+    for (t = 0; t < sizeof(filteredTypes) / sizeof(filteredTypes[0]); t++) {
+        int covered = 0;
+        theme_element_t *elem;
+
+        for (elem = elems->first; elem != NULL; elem = elem->next) {
+            if (elem->type == filteredTypes[t] && elem->deviceFilter)
+                covered |= elem->deviceFilter;
+        }
+        if (!covered)
+            continue;
+        for (elem = elems->first; elem != NULL; elem = elem->next) {
+            if (elem->type == filteredTypes[t] && !elem->deviceFilter)
+                elem->deviceCoverage = covered;
+        }
+    }
+}
+
 // Common functions for Text ////////////////////////////////////////////////////////////////////////////////////////////////
 
 static void endMutableText(theme_element_t *elem)
@@ -1137,6 +1265,8 @@ static theme_element_t *initBasic(const char *themePath, config_set_t *themeConf
     elem->type = type;
     elem->reflection = 0;
     elem->reflectionOffset = 0;
+    elem->deviceFilter = 0;   // malloc'd without memset: MUST be zeroed explicitly (0 = unfiltered)
+    elem->deviceCoverage = 0; // filled at validateGUIElems for unfiltered MenuIcon/ItemsList/HintText
     elem->extended = NULL;
     elem->drawElem = NULL;
     elem->endElem = &endBasic;
@@ -1231,6 +1361,11 @@ static theme_element_t *initBasic(const char *themePath, config_set_t *themeConf
         elem->reflectionOffset = intValue;
     }
 
+    // Optional per-device filter (MenuIcon/ItemsList/HintText consume it; harmless elsewhere).
+    snprintf(elemProp, sizeof(elemProp), "%s_devices", name);
+    if (configGetStr(themeConfig, elemProp, &temp))
+        elem->deviceFilter = thmParseDeviceList(temp);
+
     return elem;
 }
 
@@ -1256,6 +1391,8 @@ static void initBackground(const char *themePath, config_set_t *themeConfig, the
 
 static void drawMenuIcon(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
 {
+    if (thmElemSkipsDevice(elem, menu->item->icon_id))
+        return; // devices= filter: not this page's element
     GSTEXTURE *menuIconTex = thmGetTexture(menu->item->icon_id);
     if (menuIconTex && menuIconTex->Mem)
         rmDrawPixmap(menuIconTex, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
@@ -1323,6 +1460,11 @@ static void drawBDMIndex(struct menu_list *menu, struct submenu_list *item, conf
 
 static void drawItemsList(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
 {
+    // devices= filter: the nav pointer (gTheme->itemsList) is resolved with the SAME matching rules
+    // (thmResolveItemsList), so the rows that draw are always the rows navigation counts.
+    if (thmElemSkipsDevice(elem, menu->item->icon_id))
+        return;
+
     if (item) {
         items_list_t *itemsList = (items_list_t *)elem->extended;
         item_list_t *list = menu->item->userdata;
@@ -1437,6 +1579,9 @@ static void drawItemText(struct menu_list *menu, struct submenu_list *item, conf
 
 static void drawHintText(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
 {
+    if (thmElemSkipsDevice(elem, menu->item->icon_id))
+        return; // devices= filter: not this page's element
+
     menu_hint_item_t *hint = menu->item->hints;
     if (hint) {
         int x = elem->posX;
@@ -1488,7 +1633,12 @@ static void validateBackgroundElems(const char *themePath, config_set_t *themeCo
     }
 }
 
-static void validateItemsList(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_element_t *list, theme_elems_t *mainElems)
+// Returns the validated list -- the caller MUST store it back into the slot: when no list exists a
+// default one is created here, and before the write-back the slot stayed NULL while the default was
+// only chained for drawing, leaving gTheme->itemsList NULL (menusys derefs it without a check). That
+// was unreachable while every theme carried an unfiltered ItemsList; devices=-filtered ItemsLists
+// (which deliberately claim no slot) make it a one-key theme edit away.
+static theme_element_t *validateItemsList(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_element_t *list, theme_elems_t *mainElems)
 {
     if (list) {
         items_list_t *itemsList = (items_list_t *)list->extended;
@@ -1518,6 +1668,22 @@ static void validateItemsList(const char *themePath, config_set_t *themeConfig, 
         initItemsList(themePath, themeConfig, theme, list, "il", NULL);
         list->next = mainElems->first->next; // Position the itemsList as second element (right after the Background)
         mainElems->first->next = list;
+    }
+
+    return list;
+}
+
+// Run validateItemsList's decorator linking for devices=-FILTERED ItemsList elements: they claim no
+// slot, so the slot-based pass above never sees them -- without this their `decorator` string would
+// keep pointing into themeConfig (freed at the end of thmLoad) and the decorator image would never
+// link. Filtered lists are always non-NULL here, so this can never take the create-default branch.
+static void validateFilteredItemsLists(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_elems_t *mainElems)
+{
+    theme_element_t *elem;
+
+    for (elem = mainElems->first; elem != NULL; elem = elem->next) {
+        if (elem->type == ELEM_TYPE_ITEMS_LIST && elem->deviceFilter)
+            validateItemsList(themePath, themeConfig, theme, elem, mainElems);
     }
 }
 
@@ -1731,11 +1897,32 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
     validateBackgroundElems(themePath, themeConfig, theme, &theme->favsMainElems, &theme->favsInfoElems);
     validateBackgroundElems(themePath, themeConfig, theme, &theme->vcdMainElems, &theme->vcdInfoElems);
 
-    // 2. check we have a valid ItemsList element, and link its decorator to the target element
-    validateItemsList(themePath, themeConfig, theme, theme->gamesItemsList, &theme->mainElems);
-    validateItemsList(themePath, themeConfig, theme, theme->appsItemsList, &theme->appsMainElems);
-    validateItemsList(themePath, themeConfig, theme, theme->favsItemsList, &theme->favsMainElems);
-    validateItemsList(themePath, themeConfig, theme, theme->vcdItemsList, &theme->vcdMainElems);
+    // 2. check we have a valid ItemsList element, and link its decorator to the target element.
+    // Store the result back: validateItemsList may CREATE the default list, and a NULL slot is a
+    // menusys NULL deref (see the function comment).
+    theme->gamesItemsList = validateItemsList(themePath, themeConfig, theme, theme->gamesItemsList, &theme->mainElems);
+    theme->appsItemsList = validateItemsList(themePath, themeConfig, theme, theme->appsItemsList, &theme->appsMainElems);
+    theme->favsItemsList = validateItemsList(themePath, themeConfig, theme, theme->favsItemsList, &theme->favsMainElems);
+    theme->vcdItemsList = validateItemsList(themePath, themeConfig, theme, theme->vcdItemsList, &theme->vcdMainElems);
+
+    // devices=-filtered ItemsList overrides: link their decorators (they own no slot, so the pass
+    // above never reaches them)...
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->mainElems);
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->appsMainElems);
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->favsMainElems);
+    validateFilteredItemsLists(themePath, themeConfig, theme, &theme->vcdMainElems);
+
+    // ...then precompute the unfiltered elements' coverage so an unfiltered MenuIcon/ItemsList/
+    // HintText yields to filtered same-type siblings on the devices those cover. Must run AFTER the
+    // slot pass: the auto-created default list needs its coverage too.
+    thmComputeDeviceCoverage(&theme->mainElems);
+    thmComputeDeviceCoverage(&theme->infoElems);
+    thmComputeDeviceCoverage(&theme->appsMainElems);
+    thmComputeDeviceCoverage(&theme->appsInfoElems);
+    thmComputeDeviceCoverage(&theme->favsMainElems);
+    thmComputeDeviceCoverage(&theme->favsInfoElems);
+    thmComputeDeviceCoverage(&theme->vcdMainElems);
+    thmComputeDeviceCoverage(&theme->vcdInfoElems);
 
     // Items-list decorator covers need their own cache; sharing with selected covers defeats MMCE cover clamping.
     splitDecoratorCoverCache(theme, theme->gamesItemsList);
@@ -1804,7 +1991,18 @@ static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t 
                 elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_MENU_TEXT, screenWidth >> 1, 20, ALIGN_CENTER, 200, 20, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                 elem->drawElem = &drawMenuText;
             } else if (!strcmp(elementsType[ELEM_TYPE_ITEMS_LIST], type)) {
-                if (!theme->gamesItemsList) {
+                // A devices=-filtered ItemsList is a per-device OVERRIDE: it joins its family's
+                // draw list but must NOT claim one of the four global nav slots below (games/apps/
+                // favs/vcd are claimed in strict parse order; a filtered element in that chain
+                // would corrupt the family-to-slot mapping and could silently drop later lists).
+                // Navigation resolves it per page via thmResolveItemsList instead.
+                char devProp[64];
+                const char *devValue;
+                snprintf(devProp, sizeof(devProp), "%s_devices", name);
+                if (configGetStr(themeConfig, devProp, &devValue) && thmParseDeviceList(devValue) != 0) {
+                    elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 42, 42, ALIGN_NONE, 400, 360, SCALING_RATIO, theme->textColor, theme->fonts[0]);
+                    initItemsList(themePath, themeConfig, theme, elem, name, NULL);
+                } else if (!theme->gamesItemsList) {
                     elem = initBasic(themePath, themeConfig, theme, name, ELEM_TYPE_ITEMS_LIST, 0, 0, ALIGN_NONE, DIM_UNDEF, DIM_UNDEF, SCALING_RATIO, theme->textColor, theme->fonts[0]);
                     initItemsList(themePath, themeConfig, theme, elem, name, NULL);
                     theme->gamesItemsList = elem;


### PR DESCRIPTION
## What

New optional theme key `devices=usb,hdd,mmce,...` on **MenuIcon**, **ItemsList** and **HintText** blocks. A filtered element draws **only** on the listed device pages; an unfiltered element of the same type in the same family automatically stands down there and stays the default everywhere else. Requested as: *"align each page's device icon independently"* — all three shared-position element types got the treatment.

## How

- **Vocabulary** (`thmDeviceVocab`): `usb, ilink, mx4sio, hdd_bd, hdd, eth, smb (=eth), mmce, udpbd, udpfs, app, fav, bdm`. Matching keys on the page's **visible icon identity** (`menu->item->icon_id`): BDM pages re-resolve their icon per detected driver at mount time, so a filter can never disagree with the icon on screen; `bdm` names the generic pre-identification page. The table is deliberately NOT derived from texture names (the generic BDM page's legacy texture name is literally "usb").
- **Draw gates** in `drawMenuIcon`/`drawItemsList`/`drawHintText` via one shared predicate (`thmElemSkipsDevice`): filtered → draw only on match; unfiltered → skip pages a filtered same-type sibling covers (`deviceCoverage`, precomputed once per family at theme load — the per-frame gate never walks the family).
- **ItemsList is the landmine**: the four nav slots (games/apps/favs/vcd) are claimed in strict global parse order, so a filtered list must claim **none** of them — it's an override. Navigation resolves the active list per page through `thmResolveItemsList` — the **same matching rule** the draw gate uses — in `menuRenderMain`/`menuRenderInfo`, so paging math (`displayedItems`) always counts the rows actually on screen. Filtered lists still get their `decorator=` linked (`validateFilteredItemsLists`); without that pass the decorator string would dangle into the freed `themeConfig`.
- **Latent crash fixed en route**: `validateItemsList` created the default `il` list when a slot was empty but never wrote it back (by-value parameter) — leaving `gTheme->itemsList` NULL, which menusys derefs without a check on the first nav keypress. It now returns the list and `validateGUIElems` stores it. Unreachable before only because every real theme carried an unfiltered ItemsList; filtered-only themes made it one theme key away.

## Compatibility

- Themes without the key: **behavior-identical** — both new fields are explicitly zeroed in `initBasic` (its `malloc` has no memset) and every gate no-ops on zero. One deliberate nuance the adversarial verify surfaced: a theme whose apps/favs/vcd family has no ItemsList already *drew* the auto-created default list but paged by the games list's row count — paging now counts the rows actually on screen (a correction, not a regression).
- Unknown device names LOG and are skipped; a value with nothing valid degrades to *shared placement*, never to a hidden element.
- Other element types parse the key but ignore it.

## Docs

- `docs/THEME_ENGINE.md`: §3 property row + new §5 "Per-device placement" (vocab table, worked example, rules).
- `README.md`: fork-additions bullet.
- Docs site (`riptopl-ghpages`): themes.html section + search-index entry — committed locally, push held until this rolls.

## Testing

- Full clean container build (ps2dev:latest) green; only warning is the pre-existing `system.c` const-qualifier one from master.
- clang-format 12 applied.
- Adversarial verification pass running; findings (if any) will be fixed on this branch before merge.
- HW validation: needs a themer to exercise `devices=` on real pages (PCSX2 covers USB/SMB pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
**Post-review update:** adversarial verify returned no blockers/majors (4 minors, all addressed or documented in the second commit); Gemini's review (strtok_r + dynamic buffer + quiet re-parse) was valid and is applied in the same commit. The argv-pool tail-drop (a validated `-mc` can theoretically be shed with only a LOG) is declined here: it runs post-deinit where no toast can render, and the pool math makes it near-unreachable.