### PR TITLE
fix(gui): use-after-free — UI Settings dialog vs IO-thread theme/language list rebuilds

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -45,7 +45,7 @@ static int gInitComplete;
 static gui_callback_t gFrameHook;
 
 static s32 gSemaId;
-static s32 gGUILockSemaId;
+static s32 gGUILockSemaId = -1; // -1 = not created yet (guiLock/guiUnlock no-op; see guiLock)
 static ee_sema_t gQueueSema;
 
 static int screenWidth;
@@ -190,15 +190,23 @@ void guiEnd()
 
     DeleteSema(gSemaId);
     DeleteSema(gGUILockSemaId);
+    gGUILockSemaId = -1; // post-shutdown callers no-op instead of waiting on a deleted id
 }
 
 void guiLock(void)
 {
+    // Not-ready guard: lngInit/thmInit rebuild the GUI name lists BEFORE guiInit creates this
+    // semaphore (opl.c init order), and everything is single-threaded until the GUI/IO threads
+    // exist -- a no-op lock is correct there, and WaitSema on id 0/garbage is not.
+    if (gGUILockSemaId < 0)
+        return;
     WaitSema(gGUILockSemaId);
 }
 
 void guiUnlock(void)
 {
+    if (gGUILockSemaId < 0)
+        return;
     SignalSema(gGUILockSemaId);
 }
 
@@ -799,12 +807,63 @@ static int guiUIUpdater(int modified)
     return 0;
 }
 
+// Deep-copy a NULL-terminated name list under guiLock, for handing to diaSetEnum: the source
+// lists (thmGetGuiList/lngGetGuiList) live on the heap and are freed+rebuilt on the IO worker
+// (thmRebuildGuiNames/lngRebuildLangNames; thmReinit also frees the theme NAME strings on device
+// removal) -- the rebuilders take guiLock around the mutation, so copying under the same lock
+// makes the copy race-free. Returns NULL on OOM (caller falls back to the live list).
+static const char **guiCopyNameList(const char **src)
+{
+    int n = 0, i;
+    const char **copy;
+
+    if (src == NULL)
+        return NULL;
+
+    guiLock();
+    while (src[n] != NULL)
+        n++;
+    copy = (const char **)malloc((n + 1) * sizeof(char *));
+    if (copy != NULL) {
+        for (i = 0; i < n; i++) {
+            char *dup = (char *)malloc(strlen(src[i]) + 1);
+            if (dup == NULL) {
+                while (--i >= 0)
+                    free((void *)copy[i]);
+                free((void *)copy);
+                copy = NULL;
+                break;
+            }
+            strcpy(dup, src[i]);
+            copy[i] = dup;
+        }
+        if (copy != NULL)
+            copy[n] = NULL;
+    }
+    guiUnlock();
+    return copy;
+}
+
+static void guiFreeNameList(const char **list)
+{
+    int i;
+
+    if (list == NULL)
+        return;
+    for (i = 0; list[i] != NULL; i++)
+        free((void *)list[i]);
+    free((void *)list);
+}
+
 void guiShowUIConfig(void)
 {
     int themeID = -1, langID = -1;
     curTheme = -1;
     showCfgPopup = 0;
     guiResetNotifications();
+
+    const char **themeNamesSnap = NULL;
+    const char **langNamesSnap = NULL;
 
     // clang-format off
     const char *vmodeNames[] = {_l(_STR_AUTO)
@@ -829,8 +888,19 @@ void guiShowUIConfig(void)
 reselect_video_mode:
     previousVMode = gVMode;
     previousTheme = thmGetGuiValue();
-    diaSetEnum(diaUIConfig, UICFG_THEME, (const char **)thmGetGuiList());
-    diaSetEnum(diaUIConfig, UICFG_LANG, (const char **)lngGetGuiList());
+    // Snapshot the theme/language name lists into dialog-owned copies: diaSetEnum stores raw
+    // pointers, and BOTH the outer arrays (thmRebuildGuiNames/lngRebuildLangNames free+realloc)
+    // AND the theme name strings (thmReinit frees them on device removal) are rebuilt on the IO
+    // worker when a deferred device update lands. Dialog frames render OUTSIDE guiStartFrame's
+    // lock, so a device event draining mid-dialog dereferenced freed memory. Re-snapshot on every
+    // reselect pass (applyConfig below can legitimately change the lists); on OOM fall back to
+    // the live list -- the pre-existing narrow race, not a new failure mode.
+    guiFreeNameList(themeNamesSnap);
+    guiFreeNameList(langNamesSnap);
+    themeNamesSnap = guiCopyNameList((const char **)thmGetGuiList());
+    langNamesSnap = guiCopyNameList((const char **)lngGetGuiList());
+    diaSetEnum(diaUIConfig, UICFG_THEME, themeNamesSnap != NULL ? themeNamesSnap : (const char **)thmGetGuiList());
+    diaSetEnum(diaUIConfig, UICFG_LANG, langNamesSnap != NULL ? langNamesSnap : (const char **)lngGetGuiList());
     diaSetEnum(diaUIConfig, UICFG_VMODE, vmodeNames);
     diaSetInt(diaUIConfig, UICFG_THEME, thmGetGuiValue());
     diaSetInt(diaUIConfig, UICFG_LANG, lngGetGuiValue());
@@ -913,6 +983,9 @@ reselect_video_mode:
             goto reselect_video_mode;
         }
     }
+
+    guiFreeNameList(themeNamesSnap);
+    guiFreeNameList(langNamesSnap);
 }
 
 static int netConfigUpdater(int modified)

--- a/src/gui.c
+++ b/src/gui.c
@@ -807,11 +807,12 @@ static int guiUIUpdater(int modified)
     return 0;
 }
 
-// Deep-copy a NULL-terminated name list under guiLock, for handing to diaSetEnum: the source
-// lists (thmGetGuiList/lngGetGuiList) live on the heap and are freed+rebuilt on the IO worker
-// (thmRebuildGuiNames/lngRebuildLangNames; thmReinit also frees the theme NAME strings on device
-// removal) -- the rebuilders take guiLock around the mutation, so copying under the same lock
-// makes the copy race-free. Returns NULL on OOM (caller falls back to the live list).
+// Deep-copy a NULL-terminated name list for handing to diaSetEnum. The CALLER must hold guiLock
+// across BOTH the getter fetch (thmGetGuiList/lngGetGuiList) and this copy: the source lists live
+// on the heap and are freed+rebuilt under guiLock on the IO worker (thmRebuildGuiNames/
+// lngRebuildLangNames; thmReinit also frees the theme NAME strings on device removal), and taking
+// the lock only inside this function left a preemption window between fetching the pointer and
+// locking (Gemini review of #165). Returns NULL on OOM (caller falls back to the live list).
 static const char **guiCopyNameList(const char **src)
 {
     int n = 0, i;
@@ -820,7 +821,6 @@ static const char **guiCopyNameList(const char **src)
     if (src == NULL)
         return NULL;
 
-    guiLock();
     while (src[n] != NULL)
         n++;
     copy = (const char **)malloc((n + 1) * sizeof(char *));
@@ -840,7 +840,6 @@ static const char **guiCopyNameList(const char **src)
         if (copy != NULL)
             copy[n] = NULL;
     }
-    guiUnlock();
     return copy;
 }
 
@@ -897,8 +896,10 @@ reselect_video_mode:
     // the live list -- the pre-existing narrow race, not a new failure mode.
     guiFreeNameList(themeNamesSnap);
     guiFreeNameList(langNamesSnap);
+    guiLock(); // must cover the getter FETCH too, not just the copy (Gemini review of #165)
     themeNamesSnap = guiCopyNameList((const char **)thmGetGuiList());
     langNamesSnap = guiCopyNameList((const char **)lngGetGuiList());
+    guiUnlock();
     diaSetEnum(diaUIConfig, UICFG_THEME, themeNamesSnap != NULL ? themeNamesSnap : (const char **)thmGetGuiList());
     diaSetEnum(diaUIConfig, UICFG_LANG, langNamesSnap != NULL ? langNamesSnap : (const char **)lngGetGuiList());
     diaSetEnum(diaUIConfig, UICFG_VMODE, vmodeNames);

--- a/src/lang.c
+++ b/src/lang.c
@@ -1,5 +1,6 @@
 #include "include/opl.h"
 #include "include/lang.h"
+#include "include/gui.h" // guiLock/guiUnlock -- name-list rebuild vs GUI readers
 #include "include/util.h"
 #include "include/fntsys.h"
 #include "include/ioman.h"
@@ -174,7 +175,12 @@ int lngAddLanguages(char *path, const char *separator, int mode)
 
     result = listDir(path, separator, MAX_LANGUAGE_FILES - nLanguages, &lngReadEntry);
     nLanguages += result;
+    // Serialize the name-list free+swap against the GUI's readers (see thmRebuildGuiNames):
+    // this runs on the IO worker for device-triggered language discovery, and guiShowUIConfig
+    // hands the list to its dialog. Lock is a not-ready no-op during pre-GUI init.
+    guiLock();
     lngRebuildLangNames();
+    guiUnlock();
 
     const char *temp;
     if (configGetStr(configGetByType(CONFIG_OPL), "language_text", &temp)) {

--- a/src/themes.c
+++ b/src/themes.c
@@ -2565,6 +2565,12 @@ static int thmLoad(const char *themePath)
     return 0;
 }
 
+// Callers MUST hold guiLock (except pre-GUI single-threaded init, where the lock is a not-ready
+// no-op): this free()s the list the UI-Settings dialog may be handed via thmGetGuiList, and it
+// runs on the IO worker for device-triggered rebuilds. guiShowUIConfig snapshots the list under
+// the same lock. NOT self-locking: thmReinit must hold the lock across its name-string frees AND
+// this rebuild as ONE critical section (between the two, the published list points at freed
+// strings), and the sema is not recursive.
 static void thmRebuildGuiNames(void)
 {
     if (guiThemesNames)
@@ -2592,7 +2598,11 @@ int thmAddElements(char *path, const char *separator, int forceRefresh)
 
     result = listDir(path, separator, THM_MAX_FILES - nThemes, &thmReadEntry);
     nThemes += result;
+    // Appends above only fill NEW themes[] slots (the published name list references old slots
+    // untouched); the rebuild's free+swap is what must be serialized against the GUI's readers.
+    guiLock();
     thmRebuildGuiNames();
+    guiUnlock();
 
     const char *temp;
     if (configGetStr(configGetByType(CONFIG_OPL), "theme", &temp)) {
@@ -2638,6 +2648,10 @@ void thmReinit(const char *path)
         snprintf(activeName, sizeof(activeName), "<Coverflow>"); // built-in; its id (nThemes+1) shifts as themes are removed
     }
 
+    // One guiLock section across the removal loop AND the rebuild: the frees below invalidate
+    // strings the CURRENTLY PUBLISHED guiThemesNames points at, so the GUI-side readers
+    // (frame-locked renders, guiShowUIConfig's snapshot) must not run between free and swap.
+    guiLock();
     int i = 0;
     while (i < nThemes) {
         if (strncmp(themes[i].filePath, path, strlen(path)) == 0) {
@@ -2654,6 +2668,7 @@ void thmReinit(const char *path)
     }
 
     thmRebuildGuiNames();
+    guiUnlock();
 
     if (activeOnDevice) {
         // The displayed theme's files just went away with its device: drop to the built-in default.


### PR DESCRIPTION
## The bug (found by #164's diaSetEnum lifetime sweep; upstream-inherited)

The UI Settings dialog hands `thmGetGuiList()`/`lngGetGuiList()` to `diaSetEnum`, which stores the **raw pointers**. Both are heap arrays that get `free()`d and rebuilt **on the IO worker** whenever a deferred device update discovers THM/LNG folders (bdm/mmce/eth/hdd update paths), and `thmReinit` additionally frees the theme **name strings** on device removal. Dialog frames render *outside* `guiStartFrame`'s lock, so a device event draining while UI Settings is open dereferenced freed memory on the GUI thread. Narrow window (the update must be queued just before dialog entry — the dialog loop queues no new ones), but a real use-after-free.

## Fix — the repo's existing `guiLock` idiom (IO-thread structure swaps under the frame lock, same as `submenuRebuildCache`)

- **Write side**: the list free+swap now runs under `guiLock` in `thmAddElements`, `lngAddLanguages`, and `thmReinit` — the latter as **one critical section** across its name-string frees *and* the rebuild, since between them the published list points at freed strings. `thmRebuildGuiNames` documents the caller-holds-lock contract (the sema isn't recursive).
- **Read side**: `guiShowUIConfig` deep-copies both lists under the same lock into dialog-owned snapshots, re-snapshots each `reselect_video_mode` pass (`applyConfig` can legitimately change the lists), and frees them at exit. The dialog never touches shared storage again; frame-locked renders were already protected and stay so. On OOM the code falls back to the live list — the pre-existing narrow race, not a new failure mode.
- **Init-order guard**: `guiLock`/`guiUnlock` no-op until `guiInit` creates the semaphore (`lngInit`/`thmInit` rebuild the lists before that, single-threaded) and after `guiEnd` deletes it — previously the sema id was uninitialized in that window, so locking there would have waited on id 0/garbage.

## Deadlock audit

- Existing `guiLock` sections (opl.c submenu-cache rebuilds) never call into the now-locking functions.
- The GUI thread never holds `guiLock` when `guiShowUIConfig` runs — input handlers execute after `guiEndFrame` (gui.c main loops).
- `guiUIUpdater` (the dialog's modification callback) only reads ints and sets colors — it never re-sets the enums, so the snapshot stays authoritative for the dialog's lifetime.
- Init/shutdown callers hit the not-ready guard.

## Testing

- Clean container build green; clang-format 12 applied.
- The race needs a device hot-plug event landing exactly as UI Settings opens — not deterministically reproducible on PCSX2; the fix is correctness-by-construction (locked writer + snapshot reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)