### PR TITLE
Opt-in folder browsing in the game list

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -76,6 +76,7 @@ features, code, and ideas from:
   - POPSLoader                      https://github.com/NathanNeurotic/POPSLoader
   - OPL RetroGEM ID (CosmicScale)   https://github.com/CosmicScale/Open-PS2-Loader-Retro-GEM
   - nhddl (pcm720)                  https://github.com/pcm720/nhddl
+  - Modulo-R1 (AdityaKumar7209)     https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2
   - official OPL                    https://github.com/ps2homebrew/Open-PS2-Loader
 
 Special and sincere thanks to:
@@ -90,6 +91,9 @@ Special and sincere thanks to:
   - saildot4k - for BDMA-ATA (exFAT internal-HDD block-device support), and the
     fixes, feedback, and oversight that shaped this fork's block-device work.
   - Berion - for the artwork and theme design that has shaped how OPL looks.
+  - AdityaKumar7209 - whose Modulo-R1 project inspired this fork's folder
+    browsing in the game list. We didn't use their code; the idea of navigating
+    game subfolders came from seeing it there.
   - Ifcaro and jimmikaelkael - the original Open PS2 Loader authors - and every
     contributor across OPL's long history, all named above in this file.
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 
 FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o elfldr_noreset.o elfldr.o lang.o lang_internal.o config.o hdd.o dialogs.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o udpfssupport.o hddsupport.o zso.o lz4.o \
-		appsupport.o mmcesupport.o favsupport.o vcdsupport.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
+		appsupport.o mmcesupport.o favsupport.o vcdsupport.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
 
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
 		bdm.o bdmfs_fatfs.o usbmass_bd.o iLinkman.o IEEE1394_bd.o mx4sio_bd.o \

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ This build layers several features on top of upstream OPL:
   are stored in a shared `favourites.bin`, and RiptOPL will **import an existing uOPL / wOPL
   favourites file** if it finds one — so your favourites carry over from those builds.
 - **Folder browsing (opt-in):** turn on **Browse Folders in Game List** in **Settings** to have
-  subdirectories inside your `CD` / `DVD` folders appear as browsable entries (shown with a
-  trailing `/`). Select a folder to open it, and press the **cancel button** to go back up — a
+  subdirectories inside your `CD` / `DVD` folders appear as browsable entries (grouped at the
+  top of the list, shown with a trailing `/`). Select a folder to open it, and press the
+  **cancel button** to go back up — a
   breadcrumb in the page title shows where you are. Each folder view is just the normal game
   list, so covers, favourites, coverflow and per-game settings all work inside folders. Works on
   USB / MX4SIO / iLink / internal-BDM, MMCE and UDPFS-Files. Left off, a flat library looks and
@@ -197,7 +198,8 @@ and ideas from [rickgaiser's OPL](https://github.com/rickgaiser/Open-PS2-Loader)
 [wOPL](https://github.com/KrahJohlito/wOPL), [OPL DB](https://github.com/Jay-Jay-OPL/OPL-Daily-Builds),
 [POPSLoader](https://github.com/NathanNeurotic/POPSLoader),
 [OPL RetroGEM ID by CosmicScale](https://github.com/CosmicScale/Open-PS2-Loader-Retro-GEM),
-[nhddl](https://github.com/pcm720/nhddl), and
+[nhddl](https://github.com/pcm720/nhddl),
+[Modulo-R1](https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2), and
 [official OPL](https://github.com/ps2homebrew/Open-PS2-Loader).
 
 With special and sincere thanks to:
@@ -215,6 +217,9 @@ With special and sincere thanks to:
   has repeatedly caught issues and shaped fixes across this fork. Invaluable QA.
 - **Berion** — for the artwork and theme design that has shaped how OPL *looks* for years.
   The visual language this fork builds on owes a great deal to that craft.
+- **AdityaKumar7209** — whose [**Modulo-R1**](https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2)
+  project inspired this fork's **folder browsing** in the game list. We didn't use their code, but the
+  idea of navigating game subfolders came from seeing it there — thank you for the spark.
 - **Ifcaro** and **jimmikaelkael** — the original Open PS2 Loader authors — and every
   contributor across OPL's long history.
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ This build layers several features on top of upstream OPL:
   from every device into one list, and a star marks favourited titles everywhere. Favourites
   are stored in a shared `favourites.bin`, and RiptOPL will **import an existing uOPL / wOPL
   favourites file** if it finds one — so your favourites carry over from those builds.
+- **Folder browsing (opt-in):** turn on **Browse Folders in Game List** in **Settings** to have
+  subdirectories inside your `CD` / `DVD` folders appear as browsable entries (shown with a
+  trailing `/`). Select a folder to open it, and press the **cancel button** to go back up — a
+  breadcrumb in the page title shows where you are. Each folder view is just the normal game
+  list, so covers, favourites, coverflow and per-game settings all work inside folders. Works on
+  USB / MX4SIO / iLink / internal-BDM, MMCE and UDPFS-Files. Left off, a flat library looks and
+  behaves exactly as before.
 - **Neutrino external core (per-game):** hand a game off to an external `neutrino.elf`
   instead of OPL's built-in core, chosen per title, with custom launch flags you can set
   globally and per-game. See **[docs/NEUTRINO.md](docs/NEUTRINO.md)**.

--- a/include/config.h
+++ b/include/config.h
@@ -124,6 +124,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_BDM_PREFIX           "usb_prefix" // Leave this "usb" for compatibility
 #define CONFIG_OPL_ETH_PREFIX           "eth_prefix"
 #define CONFIG_OPL_REMEMBER_LAST        "remember_last"
+#define CONFIG_OPL_FOLDER_NAV           "folder_nav"
 #define CONFIG_OPL_AUTOSTART_LAST       "autostart_last"
 #define CONFIG_OPL_BDM_MODE             "usb_mode" // Leave this "usb" for compatibility
 #define CONFIG_OPL_HDD_MODE             "hdd_mode"

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -58,6 +58,7 @@ enum UI_ITEMS {
     CFG_NETPROTOCOL,     // unified network-protocol selector (Off/SMB/UDPFS)
     CFG_UDPFSMODE,       // when UDPFS is selected: Files (udpfs_ioman filesystem) vs Image (udpfs_bd block/massN:)
     CFG_LASTPLAYED,
+    CFG_FOLDERNAV,
     CFG_LBL_AUTOSTARTLAST,
     CFG_AUTOSTARTLAST,
     CFG_SELECTBUTTON,

--- a/include/folderbrowse.h
+++ b/include/folderbrowse.h
@@ -1,0 +1,46 @@
+#ifndef __FOLDERBROWSE_H
+#define __FOLDERBROWSE_H
+
+// Lazy per-device folder navigation for the game list (opt-in: gEnableFolderNav).
+//
+// A subdirectory found under <prefix>CD/ or <prefix>DVD/ is listed as a GAME_FORMAT_FOLDER row.
+// Selecting it (the select button) DESCENDS -- the list rescans one level deeper; the cancel
+// button ASCENDS back up. Each folder view is the same flat game list repopulated in place, so
+// covers / favourites / coverflow / per-game settings all keep working unchanged.
+//
+// Only the loose-file tree scanners participate (BDM/USB/MX4SIO/iLink/exFAT-HDD-BDM, MMCE and
+// UDPFS-Files) -- every device that reaches sbReadList/scanForISO with a "/" separator. APA-HDD
+// (HDL partitions), the UDPFS block device and the VCD/POPS view are structurally excluded: they
+// never scan a CD/DVD directory tree. SMB/ETH is deferred (it uses a "\\" separator).
+//
+// The state model deliberately mirrors the proven VCD-view machinery (vcdsupport.c): a per-mode
+// subpath + a dirty flag consumed in each device's NeedsUpdate to force the deferred rescan.
+
+#define FOLDER_SUB_MAX   128 // joined subpath cap; fits <prefix>CD/<sub> inside the 256-byte path buffers
+#define FOLDER_DEPTH_MAX 8   // max nesting levels below the CD/DVD root
+
+// True only for the loose-file tree device modes that can browse folders.
+int folderModeSupported(int mode);
+
+// The current subpath BELOW the CD/DVD root, "/"-joined (e.g. "RPGs/SNES"); "" at the device root.
+// Never returns NULL. Returns "" when folder-nav is off or the mode is not folder-capable.
+const char *folderGetSub(int mode);
+
+// Nesting depth (0 == at the device root).
+int folderDepth(int mode);
+
+// Push a folder level (descend). Returns 1 on success, 0 if refused (disabled, at depth cap, or the
+// joined path would overflow). Marks the mode dirty so its next NeedsUpdate forces a rescan.
+int folderDescend(int mode, const char *name);
+
+// Pop a folder level (ascend). Returns 1 if it actually ascended, 0 if already at the root.
+int folderAscend(int mode);
+
+// Force the mode back to the device root (marks dirty only if it was not already at root).
+void folderReset(int mode);
+
+// One-shot: returns 1 once after a descend/ascend/reset, so NeedsUpdate can force the rescan even
+// when the device's own change-detection would otherwise short-circuit (mirrors vcdConsumeDirty).
+int folderConsumeDirty(int mode);
+
+#endif

--- a/include/gui.h
+++ b/include/gui.h
@@ -39,6 +39,7 @@ struct gui_update_t
             int text_id;
             int selected;
             void *owner;
+            int isFolder; // folder-browse row (GAME_FORMAT_FOLDER) -> copied onto the submenu item
         } submenu;
 
         struct

--- a/include/menusys.h
+++ b/include/menusys.h
@@ -27,6 +27,9 @@ typedef struct submenu_item
     void *owner;
     /// 1 when the item is marked as a favourite (a star is drawn next to it)
     int favourited;
+    /// 1 when this row is a browsable folder (GAME_FORMAT_FOLDER), not a launchable game. The
+    /// dispatch descends into it instead of launching; the renderer marks it and skips its cover.
+    int isFolder;
 } submenu_item_t;
 
 typedef struct submenu_list

--- a/include/opl.h
+++ b/include/opl.h
@@ -293,6 +293,7 @@ extern char gETHPrefix[32];
 extern char gMMCEPrefix[32];
 
 extern int gRememberLastPlayed;
+extern int gEnableFolderNav; // opt-in: browse subdirectories inside a device's game list
 
 // Last Played Auto Start
 extern int KeyPressedOnce;

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -14,6 +14,9 @@ enum GAME_FORMAT {
     GAME_FORMAT_USBLD = 0,
     GAME_FORMAT_OLD_ISO,
     GAME_FORMAT_ISO,
+    // A browsable subdirectory row (folder navigation, opt-in). Never launched, never written to the
+    // games.bin cache and never stored as a favourite; the dispatch intercepts it to descend instead.
+    GAME_FORMAT_FOLDER,
 };
 
 typedef struct
@@ -42,7 +45,15 @@ typedef struct
 int isValidIsoName(char *name, int *pNameLen);
 int sbIsSameSize(const char *prefix, int prevSize);
 int sbCreateSemaphore(void);
-int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gamecount);
+// Scan a device's game list. sub is the folder-browse subpath below CD/DVD ("" or NULL = the device
+// root, the normal case); when set, the CD/DVD scans descend into it, subdirectories are listed as
+// GAME_FORMAT_FOLDER rows, and the ul.cfg (USBLD) leg -- a device-root-only concept -- is skipped.
+int sbReadList(base_game_info_t **list, const char *prefix, const char *sub, int *fsize, int *gamecount);
+
+// Set the folder-browse subpath the path composers (sbCreatePath / sbPopulateConfig) inject between
+// CD|DVD and the game name. A device leg calls this with folderGetSub(mode) before launch / delete /
+// rename so a game inside a subfolder resolves to <prefix>CD|DVD/<sub>/<name>. "" or NULL = root.
+void sbSetBrowseSub(const char *sub);
 int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman, void **cdvdman_irx, int *patchindex);
 void sbUnprepare(void *pCommon);
 void sbRebuildULCfg(base_game_info_t **list, const char *prefix, int gamecount, int excludeID);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -252,6 +252,10 @@ gui_strings:
   string: Write Operations
 - label: LASTPLAYED
   string: Remember Last Played Game
+- label: FOLDER_NAV
+  string: Browse Folders in Game List
+- label: HINT_FOLDER_NAV
+  string: Show subfolders of CD/DVD as browsable entries; select to open, cancel to go back
 - label: SELECTBUTTON
   string: Select Button
 - label: ERR_FRAGMENTED

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -4,6 +4,7 @@
 #include "include/supportbase.h"
 #include "include/bdmsupport.h"
 #include "include/vcdsupport.h"
+#include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/themes.h"
 #include "include/textures.h"
@@ -500,6 +501,12 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     if (vcdConsumeDirty(itemList->mode))
         return 1;
 
+    // Folder browsing: a descend/ascend marks the mode dirty but bumps nothing the tick gate below
+    // watches, so consume it here (same discipline as vcdConsumeDirty) or the deeper/shallower list
+    // never rebuilds on a device already scanned this BdmGeneration.
+    if (folderConsumeDirty(itemList->mode))
+        return 1;
+
     if (pDeviceData->bdmDeviceTick == BdmGeneration) {
         if (pOwner != NULL && pOwner->menuItem.visible == 0)
             return 0;
@@ -584,7 +591,7 @@ static int bdmUpdateGameList(item_list_t *itemList)
         if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
             pDeviceData->bdmGameCount = r;
     } else
-        sbReadList(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, &pDeviceData->bdmULSizePrev, &pDeviceData->bdmGameCount);
+        sbReadList(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, folderGetSub(itemList->mode), &pDeviceData->bdmULSizePrev, &pDeviceData->bdmGameCount);
     return pDeviceData->bdmGameCount;
 }
 
@@ -631,6 +638,7 @@ static void bdmDeleteGame(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // delete inside the current subfolder, not the root
     sbDelete(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, "/", pDeviceData->bdmGameCount, id);
     pDeviceData->bdmULSizePrev = -2;
     pDeviceData->ForceRefresh = 1;
@@ -640,6 +648,7 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // rename inside the current subfolder, not the root
     sbRename(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, "/", pDeviceData->bdmGameCount, id, newName);
     pDeviceData->bdmULSizePrev = -2;
     pDeviceData->ForceRefresh = 1;
@@ -878,6 +887,13 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         pDeviceData = gAutoLaunchDeviceData;
         game = gAutoLaunchBDMGame;
     }
+
+    // Folder browsing: a folder row is never launchable (the dispatch descends instead of reaching
+    // here); guard defensively. Otherwise pin the path composers to the current subfolder so a game
+    // inside it resolves to <prefix>CD|DVD/<sub>/<name>.
+    if (game != NULL && game->format == GAME_FORMAT_FOLDER)
+        return;
+    sbSetBrowseSub(folderGetSub(itemList->mode));
 
     // VCD view: this device is showing PS1 VCDs -> hand off to POPSTARTER (by name) instead of the
     // disc / Neutrino path below (which is entirely disc-specific). The BDM_TYPE_ATA internal exFAT HDD

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -198,6 +198,11 @@ struct UIItem diaConfig[] = {
     {UI_INT, CFG_AUTOSTARTLAST, 1, 1, _STR_HINT_AUTOSTARTLAST, 0, 0, {.intvalue = {0, 0, 0, 9}}},
     {UI_BREAK},
 
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_FOLDER_NAV}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_FOLDERNAV, 1, 1, _STR_HINT_FOLDER_NAV, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     {UI_BREAK},
     {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Prefix Paths", -1}}},
     {UI_SPLITTER},

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -526,7 +526,7 @@ static int ethUpdateGameList(item_list_t *itemList)
             int r = vcdFillGameList(ethPrefix, &ethGames);
             if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
                 ethGameCount = r;
-        } else if ((sbReadList(&ethGames, ethPrefix, &ethULSizePrev, &ethGameCount)) < 0) {
+        } else if ((sbReadList(&ethGames, ethPrefix, NULL, &ethULSizePrev, &ethGameCount)) < 0) {
             gNetworkStartup = ERROR_ETH_SMB_LISTGAMES;
             ethDisplayErrorStatus();
         }

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -526,7 +526,9 @@ static int ethUpdateGameList(item_list_t *itemList)
             int r = vcdFillGameList(ethPrefix, &ethGames);
             if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
                 ethGameCount = r;
-        } else if ((sbReadList(&ethGames, ethPrefix, NULL, &ethULSizePrev, &ethGameCount)) < 0) {
+            // NULL sub opts SMB/ETH out of folder-row collection: it uses a "\\" separator and does not
+            // participate in folder browsing (see the folderlist gate in sbReadList).
+        } else if ((sbReadList(&ethGames, ethPrefix, /* sub: */ NULL, &ethULSizePrev, &ethGameCount)) < 0) {
             gNetworkStartup = ERROR_ETH_SMB_LISTGAMES;
             ethDisplayErrorStatus();
         }

--- a/src/folderbrowse.c
+++ b/src/folderbrowse.c
@@ -43,14 +43,16 @@ int folderDescend(int mode, const char *name)
         return 0;
 
     char joined[FOLDER_SUB_MAX];
+    int len;
     if (folderSub[mode][0] == '\0')
-        snprintf(joined, sizeof(joined), "%s", name);
+        len = snprintf(joined, sizeof(joined), "%s", name);
     else
-        snprintf(joined, sizeof(joined), "%s/%s", folderSub[mode], name);
+        len = snprintf(joined, sizeof(joined), "%s/%s", folderSub[mode], name);
 
     // Refuse a join that would not fit: a truncated subpath would scan the WRONG directory, so the
-    // user simply stays where they are (a folder with a name this long is not navigable).
-    if (strlen(joined) >= sizeof(folderSub[mode]) - 1)
+    // user simply stays where they are (a folder with a name this long is not navigable). snprintf
+    // returns the length it WOULD have written, so len >= buffer size means it did not fit.
+    if (len < 0 || (size_t)len >= sizeof(folderSub[mode]))
         return 0;
 
     strcpy(folderSub[mode], joined);

--- a/src/folderbrowse.c
+++ b/src/folderbrowse.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "include/opl.h" // umbrella: SDK base types (u32/GSTEXTURE) that iosupport.h depends on
+#include "include/iosupport.h"
+#include "include/folderbrowse.h"
+
+// Set by opl.c from the "folder_nav" config key. Folder browsing is entirely inert unless this is
+// on: scanForISO never emits a folder row and every helper below returns the root ("") state.
+extern int gEnableFolderNav;
+
+static char folderSub[MODE_COUNT][FOLDER_SUB_MAX]; // "/"-joined subpath below CD/DVD; "" == root
+static unsigned char folderDirtyFlag[MODE_COUNT];  // 1 = descended/ascended/reset -> force one rescan
+static unsigned char folderLevels[MODE_COUNT];     // pushed segment count (depth)
+
+int folderModeSupported(int mode)
+{
+    // Loose-file tree scanners only (sbReadList/base_game_info_t, "/" separator): BDM (all 8 slots),
+    // MMCE and UDPFS-Files. APA-HDD (HDL), the UDPFS block device and the VCD/POPS view do not scan a
+    // CD/DVD directory tree, so they are excluded. SMB/ETH is deferred (uses "\\").
+    return (mode >= BDM_MODE && mode <= BDM_MODE_LAST) || mode == MMCE_MODE || mode == UDPFS_MODE;
+}
+
+const char *folderGetSub(int mode)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return "";
+    return folderSub[mode];
+}
+
+int folderDepth(int mode)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return 0;
+    return folderLevels[mode];
+}
+
+int folderDescend(int mode, const char *name)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return 0;
+    if (name == NULL || name[0] == '\0' || folderLevels[mode] >= FOLDER_DEPTH_MAX)
+        return 0;
+
+    char joined[FOLDER_SUB_MAX];
+    if (folderSub[mode][0] == '\0')
+        snprintf(joined, sizeof(joined), "%s", name);
+    else
+        snprintf(joined, sizeof(joined), "%s/%s", folderSub[mode], name);
+
+    // Refuse a join that would not fit: a truncated subpath would scan the WRONG directory, so the
+    // user simply stays where they are (a folder with a name this long is not navigable).
+    if (strlen(joined) >= sizeof(folderSub[mode]) - 1)
+        return 0;
+
+    strcpy(folderSub[mode], joined);
+    folderLevels[mode]++;
+    folderDirtyFlag[mode] = 1;
+    return 1;
+}
+
+int folderAscend(int mode)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return 0;
+    if (folderLevels[mode] == 0)
+        return 0;
+
+    char *slash = strrchr(folderSub[mode], '/');
+    if (slash != NULL)
+        *slash = '\0'; // drop the last "/segment"
+    else
+        folderSub[mode][0] = '\0'; // back to root
+
+    folderLevels[mode]--;
+    folderDirtyFlag[mode] = 1;
+    return 1;
+}
+
+void folderReset(int mode)
+{
+    if (mode < 0 || mode >= MODE_COUNT)
+        return;
+    // Reset the raw state even for modes that are not folder-capable / when the toggle is off, so a
+    // stale subpath can never leak across a device switch. Mark dirty only when something changed.
+    if (folderSub[mode][0] != '\0' || folderLevels[mode] != 0) {
+        folderSub[mode][0] = '\0';
+        folderLevels[mode] = 0;
+        folderDirtyFlag[mode] = 1;
+    }
+}
+
+int folderConsumeDirty(int mode)
+{
+    if (mode < 0 || mode >= MODE_COUNT || !folderDirtyFlag[mode])
+        return 0;
+    folderDirtyFlag[mode] = 0;
+    return 1;
+}

--- a/src/gui.c
+++ b/src/gui.c
@@ -594,6 +594,7 @@ void guiShowConfig()
 
     diaSetInt(diaConfig, CFG_ENWRITEOP, gEnableWrite);
     diaSetInt(diaConfig, CFG_LASTPLAYED, gRememberLastPlayed);
+    diaSetInt(diaConfig, CFG_FOLDERNAV, gEnableFolderNav);
     diaSetInt(diaConfig, CFG_AUTOSTARTLAST, gAutoStartLastPlayed);
     diaSetVisible(diaConfig, CFG_AUTOSTARTLAST, gRememberLastPlayed);
     diaSetVisible(diaConfig, CFG_LBL_AUTOSTARTLAST, gRememberLastPlayed);
@@ -623,6 +624,7 @@ reshow_config:
         diaGetInt(diaConfig, CFG_NEUTRINO_GSMCOMP, &gNeutrinoGsmCompDefault);
         diaGetInt(diaConfig, CFG_ENWRITEOP, &gEnableWrite);
         diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
+        diaGetInt(diaConfig, CFG_FOLDERNAV, &gEnableFolderNav);
         diaGetInt(diaConfig, CFG_AUTOSTARTLAST, &gAutoStartLastPlayed);
         diaGetString(diaConfig, CFG_BDMPREFIX, gBDMPrefix, sizeof(gBDMPrefix));
         diaGetString(diaConfig, CFG_ETHPREFIX, gETHPrefix, sizeof(gETHPrefix));
@@ -1625,6 +1627,8 @@ static void guiHandleOp(struct gui_update_t *item)
 
         case GUI_OP_APPEND_MENU:
             result = submenuAppendItem(item->menu.subMenu, item->submenu.icon_id, item->submenu.text, item->submenu.id, item->submenu.text_id, item->submenu.owner);
+            if (result != NULL)
+                result->item.isFolder = item->submenu.isFolder; // folder-browse row marker
             // coverflow wrap tail: submenuAppendItem always returns the new tail
             item->menu.menu->last = result;
             if (!item->menu.menu->submenu) { // first subitem in list

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -11,6 +11,7 @@
 #include "include/favsupport.h"
 #include "include/bdmsupport.h"
 #include "include/vcdsupport.h" // vcdViewActive -- VCD view renders with the apps element family
+#include "include/folderbrowse.h"
 #include "include/renderman.h"
 #include "include/fntsys.h"
 #include "include/lang.h"
@@ -663,6 +664,7 @@ static submenu_list_t *submenuAllocItem(int icon_id, char *text, int id, int tex
     it->item.cache_uid = NULL;
     it->item.owner = owner;
     it->item.favourited = 0;
+    it->item.isFolder = 0;
     submenuRebuildCache(it);
 
     return it;
@@ -842,7 +844,12 @@ void submenuSort(submenu_list_t **submenu)
             char *txt1 = submenuItemGetText(&tip->item);
             char *txt2 = submenuItemGetText(&nxt->item);
 
-            int cmp = strcasecmp(txt1, txt2);
+            // Folder browsing: folders group ahead of games; within each group sort by title.
+            int cmp;
+            if (tip->item.isFolder != nxt->item.isFolder)
+                cmp = tip->item.isFolder ? -1 : 1;
+            else
+                cmp = strcasecmp(txt1, txt2);
 
             if (cmp > 0) {
                 swap(tip, nxt);
@@ -860,6 +867,25 @@ void submenuSort(submenu_list_t **submenu)
     *submenu = head;
 }
 
+// Folder browsing: return the device page we are leaving to its folder root, so a device is never
+// parked inside a subfolder while off-screen. This keeps folder navigation a per-visit affair and
+// guarantees the Favourites tab / last-played always resolve against a device's root list. It also
+// frees the single shared breadcrumb buffer for the next device by restoring the device-name title.
+static void menuFolderResetLeaving(struct menu_list *leaving)
+{
+    if (leaving == NULL || leaving->item == NULL || leaving->item->userdata == NULL)
+        return;
+    item_list_t *support = (item_list_t *)leaving->item->userdata;
+    if (!folderModeSupported(support->mode) || folderDepth(support->mode) == 0)
+        return;
+    folderReset(support->mode);
+    leaving->item->text = NULL;
+    leaving->item->text_id = support->itemTextId(support); // restore the device name (was the breadcrumb)
+    // Queue the rebuild now (folderReset marked the mode dirty) so the device is back at its root list
+    // promptly -- the Favourites tab / last-played resolve against that root, not the subfolder we left.
+    ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
+}
+
 static void menuNextH()
 {
     struct menu_list *next = selected_item->next;
@@ -868,6 +894,7 @@ static void menuNextH()
 
     // If we found a valid menu transition to it.
     if (next != NULL) {
+        menuFolderResetLeaving(selected_item);
         selected_item = next;
         itemConfigId = -1;
         menuInvalidateArtSelection();
@@ -882,6 +909,7 @@ static void menuPrevH()
         prev = prev->prev;
 
     if (prev != NULL) {
+        menuFolderResetLeaving(selected_item);
         selected_item = prev;
         itemConfigId = -1;
         menuInvalidateArtSelection();

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -4,6 +4,7 @@
 #include "include/supportbase.h"
 #include "include/mmcesupport.h"
 #include "include/vcdsupport.h"
+#include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/themes.h"
 #include "include/textures.h"
@@ -409,6 +410,9 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     // VCD view: force a rescan once on toggle, then skip the disc heuristics while showing VCDs.
     if (vcdConsumeDirty(itemList->mode))
         return 1;
+    // Folder browsing: descend/ascend forces one rescan (consumed before the NOUPDATE latch below).
+    if (folderConsumeDirty(itemList->mode))
+        return 1;
     if (vcdViewActive(itemList->mode))
         return 0;
 
@@ -485,7 +489,7 @@ static int mmceUpdateGameList(item_list_t *itemList)
             mmceVcdGameCount = r;
         return mmceVcdGameCount;
     }
-    sbReadList(&mmceGames, mmcePrefix, &mmceULSizePrev, &mmceGameCount);
+    sbReadList(&mmceGames, mmcePrefix, folderGetSub(itemList->mode), &mmceULSizePrev, &mmceGameCount);
     return mmceGameCount;
 }
 
@@ -544,8 +548,9 @@ static void mmceDeleteGame(item_list_t *itemList, int id)
     if (vcdViewActive(itemList->mode))
         return; // #120: a VCD is not an ISO game -- no delete in VCD view
     if (mmceActiveGame(itemList, id) == &mmceEmptyGame)
-        return; // stale id in the VCD->ISO toggle window (vcdViewActive already flipped, old VCD submenu id
-                // still live): sbDelete does NOT bounds-check, so this avoids an OOB/NULL deref + wrong unlink
+        return;                                   // stale id in the VCD->ISO toggle window (vcdViewActive already flipped, old VCD submenu id
+                                                  // still live): sbDelete does NOT bounds-check, so this avoids an OOB/NULL deref + wrong unlink
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // delete inside the current subfolder, not the root
     sbDelete(&mmceGames, mmcePrefix, "/", mmceGameCount, id);
     mmceULSizePrev = -2;
 }
@@ -555,7 +560,8 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
     if (vcdViewActive(itemList->mode))
         return; // #120: no rename in VCD view
     if (mmceActiveGame(itemList, id) == &mmceEmptyGame)
-        return; // stale id in the VCD->ISO toggle window (see mmceDeleteGame) -> avoid sbRename OOB
+        return;                                   // stale id in the VCD->ISO toggle window (see mmceDeleteGame) -> avoid sbRename OOB
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // rename inside the current subfolder, not the root
     sbRename(&mmceGames, mmcePrefix, "/", mmceGameCount, id, newName);
     mmceULSizePrev = -2;
 }
@@ -601,6 +607,12 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
             return; // stale id during the L3 toggle window (see mmceActiveGame) -> nothing to launch
     } else
         game = gAutoLaunchBDMGame;
+
+    // Folder browsing: a folder row is never launched (the dispatch descends first); guard defensively
+    // and pin the path composers to the current subfolder so a nested game resolves.
+    if (game != NULL && game->format == GAME_FORMAT_FOLDER)
+        return;
+    sbSetBrowseSub(folderGetSub(itemList->mode));
 
     // VCD view: hand off to POPSTARTER (by name) instead of the disc path below. Menu-launch only.
     if (gAutoLaunchBDMGame == NULL && game != NULL && vcdViewActive(itemList->mode)) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -944,7 +944,7 @@ static void updateMenuFromGameList(opl_io_module_t *mdl)
     // browse state resets to root on device switch), so a single static crumb buffer is safe.
     const int folderMode = folderModeSupported(mdl->support->mode);
     if (folderMode && folderDepth(mdl->support->mode) > 0) {
-        static char folderCrumb[192];
+        static char folderCrumb[256]; // generous headroom for a localized device name + subpath
         snprintf(folderCrumb, sizeof(folderCrumb), "%s: %s", _l(mdl->support->itemTextId(mdl->support)), folderGetSub(mdl->support->mode));
         mdl->menuItem.text = folderCrumb;
         mdl->menuItem.text_id = -1;

--- a/src/opl.c
+++ b/src/opl.c
@@ -39,6 +39,7 @@
 #include "include/xparam.h"
 #include "include/favsupport.h"
 #include "include/vcdsupport.h"
+#include "include/folderbrowse.h"
 
 // FIXME: We should not need this function.
 //        Use newlib's 'stat' to get GMT time.
@@ -226,6 +227,7 @@ char gBDMPrefix[32];
 char gMMCEPrefix[32];
 char gETHPrefix[32];
 int gRememberLastPlayed;
+int gEnableFolderNav;
 int KeyPressedOnce;
 int gAutoStartLastPlayed;
 int RemainSecs, DisableCron;
@@ -331,6 +333,13 @@ static void itemExecSelect(struct menu_item *curMenu)
     if (support) {
         if (support->enabled) {
             if (curMenu->current) {
+                // Folder browsing: a folder row DESCENDS (rescan one level deeper) instead of
+                // launching. folderDescend marks the mode dirty; the deferred update rebuilds the list.
+                if (curMenu->current->item.isFolder) {
+                    if (folderDescend(support->mode, curMenu->current->item.text))
+                        ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
+                    return;
+                }
                 config_set_t *configSet = menuLoadConfigDirect();
                 // Flash the GameID barcode (Pixel FX/RetroGEM HDMI auto-profile) before handoff; this
                 // single menu chokepoint covers both the Neutrino and OPL-native cores. No-op when off.
@@ -369,20 +378,41 @@ static void itemExecRefresh(struct menu_item *curMenu)
     }
 }
 
+// Folder browsing: the cancel button (whichever of Cross/Circle is NOT the select button) ascends one
+// folder level when inside a subfolder. At the device root it is a no-op -- there is no "back" out of
+// a device page -- so this never changes behaviour for users who aren't browsing folders.
+static void itemFolderAscend(struct menu_item *curMenu)
+{
+    item_list_t *support = curMenu ? curMenu->userdata : NULL;
+    if (support == NULL || folderDepth(support->mode) == 0)
+        return;
+    if (folderAscend(support->mode)) {
+        sfxPlay(SFX_CANCEL);
+        ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
+    }
+}
+
 static void itemExecCross(struct menu_item *curMenu)
 {
     if (gSelectButton == KEY_CROSS)
         itemExecSelect(curMenu);
+    else
+        itemFolderAscend(curMenu); // Cross is the cancel button here -> ascend a folder level
 }
 
 static void itemExecCircle(struct menu_item *curMenu)
 {
     if (gSelectButton == KEY_CIRCLE)
         itemExecSelect(curMenu);
+    else
+        itemFolderAscend(curMenu); // Circle is the cancel button here -> ascend a folder level
 }
 
 static void itemExecSquare(struct menu_item *curMenu)
 {
+    // Folder browsing: a folder row has no info screen (#Size/#DiscType would stat a directory).
+    if (curMenu->current && curMenu->current->item.isFolder)
+        return;
     if (curMenu->current && gTheme->infoElems.first) {
         // #Size is skipped while scrolling so the badges paint instantly; resolve it now (async) --
         // but NEVER for a VCD (PS1) list. A VCD carries no meaningful #Size: vcdFillGameList tags the
@@ -408,6 +438,10 @@ static void itemExecSquare(struct menu_item *curMenu)
 static void itemExecTriangle(struct menu_item *curMenu)
 {
     if (!curMenu->current)
+        return;
+
+    // Folder browsing: a folder row has no per-game settings menu.
+    if (curMenu->current->item.isFolder)
         return;
 
     item_list_t *support = curMenu->userdata;
@@ -447,6 +481,12 @@ static void itemExecFav(struct menu_item *curMenu)
 
     submenu_item_t *it = &curMenu->current->item;
 
+    // Folder browsing: on a source list a folder row is not favouritable, and a game favourited from
+    // INSIDE a subfolder would resolve by index against the wrong (root) view later -- suppress both in
+    // v1. Root favourites are unchanged; the Favourites tab's own removals are unaffected.
+    if (support->mode != FAV_MODE && (it->isFolder || folderDepth(support->mode) > 0))
+        return;
+
     if (support->mode == FAV_MODE) {
         favRemoveByIndex(it->id);
     } else {
@@ -485,6 +525,9 @@ static void itemExecToggleView(struct menu_item *curMenu)
     if (gDefaultGameView != GAME_VIEW_BOTH)
         return; // the global default-view setting locks the page to one type -> L3 is inert
 
+    // Folder browsing: the VCD/POPS list has no folder tree, so drop any ISO-view subfolder position
+    // back to root on a view toggle (the deferred rebuild below restores the plain device title).
+    folderReset(support->mode);
     vcdToggleView(support->mode);
     sfxPlay(SFX_CONFIRM);
     guiWarning(vcdViewActive(support->mode) ? _l(_STR_VCD_ON) : _l(_STR_VCD_OFF), 2);
@@ -894,6 +937,19 @@ static void updateMenuFromGameList(opl_io_module_t *mdl)
     // read the new game list
     struct gui_update_t *gup = NULL;
     int count = mdl->support->itemUpdate(mdl->support);
+
+    // Folder browsing: while inside a subfolder, show the breadcrumb ("Device: RPGs/SNES") as the page
+    // title. folderGetSub() points at persistent static state, so the char* stays valid. At the device
+    // root the device name set above stands. Only one device is ever inside a folder at a time (the
+    // browse state resets to root on device switch), so a single static crumb buffer is safe.
+    const int folderMode = folderModeSupported(mdl->support->mode);
+    if (folderMode && folderDepth(mdl->support->mode) > 0) {
+        static char folderCrumb[192];
+        snprintf(folderCrumb, sizeof(folderCrumb), "%s: %s", _l(mdl->support->itemTextId(mdl->support)), folderGetSub(mdl->support->mode));
+        mdl->menuItem.text = folderCrumb;
+        mdl->menuItem.text_id = -1;
+    }
+
     if (count > 0) {
         int i;
 
@@ -906,14 +962,24 @@ static void updateMenuFromGameList(opl_io_module_t *mdl)
             gup->menu.menu = &mdl->menuItem;
             gup->menu.subMenu = &mdl->subMenu;
 
+            // Folder browsing: flag folder rows so the dispatch descends and the renderer marks them.
+            // Only the loose-file tree devices return base_game_info_t from itemGet, so gate on the mode.
+            int isFolderRow = 0;
+            if (folderMode && mdl->support->itemGet != NULL) {
+                base_game_info_t *ginfo = (base_game_info_t *)mdl->support->itemGet(mdl->support, i);
+                isFolderRow = (ginfo != NULL && ginfo->format == GAME_FORMAT_FOLDER);
+            }
+
             gup->submenu.icon_id = -1;
             gup->submenu.id = i;
             gup->submenu.text = mdl->support->itemGetName(mdl->support, i);
             gup->submenu.text_id = -1;
             gup->submenu.selected = 0;
             gup->submenu.owner = (void *)mdl->support; // producing list; Favourites proxies back to it
+            gup->submenu.isFolder = isFolderRow;
 
-            if (gRememberLastPlayed && temp && strcmp(temp, mdl->support->itemGetStartup(mdl->support, i)) == 0) {
+            // Last-played auto-select never targets a folder row (its startup is empty).
+            if (gRememberLastPlayed && temp && !isFolderRow && strcmp(temp, mdl->support->itemGetStartup(mdl->support, i)) == 0) {
                 gup->submenu.selected = 1; // Select Last Played Game
             }
 
@@ -1545,6 +1611,7 @@ static void _loadConfig()
             configGetStrCopy(configOPL, CONFIG_OPL_BDM_PREFIX, gBDMPrefix, sizeof(gBDMPrefix));
             configGetStrCopy(configOPL, CONFIG_OPL_ETH_PREFIX, gETHPrefix, sizeof(gETHPrefix));
             configGetInt(configOPL, CONFIG_OPL_REMEMBER_LAST, &gRememberLastPlayed);
+            configGetInt(configOPL, CONFIG_OPL_FOLDER_NAV, &gEnableFolderNav);
             configGetInt(configOPL, CONFIG_OPL_AUTOSTART_LAST, &gAutoStartLastPlayed);
             configGetInt(configOPL, CONFIG_OPL_BDM_MODE, &gBDMStartMode);
             configGetInt(configOPL, CONFIG_OPL_HDD_MODE, &gHDDStartMode);
@@ -1881,6 +1948,7 @@ static void _saveConfig()
         configSetStr(configOPL, CONFIG_OPL_BDM_PREFIX, gBDMPrefix);
         configSetStr(configOPL, CONFIG_OPL_ETH_PREFIX, gETHPrefix);
         configSetInt(configOPL, CONFIG_OPL_REMEMBER_LAST, gRememberLastPlayed);
+        configSetInt(configOPL, CONFIG_OPL_FOLDER_NAV, gEnableFolderNav);
         configSetInt(configOPL, CONFIG_OPL_AUTOSTART_LAST, gAutoStartLastPlayed);
         configSetInt(configOPL, CONFIG_OPL_BDM_MODE, gBDMStartMode);
         configSetInt(configOPL, CONFIG_OPL_HDD_MODE, gHDDStartMode);
@@ -2653,6 +2721,7 @@ static void setDefaults(void)
     gHDDGameListCache = 0;
     gEnableWrite = 1;
     gRememberLastPlayed = 0;
+    gEnableFolderNav = 0; // opt-in; a flat library is byte-identical to before
     gAutoStartLastPlayed = 9;
     gSelectButton = KEY_CROSS; // Default to Cross-select (western layout); swap_select_btn=0 restores Circle
     gMMCEPrefix[0] = '\0';

--- a/src/opl.c
+++ b/src/opl.c
@@ -951,39 +951,49 @@ static void updateMenuFromGameList(opl_io_module_t *mdl)
     }
 
     if (count > 0) {
-        int i;
+        // Folder browsing: emit in TWO passes -- folders first, then the games -- so folders always sit
+        // at the TOP of the list regardless of the Auto Sort setting. Each row keeps id=i (its array
+        // index), so favourites still resolve by id+text no matter the display order. Devices that never
+        // produce folder rows use a single pass, byte-for-byte the original behaviour. When Auto Sort is
+        // on, submenuSort's folder-first comparator keeps this grouping while sorting each group.
+        int passes = (gEnableFolderNav && folderMode) ? 2 : 1;
+        int pass, i;
 
-        for (i = 0; i < count; ++i) {
+        for (pass = 0; pass < passes; ++pass) {
+            for (i = 0; i < count; ++i) {
+                // Flag folder rows so the dispatch descends and the renderer marks them. Only the
+                // loose-file tree devices return base_game_info_t from itemGet, so gate on the mode.
+                int isFolderRow = 0;
+                if (folderMode && mdl->support->itemGet != NULL) {
+                    base_game_info_t *ginfo = (base_game_info_t *)mdl->support->itemGet(mdl->support, i);
+                    isFolderRow = (ginfo != NULL && ginfo->format == GAME_FORMAT_FOLDER);
+                }
+                // Pass 0 emits folders, pass 1 emits games (single-pass mode emits every row).
+                if (passes == 2 && ((pass == 0) != (isFolderRow != 0)))
+                    continue;
 
-            gup = guiOpCreate(GUI_OP_APPEND_MENU);
-            if (!gup) // OOM: skip this entry rather than deref NULL
-                continue;
+                gup = guiOpCreate(GUI_OP_APPEND_MENU);
+                if (!gup) // OOM: skip this entry rather than deref NULL
+                    continue;
 
-            gup->menu.menu = &mdl->menuItem;
-            gup->menu.subMenu = &mdl->subMenu;
+                gup->menu.menu = &mdl->menuItem;
+                gup->menu.subMenu = &mdl->subMenu;
 
-            // Folder browsing: flag folder rows so the dispatch descends and the renderer marks them.
-            // Only the loose-file tree devices return base_game_info_t from itemGet, so gate on the mode.
-            int isFolderRow = 0;
-            if (folderMode && mdl->support->itemGet != NULL) {
-                base_game_info_t *ginfo = (base_game_info_t *)mdl->support->itemGet(mdl->support, i);
-                isFolderRow = (ginfo != NULL && ginfo->format == GAME_FORMAT_FOLDER);
+                gup->submenu.icon_id = -1;
+                gup->submenu.id = i;
+                gup->submenu.text = mdl->support->itemGetName(mdl->support, i);
+                gup->submenu.text_id = -1;
+                gup->submenu.selected = 0;
+                gup->submenu.owner = (void *)mdl->support; // producing list; Favourites proxies back to it
+                gup->submenu.isFolder = isFolderRow;
+
+                // Last-played auto-select never targets a folder row (its startup is empty).
+                if (gRememberLastPlayed && temp && !isFolderRow && strcmp(temp, mdl->support->itemGetStartup(mdl->support, i)) == 0) {
+                    gup->submenu.selected = 1; // Select Last Played Game
+                }
+
+                guiDeferUpdate(gup);
             }
-
-            gup->submenu.icon_id = -1;
-            gup->submenu.id = i;
-            gup->submenu.text = mdl->support->itemGetName(mdl->support, i);
-            gup->submenu.text_id = -1;
-            gup->submenu.selected = 0;
-            gup->submenu.owner = (void *)mdl->support; // producing list; Favourites proxies back to it
-            gup->submenu.isFolder = isFolderRow;
-
-            // Last-played auto-select never targets a folder row (its startup is empty).
-            if (gRememberLastPlayed && temp && !isFolderRow && strcmp(temp, mdl->support->itemGetStartup(mdl->support, i)) == 0) {
-                gup->submenu.selected = 1; // Select Last Played Game
-            }
-
-            guiDeferUpdate(gup);
         }
     }
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -6,7 +6,8 @@
 #include "include/system.h"
 #include "include/supportbase.h"
 #include "include/vcdsupport.h"
-#include "include/bdmsupport.h" // bdmGetDeviceRootByType + BDM_TYPE_* for the Neutrino device-TYPE picker
+#include "include/folderbrowse.h" // FOLDER_SUB_MAX + folder-browse subpath state
+#include "include/bdmsupport.h"   // bdmGetDeviceRootByType + BDM_TYPE_* for the Neutrino device-TYPE picker
 #include "include/ioman.h"
 #include "modules/iopcore/common/cdvd_config.h"
 #include "include/cheatman.h"
@@ -295,7 +296,10 @@ static int queryISOGameListCache(const struct game_cache_list *cache, base_game_
     return ENOENT;
 }
 
-static int scanForISO(char *path, char type, struct game_list_t **glist)
+// folderlist (folder-browse only, else NULL) collects subdirectory rows in a list SEPARATE from
+// glist so they never reach the games.bin cache (updateISOGameList would otherwise cache them as
+// phantom entries and poison its change-detection). Folder rows are not counted in the return value.
+static int scanForISO(char *path, char type, struct game_list_t **glist, struct game_list_t **folderlist)
 {
     int count = 0;
     struct game_cache_list cache = {0, NULL};
@@ -315,8 +319,35 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
             int NameLen;
             int format = isValidIsoName(dirent->d_name, &NameLen);
 
-            if (format <= 0 || NameLen > ISO_GAME_NAME_MAX)
+            if (format <= 0 || NameLen > ISO_GAME_NAME_MAX) {
+                // Not a launchable ISO. With folder browsing on, a subdirectory here becomes a
+                // GAME_FORMAT_FOLDER row. d_type is untrustworthy on MMCE clone firmware (mmceman
+                // passes card-mode bits verbatim), so confirm it is a directory with an opendir probe
+                // rather than trusting the dirent flag. Leading-dot entries ("."/".."/hidden) are
+                // skipped. Folders go on the separate folderlist so the cache never sees them.
+                if (folderlist != NULL && dirent->d_name[0] != '.') {
+                    size_t dnlen = strlen(dirent->d_name);
+                    if (dnlen <= ISO_GAME_NAME_MAX && base_path_len + 1 + dnlen < sizeof(fullpath)) {
+                        strcpy(fullpath + base_path_len + 1, dirent->d_name);
+                        DIR *probe = opendir(fullpath);
+                        if (probe != NULL) {
+                            closedir(probe);
+                            struct game_list_t *fnode = malloc(sizeof(struct game_list_t));
+                            if (fnode != NULL) {
+                                base_game_info_t *fg = &fnode->gameinfo;
+                                memset(fg, 0, sizeof(base_game_info_t));
+                                fg->format = GAME_FORMAT_FOLDER;
+                                fg->media = type;
+                                strncpy(fg->name, dirent->d_name, ISO_GAME_NAME_MAX);
+                                fg->name[ISO_GAME_NAME_MAX] = '\0';
+                                fnode->next = *folderlist;
+                                *folderlist = fnode;
+                            }
+                        }
+                    }
+                }
                 continue; // Skip files that cannot be supported properly.
+            }
 
             // d_name is filesystem-provided and can exceed what fits in fullpath
             // (NameLen bounds the stripped name, not the raw d_name plus the path
@@ -397,11 +428,53 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
     return count;
 }
 
-int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gamecount)
+// Folder browsing: the current subpath below CD/DVD that the path composers inject. Set by sbReadList
+// (from the sub it is scanning) and re-set explicitly by each device's launch/delete/rename leg via
+// sbSetBrowseSub(folderGetSub(mode)), so a game inside a subfolder resolves correctly even when the
+// launch does not go through a fresh scan (e.g. the Favourites tab launching another device's game).
+static char sbBrowseSub[FOLDER_SUB_MAX] = "";
+
+void sbSetBrowseSub(const char *sub)
 {
-    int fd, size, id = 0;
+    if (sub == NULL)
+        sub = "";
+    snprintf(sbBrowseSub, sizeof(sbBrowseSub), "%s", sub);
+}
+
+// De-duplicate folder rows across the CD and DVD passes (a single logical subfolder can hold both
+// media, e.g. CD/RPGs and DVD/RPGs -> one "RPGs" row). Keeps the first occurrence, frees the rest.
+// Returns the count of remaining unique folders.
+static int sbDedupFolderList(struct game_list_t **head)
+{
+    int n = 0;
+    struct game_list_t *a = *head;
+    while (a != NULL) {
+        struct game_list_t *b = a;
+        while (b->next != NULL) {
+            if (strcasecmp(b->next->gameinfo.name, a->gameinfo.name) == 0) {
+                struct game_list_t *dup = b->next;
+                b->next = dup->next;
+                free(dup);
+            } else {
+                b = b->next;
+            }
+        }
+        n++;
+        a = a->next;
+    }
+    return n;
+}
+
+int sbReadList(base_game_info_t **list, const char *prefix, const char *sub, int *fsize, int *gamecount)
+{
+    int fd = -1, size, id = 0;
     int count, cdRet, dvdRet;
     char path[256];
+    const int atRoot = (sub == NULL || sub[0] == '\0');
+
+    // Make this the active subpath for the path composers used before the next scan (size stat /
+    // launch). A device leg also re-sets it explicitly at launch time.
+    sbSetBrowseSub(sub);
 
     // Build into a LOCAL list and leave the caller's *list/*gamecount/*fsize UNTOUCHED until we know
     // the scan actually reached the device. On a TOTAL device-read failure (every directory's opendir
@@ -414,22 +487,37 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
 
     // temporary storage for the game names
     struct game_list_t *dlist_head = NULL;
+    // Folder rows (kept out of the games.bin cache). Only collected when folder browsing is on.
+    struct game_list_t *folder_head = NULL;
+    struct game_list_t **folderlist = gEnableFolderNav ? &folder_head : NULL;
 
-    // count iso games in "cd" directory
-    snprintf(path, sizeof(path), "%sCD", prefix);
-    cdRet = scanForISO(path, SCECdPS2CD, &dlist_head);
+    // count iso games in "cd" directory (descending into the browse subpath when set)
+    if (atRoot)
+        snprintf(path, sizeof(path), "%sCD", prefix);
+    else
+        snprintf(path, sizeof(path), "%sCD/%s", prefix, sub);
+    cdRet = scanForISO(path, SCECdPS2CD, &dlist_head, folderlist);
     count = cdRet;
 
     // count iso games in "dvd" directory
-    snprintf(path, sizeof(path), "%sDVD", prefix);
-    dvdRet = scanForISO(path, SCECdPS2DVD, &dlist_head);
+    if (atRoot)
+        snprintf(path, sizeof(path), "%sDVD", prefix);
+    else
+        snprintf(path, sizeof(path), "%sDVD/%s", prefix, sub);
+    dvdRet = scanForISO(path, SCECdPS2DVD, &dlist_head, folderlist);
     if (dvdRet >= 0) {
         count = count < 0 ? dvdRet : count + dvdRet;
     }
 
-    // count and process games in ul.cfg
-    snprintf(path, sizeof(path), "%sul.cfg", prefix);
-    fd = openFile(path, O_RDONLY);
+    // Merge the CD/DVD folder rows into one deduped set.
+    int fcount = (folder_head != NULL) ? sbDedupFolderList(&folder_head) : 0;
+
+    // count and process games in ul.cfg -- a device-ROOT concept (USBLD split games live at the
+    // library root); never present or scanned inside a browse subfolder.
+    if (atRoot) {
+        snprintf(path, sizeof(path), "%sul.cfg", prefix);
+        fd = openFile(path, O_RDONLY);
+    }
     if (fd >= 0) {
         USBExtreme_game_entry_t GameEntry;
 
@@ -439,9 +527,10 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
         newfsize = size;
         count += size / sizeof(USBExtreme_game_entry_t);
 
-        if (count > 0) {
-            if ((newlist = (base_game_info_t *)malloc(sizeof(base_game_info_t) * count)) != NULL) {
-                memset(newlist, 0, sizeof(base_game_info_t) * count);
+        int total = (count > 0 ? count : 0) + fcount;
+        if (total > 0) {
+            if ((newlist = (base_game_info_t *)malloc(sizeof(base_game_info_t) * total)) != NULL) {
+                memset(newlist, 0, sizeof(base_game_info_t) * total);
 
                 while (size > 0) {
                     base_game_info_t *g = &newlist[id++];
@@ -481,27 +570,39 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
             }
         }
         close(fd);
-    } else if (count > 0) {
-        newlist = (base_game_info_t *)malloc(sizeof(base_game_info_t) * count);
+    } else if (count + fcount > 0) {
+        newlist = (base_game_info_t *)malloc(sizeof(base_game_info_t) * (count + fcount));
+        if (newlist != NULL)
+            memset(newlist, 0, sizeof(base_game_info_t) * (count + fcount));
     }
 
+    const int total = (count > 0 ? count : 0) + fcount;
     if (newlist != NULL) {
-        // copy the dlist into the list
-        while ((id < count) && dlist_head) {
-            // copy one game, advance
+        // copy the dlist into the list, then append the folder rows after the games
+        while ((id < total) && dlist_head) {
             struct game_list_t *cur = dlist_head;
             dlist_head = dlist_head->next;
-
+            memcpy(&newlist[id++], &cur->gameinfo, sizeof(base_game_info_t));
+            free(cur);
+        }
+        while ((id < total) && folder_head) {
+            struct game_list_t *cur = folder_head;
+            folder_head = folder_head->next;
             memcpy(&newlist[id++], &cur->gameinfo, sizeof(base_game_info_t));
             free(cur);
         }
     } else
         count = 0;
 
-    // Free any ISO game_list_t nodes not consumed above (e.g. when the output array alloc failed).
+    // Free any nodes not consumed above (e.g. when the output array alloc failed).
     while (dlist_head) {
         struct game_list_t *cur = dlist_head;
         dlist_head = dlist_head->next;
+        free(cur);
+    }
+    while (folder_head) {
+        struct game_list_t *cur = folder_head;
+        folder_head = folder_head->next;
         free(cur);
     }
 
@@ -513,13 +614,16 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
         return *gamecount; // *list / *gamecount / *fsize untouched -> last-good list stays on screen
     }
 
-    // Success or genuinely-empty: publish the freshly-built list (frees the previous one).
+    // Success or genuinely-empty: publish the freshly-built list (frees the previous one). Guard on
+    // newlist so a failed allocation publishes an EMPTY list (count 0) rather than a NULL pointer with
+    // a non-zero count -- an OOB on the very next render.
+    const int published = (newlist != NULL && total > 0) ? total : 0;
     free(*list);
     *list = newlist;
     *fsize = newfsize;
-    *gamecount = (count > 0) ? count : 0;
+    *gamecount = published;
 
-    return count;
+    return published;
 }
 
 extern int probed_fd;
@@ -1056,15 +1160,26 @@ void sbRebuildULCfg(base_game_info_t **list, const char *prefix, int gamecount, 
 
 static void sbCreatePath_name(const base_game_info_t *game, char *path, const char *prefix, const char *sep, int part, const char *game_name)
 {
+    // Folder browsing: a game inside a subfolder sits at <prefix>CD|DVD/<sub>/<name>. sbBrowseSub is
+    // "" for the normal device-root case, so subseg collapses to nothing and the path is unchanged.
+    char subseg[FOLDER_SUB_MAX + 2];
+    if (sbBrowseSub[0] != '\0')
+        snprintf(subseg, sizeof(subseg), "%s%s", sbBrowseSub, sep);
+    else
+        subseg[0] = '\0';
+
     switch (game->format) {
         case GAME_FORMAT_USBLD:
             snprintf(path, 256, "%sul.%08X.%s.%02x", prefix, USBA_crc32(game_name), game->startup, part);
             break;
         case GAME_FORMAT_ISO:
-            snprintf(path, 256, "%s%s%s%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, game_name, game->extension);
+            snprintf(path, 256, "%s%s%s%s%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, subseg, game_name, game->extension);
             break;
         case GAME_FORMAT_OLD_ISO:
-            snprintf(path, 256, "%s%s%s%s.%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, game->startup, game_name, game->extension);
+            snprintf(path, 256, "%s%s%s%s%s.%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, subseg, game->startup, game_name, game->extension);
+            break;
+        case GAME_FORMAT_FOLDER:
+            path[0] = '\0'; // a folder is never launched / deleted / renamed / pathed
             break;
     }
 }
@@ -1172,16 +1287,24 @@ config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const
     // misses, leaves sizeMB at 0, never caches, and re-probes the shared MMCE bus on every info entry (#120).
     // Hard-stop it by EXTENSION here (not mutable view state) so a .VCD can never reach the ISO stat path,
     // even during the L3 view-toggle window (game->sizeMB stays 0 -> "0 MiB" is still written below).
+    // Folder browsing: prepend the current subpath so the stat resolves a game that lives inside a
+    // subfolder. sbBrowseSub is "" at the device root, collapsing subseg away.
+    char subseg[FOLDER_SUB_MAX + 2];
+    if (sbBrowseSub[0] != '\0')
+        snprintf(subseg, sizeof(subseg), "%s%s", sbBrowseSub, sep);
+    else
+        subseg[0] = '\0';
+
     if (sbConfigStatSize && !isVcd && game->sizeMB == 0) {
         char gamepath[256];
 
         if (game->format == GAME_FORMAT_ISO) {
-            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->name, game->extension);
+            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, subseg, game->name, game->extension);
 
             if (stat(gamepath, &st) == 0)
                 game->sizeMB = st.st_size >> 20;
         } else if (game->format == GAME_FORMAT_OLD_ISO) {
-            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s.%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->startup, game->name, game->extension);
+            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s.%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, subseg, game->startup, game->name, game->extension);
 
             if (stat(gamepath, &st) == 0)
                 game->sizeMB = st.st_size >> 20;
@@ -1212,8 +1335,11 @@ config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const
         configSetStr(config, CONFIG_ITEM_FORMAT, "UL");
 
     // #System/#Media/#DiscType badges: a PS1 (POPSTARTER/.VCD) disc is always a CD; PS2 uses game->media.
-    int isPS1 = !strcasecmp(game->extension, ".VCD");
-    sbSetDiscAttributes(config, isPS1, isPS1 || game->media == SCECdPS2CD);
+    // A folder row is not a disc -- leave the disc attributes unset so no disc badge renders on it.
+    if (game->format != GAME_FORMAT_FOLDER) {
+        int isPS1 = !strcasecmp(game->extension, ".VCD");
+        sbSetDiscAttributes(config, isPS1, isPS1 || game->media == SCECdPS2CD);
+    }
 
     configSetStr(config, CONFIG_ITEM_STARTUP, isVcd ? game->name : game->startup);
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -338,8 +338,8 @@ static int scanForISO(char *path, char type, struct game_list_t **glist, struct 
                                 memset(fg, 0, sizeof(base_game_info_t));
                                 fg->format = GAME_FORMAT_FOLDER;
                                 fg->media = type;
-                                strncpy(fg->name, dirent->d_name, ISO_GAME_NAME_MAX);
-                                fg->name[ISO_GAME_NAME_MAX] = '\0';
+                                strncpy(fg->name, dirent->d_name, sizeof(fg->name) - 1);
+                                fg->name[sizeof(fg->name) - 1] = '\0';
                                 fnode->next = *folderlist;
                                 *folderlist = fnode;
                             }
@@ -511,6 +511,12 @@ int sbReadList(base_game_info_t **list, const char *prefix, const char *sub, int
 
     // Merge the CD/DVD folder rows into one deduped set.
     int fcount = (folder_head != NULL) ? sbDedupFolderList(&folder_head) : 0;
+
+    // Normalise a total-failure count to 0 up front, so every allocation/copy below works off a
+    // non-negative game count. (A failed scan emits no folders, so fcount is 0 here today, but this
+    // keeps the invariant explicit and robust to future changes.)
+    if (count < 0)
+        count = 0;
 
     // count and process games in ul.cfg -- a device-ROOT concept (USBLD split games live at the
     // library root); never present or scanned inside a browse subfolder.

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -487,9 +487,14 @@ int sbReadList(base_game_info_t **list, const char *prefix, const char *sub, int
 
     // temporary storage for the game names
     struct game_list_t *dlist_head = NULL;
-    // Folder rows (kept out of the games.bin cache). Only collected when folder browsing is on.
+    // Folder rows (kept out of the games.bin cache). Collected only when folder browsing is on AND the
+    // caller opted in by passing a non-NULL sub. A NULL sub is the opt-OUT signal for devices that do
+    // not participate in folder browsing (ETH/SMB, which uses a "\\" separator): without this gate a
+    // subdirectory in an SMB share would be listed as an ordinary, un-navigable, unlaunchable row on a
+    // device whose updateMenuFromGameList never flags it as a folder. The folder-capable callers
+    // (bdm/mmce/udpfs) always pass folderGetSub(mode), which is non-NULL ("" at the device root).
     struct game_list_t *folder_head = NULL;
-    struct game_list_t **folderlist = gEnableFolderNav ? &folder_head : NULL;
+    struct game_list_t **folderlist = (gEnableFolderNav && sub != NULL) ? &folder_head : NULL;
 
     // count iso games in "cd" directory (descending into the browse subpath when set)
     if (atRoot)

--- a/src/themes.c
+++ b/src/themes.c
@@ -780,6 +780,12 @@ static void initStaticImage(const char *themePath, config_set_t *themeConfig, th
 
 static GSTEXTURE *getGameImageTexture(image_cache_t *cache, void *support, struct submenu_item *item)
 {
+    // Folder browsing: a folder row has no cover art (and no startup key). Never route it through the
+    // cover cache -- an empty key would thrash the cache and paint the empty case frame. Applies to
+    // every consumer: the list decorator, the big cover panel and the coverflow carousel.
+    if (item != NULL && item->isFolder)
+        return NULL;
+
     if (gEnableArt) {
         item_list_t *list = (item_list_t *)support;
         char *startup = list->itemGetStartup(list, item->id);
@@ -1508,10 +1514,22 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
             else
                 color = elem->color;
 
-            if (itemsList->decoratorImage) {
-                GSTEXTURE *itemIconTex;
+            // Folder browsing: a folder row shows its name with a trailing "/" and is NEVER routed
+            // through the cover cache (it has no startup key -- doing so would thrash the cache and
+            // paint the empty case frame). The default decorator slot keeps the text aligned with games.
+            const char *dispText = vcdDisplayName(list ? list->mode : -1, submenuItemGetText(&ps->item));
+            char folderBuf[256];
+            if (ps->item.isFolder) {
+                snprintf(folderBuf, sizeof(folderBuf), "%s/", dispText);
+                dispText = folderBuf;
+            }
 
-                if (list != NULL && list->mode == MMCE_MODE && itemsList->decoratorImage->cache != NULL) {
+            if (itemsList->decoratorImage) {
+                GSTEXTURE *itemIconTex = NULL;
+
+                if (ps->item.isFolder) {
+                    itemIconTex = NULL; // folders never carry a cover
+                } else if (list != NULL && list->mode == MMCE_MODE && itemsList->decoratorImage->cache != NULL) {
                     image_cache_t *cache = itemsList->decoratorImage->cache;
 
                     if (mmceSelectionChanged && ps == item)
@@ -1527,9 +1545,9 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
                     if (itemsList->decoratorImage->defaultTexture)
                         rmDrawPixmap(&itemsList->decoratorImage->defaultTexture->source, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol, 0);
                 }
-                textEndX = fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, vcdDisplayName(list ? list->mode : -1, submenuItemGetText(&ps->item)), color);
+                textEndX = fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, dispText, color);
             } else
-                textEndX = fntRenderString(elem->font, elem->posX, posY, elem->aligned, elem->width, elem->height, vcdDisplayName(list ? list->mode : -1, submenuItemGetText(&ps->item)), color);
+                textEndX = fntRenderString(elem->font, elem->posX, posY, elem->aligned, elem->width, elem->height, dispText, color);
 
             // Favourites: draw a small star just after the item text.
             if (ps->item.favourited) {

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -4,6 +4,7 @@
 #include "include/supportbase.h"
 #include "include/udpfssupport.h"
 #include "include/vcdsupport.h"
+#include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/renderman.h"
 #include "include/themes.h"
@@ -125,6 +126,9 @@ static int udpfsNeedsUpdate(item_list_t *itemList)
     // VCD view: force a rescan once on toggle, then refresh on toggle only (skip disc heuristics).
     if (vcdConsumeDirty(itemList->mode))
         return 1;
+    // Folder browsing: descend/ascend forces one rescan.
+    if (folderConsumeDirty(itemList->mode))
+        return 1;
     if (vcdViewActive(itemList->mode))
         return 0;
 
@@ -169,7 +173,7 @@ static int udpfsUpdateGameList(item_list_t *itemList)
         int r = vcdFillGameList(udpfsPrefix, &udpfsGames);
         if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
             udpfsGameCount = r;
-    } else if (sbReadList(&udpfsGames, udpfsPrefix, &udpfsULSizePrev, &udpfsGameCount) < 0) {
+    } else if (sbReadList(&udpfsGames, udpfsPrefix, folderGetSub(itemList->mode), &udpfsULSizePrev, &udpfsGameCount) < 0) {
         udpfsGameCount = 0;
     }
     return udpfsGameCount;
@@ -208,12 +212,14 @@ static char *udpfsGetGameStartup(item_list_t *itemList, int id)
 
 static void udpfsDeleteGame(item_list_t *itemList, int id)
 {
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // delete inside the current subfolder, not the root
     sbDelete(&udpfsGames, udpfsPrefix, "/", udpfsGameCount, id);
     udpfsULSizePrev = -2;
 }
 
 static void udpfsRenameGame(item_list_t *itemList, int id, char *newName)
 {
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // rename inside the current subfolder, not the root
     sbRename(&udpfsGames, udpfsPrefix, "/", udpfsGameCount, id, newName);
     udpfsULSizePrev = -2;
 }
@@ -234,6 +240,12 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     int result;
     char filename[32], partname[256];
     base_game_info_t *game = &udpfsGames[id];
+
+    // Folder browsing: a folder row is never launched (the dispatch descends first); guard defensively
+    // and pin the path composers to the current subfolder so a nested game resolves.
+    if (game != NULL && game->format == GAME_FORMAT_FOLDER)
+        return;
+    sbSetBrowseSub(folderGetSub(itemList->mode));
 
     // VCD view: udpfs cannot host a POPSTARTER launch (network filesystem) -> hand off to the guard.
     if (game != NULL && vcdViewActive(itemList->mode)) {


### PR DESCRIPTION
## What

Adds a **default-OFF** `Browse Folders in Game List` setting (Settings screen). When on, subdirectories inside a device's `CD` / `DVD` folders show up as **browsable rows** (marked with a trailing `/`):

- **Select** a folder → descend (the list rescans one level deeper)
- **Cancel button** → ascend back up
- A **breadcrumb** in the page title (`Device: RPGs/SNES`) shows where you are
- Folders group **ahead of games**, then sort by title

Each folder view is just the normal flat game list repopulated in place, so **covers, favourites, coverflow, sort and per-game settings all keep working inside folders** with zero changes to their code.

## Scope

In scope (loose-file tree scanners reaching `sbReadList` with a `/` separator): **BDM** (USB / MX4SIO / iLink / internal-exFAT), **MMCE**, **UDPFS-Files**.

Out of scope by design: **APA-HDD** (HDL partitions), the **UDPFS block device**, and the **VCD/POPS** view — none scan a CD/DVD tree. **SMB/ETH deferred** (it uses a `\` separator).

## Design & safety

State mirrors the proven VCD-view machinery — a per-mode subpath + dirty flag consumed in each device's `NeedsUpdate` (new `src/folderbrowse.c`).

- **Default OFF ⇒ byte-identical to before.** `scanForISO` never emits a folder row unless `gEnableFolderNav`; all helpers return the root state. It only lights up where a user actually created subfolders.
- **Folders never touch the games.bin cache** — they're collected in a separate list, so the on-disk cache and its change-detection are unaffected.
- **Existing favourites keep resolving.** Folders are appended at the **array tail** (only the display sort floats them to the front), so a game's array index — the value favourites store — is unchanged whether folders are on or off. Favourites match by `id`+`text`, so nothing shifts.
- **Nested-game favourites are suppressed in v1** (no regression — nested games weren't launchable at all before). Leaving a device page resets its folder state to root and queues a rebuild, so the **Favourites tab / last-played always resolve against a device's root list**.
- Folder rows are **never launched, favourited, or shown on the info/options screens**; they're excluded from the cover cache (no empty-frame thrash) and from the last-played cursor match.
- **Folder detection uses an `opendir` probe** rather than `d_type` (unreliable on MMCE clone firmware, per the fork's MMCE theme-discovery precedent).
- Path/depth bounded (`FOLDER_SUB_MAX` / `FOLDER_DEPTH_MAX`); deep or over-long joins are refused rather than truncated into the wrong directory.

## Testing

- Full `opl.elf` build **green** (ps2dev:latest, `MAKE_EXIT=0`), zero warnings / undefined references.
- All 11 touched translation-independent objects compile clean; new lang strings (`_STR_FOLDER_NAV` / `_STR_HINT_FOLDER_NAV`) generate and link.
- `clang-format` (v12.0.1, matches CI) clean on every changed file.
- **Hardware-pending:** on-console behaviour of descend/ascend and the MMCE opendir-probe cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)