### PR TITLE
feat(pad): opt-in controller vibration in the menus (#172)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -125,6 +125,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_ETH_PREFIX           "eth_prefix"
 #define CONFIG_OPL_REMEMBER_LAST        "remember_last"
 #define CONFIG_OPL_FOLDER_NAV           "folder_nav"
+#define CONFIG_OPL_RUMBLE               "enable_rumble"
 #define CONFIG_OPL_AUTOSTART_LAST       "autostart_last"
 #define CONFIG_OPL_BDM_MODE             "usb_mode" // Leave this "usb" for compatibility
 #define CONFIG_OPL_HDD_MODE             "hdd_mode"

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -59,6 +59,7 @@ enum UI_ITEMS {
     CFG_UDPFSMODE,       // when UDPFS is selected: Files (udpfs_ioman filesystem) vs Image (udpfs_bd block/massN:)
     CFG_LASTPLAYED,
     CFG_FOLDERNAV,
+    CFG_RUMBLE,
     CFG_LBL_AUTOSTARTLAST,
     CFG_AUTOSTARTLAST,
     CFG_SELECTBUTTON,

--- a/include/opl.h
+++ b/include/opl.h
@@ -294,6 +294,7 @@ extern char gMMCEPrefix[32];
 
 extern int gRememberLastPlayed;
 extern int gEnableFolderNav; // opt-in: browse subdirectories inside a device's game list
+extern int gEnableRumble;    // opt-in: short pad rumble tap when the menu cursor moves (#172)
 
 // Last Played Auto Start
 extern int KeyPressedOnce;

--- a/include/pad.h
+++ b/include/pad.h
@@ -24,6 +24,13 @@ int startPads();
 int readPads();
 void unloadPads();
 
+// Menu rumble (#172), gated by gEnableRumble. padRumbleTap() arms a short tap on every capable pad and
+// never blocks -- safe to call from the GUI thread. padRumbleStopAll() force-stops every actuator and
+// MUST be called before anything that stops polling the pad (game launch / exit): closing the pad ports
+// does NOT clear the motors, so one left running keeps buzzing into the game.
+void padRumbleTap(void);
+void padRumbleStopAll(void);
+
 int getKey(int num);
 
 int getKeyOn(int num);

--- a/include/pad.h
+++ b/include/pad.h
@@ -24,11 +24,18 @@ int startPads();
 int readPads();
 void unloadPads();
 
-// Menu rumble (#172), gated by gEnableRumble. padRumbleTap() arms a short tap on every capable pad and
-// never blocks -- safe to call from the GUI thread. padRumbleStopAll() force-stops every actuator and
-// MUST be called before anything that stops polling the pad (game launch / exit): closing the pad ports
-// does NOT clear the motors, so one left running keeps buzzing into the game.
-void padRumbleTap(void);
+// Menu rumble (#172), gated by gEnableRumble. Tap/Bump arm a pulse on every capable pad and never
+// block -- safe to call from the GUI thread; they no-op when disabled or the pad can't rumble.
+void padRumbleTap(void);  // light tick: cursor moved
+void padRumbleBump(void); // firmer: confirm / cancel
+
+// Play out any in-flight pulse then stop. Call before anything that blocks the GUI thread for long,
+// since readPads() -- which ticks the decay -- stops running then; the launch path would otherwise turn
+// a 90ms bump into a multi-second buzz. Adds at most ~90ms.
+void padRumbleFlush(void);
+
+// Force-stop every actuator. MUST run before anything that stops polling the pad (game launch / exit):
+// closing the pad ports does NOT clear the motors, so one left running keeps buzzing into the game.
 void padRumbleStopAll(void);
 
 int getKey(int num);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -252,14 +252,6 @@ gui_strings:
   string: Write Operations
 - label: LASTPLAYED
   string: Remember Last Played Game
-- label: RUMBLE
-  string: Controller Vibration in Menus
-- label: HINT_RUMBLE
-  string: Short vibration when moving the cursor, confirming or going back -- needs a DualShock in analog mode
-- label: FOLDER_NAV
-  string: Browse Folders in Game List
-- label: HINT_FOLDER_NAV
-  string: Show subfolders of CD/DVD as browsable entries; select to open, cancel to go back
 - label: SELECTBUTTON
   string: Select Button
 - label: ERR_FRAGMENTED
@@ -1001,3 +993,11 @@ gui_strings:
   string: VCD Settings
 - label: FINANCIAL_SUPPORT
   string: Financial Support
+- label: FOLDER_NAV
+  string: Browse Folders in Game List
+- label: HINT_FOLDER_NAV
+  string: Show subfolders of CD/DVD as browsable entries; select to open, cancel to go back
+- label: RUMBLE
+  string: Controller Vibration in Menus
+- label: HINT_RUMBLE
+  string: Short vibration when moving the cursor, confirming or going back -- needs a DualShock in analog mode

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -255,7 +255,7 @@ gui_strings:
 - label: RUMBLE
   string: Controller Vibration in Menus
 - label: HINT_RUMBLE
-  string: Short vibration tap when the cursor moves -- needs a DualShock in analog mode
+  string: Short vibration when moving the cursor, confirming or going back -- needs a DualShock in analog mode
 - label: FOLDER_NAV
   string: Browse Folders in Game List
 - label: HINT_FOLDER_NAV

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -252,6 +252,10 @@ gui_strings:
   string: Write Operations
 - label: LASTPLAYED
   string: Remember Last Played Game
+- label: RUMBLE
+  string: Controller Vibration in Menus
+- label: HINT_RUMBLE
+  string: Short vibration tap when the cursor moves -- needs a DualShock in analog mode
 - label: FOLDER_NAV
   string: Browse Folders in Game List
 - label: HINT_FOLDER_NAV

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -203,6 +203,11 @@ struct UIItem diaConfig[] = {
     {UI_BOOL, CFG_FOLDERNAV, 1, 1, _STR_HINT_FOLDER_NAV, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_RUMBLE}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_RUMBLE, 1, 1, _STR_HINT_RUMBLE, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     {UI_BREAK},
     {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Prefix Paths", -1}}},
     {UI_SPLITTER},

--- a/src/gui.c
+++ b/src/gui.c
@@ -595,6 +595,7 @@ void guiShowConfig()
     diaSetInt(diaConfig, CFG_ENWRITEOP, gEnableWrite);
     diaSetInt(diaConfig, CFG_LASTPLAYED, gRememberLastPlayed);
     diaSetInt(diaConfig, CFG_FOLDERNAV, gEnableFolderNav);
+    diaSetInt(diaConfig, CFG_RUMBLE, gEnableRumble);
     diaSetInt(diaConfig, CFG_AUTOSTARTLAST, gAutoStartLastPlayed);
     diaSetVisible(diaConfig, CFG_AUTOSTARTLAST, gRememberLastPlayed);
     diaSetVisible(diaConfig, CFG_LBL_AUTOSTARTLAST, gRememberLastPlayed);
@@ -625,6 +626,7 @@ reshow_config:
         diaGetInt(diaConfig, CFG_ENWRITEOP, &gEnableWrite);
         diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
         diaGetInt(diaConfig, CFG_FOLDERNAV, &gEnableFolderNav);
+        diaGetInt(diaConfig, CFG_RUMBLE, &gEnableRumble);
         diaGetInt(diaConfig, CFG_AUTOSTARTLAST, &gAutoStartLastPlayed);
         diaGetString(diaConfig, CFG_BDMPREFIX, gBDMPrefix, sizeof(gBDMPrefix));
         diaGetString(diaConfig, CFG_ETHPREFIX, gETHPrefix, sizeof(gETHPrefix));

--- a/src/opl.c
+++ b/src/opl.c
@@ -3218,6 +3218,15 @@ int main(int argc, char *argv[])
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &deferredInit);
 
     guiIntroLoop();
+
+    // Menu rumble: "OPL is ready" tap. Armed HERE rather than off sfxPlay(SFX_BOOT) for two reasons.
+    // (1) Correctness: SFX_BOOT plays from inside guiIntroLoop(), whose loop never polls readPads(),
+    // so the decay countdown would be frozen for the whole intro -- seconds of buzz instead of a tap.
+    // Out here guiMainLoop() is about to start ticking it. (2) Meaning: this is the instant the menu
+    // is actually usable, which is what "ready" means to the user -- and it does not depend on the
+    // boot SOUND being enabled. No-op when rumble is off or the pad can't do it.
+    padRumbleBump();
+
     guiMainLoop();
 
     return 0;

--- a/src/opl.c
+++ b/src/opl.c
@@ -341,6 +341,14 @@ static void itemExecSelect(struct menu_item *curMenu)
                         ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
                     return;
                 }
+                // Menu rumble: play out the confirm bump and stop the motors BEFORE the launch prep.
+                // Everything below blocks the GUI thread -- the config read, guiShowGameID's frame hold,
+                // and all of itemLaunch (sbPrepare, VMC checks, cheats, fragment counting, and
+                // mmceSendGameID's card-switch wait) -- and readPads(), which ticks the decay, does not
+                // run during any of it. Without this the bump would buzz for the entire loading screen.
+                // Costs ~90ms at most, on a path that already takes seconds. No-op when rumble is off.
+                padRumbleFlush();
+
                 config_set_t *configSet = menuLoadConfigDirect();
                 // Flash the GameID barcode (Pixel FX/RetroGEM HDMI auto-profile) before handoff; this
                 // single menu chokepoint covers both the Neutrino and OPL-native cores. No-op when off.

--- a/src/opl.c
+++ b/src/opl.c
@@ -228,6 +228,7 @@ char gMMCEPrefix[32];
 char gETHPrefix[32];
 int gRememberLastPlayed;
 int gEnableFolderNav;
+int gEnableRumble;
 int KeyPressedOnce;
 int gAutoStartLastPlayed;
 int RemainSecs, DisableCron;
@@ -1622,6 +1623,7 @@ static void _loadConfig()
             configGetStrCopy(configOPL, CONFIG_OPL_ETH_PREFIX, gETHPrefix, sizeof(gETHPrefix));
             configGetInt(configOPL, CONFIG_OPL_REMEMBER_LAST, &gRememberLastPlayed);
             configGetInt(configOPL, CONFIG_OPL_FOLDER_NAV, &gEnableFolderNav);
+            configGetInt(configOPL, CONFIG_OPL_RUMBLE, &gEnableRumble);
             configGetInt(configOPL, CONFIG_OPL_AUTOSTART_LAST, &gAutoStartLastPlayed);
             configGetInt(configOPL, CONFIG_OPL_BDM_MODE, &gBDMStartMode);
             configGetInt(configOPL, CONFIG_OPL_HDD_MODE, &gHDDStartMode);
@@ -1959,6 +1961,7 @@ static void _saveConfig()
         configSetStr(configOPL, CONFIG_OPL_ETH_PREFIX, gETHPrefix);
         configSetInt(configOPL, CONFIG_OPL_REMEMBER_LAST, gRememberLastPlayed);
         configSetInt(configOPL, CONFIG_OPL_FOLDER_NAV, gEnableFolderNav);
+        configSetInt(configOPL, CONFIG_OPL_RUMBLE, gEnableRumble);
         configSetInt(configOPL, CONFIG_OPL_AUTOSTART_LAST, gAutoStartLastPlayed);
         configSetInt(configOPL, CONFIG_OPL_BDM_MODE, gBDMStartMode);
         configSetInt(configOPL, CONFIG_OPL_HDD_MODE, gHDDStartMode);
@@ -2582,6 +2585,13 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
 
+    /* Menu rumble (#172): kill the actuators FIRST, before anything below can block. Every launch and
+     * exit path funnels through here, and closing the pad ports later does NOT clear the motors -- so a
+     * tap still in flight would buzz on forever, straight into the game. This must stay at the TOP: the
+     * IO drain below can take up to LAUNCH_IO_DRAIN_TICKS (10s) on a slow or dying device, and the pad
+     * would grind through that entire loading screen if the stop lived down beside unloadPads(). */
+    padRumbleStopAll();
+
     /* Cut launch/exit latency by stopping queued art I/O before globally
      * blocking the I/O worker. This avoids waiting for stale cover requests
      * that are no longer needed once we are deinitializing. */
@@ -2732,6 +2742,7 @@ static void setDefaults(void)
     gEnableWrite = 1;
     gRememberLastPlayed = 0;
     gEnableFolderNav = 0; // opt-in; a flat library is byte-identical to before
+    gEnableRumble = 0;    // opt-in: nobody expects a menu to buzz, and these motors are 20+ years old
     gAutoStartLastPlayed = 9;
     gSelectButton = KEY_CROSS; // Default to Cross-select (western layout); swap_select_btn=0 restores Circle
     gMMCEPrefix[0] = '\0';

--- a/src/pad.c
+++ b/src/pad.c
@@ -153,6 +153,14 @@ static int initializePad(struct pad_data_t *pad)
 
     LOG("PAD initializing pad %d,%d\n", pad->port, pad->slot);
 
+    // Menu rumble state belongs to the CURRENT connection: a re-init (fresh pad, or the analog
+    // self-heal firing on a transient digital report) invalidates it. Clear it before the alignment
+    // below re-proves itself -- otherwise a pad unplugged mid-tap comes back with rumbleOn stuck at 1
+    // and padRumbleArm()'s "already on, don't re-send" guard would skip it forever.
+    pad->actAligned = 0;
+    pad->rumbleOn = 0;
+    pad->rumbleMsLeft = 0;
+
     // is there any device connected to that port?
     state = waitPadReady(pad);
     if (state == PAD_STATE_DISCONN) {
@@ -633,8 +641,18 @@ int readPads()
                 continue;
             pad->rumbleMsLeft = 0;
         }
-        if (pad->rumbleOn && padRumbleSendNative(pad, 0) == 1)
-            pad->rumbleOn = 0; // still on next frame if the IOP dropped it -- we simply retry then
+        if (!pad->rumbleOn)
+            continue;
+
+        // A pad that is gone (or mid re-init) will never accept the off -- and retrying would fire a
+        // BLOCKING RPC at it EVERY frame, forever. Just drop the state: freepad clears the latched
+        // actuator bytes itself on padPortOpen, so a reconnecting pad cannot come back still buzzing.
+        if (!isPadReadyState(pad->state)) {
+            pad->rumbleOn = 0;
+            continue;
+        }
+        if (padRumbleSendNative(pad, 0) == 1)
+            pad->rumbleOn = 0; // else retry next frame: the IOP briefly drops it outside TASK_UPDATE_PAD
     }
 
     for (i = 0; i < 16; ++i) {

--- a/src/pad.c
+++ b/src/pad.c
@@ -469,7 +469,9 @@ static int getKeyDelay(int id, int repeat)
 // menu's pad path otherwise issues none, so only ever send it on a CHANGE: ~2 RPCs per tap, none while
 // idle. Never per frame.
 
-#define RUMBLE_TAP_MS     50  // pulse length; long enough to feel, short enough not to blur into the next
+#define RUMBLE_TAP_MS     50  // cursor tick: long enough to feel, short enough not to blur into the next
+#define RUMBLE_BUMP_MS    90  // confirm/cancel: same engine, just held a little longer so a decision \
+                              // feels more definite than a scroll (the small engine has no intensity)
 #define RUMBLE_MIN_GAP_MS 120 // floor between taps: key-repeat is ~100ms, and an ERM never fully spins \
                               // down, so an unthrottled tap-per-tick becomes a continuous grind
 static u32 rumbleLastMs = 0;
@@ -492,9 +494,7 @@ static int padRumbleSendNative(struct pad_data_t *pad, int on)
     return padSetActDirect(pad->port, pad->slot, act);
 }
 
-/** Arm a short rumble tap on every capable pad. Safe to call from the GUI thread; never blocks and
- *  silently no-ops when disabled, rate-limited, or the pad can't rumble. */
-void padRumbleTap(void)
+static void padRumbleArm(int durationMs)
 {
     int i;
 
@@ -513,7 +513,7 @@ void padRumbleTap(void)
         // Arm the countdown for EVERY pad: a ds34 (DS3/4/5 over USB/BT) pad is not a native PS2 pad --
         // it never goes through padInfoAct/padSetActAlign -- and instead reads this straight off
         // readPad()'s existing every-poll re-send. Harmless on a pad that ends up rumbling nothing.
-        pad->rumbleMsLeft = RUMBLE_TAP_MS;
+        pad->rumbleMsLeft = durationMs;
 
         // A native PS2 pad additionally needs its actuator driven, and only if it genuinely can.
         // Skip when already on: the motor is running, so re-sending is a pointless blocking RPC.
@@ -522,6 +522,48 @@ void padRumbleTap(void)
         if (padRumbleSendNative(pad, 1) == 1)
             pad->rumbleOn = 1; // dropped (pad mid re-init)? skip this tap rather than stall the GUI
     }
+}
+
+/** Light tick for a cursor move. Safe from the GUI thread; never blocks and silently no-ops when
+ *  disabled, rate-limited, or the pad can't rumble. */
+void padRumbleTap(void)
+{
+    padRumbleArm(RUMBLE_TAP_MS);
+}
+
+/** Slightly firmer bump for a confirm / cancel -- a decision should feel more definite than a scroll.
+ *  On the LAUNCH edge the caller must follow this with padRumbleFlush(); see there for why. */
+void padRumbleBump(void)
+{
+    padRumbleArm(RUMBLE_BUMP_MS);
+}
+
+/** Play out any in-flight pulse, then stop the motors.
+ *
+ *  Call this before anything that blocks the GUI thread for a long time, because readPads() -- the ONLY
+ *  thing that ticks the decay countdown -- stops running while it does. The launch path is the case that
+ *  matters: between the confirm and deinitEx()'s stop sit menuLoadConfigDirect(), guiShowGameID()'s
+ *  frame hold, and the whole of itemLaunch (sbPrepare, VMC superblock checks, cheats, fragment counting,
+ *  and mmceSendGameID's card-switch wait, which alone can take seconds). Without this the confirm bump
+ *  would run for that entire window -- a multi-second buzz instead of a 90ms tap.
+ *
+ *  Bounded by RUMBLE_BUMP_MS, i.e. at worst it adds ~90ms to a launch that already takes seconds. */
+void padRumbleFlush(void)
+{
+    int i, waitMs = 0;
+
+    for (i = 0; i < pad_count; ++i) {
+        if (pad_data[i].rumbleMsLeft > waitMs)
+            waitMs = pad_data[i].rumbleMsLeft;
+    }
+
+    if (waitMs > 0) {
+        if (waitMs > RUMBLE_BUMP_MS)
+            waitMs = RUMBLE_BUMP_MS; // belt: never stall the launch on a bad counter
+        DelayThread(waitMs * 1000);  // ms -> us
+    }
+
+    padRumbleStopAll();
 }
 
 /** Stop every actuator NOW and make sure it sticks. Call before anything that stops polling the pad

--- a/src/pad.c
+++ b/src/pad.c
@@ -42,6 +42,13 @@ struct pad_data_t
     int actuators;
     int analogCapable; // -1 unknown/not ready, 0 digital-only, 1 DualShock-capable
     int analogRetryDelay;
+
+    // Menu rumble (#172). actuators != 0 only says the pad HAS motors -- padSetActAlign can still fail
+    // or be skipped by initializePad's early returns, so latch the confirmed alignment separately and
+    // require it before ever driving an actuator.
+    unsigned char actAligned;
+    unsigned char rumbleOn; // 1 = an "on" was sent that still owes its matching "off"
+    int rumbleMsLeft;       // ms remaining; ticked down in readPads() (see the ms-vs-frames note there)
 };
 
 // Pad commands are asynchronous. Keep every wait bounded so a transient SIO2/pad error cannot hang the
@@ -269,8 +276,12 @@ static int initializePad(struct pad_data_t *pad)
             return PAD_INIT_OK;
         tmp = padSetActAlign(pad->port, pad->slot, pad->actAlign);
         LOG("PAD padSetActAlign: %d\n", tmp);
-        if (tmp == 1 && !waitPadRequestComplete(pad))
-            LOG("PAD padSetActAlign request failed\n");
+        if (tmp == 1) {
+            if (waitPadRequestComplete(pad))
+                pad->actAligned = 1; // accepted AND observed complete -- the only gate rumble trusts
+            else
+                LOG("PAD padSetActAlign request failed\n");
+        }
     } else {
         LOG("PAD Did not find any actuators.\n");
     }
@@ -383,9 +394,16 @@ static int readPad(struct pad_data_t *pad)
     }
 
 #ifdef PADEMU
+    // Menu rumble on a ds34 pad rides this existing every-poll re-send, so it needs no RPC discipline
+    // of its own and stops for free when the countdown expires. Params are (port, lrum, rrum) where
+    // lrum = LEFT = heavy weight and rrum = RIGHT = light -- the INVERSE order of libpad's actAlign
+    // (small first). Use the LIGHT engine to match the native small-engine tap; a DS3's light motor is
+    // on/off in hardware, so drive it full rather than with a graded value.
+    u8 rrum = (gEnableRumble && pad->rumbleMsLeft > 0) ? 0xFF : 0;
+
     if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING) {
         ret = ds34bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34bt_set_rumble(pad->port, 0, 0);
+        ds34bt_set_rumble(pad->port, 0, rrum);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -394,7 +412,7 @@ static int readPad(struct pad_data_t *pad)
 
     if (ds34usb_get_status(pad->port) & DS34USB_STATE_RUNNING) {
         ret = ds34usb_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34usb_set_rumble(pad->port, 0, 0);
+        ds34usb_set_rumble(pad->port, 0, rrum);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -435,6 +453,113 @@ static int getKeyDelay(int id, int repeat)
     return delay;
 }
 
+// ---- Menu rumble (#172) ---------------------------------------------------------------------------
+//
+// A short tap on the pad when the cursor moves. Everything expensive was already in place: the pad is
+// locked into DualShock mode and padSetActAlign() has enabled both engines -- we simply never fired
+// padSetActDirect().
+//
+// Engine choice: the SMALL engine only (actAlign[0], on/off). The big engine (actAlign[1], 0..255) is
+// an offset-weight ERM -- it needs ~50-80ms just to start turning and then coasts well past a menu
+// tick, so it is the wrong tool for a "click".
+//
+// Cost: padSetActDirect adds ZERO SIO2 traffic -- it is a SIF RPC that latches 6 bytes on the IOP,
+// which freepad folds into the READ_DATA poll it already sends every vblank (the SIO2 frame length
+// comes from the pad's mode, not the actuator payload). It IS a BLOCKING EE->IOP RPC though, and the
+// menu's pad path otherwise issues none, so only ever send it on a CHANGE: ~2 RPCs per tap, none while
+// idle. Never per frame.
+
+#define RUMBLE_TAP_MS     50  // pulse length; long enough to feel, short enough not to blur into the next
+#define RUMBLE_MIN_GAP_MS 120 // floor between taps: key-repeat is ~100ms, and an ERM never fully spins \
+                              // down, so an unthrottled tap-per-tick becomes a continuous grind
+static u32 rumbleLastMs = 0;
+
+static int padRumbleCapable(struct pad_data_t *pad)
+{
+    // analogCapable is deliberately tri-state (PR #151): -1 = not yet known. Only 1 may rumble --
+    // never treat "unknown" as a yes. actAligned proves padSetActAlign actually landed.
+    return (pad->analogCapable == 1) && (pad->actuators > 0) && pad->actAligned && isPadReadyState(pad->state);
+}
+
+// Drive a native PS2 pad's actuators. Returns 1 when the IOP accepted it. NOTE: the IOP silently
+// DROPS this (returns 0) unless it is in TASK_UPDATE_PAD -- e.g. while initializePad's mode/align
+// threads run -- so a caller that must not lose the command has to retry (see padRumbleStopAll).
+static int padRumbleSendNative(struct pad_data_t *pad, int on)
+{
+    char act[6] = {0, 0, 0, 0, 0, 0};
+    act[0] = on ? 1 : 0; // small engine (on/off)
+    act[1] = 0;          // big engine stays parked
+    return padSetActDirect(pad->port, pad->slot, act);
+}
+
+/** Arm a short rumble tap on every capable pad. Safe to call from the GUI thread; never blocks and
+ *  silently no-ops when disabled, rate-limited, or the pad can't rumble. */
+void padRumbleTap(void)
+{
+    int i;
+
+    if (!gEnableRumble)
+        return;
+
+    // Rate limit on the SAME clock readPads() ticks with, so held-direction key-repeat can't grind.
+    u32 now = cpu_ticks() / CLOCKS_PER_MILISEC;
+    if (rumbleLastMs != 0 && (now - rumbleLastMs) < RUMBLE_MIN_GAP_MS)
+        return;
+    rumbleLastMs = now;
+
+    for (i = 0; i < pad_count; ++i) {
+        struct pad_data_t *pad = &pad_data[i];
+
+        // Arm the countdown for EVERY pad: a ds34 (DS3/4/5 over USB/BT) pad is not a native PS2 pad --
+        // it never goes through padInfoAct/padSetActAlign -- and instead reads this straight off
+        // readPad()'s existing every-poll re-send. Harmless on a pad that ends up rumbling nothing.
+        pad->rumbleMsLeft = RUMBLE_TAP_MS;
+
+        // A native PS2 pad additionally needs its actuator driven, and only if it genuinely can.
+        // Skip when already on: the motor is running, so re-sending is a pointless blocking RPC.
+        if (!padRumbleCapable(pad) || pad->rumbleOn)
+            continue;
+        if (padRumbleSendNative(pad, 1) == 1)
+            pad->rumbleOn = 1; // dropped (pad mid re-init)? skip this tap rather than stall the GUI
+    }
+}
+
+/** Stop every actuator NOW and make sure it sticks. Call before anything that stops polling the pad
+ *  (game launch / exit): padPortClose and padEnd do NOT clear actuators, so a motor left on keeps
+ *  spinning straight into the game. */
+void padRumbleStopAll(void)
+{
+    int i, polls;
+
+    for (i = 0; i < pad_count; ++i) {
+        struct pad_data_t *pad = &pad_data[i];
+
+#ifdef PADEMU
+        // ds34 pads are re-sent their rumble state every poll, so zeroing the state is enough -- but
+        // once polling stops nothing re-sends, so push an explicit off too.
+        ds34bt_set_rumble(pad->port, 0, 0);
+        ds34usb_set_rumble(pad->port, 0, 0);
+#endif
+        pad->rumbleMsLeft = 0;
+
+        if (!pad->rumbleOn)
+            continue;
+
+        // The IOP drops padSetActDirect unless it is in TASK_UPDATE_PAD, and the latched ON value
+        // survives to be re-asserted on the next poll -- so a fire-and-forget off can be silently
+        // lost. Retry on the same bounded budget waitPadReady uses. (padSetActDirect never raises
+        // PAD_RSTAT_BUSY, so there is no request to wait on -- only the return value tells us.)
+        for (polls = 0; polls < PAD_WAIT_POLLS; polls++) {
+            if (padRumbleSendNative(pad, 0) == 1)
+                break;
+            DelayThread(PAD_WAIT_POLL_US);
+        }
+        if (polls == PAD_WAIT_POLLS)
+            LOG("PAD rumble off was dropped for pad %d,%d\n", pad->port, pad->slot);
+        pad->rumbleOn = 0;
+    }
+}
+
 /** polling method. Call every frame. */
 int readPads()
 {
@@ -451,6 +576,23 @@ int readPads()
 
     for (i = 0; i < pad_count; ++i) {
         rslt |= readPad(&pad_data[i]);
+    }
+
+    // Expire any rumble tap. Deliberately ms-based off time_since_last rather than a frame counter:
+    // a few call sites poll readPads() twice within one frame to flush input, which would make a
+    // frame counter double-decrement and cut the tap short. The ms delta is immune (the second call
+    // sees ~0ms). One RPC to switch the motor off, then never again until the next tap.
+    for (i = 0; i < pad_count; ++i) {
+        struct pad_data_t *pad = &pad_data[i];
+
+        if (pad->rumbleMsLeft > 0) {
+            pad->rumbleMsLeft -= (int)time_since_last;
+            if (pad->rumbleMsLeft > 0)
+                continue;
+            pad->rumbleMsLeft = 0;
+        }
+        if (pad->rumbleOn && padRumbleSendNative(pad, 0) == 1)
+            pad->rumbleOn = 0; // still on next frame if the IOP dropped it -- we simply retry then
     }
 
     for (i = 0; i < 16; ++i) {
@@ -572,6 +714,11 @@ static void unloadPad(struct pad_data_t *pad)
 void unloadPads()
 {
     int i;
+
+    // Backstop before ANY port closes: padPortClose/padEnd do NOT clear the actuators -- polling just
+    // stops and the pad keeps whatever it was last told, i.e. it buzzes forever. The primary stop is at
+    // deinitEx() entry; this covers the callers that unload pads without going through it.
+    padRumbleStopAll();
 
     for (i = 0; i < pad_count; ++i)
         unloadPad(&pad_data[i]);

--- a/src/sound.c
+++ b/src/sound.c
@@ -260,16 +260,19 @@ void sfxPlay(int id)
 {
     int channel;
 
-    // Menu rumble (#172): mirror the navigation tick on the pad. Deliberately ABOVE both gates below --
-    // rumble is haptic feedback, not sound, so it must survive a user who plays with SFX off (or a
-    // build where audsrv never came up). Every cursor move in the whole GUI already funnels through
-    // sfxPlay(), so this one line covers them all with no new call sites.
+    // Menu rumble (#172): mirror the GUI's own feedback on the pad. Deliberately ABOVE both gates
+    // below -- rumble is haptic feedback, not sound, so it must survive a user who plays with SFX off
+    // (or a build where audsrv never came up). Every cursor move / confirm / cancel in the whole GUI
+    // already funnels through sfxPlay(), so these lines cover them all with no new call sites.
+    // Both arms rate-limit themselves and never block.
     //
-    // SFX_CURSOR ONLY, on purpose: SFX_CONFIRM is also the LAUNCH edge, and the tap's decay clock is
-    // ticked by readPads(), which stops running during the launch handoff -- a tap armed there would
-    // buzz for the whole loading screen instead of 50ms. padRumbleTap() rate-limits itself.
+    // NOTE: SFX_CONFIRM is also the LAUNCH edge, and the pulse's decay clock is ticked by readPads(),
+    // which stops running during the launch handoff -- so itemExecSelect() calls padRumbleFlush()
+    // before that blocking work, or this bump would run for the whole loading screen. See pad.c.
     if (id == SFX_CURSOR)
         padRumbleTap();
+    else if (id == SFX_CONFIRM || id == SFX_CANCEL)
+        padRumbleBump();
 
     if (!audio_initialized) {
         LOG("SFX: %s: ERROR: not initialized!\n", __FUNCTION__);

--- a/src/sound.c
+++ b/src/sound.c
@@ -11,6 +11,7 @@
 #include "include/opl.h"
 #include "include/ioman.h"
 #include "include/themes.h"
+#include "include/pad.h" // padRumbleTap -- menu rumble mirrors the cursor tick (#172)
 
 // Silence unused variable warnings from vorbisfile.h
 static ov_callbacks OV_CALLBACKS_NOCLOSE __attribute__((unused));
@@ -258,6 +259,17 @@ int sfxGetSoundDuration(int id)
 void sfxPlay(int id)
 {
     int channel;
+
+    // Menu rumble (#172): mirror the navigation tick on the pad. Deliberately ABOVE both gates below --
+    // rumble is haptic feedback, not sound, so it must survive a user who plays with SFX off (or a
+    // build where audsrv never came up). Every cursor move in the whole GUI already funnels through
+    // sfxPlay(), so this one line covers them all with no new call sites.
+    //
+    // SFX_CURSOR ONLY, on purpose: SFX_CONFIRM is also the LAUNCH edge, and the tap's decay clock is
+    // ticked by readPads(), which stops running during the launch handoff -- a tap armed there would
+    // buzz for the whole loading screen instead of 50ms. padRumbleTap() rate-limits itself.
+    if (id == SFX_CURSOR)
+        padRumbleTap();
 
     if (!audio_initialized) {
         LOG("SFX: %s: ERROR: not initialized!\n", __FUNCTION__);

--- a/src/sound.c
+++ b/src/sound.c
@@ -271,8 +271,17 @@ void sfxPlay(int id)
     // before that blocking work, or this bump would run for the whole loading screen. See pad.c.
     if (id == SFX_CURSOR)
         padRumbleTap();
-    else if (id == SFX_CONFIRM || id == SFX_CANCEL)
+    else if (id == SFX_CONFIRM || id == SFX_CANCEL || id == SFX_MESSAGE)
         padRumbleBump();
+    // SFX_MESSAGE (notifications / message boxes) is safe to arm from here: every one of its sites
+    // renders from a loop that polls readPads() -- the main loop for guiShowNotifications, and
+    // guiMsgBox's own modal loop -- so the pulse decays normally.
+    //
+    // SFX_BOOT is deliberately NOT armed here. It plays from inside guiIntroLoop(), whose loop never
+    // polls readPads(), so the decay would be frozen for the whole intro (it runs for the length of
+    // the boot jingle) -- seconds of buzz. The "ready" tap is armed in main() right after the intro
+    // returns instead, which is the moment the user actually cares about and where the main loop is
+    // about to start ticking the decay.
 
     if (!audio_initialized) {
         LOG("SFX: %s: ERROR: not initialized!\n", __FUNCTION__);


### PR DESCRIPTION
Implements @Blade1984000's request in #172 — haptic feedback when moving through the main menu / game list.

## It was already 90% built

`initializePad()` already locks the pad into `PAD_MMODE_DUALSHOCK`, queries `padInfoAct()`, and calls `padSetActAlign()` with **both engines enabled**. That's the whole fiddly PS2 rumble ritual — we just never called `padSetActDirect()`. This mostly pulls the trigger.

**What you get** (all **default OFF**, `gEnableRumble` / `enable_rumble`, General Settings):

| Action | Pulse |
|---|---|
| Cursor move (list scroll, device tabs) | 50ms light tick |
| Confirm / cancel | 90ms — a touch firmer, so a decision feels more definite than a scroll |

Same small engine for both (it has no intensity control) — just held longer.

## Design

- **One hook, no new call sites.** Every cursor move / confirm / cancel in the GUI already funnels through `sfxPlay()`, so the trigger is two lines there. It sits **above** the `audio_initialized` and `gEnableSFX` gates — rumble is haptics, not sound, so it must still work for someone playing with SFX off.
- **Small engine only.** The big engine is an offset-weight ERM: ~50-80ms just to start turning, then it coasts well past a menu tick. Wrong tool for a click.
- **Milliseconds, not frames.** A few sites poll `readPads()` twice in one frame to flush input; a frame counter would double-decrement and cut the pulse short. `readPads()` already computes a ms delta — the pulse rides that.
- **Rate limited (120ms floor).** Key-repeat is ~100ms and an ERM never fully spins down, so an unthrottled tap-per-tick becomes a continuous grind — plus real wear on 20-year-old motors nobody can replace.
- **RPC only on change.** `padSetActDirect` is a *blocking* EE→IOP SIF RPC, and the menu's pad path otherwise issues none — so it's sent twice per pulse and never while idle.

### The launch edge (why confirm needed care)

`SFX_CONFIRM` is also the **launch edge**, and `readPads()` — the only thing that ticks the decay — doesn't run during the handoff. Between the confirm and `deinitEx`'s stop sit `menuLoadConfigDirect()`, `guiShowGameID()`'s frame hold (a bare `guiStartFrame`/`guiEndFrame` loop with no pad poll), and all of `itemLaunch`: `sbPrepare`, VMC superblock checks, cheats, fragment counting, and `mmceSendGameID`'s card-switch wait — **which alone can take ~3s**. A bump armed there would buzz for the whole loading screen.

So `itemExecSelect()` calls the new **`padRumbleFlush()`** right before that blocking work: it plays out the pulse and stops the motors. The launch gets a real 90ms bump, then silence. Bounded by `RUMBLE_BUMP_MS` — at most ~90ms added to a path that already takes seconds. Non-launch confirms (favourite toggle, view toggle, dialogs) need none of it; the GUI loop keeps running so they decay normally.

### On SIO2 / #120

I went in assuming per-tick rumble would add SIO2 traffic and could aggravate the MMCE/MX4SIO contention behind #120. **Traced it in the PS2SDK source and that's wrong:** `padSetActDirect` never touches SIO2 — it latches 6 bytes on the IOP, which freepad folds into the `READ_DATA` poll it *already* sends every vblank, and the SIO2 frame length comes from the pad's **mode**, not the actuator payload. Same bus time whether rumble is on or off. No MMCE gating added — that would've been cargo-cult mitigation for a mechanism that doesn't exist. The *real* new cost is the blocking RPC, handled by only-on-change.

## Safety — a motor left on keeps spinning into the game

- `padPortClose`/`padEnd` do **not** clear actuators; polling just stops and the pad holds its last commanded state. `padRumbleStopAll()` runs at **`deinitEx()` entry** (every launch/exit funnels through it) — at the **top**, because the IO drain below can take up to **10s** on a dying device and the pad would grind through that whole loading screen if the stop lived down by `unloadPads()`. `unloadPads()` gets a second one for the callers that bypass `deinitEx`.
- **The stop is a bounded retry, not fire-and-forget.** The IOP silently *drops* `padSetActDirect` unless it's in `TASK_UPDATE_PAD` — e.g. while the analog self-heal re-init runs, which happens routinely — while the latched ON value survives and is re-asserted on the next poll. Fire-and-forget would ship as an intermittent stuck-rumble.
- **New `actAligned` flag.** `actuators != 0` only proves the pad *has* motors; `padSetActAlign` can still fail or be skipped by an early return. Rumble now requires alignment actually confirmed, plus `analogCapable == 1` — never `-1` "unknown" (the #151 tri-state lesson) — and a ready pad state.
- **ds34 (DS3/4/5)** pads ride `readPad()`'s existing every-poll re-send, so they need no RPC discipline and stop for free on expiry. Their param order is the **inverse** of libpad's (`lrum`=heavy first vs `actAlign` small first) — noted at the conversion. All ds34 calls stay inside `#ifdef PADEMU`.

## Testing

- Builds green with **PADEMU=0 and PADEMU=1**; clang-format clean.
- **HW-UNVALIDATED** — an emulator tells you nothing about real actuators. Default OFF, so the risk is opt-in. Won't do anything on a digital-only/clone pad (graceful no-op by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)