### PR TITLE
feat(neutrino): global Neutrino Video (-gsm) default + per-game Default row (1080ix3 trick, #154 thread)

### DIFF
--- a/docs/NEUTRINO.md
+++ b/docs/NEUTRINO.md
@@ -70,7 +70,7 @@ settings:
 | `-gc=<modes>` | only if the game has OPL compatibility modes set |
 | `-dbc` | only if **Debug Colors** is enabled |
 | `-logo` | only if **PS2 Logo** is enabled |
-| `-gsm=<mode>` | only if a per-game **Neutrino Video** mode is set (Compatibility screen) |
+| `-gsm=<mode>` | only if a **Neutrino Video** mode resolves for the game (per-game picker, or the global **Settings → Neutrino Video** default when the per-game picker is "Default") |
 
 On top of those, you can pass **extra Neutrino flags** (e.g. media-type or video tweaks)
 in two places. Both are **appended after** the auto-built arguments; **global first, then
@@ -205,10 +205,20 @@ features — see the mapping below).
 
 When a game's core is **Neutrino**:
 - **Compatibility screen:** the **Neutrino Launch Args** field is editable, and a **Neutrino
-  Video** picker (Off / 240p / 480p / 1080i) appears beside it — it maps to Neutrino's `-gsm`
-  (`fp1` / `fp2` / `1080ix1`; Off emits nothing) and is the Neutrino-side stand-in for the hidden
-  OPL GSM panel. The picker is the *default*: a manual `-gsm` typed into **Launch Args** takes
-  precedence (OPL emits only one `-gsm`, since Neutrino aborts on a duplicate/malformed value).
+  Video** picker (Off / 240p / 480p / 1080i x1–x3 / Default) appears beside it — it maps to
+  Neutrino's `-gsm` (`fp1` / `fp2` / `1080ix1..3`; Off emits nothing) and is the Neutrino-side
+  stand-in for the hidden OPL GSM panel. **Default** follows the *global* Neutrino Video setting
+  in **Settings** (so you can force e.g. `-gsm=1080ix3` for every Neutrino game at once); an
+  explicit per-game value — including **Off** — overrides the global. The picker is the *default*
+  source of `-gsm`: a manual `-gsm` typed into **Launch Args** takes precedence (OPL emits only
+  one `-gsm`, since Neutrino aborts on a duplicate/malformed value).
+
+  > **The "1080p impression" trick:** on 1080-class displays, `1080i x3` (`-gsm=1080ix3`) is the
+  > community workaround for progressive-looking output — the same effect people previously got by
+  > launching Neutrino from PS2BBLE/OSDmenu with `-gsm=1080ix3`. Set it per game, or globally via
+  > **Settings → Neutrino Video** and leave games on "Default". (True 1080p does not exist in any
+  > OPL/GS mode table — the GS outputs `1080i`, and OPL's own UI lacks the VRAM for a 1080p
+  > framebuffer.)
   OPL compat **mode 4 (Skip Videos)** and **mode 6 (Disable IGR)** are greyed —
   they're OPL ee-core features with **no Neutrino equivalent** (Neutrino has no in-game reset, and
   no PSS/BIK video-skip), so OPL never forwards them. **DL Defaults** is greyed too (it pulls

--- a/include/config.h
+++ b/include/config.h
@@ -99,7 +99,9 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_OVERSCAN             "overscan"
 #define CONFIG_OPL_DISABLE_DEBUG        "disable_debug"
 #define CONFIG_OPL_PS2LOGO              "ps2logo"
-#define CONFIG_OPL_DEFAULT_CORE         "default_core" // global default Loader Core (0=<OPL>, 1=Neutrino); a game's per-game "$CoreLoader" overrides it, absent = follow this
+#define CONFIG_OPL_DEFAULT_CORE         "default_core"              // global default Loader Core (0=<OPL>, 1=Neutrino); a game's per-game "$CoreLoader" overrides it, absent = follow this
+#define CONFIG_OPL_NEUTRINO_VIDEO       "neutrino_video_default"    // global default Neutrino -gsm video mode (0=Off..5=1080i x3); per-game "$NeutrinoVideo" overrides, absent = follow this
+#define CONFIG_OPL_NEUTRINO_GSMCOMP     "neutrino_gsm_comp_default" // global default -gsm ":c" field-flip half (0=off, 1-3=type); per-game "$NeutrinoGsmComp" overrides, absent = follow this
 #define CONFIG_OPL_NEUTRINO_ARGS        "neutrino_args"
 #define CONFIG_OPL_NEUTRINO_PATH        "neutrino_path"
 #define CONFIG_OPL_NEUTRINO_DEVICE      "neutrino_device"   // legacy device-INDEX (mc0/mass0/mmce0); read-only, migrated

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -81,6 +81,8 @@ enum UI_ITEMS {
     CFG_DEFAULT_CORE, // global default Loader Core (gDefaultCoreLoader); per-game "Default" follows it
     CFG_NEUTRINO_ARGS,
     CFG_NEUTRINO_DEVICE,
+    CFG_NEUTRINO_VIDEO,   // global default Neutrino -gsm video mode (gNeutrinoVideoDefault); per-game "Default" follows it
+    CFG_NEUTRINO_GSMCOMP, // global default -gsm ":c" comp half (gNeutrinoGsmCompDefault)
     CFG_POPSTARTER_DEVICE,
     CFG_LBL_POPSTARTER_PATH,
     CFG_POPSTARTER_PATH,

--- a/include/opl.h
+++ b/include/opl.h
@@ -240,22 +240,24 @@ extern char gNeutrinoArgs[256];
 extern char gNeutrinoPath[256]; // custom neutrino.elf path (General Settings); "" = mc0:/mc1: auto-detect
 // Neutrino Device picker: a driver-accurate device TYPE that holds <root>:/neutrino/neutrino.elf.
 // (Replaces the old device-INDEX enum mc0/mc1/mass0-7/mmce0/mmce1; legacy ints are migrated on load.)
-enum { NEUTRINO_DEV_AUTO = 0,     // game device, then mc0/mc1 (legacy behaviour)
-       NEUTRINO_DEV_MC,           // mc0: / mc1:
-       NEUTRINO_DEV_USB,          // BDM "usb"        -> the mounted massN:
-       NEUTRINO_DEV_MX4SIO,       // BDM "mx4sio"/sdc -> the mounted massN:
-       NEUTRINO_DEV_MMCE,         // mmce0: / mmce1:
-       NEUTRINO_DEV_EXFAT_HDD,    // BDM "ata" internal exFAT HDD -> the mounted massN:
-       NEUTRINO_DEV_APA_HDD,      // APA HDD: the mounted OPL data partition (pfs0:)
-       NEUTRINO_DEV_GAME };       // the active game's OWN device ONLY (co-located neutrino.elf); no MC/boot fallback (a miss toasts "not found"). Appended at the enum end to keep saved neutrino_devtype ints stable.
-extern int gNeutrinoDevice;       // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy neutrino_path
-extern int gDefaultCoreLoader;    // global default Loader Core: 0 = <OPL> (native), 1 = Neutrino. A game's per-game $CoreLoader overrides it; absent per-game key = follow this global.
-extern int gNeutrinoElfArg;       // opt-in (settings key only, no UI): auto-emit -elf=cdrom0:\<startup>;1 on Neutrino launches
-extern char gPopstarterPath[256]; // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
-extern char gBootDir[256];        // boot directory (cwd) OPL launched from, e.g. "mass0:/APPS"; "" if undeterminable
-extern int gDeinitTerminal;       // 1 while deinit() runs for exit/poweroff, 0 for a game/app LAUNCH teardown.
-                                  // Launch teardown must NOT power shared buses down (dev9: the post-deinit
-                                  // POPSTARTER.ELF read comes off the ATA-backed massN: mount).
+enum { NEUTRINO_DEV_AUTO = 0,       // game device, then mc0/mc1 (legacy behaviour)
+       NEUTRINO_DEV_MC,             // mc0: / mc1:
+       NEUTRINO_DEV_USB,            // BDM "usb"        -> the mounted massN:
+       NEUTRINO_DEV_MX4SIO,         // BDM "mx4sio"/sdc -> the mounted massN:
+       NEUTRINO_DEV_MMCE,           // mmce0: / mmce1:
+       NEUTRINO_DEV_EXFAT_HDD,      // BDM "ata" internal exFAT HDD -> the mounted massN:
+       NEUTRINO_DEV_APA_HDD,        // APA HDD: the mounted OPL data partition (pfs0:)
+       NEUTRINO_DEV_GAME };         // the active game's OWN device ONLY (co-located neutrino.elf); no MC/boot fallback (a miss toasts "not found"). Appended at the enum end to keep saved neutrino_devtype ints stable.
+extern int gNeutrinoDevice;         // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy neutrino_path
+extern int gDefaultCoreLoader;      // global default Loader Core: 0 = <OPL> (native), 1 = Neutrino. A game's per-game $CoreLoader overrides it; absent per-game key = follow this global.
+extern int gNeutrinoVideoDefault;   // global default Neutrino -gsm video mode (0=Off..5=1080i x3, indices = system.c gsmVideoTokens). Per-game $NeutrinoVideo overrides; absent per-game key = follow this.
+extern int gNeutrinoGsmCompDefault; // global default -gsm ":c" field-flip half (0=off, 1-3=type); only emitted when the effective video mode is set.
+extern int gNeutrinoElfArg;         // opt-in (settings key only, no UI): auto-emit -elf=cdrom0:\<startup>;1 on Neutrino launches
+extern char gPopstarterPath[256];   // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
+extern char gBootDir[256];          // boot directory (cwd) OPL launched from, e.g. "mass0:/APPS"; "" if undeterminable
+extern int gDeinitTerminal;         // 1 while deinit() runs for exit/poweroff, 0 for a game/app LAUNCH teardown.
+                                    // Launch teardown must NOT power shared buses down (dev9: the post-deinit
+                                    // POPSTARTER.ELF read comes off the ATA-backed massN: mount).
 // POPSTARTER.ELF Device picker: where PS1 VCD launches load POPS/POPSTARTER.ELF from. Default tries the
 // boot device (cwd) then the VCD's own device; the 6 TYPEs force a device; Custom uses gPopstarterPath.
 enum { POPS_DEV_DEFAULT = 0,    // cwd (gBootDir) /POPS/, then the VCD's own device (back-compat fallback)

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -787,7 +787,10 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
 
     // Everything Neutrino actually needs from the config/device, copied to THIS stack frame
     // (deinit below frees configSet's owner + pDeviceData).
-    int compatmask = 0, neutrinoVideo = 0, neutrinoGsmComp = 0, neutrinoBsdfs = 0;
+    // Absent per-game $NeutrinoVideo/$NeutrinoGsmComp keys = follow the global defaults (the
+    // per-game picker's "Default" row removes the keys; explicit values -- including Off=0 --
+    // persist and override).
+    int compatmask = 0, neutrinoVideo = gNeutrinoVideoDefault, neutrinoGsmComp = gNeutrinoGsmCompDefault, neutrinoBsdfs = 0;
     char neutrinoExtraArgs[256] = "";
     neutrino_vmc_args_t neutrinoVmc = {0};
     char partname[256], bdmCurrentDriver[32];

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -173,6 +173,17 @@ struct UIItem diaConfig[] = {
     {UI_ENUM, CFG_NEUTRINO_DEVICE, 1, 1, _STR_HINT_NEUTRINO_DEVICE, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
+    // Global default Neutrino Video (-gsm) + its ":c" comp half: games whose per-game picker is
+    // "Default" follow these (e.g. -gsm=1080ix3 everywhere without touching every game).
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_NEUTRINO_VIDEO}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_NEUTRINO_VIDEO, 1, 1, _STR_HINT_NEUTRINO_VIDEO, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_NEUTRINO_GSM_COMP}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_NEUTRINO_GSMCOMP, 1, 1, _STR_HINT_NEUTRINO_GSM_COMP, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_WRITE}}},
     {UI_SPACER},
     {UI_BOOL, CFG_ENWRITEOP, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},

--- a/src/gui.c
+++ b/src/gui.c
@@ -471,11 +471,17 @@ void guiShowNetCompatUpdateSingle(int id, item_list_t *support, config_set_t *co
 static int guiUpdater(int modified)
 {
     int showAutoStartLast;
+    int neutrinoVideoDef;
 
     if (modified) {
         diaGetInt(diaConfig, CFG_LASTPLAYED, &showAutoStartLast);
         diaSetVisible(diaConfig, CFG_LBL_AUTOSTARTLAST, showAutoStartLast);
         diaSetVisible(diaConfig, CFG_AUTOSTARTLAST, showAutoStartLast);
+
+        // The ":c" comp half is only ever emitted alongside a video mode (-gsm=v:c grammar) --
+        // grey it while the global Neutrino Video default is Off (same rule as the per-game rows).
+        diaGetInt(diaConfig, CFG_NEUTRINO_VIDEO, &neutrinoVideoDef);
+        diaSetEnabled(diaConfig, CFG_NEUTRINO_GSMCOMP, neutrinoVideoDef != 0);
     }
     return 0;
 }
@@ -556,6 +562,14 @@ void guiShowConfig()
     const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", _l(_STR_GAMES_DEVICE), NULL}; // device TYPE holding /neutrino/neutrino.elf (NEUTRINO_DEV_*); "Game's Device" (NEUTRINO_DEV_GAME) appended last to match the enum tail
     diaSetEnum(diaConfig, CFG_NEUTRINO_DEVICE, neutrinoDevStrs);
     diaSetInt(diaConfig, CFG_NEUTRINO_DEVICE, gNeutrinoDevice);
+    // Global default Neutrino Video (-gsm) + comp half: same indices as the per-game picker
+    // (system.c gsmVideoTokens). static: literals only, and diaSetEnum stores the raw pointer.
+    static const char *neutrinoVideoDefStrs[] = {"Off", "240p", "480p", "1080i x1", "1080i x2", "1080i x3", NULL};
+    static const char *neutrinoGsmCompDefStrs[] = {"Off", "Type 1 (GSM/OPL)", "Type 2", "Type 3", NULL};
+    diaSetEnum(diaConfig, CFG_NEUTRINO_VIDEO, neutrinoVideoDefStrs);
+    diaSetInt(diaConfig, CFG_NEUTRINO_VIDEO, gNeutrinoVideoDefault);
+    diaSetEnum(diaConfig, CFG_NEUTRINO_GSMCOMP, neutrinoGsmCompDefStrs);
+    diaSetInt(diaConfig, CFG_NEUTRINO_GSMCOMP, gNeutrinoGsmCompDefault);
     // IGR Path auto-resolves a built-in default when blank, so show a dim "Default" placeholder
     // rather than "<not set>" -- the empty value (and thus the fallback) is kept. (VCD/POPSTARTER
     // and BDMA settings moved to their own "VCD Settings" page -- see guiShowVcdConfig.)
@@ -572,6 +586,8 @@ void guiShowConfig()
     diaSetString(diaConfig, CFG_ETHPREFIX, gETHPrefix);
     diaSetString(diaConfig, CFG_MMCEPREFIX, gMMCEPrefix);
 
+    guiUpdater(1); // apply the initial comp-half grey before the dialog is drawn
+
     int ret;
 reshow_config:
     ret = diaExecuteDialog(diaConfig, -1, 1, &guiUpdater);
@@ -586,6 +602,8 @@ reshow_config:
         diaGetString(diaConfig, CFG_EXITTO, gExitPath, sizeof(gExitPath));
         diaGetInt(diaConfig, CFG_DEFAULT_CORE, &gDefaultCoreLoader);
         diaGetInt(diaConfig, CFG_NEUTRINO_DEVICE, &gNeutrinoDevice);
+        diaGetInt(diaConfig, CFG_NEUTRINO_VIDEO, &gNeutrinoVideoDefault);
+        diaGetInt(diaConfig, CFG_NEUTRINO_GSMCOMP, &gNeutrinoGsmCompDefault);
         diaGetInt(diaConfig, CFG_ENWRITEOP, &gEnableWrite);
         diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
         diaGetInt(diaConfig, CFG_AUTOSTARTLAST, &gAutoStartLastPlayed);

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -982,6 +982,12 @@ static int bsdfsDeviceCapable = 1;
 // would otherwise resolve to the global and un-grey them).
 static int coreNeverNeutrino = 0;
 
+// Appended "Default" (follow the global) enum indices for the per-game Neutrino Video / GSM-comp
+// pickers: values 0..5 / 0..3 persist 1:1 (system.c gsmVideoTokens); "Default" removes the key so
+// the launch legs fall back to gNeutrinoVideoDefault/gNeutrinoGsmCompDefault (Loader Core pattern).
+#define NEUTRINO_VIDEO_DEFAULT_IDX   6
+#define NEUTRINO_GSMCOMP_DEFAULT_IDX 4
+
 static void guiGameSetCoreAwareState(void)
 {
     int coreChoice = 0, neutrino = 0, neutrinoVideo = 0;
@@ -993,11 +999,15 @@ static void guiGameSetCoreAwareState(void)
     if (coreNeverNeutrino)
         neutrino = 0; // VCD (POPSTARTER-only): keep all Neutrino-only rows greyed regardless of the global
     diaGetInt(diaCompatConfig, COMPAT_NEUTRINO_VIDEO, &neutrinoVideo);
+    // Resolve the "Default" row to the global it follows, so the comp-half grey below reflects the
+    // EFFECTIVE video mode (a game on "Default" with a non-Off global default has a live comp row).
+    if (neutrinoVideo == NEUTRINO_VIDEO_DEFAULT_IDX)
+        neutrinoVideo = gNeutrinoVideoDefault;
 
     diaSetEnabled(diaCompatConfig, COMPAT_NEUTRINO_ARGS, neutrino);  // Neutrino-only field
     diaSetEnabled(diaCompatConfig, COMPAT_NEUTRINO_VIDEO, neutrino); // Neutrino-only -gsm video mode
     // The ":c" comp half is only ever emitted alongside a video mode (-gsm=v:c grammar), so it also
-    // greys while Neutrino Video is Off -- the updater re-runs this on every change, keeping it live.
+    // greys while the effective Neutrino Video is Off -- the updater re-runs this on every change.
     diaSetEnabled(diaCompatConfig, COMPAT_NEUTRINO_GSMCOMP, neutrino && neutrinoVideo != 0);
     // -bsdfs override: Neutrino-only AND block-backed-device-only (mmce/udpfs have no fs layer;
     // APA is always hdl). The launch side guards independently -- this grey is just honest UI.
@@ -1034,12 +1044,14 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
     diaSetEnum(diaCompatConfig, COMPAT_LOADER, loaders);
 
     // Indices map 1:1 onto system.c's gsmVideoTokens (fp1/fp2/1080ix1/ix2/ix3) -- old configs
-    // stored 0-3, which keep their meaning; x2/x3 are APPENDED so persisted values stay stable.
-    const char *neutrinoVideoModes[] = {"Off", "240p", "480p", "1080i x1", "1080i x2", "1080i x3", NULL};
+    // stored 0-3, which keep their meaning; x2/x3 and now "Default" are APPENDED so persisted
+    // values stay stable. "Default" (index NEUTRINO_VIDEO_DEFAULT_IDX) = no per-game key -> follow
+    // the global gNeutrinoVideoDefault, mirroring the Loader Core row's index-2 pattern.
+    const char *neutrinoVideoModes[] = {"Off", "240p", "480p", "1080i x1", "1080i x2", "1080i x3", _l(_STR_DEFAULT), NULL};
     diaSetEnum(diaCompatConfig, COMPAT_NEUTRINO_VIDEO, neutrinoVideoModes);
     // The ":c" compatibility half of -gsm=v:c -- field-flipping interlace fixes for games that
-    // shake/tear under a forced mode. Ignored (not emitted) while Neutrino Video is Off.
-    const char *neutrinoGsmCompModes[] = {"Off", "Type 1 (GSM/OPL)", "Type 2", "Type 3", NULL};
+    // shake/tear under a forced mode. Ignored (not emitted) while the effective video mode is Off.
+    const char *neutrinoGsmCompModes[] = {"Off", "Type 1 (GSM/OPL)", "Type 2", "Type 3", _l(_STR_DEFAULT), NULL};
     diaSetEnum(diaCompatConfig, COMPAT_NEUTRINO_GSMCOMP, neutrinoGsmCompModes);
 
     // -bsdfs override (parity-audit #11). Indices map 1:1 onto system.c's bsdfsTokens; the value
@@ -1254,18 +1266,21 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
     }
 
     {
-        int neutrinoVideo = 0;
+        // "Default" (appended index) removes the key -> the launch legs fall back to the global
+        // gNeutrinoVideoDefault. Explicit values persist -- INCLUDING 0 (Off), which used to
+        // remove the key too: an explicit per-game Off must now survive a non-Off global.
+        int neutrinoVideo = NEUTRINO_VIDEO_DEFAULT_IDX;
         diaGetInt(diaCompatConfig, COMPAT_NEUTRINO_VIDEO, &neutrinoVideo);
-        if (neutrinoVideo != 0)
+        if (neutrinoVideo != NEUTRINO_VIDEO_DEFAULT_IDX)
             result = configSetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, neutrinoVideo);
         else
             configRemoveKey(configSet, CONFIG_ITEM_NEUTRINO_VIDEO);
     }
 
     {
-        int neutrinoGsmComp = 0;
+        int neutrinoGsmComp = NEUTRINO_GSMCOMP_DEFAULT_IDX;
         diaGetInt(diaCompatConfig, COMPAT_NEUTRINO_GSMCOMP, &neutrinoGsmComp);
-        if (neutrinoGsmComp != 0)
+        if (neutrinoGsmComp != NEUTRINO_GSMCOMP_DEFAULT_IDX)
             result = configSetInt(configSet, CONFIG_ITEM_NEUTRINO_GSMCOMP, neutrinoGsmComp);
         else
             configRemoveKey(configSet, CONFIG_ITEM_NEUTRINO_GSMCOMP);
@@ -1712,15 +1727,17 @@ void guiGameLoadConfig(item_list_t *support, config_set_t *configSet)
     neutrinoArgs[0] = '\0';
     configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoArgs, sizeof(neutrinoArgs));
 
-    int neutrinoVideo = 0;
-    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
-    if (neutrinoVideo < 0 || neutrinoVideo > 5)
+    int neutrinoVideo;
+    if (!configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo))
+        neutrinoVideo = NEUTRINO_VIDEO_DEFAULT_IDX; // no per-game key -> "Default" (follow the global)
+    else if (neutrinoVideo < 0 || neutrinoVideo > 5)
         neutrinoVideo = 0; // sanitize a corrupt/out-of-range cfg value (valid: 0=Off .. 5=1080i x3)
     diaSetInt(diaCompatConfig, COMPAT_NEUTRINO_VIDEO, neutrinoVideo);
 
-    int neutrinoGsmComp = 0;
-    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_GSMCOMP, &neutrinoGsmComp);
-    if (neutrinoGsmComp < 0 || neutrinoGsmComp > 3)
+    int neutrinoGsmComp;
+    if (!configGetInt(configSet, CONFIG_ITEM_NEUTRINO_GSMCOMP, &neutrinoGsmComp))
+        neutrinoGsmComp = NEUTRINO_GSMCOMP_DEFAULT_IDX; // no per-game key -> "Default" (follow the global)
+    else if (neutrinoGsmComp < 0 || neutrinoGsmComp > 3)
         neutrinoGsmComp = 0; // sanitize (valid: 0=Off .. 3=field-flip type 3)
     diaSetInt(diaCompatConfig, COMPAT_NEUTRINO_GSMCOMP, neutrinoGsmComp);
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -781,7 +781,7 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
     }
 
     // Everything Neutrino needs, copied to THIS frame (deinit below frees `game`).
-    int compatMode = 0, neutrinoVideo = 0, neutrinoGsmComp = 0;
+    int compatMode = 0, neutrinoVideo = gNeutrinoVideoDefault, neutrinoGsmComp = gNeutrinoGsmCompDefault; // absent per-game keys = follow the globals
     char neutrinoExtraArgs[256] = "";
     char apaPart[APA_IDMAX + 1];
     configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatMode);

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -790,10 +790,10 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
     configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
     const char *neutrinoPath = NULL;
-    char neutrinoExtraArgs[256] = "";      // per-game Neutrino flags; copied before deinit teardown
-    int neutrinoVideo = 0;                 // per-game Neutrino -gsm video mode; copied before deinit
-    int neutrinoGsmComp = 0;               // per-game -gsm ":c" field-flip half; copied before deinit
-    neutrino_vmc_args_t neutrinoVmc = {0}; // per-game VMC -mc args; resolved before deinit, lives on this stack frame across the launch (#47)
+    char neutrinoExtraArgs[256] = "";              // per-game Neutrino flags; copied before deinit teardown
+    int neutrinoVideo = gNeutrinoVideoDefault;     // per-game -gsm video mode; absent key = follow the global; copied before deinit
+    int neutrinoGsmComp = gNeutrinoGsmCompDefault; // per-game -gsm ":c" field-flip half; absent key = follow the global; copied before deinit
+    neutrino_vmc_args_t neutrinoVmc = {0};         // per-game VMC -mc args; resolved before deinit, lives on this stack frame across the launch (#47)
     if (coreLoader) {
         configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
         configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);

--- a/src/opl.c
+++ b/src/opl.c
@@ -202,19 +202,21 @@ int gPadMacroSettings;
 #endif
 int gScrollSpeed;
 char gExitPath[256];
-char gNeutrinoArgs[256];   // extra command-line flags appended to every Neutrino launch
-char gNeutrinoPath[256];   // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
-int gNeutrinoDevice;       // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy gNeutrinoPath
-int gDefaultCoreLoader;    // global default Loader Core (0=<OPL>, 1=Neutrino); per-game $CoreLoader overrides, absent key = follow this
-int gNeutrinoElfArg;       // opt-in (settings key only, no UI): auto-emit -elf=cdrom0: on Neutrino launches (parity Delta-10)
-char gPopstarterPath[256]; // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
-int gPopstarterDevice;     // POPSTARTER.ELF device (POPS_DEV_*); Default = cwd then VCD device; legacy path -> Custom
-int gBdmaSource;           // BDMA SOURCE device family (VCD_BDMA_SRC_*) to read exFAT driver variants from
-int gBdmaMode;             // BDMA MODE last reflected from the mc?:/POPSTARTER/ marker (VCD_BDMA_*); not persisted
-int gBdmaApplyOnLaunch;    // auto-equip the launched VCD's matching exFAT driver before boot (1=on, default)
-int gVcdHideGameId;        // display-only: hide a leading PS1 game-ID prefix from the VCD list (1=on, default off)
-int gVcdFirstDiscOnly;     // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists (1=on, default off)
-int gWritePopstarterNet;   // mirror the network settings into POPSTARTER's IPCONFIG/SMBCONFIG on save
+char gNeutrinoArgs[256];     // extra command-line flags appended to every Neutrino launch
+char gNeutrinoPath[256];     // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
+int gNeutrinoDevice;         // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy gNeutrinoPath
+int gDefaultCoreLoader;      // global default Loader Core (0=<OPL>, 1=Neutrino); per-game $CoreLoader overrides, absent key = follow this
+int gNeutrinoVideoDefault;   // global default Neutrino -gsm video mode (0=Off..5=1080i x3); per-game $NeutrinoVideo overrides, absent key = follow this (R3Z3N's 1080i x3 "1080p impression" trick, now global)
+int gNeutrinoGsmCompDefault; // global default -gsm ":c" field-flip half (0=off, 1-3=type)
+int gNeutrinoElfArg;         // opt-in (settings key only, no UI): auto-emit -elf=cdrom0: on Neutrino launches (parity Delta-10)
+char gPopstarterPath[256];   // custom POPSTARTER.ELF path (used only when gPopstarterDevice == POPS_DEV_CUSTOM)
+int gPopstarterDevice;       // POPSTARTER.ELF device (POPS_DEV_*); Default = cwd then VCD device; legacy path -> Custom
+int gBdmaSource;             // BDMA SOURCE device family (VCD_BDMA_SRC_*) to read exFAT driver variants from
+int gBdmaMode;               // BDMA MODE last reflected from the mc?:/POPSTARTER/ marker (VCD_BDMA_*); not persisted
+int gBdmaApplyOnLaunch;      // auto-equip the launched VCD's matching exFAT driver before boot (1=on, default)
+int gVcdHideGameId;          // display-only: hide a leading PS1 game-ID prefix from the VCD list (1=on, default off)
+int gVcdFirstDiscOnly;       // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists (1=on, default off)
+int gWritePopstarterNet;     // mirror the network settings into POPSTARTER's IPCONFIG/SMBCONFIG on save
 int gEnableDebug;
 int gPS2Logo;
 int gDefaultDevice;
@@ -1420,6 +1422,12 @@ static void configReadNeutrinoGlobals(config_set_t *configOPL)
     // Global default Loader Core (0=<OPL>, 1=Neutrino). Absent in legacy configs -> keep the
     // reset default (0/<OPL>), so existing installs behave exactly as before this key existed.
     configGetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, &gDefaultCoreLoader);
+    configGetInt(configOPL, CONFIG_OPL_NEUTRINO_VIDEO, &gNeutrinoVideoDefault);
+    if (gNeutrinoVideoDefault < 0 || gNeutrinoVideoDefault > 5)
+        gNeutrinoVideoDefault = 0; // sanitize (indexes system.c gsmVideoTokens at the launch legs)
+    configGetInt(configOPL, CONFIG_OPL_NEUTRINO_GSMCOMP, &gNeutrinoGsmCompDefault);
+    if (gNeutrinoGsmCompDefault < 0 || gNeutrinoGsmCompDefault > 3)
+        gNeutrinoGsmCompDefault = 0;
     // Neutrino Device: prefer the new device-TYPE key; if absent (config predates the picker
     // change), migrate the legacy device-INDEX value -- 0=Auto, 1/2=mc0/mc1 -> MC, 11/12=
     // mmce0/mmce1 -> MMCE, 3-10=mass* -> Auto (a bare massN index can't name a driver type).
@@ -1903,7 +1911,9 @@ static void _saveConfig()
         configSetStr(configOPL, CONFIG_OPL_DEFAULT_BGM_PATH, gDefaultBGMPath);
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs);
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath);
-        configSetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, gDefaultCoreLoader);  // global default Loader Core (0=<OPL>, 1=Neutrino)
+        configSetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, gDefaultCoreLoader); // global default Loader Core (0=<OPL>, 1=Neutrino)
+        configSetInt(configOPL, CONFIG_OPL_NEUTRINO_VIDEO, gNeutrinoVideoDefault);
+        configSetInt(configOPL, CONFIG_OPL_NEUTRINO_GSMCOMP, gNeutrinoGsmCompDefault);
         configSetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, gNeutrinoDevice); // device-TYPE (NEUTRINO_DEV_*); the legacy neutrino_device key is left as-is
         configSetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, gNeutrinoElfArg);
         configSetStr(configOPL, CONFIG_OPL_POPSTARTER_PATH, gPopstarterPath);
@@ -2616,8 +2626,10 @@ static void setDefaults(void)
     gNeutrinoArgs[0] = '\0';
     gNeutrinoPath[0] = '\0';
     gNeutrinoDevice = NEUTRINO_DEV_AUTO;
-    gDefaultCoreLoader = 0; // <OPL> (native) -- preserves pre-existing behaviour until the user opts into Neutrino globally
-    gNeutrinoElfArg = 0;    // experimental Delta-10 -elf emission stays opt-in
+    gDefaultCoreLoader = 0;      // <OPL> (native) -- preserves pre-existing behaviour until the user opts into Neutrino globally
+    gNeutrinoVideoDefault = 0;   // no global -gsm until the user opts in
+    gNeutrinoGsmCompDefault = 0; // no field-flip comp half
+    gNeutrinoElfArg = 0;         // experimental Delta-10 -elf emission stays opt-in
     gPopstarterPath[0] = '\0';
     gPopstarterDevice = POPS_DEV_DEFAULT;
     gBdmaSource = VCD_BDMA_SRC_USB;

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -287,7 +287,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     // Per-game Neutrino ELF + flags, resolved BEFORE deinit frees configSet's owner.
     const char *neutrinoPath = NULL;
     char neutrinoExtraArgs[256] = "";
-    int neutrinoVideo = 0, neutrinoGsmComp = 0;
+    int neutrinoVideo = gNeutrinoVideoDefault, neutrinoGsmComp = gNeutrinoGsmCompDefault; // absent per-game keys = follow the globals
     neutrino_vmc_args_t neutrinoVmc = {0};
 
     configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));


### PR DESCRIPTION
## What (issue #154 thread — R3Z3N's "1080p impression" trick, made a first-class setting)

R3Z3N's workaround for progressive-looking output on 1080-class displays is launching Neutrino with `-gsm=1080ix3` (historically via PS2BBLE/OSDmenu). RiptOPL's per-game **Neutrino Video** picker has offered exactly that since the structured `-gsm` work — but there was no **global** knob short of typing `-gsm` into the free-text global args. Now there is:

- **Settings** gains global **Neutrino Video** + **GSM comp** pickers (`neutrino_video_default` / `neutrino_gsm_comp_default`, default Off). The comp row greys while the global video is Off (live via `guiUpdater`), same rule as the per-game rows.
- The **per-game pickers gain an appended "Default" row** (the Loader Core pattern): indices 0–5 / 0–3 keep their persisted meaning — same append discipline as the earlier 1080i x2/x3 additions — and "Default" removes the per-game key, letting the launch legs (BDM incl. UDPBD/UDPFSBD, APA, MMCE, UDPFS) fall back to the globals via the same init-then-override pattern as `gDefaultCoreLoader`.
- **Core-aware grey** resolves the "Default" row to its effective global value, so the comp half un-greys correctly for a Default game under a non-Off global.

## Semantics rider

An explicit per-game **Off now persists as `$NeutrinoVideo=0`** (it used to remove the key) so it can override a non-Off global. Pre-existing configs never stored the key for Off, so they resolve to "Default" → global (which defaults to Off) → **behavior unchanged until the user opts in globally**.

## Safety

- `system.c`'s `-gsm` emission bounds (1..5) already exclude the Default sentinel and corrupt cfg values; the globals are range-sanitized at config load.
- The "manual `-gsm` typed into args wins" precedence is untouched.
- New enum arrays follow the post-#164 lifetime doctrine (static literals in `guiShowConfig`; the per-game arrays stay function-scope because of `_l()`).

## True 1080p (for the record)

Verified against the OPL-DB source discussion: no OPL lineage has a real `GS_MODE_DTV_1080P` — the GS mode tables top out at `1080i` (plus a misleadingly-named "Non Interlaced" GS_FRAME variant), and OPL's own UI lacks the VRAM for a 1080p framebuffer. The docs now say so explicitly, so users stop hunting for a setting that never existed. If 10th-anniversary-lineage 1080p source surfaces, that's a separate future port.

## Docs

- `docs/NEUTRINO.md`: §3 arg table + §5 picker description + the "1080p impression" note.
- Docs site `neutrino.html`: same, plus the mode table gains the missing 1080i x2/x3 rows (held local until roll).

## Testing

- Clean container build green; clang-format 12 applied.
- PCSX2-visible: the global pickers, the per-game Default row, grey behavior. HW-confirmable: `-gsm=1080ix3` output on a 1080 display (Blade is the natural tester).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
