### PR TITLE
fix(gui): per-game DMA Mode showed the video-mode list (dangling enum array, #154)

### DIFF
--- a/src/dia.c
+++ b/src/dia.c
@@ -1256,6 +1256,11 @@ int diaSetLabel(struct UIItem *ui, int id, const char *text)
     return 0;
 }
 
+// LIFETIME CONTRACT: this stores enumvals' RAW POINTER -- no copy. The array must outlive every
+// render of the dialog (dialog structs are also reused across openings). A block-scoped array is
+// a dangling pointer the moment its brace closes (issue #154: the DMA row rendered the Neutrino
+// video-mode list). Use static arrays for pure literals; _l()-localized arrays must stay
+// function-scope in the function that executes the dialog (static would freeze the first language).
 int diaSetEnum(struct UIItem *ui, int id, const char **enumvals)
 {
     struct UIItem *item = diaFindByID(ui, id);

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -1019,13 +1019,18 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
 {
     int i;
 
-    if (gameEffectiveFlags(support) & MODE_FLAG_COMPAT_DMA) {
-        const char *dmaModes[] = {"MDMA 0", "MDMA 1", "MDMA 2", "UDMA 0", "UDMA 1", "UDMA 2", "UDMA 3", "UDMA 4", NULL};
-        diaSetEnum(diaCompatConfig, COMPAT_DMA, dmaModes);
-    } else {
-        const char *dmaModes[] = {NULL};
-        diaSetEnum(diaCompatConfig, COMPAT_DMA, dmaModes);
-    }
+    // static, NOT block-scoped: diaSetEnum stores the raw pointer and diaCompatConfig keeps
+    // re-rendering it (reshow_compat loop below). Block-locals dangled at the closing brace and
+    // the compiler reused their stack slot for the sibling arrays below -- on hardware the DMA
+    // row rendered the Neutrino video-mode list (issue #154, Blade). Upstream has the same
+    // block-scoped UB but no later arrays to reuse the slot, which is why it shows correct
+    // strings by luck. Literals only (no _l()), so static storage is safe across languages.
+    static const char *dmaModesFull[] = {"MDMA 0", "MDMA 1", "MDMA 2", "UDMA 0", "UDMA 1", "UDMA 2", "UDMA 3", "UDMA 4", NULL};
+    static const char *dmaModesNone[] = {NULL};
+    if (gameEffectiveFlags(support) & MODE_FLAG_COMPAT_DMA)
+        diaSetEnum(diaCompatConfig, COMPAT_DMA, dmaModesFull);
+    else
+        diaSetEnum(diaCompatConfig, COMPAT_DMA, dmaModesNone);
 
     // Index 0/1 == the stored $CoreLoader value (0=<OPL>, 1=Neutrino); index 2 "Default" = no per-game
     // key -> follow the global gDefaultCoreLoader. Keeping 0/1 aligned with the stored ints means the


### PR DESCRIPTION
## The bug (Blade, issue #154 thread)

> Press Triangle, then Game Settings, then DMA mode (resolutions like 240p, 480p, etc., are displayed here)... shouldn't it show UDMA 3, 4, 5?

Real, and ours to fix. `diaSetEnum` stores the **raw pointer** to the strings array (`dia.c` — no copy), and both `dmaModes[]` arrays in `guiGameShowCompatConfig` were declared **inside the if/else blocks** — the stored pointer dangles the instant the brace closes, before the dialog ever draws. The fork's enum arrays declared right after in the same function (Loader Core, **Neutrino Video = "Off/240p/480p/1080i x1–x3"**, GSM comp, bsdfs) legitimately reuse that dead stack slot at `-Os`, so the DMA row rendered the video-mode list — character-for-character what Blade reported.

Upstream and wOPL carry the **identical block-scoped UB** but have no later arrays in that function to clobber the slot — they show correct strings purely by stack-layout luck. Our additions turned latent UB into a visible wrong list.

## Fix

- Hoist both `dmaModes` variants to `static` (pure string literals, no `_l()`, so static storage is language-safe) — the enum pointer now outlives every render, including the `reshow_compat` re-render loop.
- Document the lifetime contract on `diaSetEnum` itself so the next enum array doesn't repeat this: raw pointer stored, must outlive every render, `_l()` arrays must NOT become static (would freeze the first language).

## Sweep

A 2-agent workflow classified **all 57 `diaSetEnum` callsites** in `gui.c`/`guigame.c`: these two were the only DANGLING ones — every other site sets its enums in the same live function frame that executes its dialog (verified including the re-render loops: `reshow_compat`, PadEmu/PadMacro/OSD while-loops, the VMC do/while). Two upstream-inherited **SUSPECT** items were noted for follow-up, unrelated to this class: the theme/language GUI name lists (`thmGetGuiList`/`lngGetGuiList`) are heap lists that an IO-thread deferred device update can free-and-rebuild while the UI-Settings dialog renders them — a narrow race requiring a device event to drain exactly as the dialog opens.

## Testing

- Clean container build green; clang-format 12 applied.
- The wrong-list symptom depends on compiler stack-slot reuse, so emulator repro isn't guaranteed — Blade on hardware is the confirmer (the DMA row should read MDMA 0–2 / UDMA 0–4 on ATA-backed games, and stay blank on USB, matching stock OPL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)