### PR TITLE
docs(themes): dual-compatibility rules for RiptOPL themes on regular OPL

### DIFF
--- a/docs/THEME_ENGINE.md
+++ b/docs/THEME_ENGINE.md
@@ -263,6 +263,26 @@ Rules worth knowing:
   twice draws both — that's an authoring error, not a picker.
 - Themes without the key are untouched — the filter only activates when `devices=` appears.
 
+### Using RiptOPL themes on regular OPL
+
+RiptOPL themes are designed to load on regular/upstream OPL and degrade gracefully — one theme can
+serve both. Regular OPL's parser never aborts on fork content: keys it doesn't know (`devices=`,
+`reflection_offset`, `overlay2`, `plasma_blend_color`, the whole `favsMain*`/`vcdMain*` families…)
+are simply never read, and unknown element types (`Coverflow`) are skipped without stopping the
+parse. What to expect there:
+
+- **Invisible:** all pure-key extras above — regular OPL renders the theme as if they weren't
+  written.
+- **Cosmetic:** `aligned=2` renders centered; `#Size`/`#DiscType`/`#System` attributes and the
+  Coverflow carousel are silently absent.
+- **Ugly but harmless:** `devices=` layouts — regular OPL draws *every* `MenuIcon`/`HintText` block
+  on *every* page (overlapping), and treats a second `ItemsList` as the apps list while still
+  drawing it on the games screen. Per-device layouts are effectively RiptOPL-only.
+- **⚠ The one rule:** **always include one plain (unfiltered) `ItemsList`**. A theme with none —
+  e.g. a Coverflow-only theme, or one where every list carries `devices=` — *crashes regular OPL on
+  the first scroll* (a latent upstream bug in its default-list repair; RiptOPL fixed it on our
+  side). Ship the plain list and the theme is safe everywhere.
+
 ---
 
 ## 6. `attribute=` values

--- a/docs/THEME_ENGINE.md
+++ b/docs/THEME_ENGINE.md
@@ -267,9 +267,9 @@ Rules worth knowing:
 
 RiptOPL themes are designed to load on regular/upstream OPL and degrade gracefully — one theme can
 serve both. Regular OPL's parser never aborts on fork content: keys it doesn't know (`devices=`,
-`reflection_offset`, `overlay2`, `plasma_blend_color`, the whole `favsMain*`/`vcdMain*` families…)
-are simply never read, and unknown element types (`Coverflow`) are skipped without stopping the
-parse. What to expect there:
+`reflection_offset`, `overlay2`, `plasma_blend_color`, the entire `favsMain*` and `vcdMain*`
+families…) are simply never read, and unknown element types (`Coverflow`) are skipped without
+stopping the parse. What to expect there:
 
 - **Invisible:** all pure-key extras above — regular OPL renders the theme as if they weren't
   written.


### PR DESCRIPTION
Docs-only. Adds a **"Using RiptOPL themes on regular OPL"** section to the Theme Engine reference, verified against ps2homebrew/master's actual parser (not from memory):

- Fork-only keys (`devices=`, `reflection_offset`, `overlay2`, `plasma_blend_color`, `favsMain*`/`vcdMain*` families…) are **never queried** by regular OPL — completely inert.
- Unknown element types (`Coverflow`) are **skipped without aborting** the parse (upstream themes.c dispatch falls through, returns 1).
- `aligned=2` renders centered there (upstream: any nonzero = center).
- `devices=` layouts degrade ugly-but-harmless: every MenuIcon/HintText draws on every page, a second ItemsList becomes the apps list while still drawing on the games screen.
- **The one crash case**: a theme with no plain unfiltered `ItemsList` trips upstream's latent `validateItemsList` NULL-slot bug (the exact bug #160 fixed on our side — verified still present in their current master at themes.c:991) → nav deref on first scroll. The docs make "always ship one plain ItemsList" the hard rule, which keeps every RiptOPL theme loadable on both.

The docs site already carries the same section (+ search-index entry), pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)