### PR TITLE
fix(themes,cheats): backlog batch 1 — filtered-decorator cache split + gCheats free-on-disable + docs drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,10 +594,10 @@ Since 05/07/2021 every OPL build dispatched to the release section of this repos
 
 1. **Symptom:** No image is shown after launching OPL (black/blank screen on TV).
 2. **Likely cause:** A forced video mode was saved that your display does not support (commonly from GSM video mode/scaling compatibility settings).
-3. **Recovery steps:** Hold __`Triangle + Cross`__ while OPL initializes to reset video mode to __`Auto`__.
+3. **Recovery steps:** Hold __`Triangle + Cross`__ while OPL initializes to force the video mode to __`480p progressive`__ — a mode virtually every display syncs (Auto resolves to interlaced 480i/576i, which is exactly what some modern displays/upscalers can't lock onto). Once you can see the UI, pick your preferred mode under **Settings**.
 4. **Verification:** Start OPL again normally and confirm the interface appears and remains visible.
 
-For GSM/video-mode mistakes, use the same recovery combo above: hold __`Triangle + Cross`__ at boot to restore __`Auto`__ video mode.
+For GSM/video-mode mistakes, use the same recovery combo above: hold __`Triangle + Cross`__ at boot to force __`480p`__ for OPL's own UI (per-game GSM overrides only apply at game launch and don't affect the OPL menu).
 
 If your issue is still unresolved, report it here: <https://www.psx-place.com/threads/open-ps2-loader-game-bug-reports.19401/>.
 

--- a/docs/PARITY-AUDIT-2026-07-06.md
+++ b/docs/PARITY-AUDIT-2026-07-06.md
@@ -153,7 +153,13 @@ RiptOPL is at or ahead of parity across wOPL, NHDDL, upstream OPL, and the ps2-m
 
 ## 7. Prioritized "fill the gaps" work queue
 
-Ranked by user-visible payoff ÷ effort, black-screen / data-loss risks first. **Corrected** against the fork's own `docs/NEUTRINO-PARITY-2026-07-05.md` and the two hand-verifications above.
+Ranked by user-visible payoff ÷ effort, black-screen / data-loss risks first.
+
+> **Status (2026-07-14): this queue is DRAINED.** Items 1, 2, 3, 5, 8, 9, 10, 11 shipped across the
+> Δ-series and the core-aware-settings/DS5/bsdfs work; item 4 (gCheats lazy alloc) shipped in the
+> cht.tar PR (`ensureCheatTable`, f7546100) plus a free-on-disable hook; item 6 (480p recovery)
+> shipped as ef91674d; item 7 (RTC last-played) is **retracted** — `CONFIG_LAST` is a single
+> global store, so last-write-wins already IS newest-wins (do not resurrect this row again). **Corrected** against the fork's own `docs/NEUTRINO-PARITY-2026-07-05.md` and the two hand-verifications above.
 
 | # | Item | Why | Sev | Effort | Where |
 |---|------|-----|-----|--------|-------|

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -35,6 +35,18 @@ cheat_entry_t *gCheats = NULL;        // lazily allocated in load_cheats (~1.03 
 static int gEnableImage;           // Prebuilt PS2RD cheat image (.img) - 0 Off, 1 On
 static u32 gImage[MAX_IMAGEWORDS]; // The loaded .img patch words (zeroed when none/failed)
 
+// Release the lazily-allocated ~1.03 MB cheat table (see ensureCheatTable). Every reader is
+// NULL-guarded (the cheat-selection menu and set_cheats_list), and the launch handoff never
+// references gCheats -- set_cheats_list flattens it into the small static gCheatList that
+// ee_core reads in-place, so freeing between launches is safe.
+static void freeCheatTable(void)
+{
+    if (gCheats != NULL) {
+        free(gCheats);
+        gCheats = NULL;
+    }
+}
+
 void InitCheatsConfig(config_set_t *configSet)
 {
     config_set_t *configGame = configGetByType(CONFIG_GAME);
@@ -57,6 +69,13 @@ void InitCheatsConfig(config_set_t *configSet)
         }
         configGetInt(configGame, CONFIG_ITEM_ENABLEIMAGE, &gEnableImage);
     }
+
+    // Cheats OFF for this launch: reclaim the ~1 MB table a previous cheats-ON launch may have
+    // left behind (it only survives OPL at all when that launch FAILED back to the GUI -- a
+    // successful launch hands off to ExecPS2). This runs in per-launch settings prep BEFORE any
+    // sbLoadCheats of the same launch, so a cheats-ON launch never sees a freed table.
+    if (!gEnableCheat)
+        freeCheatTable();
 }
 
 int GetCheatsEnabled(void)

--- a/src/themes.c
+++ b/src/themes.c
@@ -1707,6 +1707,30 @@ static int isDecoratorCoverCache(theme_element_t *list, image_cache_t *cache)
     return itemsList->decoratorImage != NULL && itemsList->decoratorImage->cache == cache;
 }
 
+// devices=-filtered ItemsLists own no slot, so the four slot checks in isDecoratorCoverImage never
+// see their decorators. Recognizing them here is the CASCADE KILLER for the filtered-decorator
+// cache split below: without it, each split's replaceSharedCoverCache treats another filtered
+// list's decorator as a plain selected cover and re-points it, so repeated splits keep cloning.
+// Walks all 8 families; keys off elem->deviceFilter (0 for every element of a devices=-free theme,
+// so such themes take zero new branches).
+static int isFilteredDecoratorCoverImage(theme_t *theme, mutable_image_t *gameImage)
+{
+    theme_elems_t *groups[8] = {&theme->mainElems, &theme->infoElems, &theme->appsMainElems, &theme->appsInfoElems,
+                                &theme->favsMainElems, &theme->favsInfoElems, &theme->vcdMainElems, &theme->vcdInfoElems};
+    int g;
+
+    for (g = 0; g < 8; g++) {
+        theme_element_t *e = groups[g]->first;
+        while (e != NULL) {
+            if (e->type == ELEM_TYPE_ITEMS_LIST && e->deviceFilter && e->extended != NULL &&
+                ((items_list_t *)e->extended)->decoratorImage == gameImage)
+                return 1;
+            e = e->next;
+        }
+    }
+    return 0;
+}
+
 static int isDecoratorCoverImage(theme_t *theme, mutable_image_t *gameImage)
 {
     items_list_t *itemsList;
@@ -1738,7 +1762,7 @@ static int isDecoratorCoverImage(theme_t *theme, mutable_image_t *gameImage)
             return 1;
     }
 
-    return 0;
+    return isFilteredDecoratorCoverImage(theme, gameImage);
 }
 
 static image_cache_t *cloneImageCache(theme_t *theme, image_cache_t *source)
@@ -1814,6 +1838,48 @@ static void splitDecoratorCoverCache(theme_t *theme, theme_element_t *list)
         cacheDestroyCache(replacementCache);
 }
 
+// Run the decorator/selected-cover split for every devices=-filtered ItemsList (they own no slot,
+// so the four slot calls in validateGUIElems never reach them). splitDecoratorCoverCache's own
+// guards (NULL extended/decoratorImage, non-COV suffix, destroy-unassigned-clone) make repeat
+// calls per shared source cache a no-op -- see the non-cascade note at the call site.
+static void splitFilteredDecoratorCoverCaches(theme_t *theme)
+{
+    int g;
+
+    if (theme == NULL)
+        return;
+
+    theme_elems_t *groups[8] = {&theme->mainElems, &theme->infoElems, &theme->appsMainElems, &theme->appsInfoElems,
+                                &theme->favsMainElems, &theme->favsInfoElems, &theme->vcdMainElems, &theme->vcdInfoElems};
+    for (g = 0; g < 8; g++) {
+        theme_element_t *e = groups[g]->first;
+        while (e != NULL) {
+            if (e->type == ELEM_TYPE_ITEMS_LIST && e->deviceFilter)
+                splitDecoratorCoverCache(theme, e);
+            e = e->next;
+        }
+    }
+}
+
+// Cache-based twin of isFilteredDecoratorCoverImage for the clamp below: true when `cache` backs a
+// devices=-filtered ItemsList's decorator in ANY family. Zero-cost for devices=-free themes.
+static int isFilteredDecoratorCoverCache(theme_t *theme, image_cache_t *cache)
+{
+    theme_elems_t *groups[8] = {&theme->mainElems, &theme->infoElems, &theme->appsMainElems, &theme->appsInfoElems,
+                                &theme->favsMainElems, &theme->favsInfoElems, &theme->vcdMainElems, &theme->vcdInfoElems};
+    int g;
+
+    for (g = 0; g < 8; g++) {
+        theme_element_t *e = groups[g]->first;
+        while (e != NULL) {
+            if (e->type == ELEM_TYPE_ITEMS_LIST && e->deviceFilter && isDecoratorCoverCache(e, cache))
+                return 1;
+            e = e->next;
+        }
+    }
+    return 0;
+}
+
 static void clampSelectedCoverCaches(theme_t *theme, theme_elems_t *elems)
 {
     theme_element_t *elem = elems->first;
@@ -1824,7 +1890,8 @@ static void clampSelectedCoverCaches(theme_t *theme, theme_elems_t *elems)
 
             if (gameImage != NULL && gameImage->cache != NULL && gameImage->cache->suffix != NULL && strcmp(gameImage->cache->suffix, "COV") == 0 &&
                 !isDecoratorCoverCache(theme->gamesItemsList, gameImage->cache) && !isDecoratorCoverCache(theme->appsItemsList, gameImage->cache) &&
-                !isDecoratorCoverCache(theme->favsItemsList, gameImage->cache) && !isDecoratorCoverCache(theme->vcdItemsList, gameImage->cache)) {
+                !isDecoratorCoverCache(theme->favsItemsList, gameImage->cache) && !isDecoratorCoverCache(theme->vcdItemsList, gameImage->cache) &&
+                !isFilteredDecoratorCoverCache(theme, gameImage->cache)) {
                 gameImage->cache->allowPrime = 0;
             }
         }
@@ -1917,9 +1984,9 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
     // devices=-filtered ItemsList overrides: link their decorators (they own no slot, so the pass
     // above never reaches them). Info families too -- a filtered ItemsList can be declared there
     // and its decorator string must not be left pointing into themeConfig (freed at end of load).
-    // NOTE: filtered decorators are NOT cache-split/exempted below (splitDecoratorCoverCache /
-    // clampSelectedCoverCaches walk the four slot lists only); a filtered list with its own COV
-    // decorator just loses idle-time priming (pop-in), nothing worse.
+    // Their decorators are ALSO cache-split (splitFilteredDecoratorCoverCaches below) and
+    // clamp-exempt (isFilteredDecoratorCoverCache), the same treatment the slot lists get --
+    // isDecoratorCoverImage recognizes them, which is what keeps repeated splits from cascading.
     validateFilteredItemsLists(themePath, themeConfig, theme, &theme->mainElems);
     validateFilteredItemsLists(themePath, themeConfig, theme, &theme->infoElems);
     validateFilteredItemsLists(themePath, themeConfig, theme, &theme->appsMainElems);
@@ -1946,6 +2013,12 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
     splitDecoratorCoverCache(theme, theme->appsItemsList);
     splitDecoratorCoverCache(theme, theme->favsItemsList);
     splitDecoratorCoverCache(theme, theme->vcdItemsList);
+
+    // devices=-filtered lists' decorators get the same split. Safe to repeat per list: with
+    // isDecoratorCoverImage recognizing every decorator (filtered included), a split's
+    // replaceSharedCoverCache can never re-point another list's decorator, so after the first
+    // effective clone per source cache the later calls find no sharers and destroy their clone.
+    splitFilteredDecoratorCoverCaches(theme);
 
     // The L3 VCD view reuses the device's own game list (same item ids), so its selected/carousel covers
     // must not share a COV cache with the ISO list -- otherwise toggling thrashes the same cache slots.

--- a/src/themes.c
+++ b/src/themes.c
@@ -1865,9 +1865,13 @@ static void splitFilteredDecoratorCoverCaches(theme_t *theme)
 // devices=-filtered ItemsList's decorator in ANY family. Zero-cost for devices=-free themes.
 static int isFilteredDecoratorCoverCache(theme_t *theme, image_cache_t *cache)
 {
+    int g;
+
+    if (theme == NULL || cache == NULL) // unreachable from the current callers; matches the sibling helpers' guards (Gemini, #168)
+        return 0;
+
     theme_elems_t *groups[8] = {&theme->mainElems, &theme->infoElems, &theme->appsMainElems, &theme->appsInfoElems,
                                 &theme->favsMainElems, &theme->favsInfoElems, &theme->vcdMainElems, &theme->vcdInfoElems};
-    int g;
 
     for (g = 0; g < 8; g++) {
         theme_element_t *e = groups[g]->first;


### PR DESCRIPTION
## Context

Nathan greenlit the engineering backlog (minus Tetris). An 8-brief scout sweep found **5 of 8 queue items already shipped** in past sessions — this PR lands the two real code residuals plus the documentation drift the sweep exposed. Full dispositions below so the queue never resurrects.

## Code

- **Filtered-decorator cache split (themes)**: `devices=`-filtered ItemsList decorators now get the identical COV-cache treatment as the four slot lists. The key move is teaching `isDecoratorCoverImage` about filtered decorators — that's the *cascade killer* (without it, each split's `replaceSharedCoverCache` re-points another filtered list's decorator and repeated splits keep cloning), and it also fixes a latent bug where `separateVcdCoverCache` could pick a filtered vcd-family decorator as its "shared" source. `splitFilteredDecoratorCoverCaches` runs after the slot splits (repeat calls per shared source cache are provable no-ops), and the prime-clamp exempts filtered decorator caches. Themes without `devices=` take **zero** new branches.
- **gCheats free-on-disable (cheats)**: the ~1.03 MB cheat table (lazily allocated since the cht.tar PR's `ensureCheatTable`) is now freed when a launch runs with cheats OFF — the only case it survives OPL at all is a cheats-ON launch failing back to the GUI. Placed in `InitCheatsConfig`'s disabled branch (per-launch prep, before any `sbLoadCheats`), so cheats-ON launches never see a freed table; all readers already NULL-guard. Commented hard: `gCheatList`/`gImage` must stay static — ee_core reads them **in-place** after the handoff.

## Docs drift

- **README**: the Triangle+Cross recovery combo has forced **480p progressive** since ef91674d — the text still promised "Auto," which is the exact mode class the combo exists to escape. Fixed both mentions; the docs site's troubleshooting page is matched (held local until roll).
- **docs/PARITY-AUDIT-2026-07-06.md**: queue marked **DRAINED** with per-item dispositions, including pinning the RTC last-played row as **RETRACTED** (its second resurrection — `CONFIG_LAST` is a single global store, so last-write-wins already is newest-wins).

## Already-shipped verdicts (no code, recorded for the queue)

| Item | Where it shipped |
|---|---|
| gCheats lazy alloc (~1 MB BSS) | f7546100 (`ensureCheatTable`, cht.tar PR) |
| 480p boot recovery | ef91674d (2026-07-06) |
| MMCE device wait bound | 2a8a2b4f (10 s cap + lazy re-probe + s64 truncation fix) |
| Second PFS slot | current `pfs1:` scan IS the `-m 2` + IO-serialization design (the leading-\0 pfsarg fix made `-m 2` real) |
| UI_HEADER + scrollable settings | 7e59e346 + aaaa7f5c (cursor-follow scroll — strictly better than wOPL's fixed-step) |

## Testing

- Clean container build, explicit exit-code capture (MAKE_EXIT=0).
- Filtered-decorator behavior needs a theme using `devices=` with its own `decorator=COV` (same HW-pending themer as #160); everything else is doc/comment or NULL-guarded-reader territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)