### PR TITLE
fix(neutrino): stop silently ignoring VMC on APA HDD and Loader Core on SMB

### DIFF
--- a/docs/NEUTRINO.md
+++ b/docs/NEUTRINO.md
@@ -40,15 +40,15 @@ above; leave it blank to use the auto-detection (which also checks a few lowerca
 
 ### Where Neutrino works
 
-| Source | Neutrino? |
-|---|---|
-| USB / iLink / MX4SIO / internal ATA (BDM) | ✅ |
-| Internal HDD (APA → HDL) | ✅ |
-| MMCE | ✅ |
-| UDPFS (network boot — Files or Image) | ✅ **required** — no OPL core, Neutrino only (see §4) |
-| SMB / ETH | ❌ (falls back to `<OPL>`) |
-| USB Extreme split images (`.ul`) | ❌ (falls back to `<OPL>`) |
-| Compressed ISO (`.zso`) | ❌ (falls back to `<OPL>`) |
+| Source | Neutrino? | VMC under Neutrino? |
+|---|---|---|
+| USB / iLink / MX4SIO / internal ATA (BDM) | ✅ | ✅ `-mcN=massN:…VMC/<name>.bin` |
+| Internal HDD (APA → HDL) | ✅ | ❌ **games boot, VMC is dropped with a warning** — Neutrino has no APA/pfs backing store to open the `.bin` from (NHDDL's HDL backend has the same no-VMC rule). The OPL core honors the same VMC normally. |
+| MMCE | ✅ | ✅ `-mcN=mmceN:/…VMC/<name>.bin` |
+| UDPFS (network boot — Files or Image) | ✅ **required** — no OPL core, Neutrino only (see §4) | ✅ `-mcN=udpfs:/VMC/<name>.bin` — the PC server must **not** run read-only, or saves fail |
+| SMB / ETH | ❌ (always launches with `<OPL>`; the core selector is locked and a stale Neutrino selection warns at launch) | n/a (OPL-core VMC works normally) |
+| USB Extreme split images (`.ul`) | ❌ (falls back to `<OPL>`) | n/a |
+| Compressed ISO (`.zso`) | ❌ (falls back to `<OPL>`) | n/a |
 
 Unsupported cases fall back to the `<OPL>` core automatically with an on-screen warning.
 
@@ -218,8 +218,11 @@ When a game's core is **Neutrino**:
 - **GSM, Cheats, PADEMU, OSD Language** panels are OPL-core-only; opening one shows
   *"not used with the Neutrino core"* instead of editing dead options (use the Neutrino Video
   picker above for video forcing).
-- **VMC** and **Compatibility** stay available — both are honored under Neutrino (VMC via
-  `-mc0`/`-mc1` on block devices).
+- **VMC** and **Compatibility** stay available — both are honored under Neutrino. VMC becomes
+  discrete `-mc0`/`-mc1` args on **BDM devices (USB/iLink/MX4SIO/exFAT HDD/UDPBD), MMCE and
+  UDPFS**; the one exception is **APA HDD**, where no `-mc` args can be emitted (Neutrino has no
+  APA/pfs backing store — the game boots and OPL warns that the VMC was dropped). See the VMC
+  notes below.
 - **UDPFS games** (both Files and Image) have no OPL core backend, so the **Loader Core selector is
   locked to Neutrino** for them (they always launch via Neutrino regardless).
 
@@ -230,3 +233,28 @@ Args field and Neutrino Video picker are greyed (never read on the OPL path).
 > compat subset (`-gc`), VMC (`-mc0`/`-mc1`), `-logo`, and the free-text **Neutrino Launch
 > Args** (the catch-all for everything else, with `$`-disable). Cheats, GSM hacks, IGR/IGS,
 > PADEMU and OSD-language are OPL-embedded-core features with no Neutrino equivalent.
+
+### VMC under Neutrino — how it actually works
+
+OPL turns the per-game **VMC** settings (`$VMC_0`/`$VMC_1`) into discrete
+`-mcN=<device>:…VMC/<name>.bin` arguments — the same `.bin`, in the same `VMC/` folder, that the
+OPL core's mcemu uses, so one card serves both cores. Rules that follow from Neutrino's design
+(verified against `rickgaiser/neutrino` source):
+
+- **The `.bin` must already exist.** Neutrino opens it `O_RDWR` with no create, and **aborts the
+  whole boot** (black screen) if it can't. OPL therefore creates/format cards at *config* time
+  (the per-game VMC menu, via genvmc — including over UDPFS), and at *launch* verifies each card
+  and skips a missing one with a warning rather than handing Neutrino an unopenable path.
+- **The VMC must live on the same device as the game.** Neutrino loads exactly one backing-store
+  driver per launch and every virtual file (ISO + VMCs) shares it — a VMC on a different device
+  than the ISO is structurally unsupported. This is also why APA HDD can't have one: the game
+  comes from raw APA (`-bsd=ata -bsdfs=hdl`), and there is no pfs backend for the `.bin`.
+- **UDPFS VMCs are writable network files**: the card lives at `VMC/<name>.bin` under the PC
+  server's shared folder, and the server must not run in read-only mode or saves fail.
+- **Block devices share Neutrino's 64-fragment budget** across ISO + VMCs; OPL pre-counts and
+  falls back/aborts with a message when it can't fit (defragment the drive if you see it).
+- **Upstream caveats** (Neutrino's `mc_emu`, as of mid-2026): only **port 1 (`-mc0`) is actually
+  emulated** — `-mc1` is accepted and opened but the second port's emulation is left inactive —
+  and the advertised card geometry is hardcoded (8192 pages ≈ first 4 MB of the image addressed)
+  rather than read from the card file. Both are Neutrino-side behaviors, not OPL's; prefer slot 1
+  and 8 MB cards for predictable results.

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -935,6 +935,10 @@ gui_strings:
   string: Network block device on -- its tab appears once the PC server answers (udpfsd -bdpath for UDPFS Image, udpbd-server for UDPBD).
 - label: NEUTRINO_VMC_MISSING
   string: Per-game VMC file not found -- launching without it (game uses its real card).
+- label: NEUTRINO_VMC_HDD_UNSUPPORTED
+  string: Neutrino cannot use a VMC on APA HDD (no pfs support) -- launching without it.
+- label: NEUTRINO_SMB_FALLBACK
+  string: SMB games have no Neutrino support -- launching with the OPL core.
 - label: NEUTRINO_DEV_UNSUPPORTED
   string: Neutrino cannot launch from this device -- launch aborted.
 - label: NEUTRINO_TOML_SYNC_FAILED

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -667,6 +667,18 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
         return;
     }
 
+    // $CoreLoader honesty: SMB has no Neutrino launch leg (nothing here builds -bsd/-dvd args),
+    // so a per-game Neutrino selection -- or a Neutrino global default -- silently resolves to the
+    // OPL core. Toast once at launch instead of leaving the setting looking honored. Pre-deinit,
+    // so the toast renders; the launch then proceeds normally. Covers Favourites-origin launches
+    // too (they delegate to this leg), which the compat-dialog lock in guigame.c cannot reach.
+    {
+        int coreLoader = gDefaultCoreLoader;
+        configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+        if (coreLoader)
+            guiWarning(_l(_STR_NEUTRINO_SMB_FALLBACK), 6);
+    }
+
     char vmc_name[32];
     int vmc_id, size_mcemu_irx = 0;
     smb_vmc_infos_t smb_vmc_infos;

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -675,6 +675,8 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
     {
         int coreLoader = gDefaultCoreLoader;
         configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+        if (coreLoader == 2)                 // "Default" sentinel: the dialog never persists it (index 2 removes the
+            coreLoader = gDefaultCoreLoader; // key), but a hand-edited cfg can carry it (Gemini, #161)
         if (coreLoader)
             guiWarning(_l(_STR_NEUTRINO_SMB_FALLBACK), 6);
     }

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -1054,8 +1054,9 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
                          ((support->mode >= BDM_MODE && support->mode <= BDM_MODE6 && !vcdViewActive(support->mode)) ||
                           support->mode == FAV_MODE);
     // VCD games launch through POPSTARTER only, so the Loader Core is inert for them -- keep every
-    // Neutrino-only row greyed even under a Neutrino global default (guiGameSetCoreAwareState reads this).
-    coreNeverNeutrino = (support != NULL && vcdViewActive(support->mode));
+    // Neutrino-only row greyed even under a Neutrino global default (guiGameSetCoreAwareState reads
+    // this). SMB likewise: ethsupport has no Neutrino launch leg, the effective core is always <OPL>.
+    coreNeverNeutrino = (support != NULL && (vcdViewActive(support->mode) || support->mode == ETH_MODE));
 
     // UDPBD games have no OPL core backend -- they always launch via Neutrino
     // (bdmsupport.c forces it). Lock the selector to Neutrino so the screen matches;
@@ -1065,6 +1066,13 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
         // Loader Core choice is meaningless. Pin it to the inert "Default" row (index 2 -> no per-game
         // $CoreLoader key persisted, as before) and lock the row so the screen doesn't imply a VCD game
         // could run under a different core.
+        diaSetInt(diaCompatConfig, COMPAT_LOADER, 2);
+        diaSetEnabled(diaCompatConfig, COMPAT_LOADER, 0);
+    } else if (support != NULL && support->mode == ETH_MODE) {
+        // SMB has no Neutrino launch leg (ethsupport never builds Neutrino args) -- the effective
+        // core is ALWAYS <OPL>. Pin the row to the inert "Default" (index 2: saving removes any
+        // stale $CoreLoader key, self-healing old Neutrino selections) and lock it. Launch-time
+        // honesty for keys set elsewhere (e.g. via Favourites) is the toast in ethLaunchGame.
         diaSetInt(diaCompatConfig, COMPAT_LOADER, 2);
         diaSetEnabled(diaCompatConfig, COMPAT_LOADER, 0);
     } else if (bdmSupportIsUDPBD(support)) {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -801,7 +801,28 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
     if (sysNeutrinoPreflight("apa", neutrinoPath) < 0)
         return 0;
 
-    // MMCE cross-device game-id (#261); HDD emits no -mc args (VMC->neutrino deferred), mask 0.
+    // Honesty toast: the OPL core honors $VMC_N on HDD (mcemu over pfs0:VMC/), but Neutrino has no
+    // APA/pfs backing store to open the .bin from post-reset -- its APA support is -bsd=ata
+    // -bsdfs=hdl, game image only (NHDDL's HDL backend has the same no-VMC rule). No -mc args can
+    // be emitted here; warn instead of silently booting without the card the user configured.
+    // Runs pre-deinit so the toast still renders.
+    {
+        int slot;
+        char vmcName[32];
+        for (slot = 0; slot < NEUTRINO_VMC_SLOTS; slot++) {
+            int slotDisabled = 0;
+            vmcName[0] = '\0';
+            configGetVMC(configSet, vmcName, sizeof(vmcName), slot);
+            configGetVMCDisable(configSet, slot, &slotDisabled);
+            if (vmcName[0] != '\0' && !slotDisabled) {
+                LOG("[NEUTRINO] apa: VMC slot %d (%s) configured but unsupported -- launching without it\n", slot, vmcName);
+                guiWarning(_l(_STR_NEUTRINO_VMC_HDD_UNSUPPORTED), 6);
+                break;
+            }
+        }
+    }
+
+    // MMCE cross-device game-id (#261); HDD emits no -mc args (no APA/pfs backing store, above), mask 0.
     mmceSendGameID(game->startup, neutrinoPath, 0);
 
     // game->startup lives in hddGames / gAutoLaunchGame, freed below (deinitEx's itemCleanUp or the

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1498,7 +1498,8 @@ void menuRenderGameMenu()
 // OSD-language settings (see docs/NEUTRINO.md), so opening those panels for a
 // Neutrino game would only edit dead options. Returns 1 when the selected game's
 // Loader Core is Neutrino. (VMC and Compatibility stay available -- both are
-// honored under Neutrino.)
+// honored under Neutrino, with one exception: APA HDD launches emit no -mc args,
+// because Neutrino has no APA/pfs backing store -- hddsupport toasts about it.)
 static int gameMenuCoreIsNeutrino(void)
 {
     int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
@@ -1507,10 +1508,12 @@ static int gameMenuCoreIsNeutrino(void)
     // VCD (PS1) games launch ONLY via POPSTARTER -- never Neutrino -- so a keyless VCD must not
     // inherit a Neutrino global default here, or its Cheats/GSM/OSD menu entries get blocked with
     // the wrong "not available under Neutrino" message (same exemption as the compat dialog's
-    // coreNeverNeutrino flag in guigame.c).
+    // coreNeverNeutrino flag in guigame.c). SMB is the same shape: ethsupport has no Neutrino
+    // launch leg, the effective core is always <OPL>, so its Cheats/GSM/PADEMU panels ARE live
+    // and must not grey under a Neutrino global default.
     if (selected_item != NULL && selected_item->item != NULL) {
         item_list_t *support = (item_list_t *)selected_item->item->userdata;
-        if (support != NULL && vcdViewActive(support->mode))
+        if (support != NULL && (vcdViewActive(support->mode) || support->mode == ETH_MODE))
             return 0;
     }
     // UDPBD games are Neutrino-only even while $CoreLoader is still its OPL default.


### PR DESCRIPTION
## Context

Nathan asked whether our Neutrino VMC settings actually work, and whether wOPL/NHDDL do it better. A 5-agent audit (our source, `rickgaiser/neutrino` source, NHDDL source, wOPL source, plus a fact-check of a ChatGPT writeup) answered: **the `-mc` pipeline is correct and ahead of both references.** wOPL emits `-mcN` with *no existence check* (Neutrino aborts the whole boot on an unopenable VMC path = black screen — our Δ2 guard toasts and skips instead); NHDDL doesn't build `-mc` args at all (users hand-write YAML) and creates nothing.

What the audit *did* find were places where the UI/docs claim more than the launch delivers. This PR fixes those.

## Per-device truth table (verified against source)

| Device | Neutrino launch | VMC under Neutrino |
|---|---|---|
| BDM (USB / iLink / MX4SIO / exFAT HDD / UDPBD) | ✅ | ✅ `-mcN=massN:…VMC/<name>.bin` |
| MMCE | ✅ | ✅ `-mcN=mmceN:/…VMC/<name>.bin` |
| UDPFS | ✅ (only core) | ✅ `-mcN=udpfs:/VMC/<name>.bin` (server must be writable) |
| APA HDD | ✅ | ❌ structural — Neutrino has no APA/pfs backing store; the `.bin` lives on `pfs0:`, unreachable post-reset. NHDDL's HDL backend has the same no-VMC rule. |
| SMB | ❌ no Neutrino leg exists | n/a (OPL-core VMC works normally) |

## Fixes

- **APA HDD**: a configured, enabled `$VMC_N` now toasts `Neutrino cannot use a VMC on APA HDD (no pfs support) -- launching without it` (pre-deinit, mirrors `sbBuildVmcNeutrinoArgs` slot semantics incl. per-slot disable). Previously: silent drop while the VMC panel stayed fully editable and docs claimed VMC is "honored under Neutrino".
- **SMB**: the compat dialog's Loader Core row is now pinned to the inert **Default** and locked (saving self-heals stale `$CoreLoader` keys — index 2 removes the key); `ethLaunchGame` toasts when a Neutrino selection resolves at launch (covers Favourites-origin launches the dialog can't reach); and — a real latent bug — `gameMenuCoreIsNeutrino` now exempts ETH like VCD, so a **Neutrino global default** no longer greys Cheats/GSM/PADEMU for SMB games, where those settings genuinely work (the effective core is always `<OPL>`).
- **docs/NEUTRINO.md**: "VMC via `-mc0`/`-mc1` on block devices" was wrong in both directions (MMCE/UDPFS are *fileid* backends and DO get `-mc`; APA is the *block* device that can't). The device table gains a VMC column, and a new **"VMC under Neutrino"** section documents the verified contract:
  - the `.bin` must pre-exist — Neutrino opens `O_RDWR` with no create and aborts on failure (`fhi_config.c`); OPL creates cards at config time via genvmc, including over UDPFS
  - the VMC must share the game's backing store (Neutrino loads exactly one BSD per launch; all FHI files share it)
  - block devices share the 64-fragment ISO+VMC budget (we already pre-count, Δ9)
  - upstream `mc_emu` caveats: **only port 1 (`-mc0`) is actually emulated** (`vmcSpec[1]` hardcoded inactive) and the advertised geometry is hardcoded at 8192 pages (≈ first 4 MB addressed) — Neutrino-side, not ours; docs now steer users to slot 1 / 8 MB cards
- Docs site (`riptopl-ghpages`): `neutrino.html` + `vmc.html` corrected to match (committed locally, push held until this rolls).

## Declined from the audit

- Protecting `-mc` entries in the ExecPS2 argv-pool tail-drop loop: it runs post-deinit where no toast can render, and the pool math makes shedding an `-mc` arg near-unreachable. The existing LOG stays.

## Testing

- Full clean container build green (incl. `make languages` regenerating `lang_autogen.h` from the two new `lng_tmpl/_base.yml` strings — English-only until the next fork-overlay rerun, per precedent).
- clang-format 12 applied.
- HW: the APA toast and SMB lock are UI-visible on PCSX2; UDPFS VMC save-back remains a HW/network item (flagged in the audit as code-verified only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
