### PR TITLE
feat(gsm): re-add 1080p as a gated, latest-SDK-only variant ELF (ee_core raster + triple-confirm)

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -332,6 +332,27 @@ jobs:
             echo "WARN: PS2DEVLATESTSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
           fi
 
+      - name: Build + stage experimental 1080p GSM loader (PS2DEVLATESTSDK)
+        # The re-added GSM 1080p mode is a hardware-UNVALIDATED synthetic raster (see ee_core
+        # DTV_1080P). It is compiled ONLY into this dedicated variant, ONLY on the latest-SDK
+        # flavour (like a stricter DS5), and gated behind a triple-confirm in the GUI. Every other
+        # asset -- all flavours' main ELFs, the -ds5 loaders, the VARIANTS zip -- is 1080p-free.
+        # Best-effort: a 1080p build hiccup must not sink the required primary flavour.
+        # LOCALVERSION carries "-PS2DEVLATESTSDK-1080p" so hardware reports self-identify.
+        run: |
+          make --trace clean
+          rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the 1080p output is unambiguous
+          if make --trace LOCALVERSION=PS2DEVLATESTSDK-1080p GSM1080P=1 release; then
+            GSM_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+            if [ -n "${GSM_ELF:-}" ] && [ -f "$GSM_ELF" ]; then
+              cp -f "$GSM_ELF" rolling/RIPTOPL-PS2DEVLATESTSDK-1080p.ELF
+            else
+              echo "WARN: PS2DEVLATESTSDK GSM1080P=1 build produced no ELF; skipping 1080p asset this run" >&2
+            fi
+          else
+            echo "WARN: PS2DEVLATESTSDK GSM1080P=1 build failed; skipping 1080p asset this run" >&2
+          fi
+
       - name: Build variant + debug extras (ps2dev:latest = standard)
         # Runs after staging the main ELF so the per-build `make clean` can't wipe it.
         run: sh ./.github/scripts/build_rolling_extras.sh "-PS2DEVLATESTSDK" "PS2DEVLATESTSDK"

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ PADEMU ?= 1
 #one per SDK flavour (WOPLSDK / PS2MAXSDK / PS2DEVLATESTSDK).
 DUALSENSE ?= 0
 
+#Enables/disables the experimental, hardware-UNVALIDATED GSM 1080p video mode (a GSM-synthetic
+#progressive raster; see ee_core DTV_1080P). Kept OFF in every default build; the rolling release
+#ships ONE ready-made GSM1080P=1 build as a named RIPTOPL-<version>-PS2DEVLATESTSDK-1080p.ELF asset
+#(latest-SDK flavour only), gated behind a triple-confirm in the GUI. When 0, none of the 1080p
+#table/GUI/engine code is compiled in.
+GSM1080P ?= 0
+
 #Enables/disables building of an edition of OPL that will support the DTL-T10000 (SDK v2.3+)
 DTL_T10000 ?= 0
 
@@ -170,6 +177,13 @@ ifeq ($(DTL_T10000),1)
   UDNL_OUT = $(PS2SDK)/iop/irx/udnl-t300.irx
 else
   UDNL_OUT = $(PS2SDK)/iop/irx/udnl.irx
+endif
+
+# Experimental 1080p GSM mode: compile the table/GUI/gate (main EE build) and the ee_core raster
+# handler (via EECORE_EXTRA_FLAGS -> ee_core/Makefile) only when explicitly requested.
+ifeq ($(GSM1080P),1)
+  EE_CFLAGS += -DGSM_1080P
+  EECORE_EXTRA_FLAGS += GSM1080P=1
 endif
 
 ifeq ($(IGS),1)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ This build layers several features on top of upstream OPL:
 - **DualSense / DualShock 5 (USB):** optional controller support — grab a ready-made
   `RIPTOPL-<version>-<SDK>-ds5.ELF` (one per SDK flavour) from the rolling release, or build
   with `make DUALSENSE=1`.
+- **Experimental 1080p GSM mode:** a re-added forced-1080p video mode (progressive
+  1920×1080) lives **only** in a dedicated `RIPTOPL-<version>-PS2DEVLATESTSDK-1080p.ELF` asset
+  (latest-SDK flavour only) so the hardware-unvalidated raster code never touches a mainline
+  build. Selecting it in the per-game GSM picker requires clearing a **three-step confirmation**;
+  if your display can't sync it, the **Triangle + Cross** boot combo forces safe 480p. Build your
+  own with `make GSM1080P=1`.
 - **Ready-to-use defaults:** a fresh install boots with sensible options already enabled —
   widescreen, cover art, notifications, sound effects + boot sound, USB, delete/rename, and
   the PS2 logo, with the device tabs in **Manual** mode. Video mode stays **Auto**. Change
@@ -247,7 +253,10 @@ screenshots (IGS), DS3/DS4 pad emulation (PADEMU), VMC, PS2RD cheats and parenta
 controls are all included in the standard ELF (no upstream-style per-feature variants).
 DualSense / DualShock 5 (USB) support is the one optional extra: the rolling release ships it
 prebuilt as named `RIPTOPL-<version>-<SDK>-ds5.ELF` assets (one per SDK flavour), or build your
-own with `make DUALSENSE=1`.
+own with `make DUALSENSE=1`. One further **experimental** variant — a forced-1080p GSM mode
+(hardware-unvalidated) — ships **only** as `RIPTOPL-<version>-PS2DEVLATESTSDK-1080p.ELF`
+(latest-SDK flavour only, gated behind a three-step in-GUI confirmation), or `make GSM1080P=1`.
+Every other asset, including the `-ds5` loaders and the VARIANTS zip, is 1080p-free.
 
 There are two release channels:
 

--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -18,6 +18,7 @@ ELFs and supporting files are published alongside it:
 | `RIPTOPL-<version>-PS2MAXSDK.ELF` | Bare loader, `ps2max/dev` (pinned) toolchain (**recommended #2**; in-app version ends `-PS2MAXSDK`). |
 | `RIPTOPL-<version>-PS2DEVLATESTSDK.ELF` | Bare loader, `ps2dev/ps2dev:latest` toolchain (bleeding-edge; in-app version ends `-PS2DEVLATESTSDK`; may not boot on all consoles). |
 | `RIPTOPL-<version>-<SDK>-ds5.ELF` | Same as the bare loader for each SDK flavour, **with DualSense (DS5 USB) pad support** compiled in (`DUALSENSE=1`). One per flavour (`-WOPLSDK-ds5` / `-PS2MAXSDK-ds5` / `-PS2DEVLATESTSDK-ds5`); same reliability order applies. The default builds keep DualSense OFF. Best-effort — a flavour's DS5 build may be absent if it failed that run. |
+| `RIPTOPL-<version>-PS2DEVLATESTSDK-1080p.ELF` | **Experimental** loader with the re-added forced-**1080p** GSM video mode compiled in (`GSM1080P=1`). **Latest-SDK flavour only** — the raster is hardware-unvalidated, so it is kept out of every other asset. Selecting 1080p in the per-game GSM picker requires clearing a **three-step confirmation**; the Triangle + Cross boot combo forces safe 480p if a display can't sync it. Best-effort. |
 | `RIPTOPL-<version>-src.zip` | Source snapshot to rebuild this exact commit. |
 | `SHA256SUMS.txt` | SHA256 of every published binary + the source snapshot. |
 | `IRX-MANIFEST*.txt` | SHA256 of every SDK-prebuilt IOP module each toolchain consumed (provenance for silent SDK-side driver swaps). |

--- a/ee_core/Makefile
+++ b/ee_core/Makefile
@@ -32,6 +32,12 @@ ifeq ($(DTL_T10000),1)
     EE_CFLAGS += -D_DTL_T10000
 endif
 
+# Experimental 1080p raster handler (DTV_1080P in gsm_engine_adv.S + its dispatch). The .S files are
+# preprocessed, so -DGSM_1080P gates the #ifdef blocks. Forwarded from the top Makefile's GSM1080P=1.
+ifeq ($(GSM1080P),1)
+    EE_CFLAGS += -DGSM_1080P
+endif
+
 ifeq ($(LOAD_DEBUG_MODULES),1)
 EE_CFLAGS += -D__LOAD_DEBUG_MODULES
     ifeq ($(DECI2_DEBUG),1)

--- a/ee_core/include/gsm_defines.h
+++ b/ee_core/include/gsm_defines.h
@@ -32,6 +32,10 @@
 
 #Add - on video modes(made possible by SP193 and reprep)
 GS_MODE_DTV_576P=0x53
+# Re-added GSM-synthetic 1080p (progressive 1920x1080). Not a ROM-native SetGsCrt mode: the
+# DTV_1080P engine handler programs the raster manually (see gsm_engine_adv.S). Historically
+# present, removed in the engine rewrite ("temporary"), re-ported here behind a triple-confirm.
+GS_MODE_DTV_1080P=0x54
 
 #GSMSourceSetGsCrt
 .equ Source_INT,      0 # HALF

--- a/ee_core/include/gsm_defines.h
+++ b/ee_core/include/gsm_defines.h
@@ -32,9 +32,6 @@
 
 #Add - on video modes(made possible by SP193 and reprep)
 GS_MODE_DTV_576P=0x53
-# Re-added GSM-synthetic 1080p (progressive 1920x1080). Not a ROM-native SetGsCrt mode: the
-# DTV_1080P engine handler programs the raster manually (see gsm_engine_adv.S). Historically
-# present, removed in the engine rewrite ("temporary"), re-ported here behind a triple-confirm.
 GS_MODE_DTV_1080P=0x54
 
 #GSMSourceSetGsCrt

--- a/ee_core/src/gsm_engine.S
+++ b/ee_core/src/gsm_engine.S
@@ -168,6 +168,7 @@ Hook_SetGsCrt:
  * Otherwise, call the original SetGsCrt() syscall handler and let it configure the GS for us.
  */
 
+#ifdef GSM_1080P                                    /* experimental 1080p variant build only */
     li      $a3, GS_MODE_DTV_1080P                  # 0x54 has NO ROM SetGsCrt case, so it is never
     bne     $a1, $a3, Chk_DTV_576P                  # native -- always route it to our own handler.
     nop
@@ -177,6 +178,7 @@ Hook_SetGsCrt:
     nop
 
 Chk_DTV_576P:
+#endif
     li      $a3, GS_MODE_DTV_576P
     la      $t0, GSMFlags
     bne     $a1, $a3, Call_SetGsCrt

--- a/ee_core/src/gsm_engine.S
+++ b/ee_core/src/gsm_engine.S
@@ -168,6 +168,15 @@ Hook_SetGsCrt:
  * Otherwise, call the original SetGsCrt() syscall handler and let it configure the GS for us.
  */
 
+    li      $a3, GS_MODE_DTV_1080P                  # 0x54 has NO ROM SetGsCrt case, so it is never
+    bne     $a1, $a3, Chk_DTV_576P                  # native -- always route it to our own handler.
+    nop
+    jal     DTV_1080P
+    nop
+    b Skip_Call_Original_SetGsCrt
+    nop
+
+Chk_DTV_576P:
     li      $a3, GS_MODE_DTV_576P
     la      $t0, GSMFlags
     bne     $a1, $a3, Call_SetGsCrt

--- a/ee_core/src/gsm_engine_adv.S
+++ b/ee_core/src/gsm_engine_adv.S
@@ -213,7 +213,7 @@ DTV_1080P_syncv:
 DTV_1080P_delay:
     vnop
     vnop
-    addiu   $v1, 0xFFFF
+    addiu   $v1, $v1, -1                   # explicit 3-operand form (matches the rest of this file)
     vnop
     vnop
     bnez    $v1, DTV_1080P_delay

--- a/ee_core/src/gsm_engine_adv.S
+++ b/ee_core/src/gsm_engine_adv.S
@@ -135,6 +135,9 @@ DTV576P_end:
 # SMODE1 write only -- an obvious bug (its other two SMODE1 writes do not), so that OR is dropped
 # here and all three writes are consistent. NOT hardware-validated in this fork -- gated behind a
 # triple-confirm + per-game opt-in + the Triangle+Cross 480p recovery combo.
+# Compiled ONLY into the dedicated GSM1080P=1 variant build (-DGSM_1080P); absent from every
+# default build so the untested raster code cannot ship in a mainline flavour.
+#ifdef GSM_1080P
 .ent DTV_1080P
 DTV_1080P:
     # $v0 = GS base address
@@ -230,6 +233,7 @@ DTV_1080P_delay:
     nop
 
 .end DTV_1080P
+#endif /* GSM_1080P */
 
 # -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/ee_core/src/gsm_engine_adv.S
+++ b/ee_core/src/gsm_engine_adv.S
@@ -127,6 +127,112 @@ DTV576P_end:
 
 # -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+# DTV_1080P: manually program a progressive 1920x1080 raster. Mode 0x54 is GSM-synthetic (the ROM
+# SetGsCrt has no case for it), so this routine writes SMODE1/SYNCH1/SYNCH2/SYNCV/SMODE2/SRFSH
+# directly. Re-ported from the pre-rewrite engine (OPL commit f5b31427). Register VALUES are the
+# ones DOCUMENTED in that source and decode cleanly against the SMODE1 table above (GCONT=1 YPbPr,
+# VHP=0 progressive); the historical code additionally OR'd the GS base address into the FIRST
+# SMODE1 write only -- an obvious bug (its other two SMODE1 writes do not), so that OR is dropped
+# here and all three writes are consistent. NOT hardware-validated in this fork -- gated behind a
+# triple-confirm + per-game opt-in + the Triangle+Cross 480p recovery combo.
+.ent DTV_1080P
+DTV_1080P:
+    # $v0 = GS base address
+    lui     $v0, (GS_BASE >> 16)
+
+# *GS_SMODE1=0x00000003422304B1  (VHP=0 progressive, GCONT=1 component, PLL reset asserted)
+    lui     $v1, 0x0003
+    ori     $v1, 0x4223
+    dsll    $v1, 16
+    ori     $v1, 0x04B1
+    sd      $v1, GS_SMODE1($v0)             # store it
+
+# Newer GS revisions ((*GS_CSR>>16 & 0xFF) >= 0x19) want different SYNCH values.
+    ld      $v1, GS_CSR($v0)
+    dsrl    $v1, 16
+    andi    $v1, 0xFF
+    sltiu   $v1, 0x19
+    bnez    $v1, DTV_1080P_oldGS
+    nop
+
+# *GS_SYNCH1=0x000344200B04182D
+    lui     $v1, 0x0003
+    ori     $v1, 0x4420
+    dsll    $v1, 16
+    ori     $v1, 0x0B04
+    dsll    $v1, 16
+    ori     $v1, 0x182D
+    sd      $v1, GS_SYNCH1($v0)             # store it
+# *GS_SYNCH2=0x0020FB61
+    lui     $v1, 0x0020
+    ori     $v1, 0xFB61
+    sd      $v1, GS_SYNCH2($v0)             # store it
+    b       DTV_1080P_syncv
+    nop
+
+DTV_1080P_oldGS:
+# *GS_SYNCH1=0x000344200B043829
+    lui     $v1, 0x0003
+    ori     $v1, 0x4420
+    dsll    $v1, 16
+    ori     $v1, 0x0B04
+    dsll    $v1, 16
+    ori     $v1, 0x3829
+    sd      $v1, GS_SYNCH1($v0)             # store it
+# *GS_SYNCH2=0x0020EB63
+    lui     $v1, 0x0020
+    ori     $v1, 0xEB63
+    sd      $v1, GS_SYNCH2($v0)             # store it
+
+DTV_1080P_syncv:
+# *GS_SYNCV=0x0150E00201C00005
+    lui     $v1, 0x0150
+    ori     $v1, 0xE002
+    dsll    $v1, 16
+    ori     $v1, 0x01C0
+    dsll    $v1, 16
+    ori     $v1, 0x0005
+    sd      $v1, GS_SYNCV($v0)              # store it
+
+# *GS_SMODE2=0  (progressive, non-interlaced -- FFMD is irrelevant; same rule as DTV_576P above)
+    sd      $zero, GS_SMODE2($v0)           # store it
+
+# *GS_SRFSH=4
+    li      $v1, 4
+    sd      $v1, GS_SRFSH($v0)              # store it
+
+# *GS_SMODE1=0x00000003422204B1  (PLL still resetting, one status bit toggled)
+    lui     $v1, 0x0003
+    ori     $v1, 0x4222
+    dsll    $v1, 16
+    ori     $v1, 0x04B1
+    sd      $v1, GS_SMODE1($v0)             # store it
+
+# Let the PLL settle before releasing reset.
+    li      $v1, 0x7A120
+DTV_1080P_delay:
+    vnop
+    vnop
+    addiu   $v1, 0xFFFF
+    vnop
+    vnop
+    bnez    $v1, DTV_1080P_delay
+    nop
+
+# *GS_SMODE1=0x00000003422004B1  (SINT/PRST cleared -- sync on, reset released)
+    lui     $v1, 0x0003
+    ori     $v1, 0x4220
+    dsll    $v1, 16
+    ori     $v1, 0x04B1
+    sd      $v1, GS_SMODE1($v0)             # store it
+
+    jr      $ra
+    nop
+
+.end DTV_1080P
+
+# -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
 # ----------------------------
 # SMODE1
 # .--------.-------.---------------.----------------------------------.-------.

--- a/include/renderman.h
+++ b/include/renderman.h
@@ -15,7 +15,10 @@
  */
 
 /// DTV 576 Progressive Scan (720x576). Not available in ROM v1.70 and earlier.
-#define GS_MODE_DTV_576P 0x53
+#define GS_MODE_DTV_576P  0x53
+/// DTV 1080 Progressive Scan (1920x1080). GSM-synthetic mode (no ROM SetGsCrt support): the ee_core
+/// DTV_1080P handler builds the raster itself. Experimental, gated behind a triple-confirm in the GUI.
+#define GS_MODE_DTV_1080P 0x54
 
 #define DIM_UNDEF -1
 

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -540,6 +540,12 @@ gui_strings:
   string: Emulate FIELD Flipping
 - label: HINT_GSM_FIELD_FIX
   string: Fix for games that glitch under progressive video modes.
+- label: GSM_1080P_WARNING
+  string: WARNING -- forcing 1080p is experimental and unverified. It may show no picture or, on some hardware, stress the console. Proceed at your own risk. Cross = continue, Circle = cancel.
+- label: GSM_1080P_PROCEED
+  string: Proceed with forcing 1080p for this game?
+- label: GSM_1080P_SURE
+  string: Are you sure? Cross applies 1080p, Circle cancels.
 - label: PARENLOCKCONFIG
   string: Parental Lock Settings
 - label: PARENLOCK_PASSWORD

--- a/src/gsm.c
+++ b/src/gsm.c
@@ -71,7 +71,9 @@ void PrepareGSM(char *cmdline, struct GsmConfig_t *config)
     // Therefore there are many variables involved here that can lead us to success or fail, depending on the already mentioned circumstances.
     //
     // clang-format off
-    static const predef_vmode_struct predef_vmode[30] = {
+    // Initializer-sized ([] not a fixed count): the GSM1080P=1 variant appends one row below, and
+    // the clamp at the end reads sizeof(predef_vmode) so it tracks 29 or 30 automatically.
+    static const predef_vmode_struct predef_vmode[] = {
         //                                                            DH    DW   MAGV MAGH  DY   DX              VS  VDP  VBPE  VBP VFPE  VFP
         {GS_INTERLACED,    GS_MODE_NTSC,        GS_FIELD, makeDISPLAY(447,  2559, 0,   3,   46,  700), makeSYNCV(6,  480,  6,    26,  6,   1)},
         {GS_INTERLACED,    GS_MODE_NTSC,        GS_FRAME, makeDISPLAY(223,  2559, 0,   3,   26,  700), makeSYNCV(6,  480,  6,    26,  6,   2)},
@@ -102,12 +104,15 @@ void PrepareGSM(char *cmdline, struct GsmConfig_t *config)
         {GS_NONINTERLACED, GS_MODE_VGA_1024_85, GS_FRAME, makeDISPLAY(767,  1023, 0,   0,   30,  290), makeSYNCV(3,  768,  0,    36,  0,   1)},
         {GS_NONINTERLACED, GS_MODE_VGA_1280_60, GS_FRAME, makeDISPLAY(1023, 1279, 1,   1,   40,  350), makeSYNCV(3,  1024, 0,    38,  0,   1)},
         {GS_NONINTERLACED, GS_MODE_VGA_1280_75, GS_FRAME, makeDISPLAY(1023, 1279, 1,   1,   40,  350), makeSYNCV(3,  1024, 0,    38,  0,   1)},
-        // APPENDED at the LAST index (not inserted after 1080i): $GSMVMode is a stored raw index,
-        // so a mid-list insert would silently remap every existing saved VGA/HDTV config. Re-added
-        // 1080p (progressive 1920x1080). display/syncv identical to the 1080i row -- only the mode
-        // (0x54, GSM-synthetic) + NONINTERLACED/FRAME differ. Emitted via the ee_core DTV_1080P
-        // handler; gated behind a triple-confirm in the GUI. EXPERIMENTAL / not HW-validated here.
-        {GS_NONINTERLACED, GS_MODE_DTV_1080P,   GS_FRAME, makeDISPLAY(1079, 1919, 1,   2,   48,  238), makeSYNCV(10, 1080, 2,    28,  0,   5)}}; //ends predef_vmode definition
+        // GSM1080P=1 variant only: APPENDED at the LAST index (not inserted after 1080i) because
+        // $GSMVMode is a stored raw index -- a mid-list insert would silently remap every existing
+        // saved VGA/HDTV config. display/syncv identical to the 1080i row; only the mode (0x54,
+        // GSM-synthetic) + NONINTERLACED/FRAME differ. Emitted via the ee_core DTV_1080P handler,
+        // behind a triple-confirm in the GUI. EXPERIMENTAL / not HW-validated.
+#ifdef GSM_1080P
+        {GS_NONINTERLACED, GS_MODE_DTV_1080P,   GS_FRAME, makeDISPLAY(1079, 1919, 1,   2,   48,  238), makeSYNCV(10, 1080, 2,    28,  0,   5)},
+#endif
+    }; //ends predef_vmode definition
     // clang-format on
     int k576p_fix, kGsDxDyOffsetSupported, fd, FIELD_fix;
     char romver[16], romverNum[5], *pROMDate;

--- a/src/gsm.c
+++ b/src/gsm.c
@@ -71,7 +71,7 @@ void PrepareGSM(char *cmdline, struct GsmConfig_t *config)
     // Therefore there are many variables involved here that can lead us to success or fail, depending on the already mentioned circumstances.
     //
     // clang-format off
-    static const predef_vmode_struct predef_vmode[29] = {
+    static const predef_vmode_struct predef_vmode[30] = {
         //                                                            DH    DW   MAGV MAGH  DY   DX              VS  VDP  VBPE  VBP VFPE  VFP
         {GS_INTERLACED,    GS_MODE_NTSC,        GS_FIELD, makeDISPLAY(447,  2559, 0,   3,   46,  700), makeSYNCV(6,  480,  6,    26,  6,   1)},
         {GS_INTERLACED,    GS_MODE_NTSC,        GS_FRAME, makeDISPLAY(223,  2559, 0,   3,   26,  700), makeSYNCV(6,  480,  6,    26,  6,   2)},
@@ -101,7 +101,13 @@ void PrepareGSM(char *cmdline, struct GsmConfig_t *config)
         {GS_NONINTERLACED, GS_MODE_VGA_1024_75, GS_FRAME, makeDISPLAY(767,  1023, 0,   0,   30,  260), makeSYNCV(3,  768,  0,    28,  0,   1)},
         {GS_NONINTERLACED, GS_MODE_VGA_1024_85, GS_FRAME, makeDISPLAY(767,  1023, 0,   0,   30,  290), makeSYNCV(3,  768,  0,    36,  0,   1)},
         {GS_NONINTERLACED, GS_MODE_VGA_1280_60, GS_FRAME, makeDISPLAY(1023, 1279, 1,   1,   40,  350), makeSYNCV(3,  1024, 0,    38,  0,   1)},
-        {GS_NONINTERLACED, GS_MODE_VGA_1280_75, GS_FRAME, makeDISPLAY(1023, 1279, 1,   1,   40,  350), makeSYNCV(3,  1024, 0,    38,  0,   1)}}; //ends predef_vmode definition
+        {GS_NONINTERLACED, GS_MODE_VGA_1280_75, GS_FRAME, makeDISPLAY(1023, 1279, 1,   1,   40,  350), makeSYNCV(3,  1024, 0,    38,  0,   1)},
+        // APPENDED at the LAST index (not inserted after 1080i): $GSMVMode is a stored raw index,
+        // so a mid-list insert would silently remap every existing saved VGA/HDTV config. Re-added
+        // 1080p (progressive 1920x1080). display/syncv identical to the 1080i row -- only the mode
+        // (0x54, GSM-synthetic) + NONINTERLACED/FRAME differ. Emitted via the ee_core DTV_1080P
+        // handler; gated behind a triple-confirm in the GUI. EXPERIMENTAL / not HW-validated here.
+        {GS_NONINTERLACED, GS_MODE_DTV_1080P,   GS_FRAME, makeDISPLAY(1079, 1919, 1,   2,   48,  238), makeSYNCV(10, 1080, 2,    28,  0,   5)}}; //ends predef_vmode definition
     // clang-format on
     int k576p_fix, kGsDxDyOffsetSupported, fd, FIELD_fix;
     char romver[16], romverNum[5], *pROMDate;
@@ -112,8 +118,9 @@ void PrepareGSM(char *cmdline, struct GsmConfig_t *config)
         gGSMVMode = 0;
 
 #ifdef _DTL_T10000
-    if (predef_vmode[gGSMVMode].mode == GS_MODE_DTV_576P) // There is no 576P code implemented for development TOOLs.
-        gGSMVMode = 2;                                    // Change to PAL instead.
+    // Dev TOOLs implement neither 576P nor the synthetic 1080P raster -> fall back to PAL.
+    if (predef_vmode[gGSMVMode].mode == GS_MODE_DTV_576P || predef_vmode[gGSMVMode].mode == GS_MODE_DTV_1080P)
+        gGSMVMode = 2; // Change to PAL instead.
 #endif
 
     k576p_fix = 0;

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -415,6 +415,10 @@ void guiGameShowGSConfig(void)
         "VGA 1024x768p @85Hz",
         "VGA 1280x1024p @60Hz",
         "VGA 1280x1024p @75Hz",
+        // APPENDED last (index 29) to keep every existing $GSMVMode index pointing at the same mode;
+        // must stay 1:1 index-aligned with predef_vmode[] in src/gsm.c. Selecting it triggers the
+        // triple-confirm gate in the save path below (VMODE_1080P index).
+        "HDTV 1080p @60Hz (EXPERIMENTAL)",
         NULL};
     // clang-format on
 
@@ -988,6 +992,10 @@ static int coreNeverNeutrino = 0;
 #define NEUTRINO_VIDEO_DEFAULT_IDX   6
 #define NEUTRINO_GSMCOMP_DEFAULT_IDX 4
 
+// Index of the appended "HDTV 1080p @60Hz (EXPERIMENTAL)" entry in gsmvmodeNames[] / predef_vmode[]
+// (both 30 long, last index 29). Selecting it must clear a triple-confirm before it is saved.
+#define GSM_VMODE_1080P_IDX 29
+
 static void guiGameSetCoreAwareState(void)
 {
     int coreChoice = 0, neutrino = 0, neutrinoVideo = 0;
@@ -1173,6 +1181,19 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
     diaGetInt(diaGSConfig, GSMCFG_GSMXOFFSET, &GSMXOffset);
     diaGetInt(diaGSConfig, GSMCFG_GSMYOFFSET, &GSMYOffset);
     diaGetInt(diaGSConfig, GSMCFG_GSMFIELDFIX, &GSMFIELDFix);
+
+    // 1080p is GSM-synthetic and hardware-unvalidated: force a THREE-STEP confirmation before it can
+    // be committed. X continues / O cancels at each step; any cancel drops the selection back to 0
+    // (Auto/off, which removes the per-game key) so 1080p is never persisted without deliberate
+    // consent. Only fires when the user actually chose 1080p AND left GSM enabled.
+    if (EnableGSM != 0 && GSMVMode == GSM_VMODE_1080P_IDX) {
+        if (!guiMsgBox(_l(_STR_GSM_1080P_WARNING), 1, NULL) ||
+            !guiMsgBox(_l(_STR_GSM_1080P_PROCEED), 1, NULL) ||
+            !guiMsgBox(_l(_STR_GSM_1080P_SURE), 1, NULL)) {
+            GSMVMode = 0; // cancelled at some step -> do not apply 1080p
+            diaSetInt(diaGSConfig, GSMCFG_GSMVMODE, GSMVMode);
+        }
+    }
 
     if (gGSMSource == SETTINGS_PERGAME) {
         result = configSetInt(configSet, CONFIG_ITEM_GSMSOURCE, gGSMSource);

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -415,10 +415,13 @@ void guiGameShowGSConfig(void)
         "VGA 1024x768p @85Hz",
         "VGA 1280x1024p @60Hz",
         "VGA 1280x1024p @75Hz",
-        // APPENDED last (index 29) to keep every existing $GSMVMode index pointing at the same mode;
-        // must stay 1:1 index-aligned with predef_vmode[] in src/gsm.c. Selecting it triggers the
-        // triple-confirm gate in the save path below (VMODE_1080P index).
+        // GSM1080P=1 variant only: APPENDED last (index 29) to keep every existing $GSMVMode index
+        // pointing at the same mode; stays 1:1 index-aligned with predef_vmode[] (gsm.c), which
+        // guards the matching row under the SAME #ifdef. Selecting it triggers the triple-confirm
+        // gate in the save path below.
+#ifdef GSM_1080P
         "HDTV 1080p @60Hz (EXPERIMENTAL)",
+#endif
         NULL};
     // clang-format on
 
@@ -993,8 +996,11 @@ static int coreNeverNeutrino = 0;
 #define NEUTRINO_GSMCOMP_DEFAULT_IDX 4
 
 // Index of the appended "HDTV 1080p @60Hz (EXPERIMENTAL)" entry in gsmvmodeNames[] / predef_vmode[]
-// (both 30 long, last index 29). Selecting it must clear a triple-confirm before it is saved.
+// (both 30 long, last index 29) -- only present in the GSM1080P=1 variant. Selecting it must clear
+// a triple-confirm before it is saved.
+#ifdef GSM_1080P
 #define GSM_VMODE_1080P_IDX 29
+#endif
 
 static void guiGameSetCoreAwareState(void)
 {
@@ -1182,10 +1188,12 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
     diaGetInt(diaGSConfig, GSMCFG_GSMYOFFSET, &GSMYOffset);
     diaGetInt(diaGSConfig, GSMCFG_GSMFIELDFIX, &GSMFIELDFix);
 
+#ifdef GSM_1080P
     // 1080p is GSM-synthetic and hardware-unvalidated: force a THREE-STEP confirmation before it can
     // be committed. X continues / O cancels at each step; any cancel drops the selection back to 0
     // (Auto/off, which removes the per-game key) so 1080p is never persisted without deliberate
-    // consent. Only fires when the user actually chose 1080p AND left GSM enabled.
+    // consent. Only fires when the user actually chose 1080p AND left GSM enabled. (Only compiled
+    // into the GSM1080P=1 variant, the only build where the picker exposes the 1080p entry.)
     if (EnableGSM != 0 && GSMVMode == GSM_VMODE_1080P_IDX) {
         if (!guiMsgBox(_l(_STR_GSM_1080P_WARNING), 1, NULL) ||
             !guiMsgBox(_l(_STR_GSM_1080P_PROCEED), 1, NULL) ||
@@ -1194,6 +1202,7 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
             diaSetInt(diaGSConfig, GSMCFG_GSMVMODE, GSMVMode);
         }
     }
+#endif
 
     if (gGSMSource == SETTINGS_PERGAME) {
         result = configSetInt(configSet, CONFIG_ITEM_GSMSOURCE, gGSMSource);


### PR DESCRIPTION
## What Nathan asked

Nathan found the pre-rewrite OPL source (commit `f5b31427`) that still carried `GS_MODE_DTV_1080P`, and asked to re-add 1080p (plus any other removed modes), gated behind a **triple confirmation** before it applies.

## Two corrections the audit surfaced

1. **Only ONE mode is actually missing from this fork** — 1080p. The "several modes" recollection refers to upstream history; RiptOPL kept every VGA/HDTV mode. The two widescreen 480p/576p rows were *retuned*, not removed (left alone).
2. **It is NOT a table-only re-add.** The current ee_core GSM engine is a rewritten generation that **dropped the DTV_1080P raster routine** (the CHANGELOG says so: *"GSM Core no longer supports 576p, 1080p, Skip FMVs - this is temporary"*). `0x54` is not a ROM-native `SetGsCrt` mode, so a naive table row would forward `0x54` to the ROM handler → no valid raster → black screen. The engine needs the handler back.

## What this lands

- **ee_core handler** (`gsm_engine_adv.S`): re-ported `DTV_1080P` that programs the progressive-1080 raster directly (SMODE1/SYNCH1/SYNCH2/SYNCV/SMODE2/SRFSH), + a dispatch branch in `Hook_SetGsCrt` (`gsm_engine.S`) routing `0x54` to it unconditionally. Register **values are the documented ones** from the historical source and decode cleanly against the engine's own SMODE1 bit table (GCONT=1 component, VHP=0 progressive). The old code OR'd the GS base address into *only its first* SMODE1 write (its other two don't) — an obvious bug, dropped here so all three are consistent. SMODE2=0 (progressive), matching the current `DTV_576P`.
- **Define**: `GS_MODE_DTV_1080P = 0x54` in `gsm_defines.h` (asm) + `renderman.h` (C) — absent from gsKit and the current tree, so the re-add wouldn't compile without it.
- **Table** (`src/gsm.c`): row **appended at the last index** (not inserted after 1080i) — `$GSMVMode` is a stored raw index, so a mid-list insert would silently remap every existing saved VGA/HDTV config. `[29]→[30]`; dev-TOOLs fallback extended.
- **GUI** (`src/guigame.c`): label appended 1:1, and a **three-step confirm gate** on save (warning → "proceed?" → "are you sure?"). X continues, O cancels; any cancel reverts to 0 so 1080p is never persisted without deliberate consent. Fires only when GSM is enabled and 1080p is the selection.
- 3 lang strings.

## Honesty / safety (please read before merge)

**The ee_core raster values are NOT hardware-validated in this fork** — GS raster timing isn't reliably testable in an emulator, and this transplants 8-year-old code into a rewritten engine. It's safe to *ship experimentally* because: GSM is strictly **per-game opt-in**, the mode sits behind the **triple gate**, and the **Triangle+Cross boot combo forces 480p recovery**. A wrong raster **blanks the screen (recoverable), it does not persist**. This needs a tester with a 1080-capable display to confirm real output — exactly what the gate + opt-in + recovery are there to make safe.

An adversarial static verification of the assembly transcription, dispatch register-safety, delay slots, and the gate logic is running; findings (if any) will be fixed on this branch before merge.

## Testing

- Clean container build green (`MAKE_EXIT=0`); the `DTV_1080P` assembly compiles and links into `ee_core.elf`.
- clang-format applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)