### PR TITLE
fix(vcd): stop listing unlaunchable VCDs; announce the silent APA/exFAT reconcile (#154 forensics)

### DIFF
--- a/docs/VCD.md
+++ b/docs/VCD.md
@@ -170,7 +170,32 @@ files for you: enable **Settings → Network Settings → Write POPSTARTER Netwo
 (copy them to `mc?:/POPSTARTER/`); if they're missing, an SMB VCD launch warns rather than
 hanging.
 
-## 7. Notes & limitations
+## 7. Troubleshooting — "my VCDs don't show up"
+
+Work down this ladder; each step isolates a different stage (from the #154 forensics):
+
+1. **Does the device page appear at all?** If not, it's the device enables, not VCD: USB/MX4SIO/
+   iLink need their toggles on; the **internal exFAT** page needs *BDM devices* + *BDM HDD* ON and
+   the **APA HDD start mode OFF** — the two internal-HDD backends are mutually exclusive, and a
+   hand-edited/cross-version config that enables both gets auto-reconciled at boot (you now get a
+   toast when that happens; check Device Settings).
+2. **Do PS2 ISOs list from the device?** If yes, the filesystem/mount layer is proven working —
+   on the WOPLSDK build the exFAT driver is *byte-identical* to wOPL's, so "works in wOPL" adds
+   no new information past this step.
+3. **Press L3.** The VCD view is per device and only reachable when *Default game view* is
+   "Both" (or the page is locked to VCD). No L3 response = check that setting.
+4. **VCDs are scanned from `<device-root>:/POPS/*.VCD`** — the game-folder prefix
+   (`usb_prefix` etc.) is deliberately **not** applied, because POPSTARTER itself only reads
+   `/POPS` at the root. A `POPS` folder inside your games subfolder will never be found.
+5. **Name rules:** basenames longer than **160 characters** and the reserved name
+   **`POPSTARTER.VCD`** are skipped at scan (the debug log says so) — previously they listed but
+   could never launch (a dead ✕ button). Rename the file.
+6. **Fails only after selecting a game?** Then listing/scan is fine and the handoff is the
+   suspect: `POPSTARTER.ELF` present in `/POPS` (or `__common/POPS` on APA)? On exFAT, the BDMA
+   equip (§5) is best-effort — a failed equip toasts but the launch still proceeds and may land
+   on OSDSYS.
+
+## 8. Notes & limitations
 
 - VCD support reuses the normal device pipeline, so covers, favourites and the theme all
   work exactly as they do for disc games.

--- a/include/opl.h
+++ b/include/opl.h
@@ -214,7 +214,8 @@ extern int gOSDLanguageEnable;
 extern int gOSDLanguageSource;
 
 extern int showCfgPopup;
-extern int showNetDhcpPopup; // boot toast: UDP transport selected while IP Type = DHCP (needs static IP)
+extern int showNetDhcpPopup;      // boot toast: UDP transport selected while IP Type = DHCP (needs static IP)
+extern int showHddReconcilePopup; // boot toast: APA + exFAT(BDM) HDD were both enabled -- one was auto-disabled (#154)
 
 #ifdef IGS
 #define IGS_VERSION "0.1"

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -937,6 +937,8 @@ gui_strings:
   string: Per-game VMC file not found -- launching without it (game uses its real card).
 - label: NEUTRINO_VMC_HDD_UNSUPPORTED
   string: Neutrino cannot use a VMC on APA HDD (no pfs support) -- launching without it.
+- label: HDD_BACKEND_RECONCILED
+  string: APA and exFAT internal HDD were both enabled -- one was disabled automatically (check Device Settings).
 - label: NEUTRINO_SMB_FALLBACK
   string: SMB games have no Neutrino support -- launching with the OPL core.
 - label: NEUTRINO_DEV_UNSUPPORTED

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -653,7 +653,7 @@ static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
     char vcdPrefix[64], vcdElf[256], vcdSelector[320];
 
-    if (pDeviceData == NULL || vcdName == NULL || vcdName[0] == '\0' || !strcmp(vcdName, "POPSTARTER"))
+    if (pDeviceData == NULL || vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
         return;
     // POPSTARTER does its own IOP reset and reloads its block drivers from the MC -- it can't bring up
     // the network (udp) block device (no BDMA variant for it), so a PS1 VCD on the udp device would just

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -624,7 +624,7 @@ static void ethLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
 {
     char vcdElf[256], vcdSelector[320];
 
-    if (!gPCShareName[0] || vcdName == NULL || vcdName[0] == '\0' || !strcmp(vcdName, "POPSTARTER"))
+    if (!gPCShareName[0] || vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
         return;
     if (!vcdResolvePopstarter(ethPrefix, vcdElf, sizeof(vcdElf))) {
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);

--- a/src/gui.c
+++ b/src/gui.c
@@ -301,7 +301,7 @@ static void guiShowNotifications(void)
     int y = 10;
     int yadd = 35;
 
-    if (showPartPopup || showThmPopup || showLngPopup || showCfgPopup || showNetDhcpPopup) {
+    if (showPartPopup || showThmPopup || showLngPopup || showCfgPopup || showNetDhcpPopup || showHddReconcilePopup) {
         if (!popupTimer) {
             popupTimer = clock() + 5000 * (CLOCKS_PER_SEC / 1000);
             sfxPlay(SFX_MESSAGE);
@@ -345,14 +345,23 @@ static void guiShowNotifications(void)
 
         // One-time network notice set at config load: a UDP transport left on DHCP (the ministack has
         // no DHCP client; it binds the static PS2 IP fields as-is, so an unset static IP fails silently).
-        if (showNetDhcpPopup)
+        if (showNetDhcpPopup) {
             guiRenderNotifications(_l(_STR_UDPBD_NEEDS_STATIC_IP), y);
+            y += yadd;
+        }
+
+        // One-time notice set at config load (#154): APA + exFAT(BDM) internal HDD were both
+        // enabled and one was auto-disabled. Rendered here (not toasted from _loadConfig) so _l()
+        // resolves AFTER the language pack loads -- Gemini review of #167.
+        if (showHddReconcilePopup)
+            guiRenderNotifications(_l(_STR_HDD_BACKEND_RECONCILED), y);
 
         if (clock() >= popupTimer) {
             guiResetNotifications();
             showPartPopup = 0;
             showCfgPopup = 0;
             showNetDhcpPopup = 0;
+            showHddReconcilePopup = 0;
         }
     }
 }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -725,7 +725,7 @@ static void hddLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     char resolvedName[VCD_NAME_MAX];
     char resolvedPart[APA_IDMAX + 1];
 
-    if (vcdName == NULL || vcdName[0] == '\0' || !strcmp(vcdName, "POPSTARTER"))
+    if (vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
         return;
 
     // Serialize against a queued HDD refresh that can use the same pfs1: slot and shared list. No art

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -567,7 +567,7 @@ static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set
 {
     char vcdElf[256], vcdSelector[320];
 
-    if (vcdName == NULL || vcdName[0] == '\0' || !strcmp(vcdName, "POPSTARTER"))
+    if (vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
         return;
     if (!vcdResolvePopstarter(mmcePrefix, vcdElf, sizeof(vcdElf))) {
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);

--- a/src/opl.c
+++ b/src/opl.c
@@ -193,7 +193,8 @@ int gFadeDelay;
 int toggleSfx;
 int showCfgPopup;
 // Boot toast (rendered by guiShowNotifications alongside showCfgPopup):
-int showNetDhcpPopup; // a UDP transport is selected but IP Type is DHCP -- ministack needs a static IP
+int showNetDhcpPopup;      // a UDP transport is selected but IP Type is DHCP -- ministack needs a static IP
+int showHddReconcilePopup; // APA + exFAT(BDM) HDD were both enabled -- one was auto-disabled at load (#154)
 #ifdef PADEMU
 int gEnablePadEmu;
 int gPadEmuSettings;
@@ -1592,9 +1593,11 @@ static void _loadConfig()
                 configSetInt(configOPL, CONFIG_OPL_HDD_MODE, gHDDStartMode);
                 configSetInt(configOPL, CONFIG_OPL_ENABLE_BDMHDD, gEnableBdmHDD);
                 // #154 forensics: this reconciliation was SILENT -- a user whose internal-exFAT (or
-                // APA) page vanished after a hand-edit/cross-version config had no clue why. Say so
-                // once; _loadConfig runs deferred (post-GUI), so the toast renders.
-                guiWarning(_l(_STR_HDD_BACKEND_RECONCILED), 8);
+                // APA) page vanished after a hand-edit/cross-version config had no clue why. Flag it
+                // for the notification popup (same pattern as showNetDhcpPopup): the render site
+                // resolves _l() per frame, so the message localizes correctly even though the
+                // language pack loads AFTER this point (applyConfig at the end of _loadConfig).
+                showHddReconcilePopup = 1;
             }
             int udpbdKeyPresent = configGetInt(configOPL, CONFIG_OPL_ENABLE_UDPBD, &gEnableUDPBD);
             configGetInt(configOPL, CONFIG_OPL_NET_BOOT_PROTOCOL, &gNetBootProtocol);

--- a/src/opl.c
+++ b/src/opl.c
@@ -1591,6 +1591,10 @@ static void _loadConfig()
                     gEnableBdmHDD = 0;
                 configSetInt(configOPL, CONFIG_OPL_HDD_MODE, gHDDStartMode);
                 configSetInt(configOPL, CONFIG_OPL_ENABLE_BDMHDD, gEnableBdmHDD);
+                // #154 forensics: this reconciliation was SILENT -- a user whose internal-exFAT (or
+                // APA) page vanished after a hand-edit/cross-version config had no clue why. Say so
+                // once; _loadConfig runs deferred (post-GUI), so the toast renders.
+                guiWarning(_l(_STR_HDD_BACKEND_RECONCILED), 8);
             }
             int udpbdKeyPresent = configGetInt(configOPL, CONFIG_OPL_ENABLE_UDPBD, &gEnableUDPBD);
             configGetInt(configOPL, CONFIG_OPL_NET_BOOT_PROTOCOL, &gNetBootProtocol);

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -104,8 +104,24 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
         if (len < 5 || strcasecmp(de->d_name + len - 4, ".VCD") != 0)
             continue;          // keep only "*.VCD" (case-insensitive)
         int baseLen = len - 4; // strip ".VCD"
+        // Skip names no launch leg can start truthfully (#154 forensics) -- listing them made a
+        // dead X button:
+        // - basenames longer than ISO_GAME_NAME_MAX: the game list stores base_game_info_t names
+        //   capped at 160, and every VCD launch resolves BY NAME -- the truncated name targets a
+        //   nonexistent file and POPSTARTER drops to OSDSYS. Rename the file to fix.
+        // - "POPSTARTER": reserved -- its selector would be "XX.POPSTARTER.ELF", colliding with
+        //   POPSTARTER's own naming; the launch legs have always rejected it (silently, which
+        //   looked like a dead X button while it was still listed). Case-insensitive: FAT is.
+        if (baseLen > ISO_GAME_NAME_MAX) {
+            LOG("VCD skip (name > %d chars, unlaunchable): %s\n", ISO_GAME_NAME_MAX, de->d_name);
+            continue;
+        }
+        if (baseLen == 10 && strncasecmp(de->d_name, "POPSTARTER", 10) == 0) {
+            LOG("VCD skip (reserved name): %s\n", de->d_name);
+            continue;
+        }
         if (baseLen > VCD_NAME_MAX - 1)
-            baseLen = VCD_NAME_MAX - 1;
+            baseLen = VCD_NAME_MAX - 1; // unreachable after the cap above; kept as a belt
         memcpy(list[count].name, de->d_name, baseLen);
         list[count].name[baseLen] = '\0';
         count++;


### PR DESCRIPTION
## Context

Nathan fed a user report + build screenshot through a third-party forensic comparison of RiptOPL `dc6d7d0` vs wOPL `ce94bd9` (both rebuilt in the immutable CI container). Its central finding — **the WOPLSDK exFAT stack is byte-identical to wOPL's** (same `bdm.irx`/`bdmfs_fatfs.irx`/`usbmass_bd_mini.irx`/`ata_bd.irx` hashes) — means "works in wOPL" proves nothing past the mount layer. But it also surfaced **two real RiptOPL VCD edge defects and one discoverability gap**, all verified against source and fixed here.

## Fixes

1. **Unlaunchable VCDs no longer list** (`vcdScanOpenDir`, the single choke point shared by BDM/SMB/MMCE/APA):
   - basenames **> 160 chars** (`ISO_GAME_NAME_MAX`): the game list caps names at 160 and every launch resolves **by name** — the truncated name targeted a nonexistent file and POPSTARTER dropped to OSDSYS. Skipped with a LOG.
   - the reserved name **`POPSTARTER.VCD`**: all four launch legs have always rejected it *silently* — a dead ✕ button while it was still listed. Skipped with a LOG; the four guards stay as belts for stale favourites, upgraded `strcmp`→`strcasecmp` (FAT is case-insensitive).
2. **The silent APA+exFAT config reconcile now toasts** (`HDD_BACKEND_RECONCILED`): the #120-audit F-12 normalization auto-disables one internal-HDD backend when a hand-edited/cross-version config enables both — previously with zero feedback, which is a prime suspect for "my internal exFAT page vanished". `_loadConfig` runs deferred post-GUI, so the notification renders.
3. **Triage docs**: `docs/VCD.md` gains a 6-step "my VCDs don't show up" ladder (device enables → PS2-ISOs-prove-the-mount → L3/view setting → root `/POPS` not the games prefix → name rules → post-select = POPSTARTER side); mirrored on the docs site under `troubleshooting.html#vcd-list-empty` (held local until roll).

## Declined from the forensics, with rationale

- **Async USBMASS orchestration**: deliberate deferred-init architecture; the boot-step localizer names a wedge, and "page never appears" resolves to config gates (now toasted where silent).
- **In-game ATA core divergence vs wOPL**: ours is the upstream-lineage core; the analysis showed difference, not defect.
- **Fragmentation check**: ours is the stricter side of the comparison, by the analysis's own verdict.

## Testing

- Clean container build verified with explicit exit-code capture (MAKE_EXIT=0).
- PCSX2-visible: the scan skips (LOG lines), the reconcile toast on a doctored config. The user report resolves via the docs ladder + the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)