### PR TITLE
fix(pad): never issue a libpad RPC during boot + rumble HUD counters (#172)

### DIFF
--- a/include/pad.h
+++ b/include/pad.h
@@ -26,6 +26,12 @@ void unloadPads();
 
 // Menu rumble (#172), gated by gEnableRumble. Tap/Bump arm a pulse on every capable pad and never
 // block -- safe to call from the GUI thread; they no-op when disabled or the pad can't rumble.
+// Rumble is INERT until this is called (once, from main(), when the boot is over and guiMainLoop is
+// about to start polling pads). Boot-time libpad RPCs raced the IO worker's IOP module loads and hung
+// the boot (#172) -- guiIntroLoop runs handleInput() against frozen paddata, so a button held at
+// power-on made sfxPlay fire every frame. See the long note in pad.c.
+void padRumbleActivate(void);
+
 void padRumbleTap(void);  // light tick: cursor moved
 void padRumbleBump(void); // firmer: confirm / cancel
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -2218,6 +2218,13 @@ static void guiDrawOverlays()
                  gDiag.padModes, gDiag.padMode0, gDiag.padMode1, gDiag.padAnalogCapable,
                  gDiag.padSelfHeal, gDiag.padUnsupported, gDiag.padSetMainModeOk, gDiag.padReqTimeout);
         fntRenderString(gTheme->fonts[0], 0, screenHeight - 40, ALIGN_NONE, 0, 0, diag, GS_SETREG_RGBA(255, 255, 0, 128));
+        // #172 rumble sub-line (see include/diag.h). Splits "we never asked the motor" (RA/RS 0) from
+        // "we asked and it ignored us" (RS climbing, pad still) -- the one thing source reading cannot
+        // tell us, and the reason this ships instead of another blind fix.
+        snprintf(diag, sizeof(diag), "RUM AN:%d AK:%d RA:%u RS:%u RD:%u",
+                 gDiag.padActuators, gDiag.padActAligned, gDiag.padRumbleArmed,
+                 gDiag.padRumbleSent, gDiag.padRumbleDropped);
+        fntRenderString(gTheme->fonts[0], 0, screenHeight - 56, ALIGN_NONE, 0, 0, diag, GS_SETREG_RGBA(255, 255, 0, 128));
     }
 }
 

--- a/src/include/diag.h
+++ b/src/include/diag.h
@@ -69,6 +69,24 @@ typedef struct
     volatile unsigned int padUnsupported;
     volatile unsigned int padSetMainModeOk;
     volatile unsigned int padReqTimeout;
+    // RUMBLE sub-line (#172 "no vibration" on HW, 2026-07-15). Rumble is invisible from here -- these
+    // split "we never asked" from "we asked and the motor ignored us", which no amount of source
+    // reading can. Read with Debug ON + Vibration ON while moving the cursor:
+    //   AN  - actuators reported by padInfoAct (0 = the pad claims no motors -> nothing we can do).
+    //   AK  - actAligned: padSetActAlign accepted AND observed complete (0 = alignment never landed,
+    //         so padRumbleCapable() gates every tap out and RS stays 0).
+    //   RS  - padSetActDirect calls the IOP ACCEPTED (returned 1). Climbing while the pad stays still
+    //         = the command lands and the ENGINE/duration is wrong, NOT our gating.
+    //   RD  - padSetActDirect calls DROPPED (returned != 1; the IOP discards them outside
+    //         TASK_UPDATE_PAD, e.g. during an initializePad re-init).
+    //   RA  - taps ARMED by sfxPlay (padRumbleArm past gEnableRumble + the rate limit). RA:0 = the
+    //         setting is off or the hook never fired; RA climbing with RS:0 = padRumbleCapable() is
+    //         the blocker -- read AN/AK/AC to see which gate.
+    volatile int padActuators;
+    volatile int padActAligned;
+    volatile unsigned int padRumbleSent;
+    volatile unsigned int padRumbleDropped;
+    volatile unsigned int padRumbleArmed;
 } opl_diag_t;
 
 extern opl_diag_t gDiag;

--- a/src/opl.c
+++ b/src/opl.c
@@ -3219,6 +3219,13 @@ int main(int argc, char *argv[])
 
     guiIntroLoop();
 
+    // Menu rumble goes live ONLY now: the boot is done and guiMainLoop below starts polling pads.
+    // Before this point guiIntroLoop runs handleInput() against a FROZEN paddata snapshot, so a button
+    // held at power-on fires sfxPlay every frame -- which was a harmless no-op until rumble hooked
+    // above sfxPlay's audio gate and turned it into blocking libpad RPCs racing the IO worker's IOP
+    // module loads (intermittent boot hang at "Loading USB storage driver...", #172).
+    padRumbleActivate();
+
     // Menu rumble: "OPL is ready" tap. Armed HERE rather than off sfxPlay(SFX_BOOT) for two reasons.
     // (1) Correctness: SFX_BOOT plays from inside guiIntroLoop(), whose loop never polls readPads(),
     // so the decay countdown would be frozen for the whole intro -- seconds of buzz instead of a tap.

--- a/src/pad.c
+++ b/src/pad.c
@@ -271,6 +271,7 @@ static int initializePad(struct pad_data_t *pad)
         return PAD_INIT_OK; // analog mode is restored; pressure/rumble setup can wait for reconnect
     pad->actuators = padInfoAct(pad->port, pad->slot, -1, 0);
     LOG("PAD # of actuators: %d\n", pad->actuators);
+    gDiag.padActuators = pad->actuators; // #172 diag: AN (0 = the pad claims no motors)
 
     if (pad->actuators != 0) {
         pad->actAlign[0] = 0; // Enable small engine
@@ -290,6 +291,7 @@ static int initializePad(struct pad_data_t *pad)
             else
                 LOG("PAD padSetActAlign request failed\n");
         }
+        gDiag.padActAligned = pad->actAligned; // #172 diag: AK (0 = alignment never landed -> no rumble)
     } else {
         LOG("PAD Did not find any actuators.\n");
     }
@@ -477,6 +479,29 @@ static int getKeyDelay(int id, int repeat)
 // menu's pad path otherwise issues none, so only ever send it on a CHANGE: ~2 RPCs per tap, none while
 // idle. Never per frame.
 
+// Rumble stays INERT until the GUI main loop is live (padRumbleActivate, called from main()).
+//
+// WHY THIS GATE EXISTS -- it fixes a real boot hang (#172), do not remove it:
+// guiIntroLoop() calls screenHandler->handleInput() every frame but NEVER calls readPads(). paddata is
+// therefore frozen on the single pre-intro read (opl.c, before the intro) and oldpaddata is still 0
+// from BSS, so getKeyOn() -- (paddata & key) && !(oldpaddata & key) -- reports ANY button held at
+// power-on as newly-pressed on EVERY intro frame, and menuHandleInputMenu fires sfxPlay(SFX_CURSOR)
+// continuously for the whole boot.
+// That was harmless for years because sfxPlay early-returns on !audio_initialized and audsrv is not up
+// until deferredAudioInit (late in the IO FIFO) -- boot-time sfxPlay was a NO-OP. The rumble hook sits
+// ABOVE that gate (deliberately: haptics must survive SFX being off), which turned that dormant path
+// into a BLOCKING EE->IOP libpad RPC every RUMBLE_MIN_GAP_MS for the entire boot, concurrent with the
+// IO worker's SifLoadModuleBuffer of USBMASS_BD/dev9/smap -> intermittent hang at "Loading USB storage
+// driver...". Holding a button during boot made it MUCH more likely -- which is why the reporter's
+// "hold START" attempt made things worse rather than better.
+static int rumbleLive = 0;
+
+// Called once from main() when the boot is done and guiMainLoop is about to start polling pads.
+void padRumbleActivate(void)
+{
+    rumbleLive = 1;
+}
+
 #define RUMBLE_TAP_MS     50  // cursor tick: long enough to feel, short enough not to blur into the next
 #define RUMBLE_BUMP_MS    90  // confirm/cancel: same engine, just held a little longer so a decision \
                               // feels more definite than a scroll (the small engine has no intensity)
@@ -499,14 +524,23 @@ static int padRumbleSendNative(struct pad_data_t *pad, int on)
     char act[6] = {0, 0, 0, 0, 0, 0};
     act[0] = on ? 1 : 0; // small engine (on/off)
     act[1] = 0;          // big engine stays parked
-    return padSetActDirect(pad->port, pad->slot, act);
+    int r = padSetActDirect(pad->port, pad->slot, act);
+    // #172 diag: RS climbing while the pad stays still means the IOP took the command and the
+    // ENGINE/duration is wrong -- not our gating. RD counts IOP drops (outside TASK_UPDATE_PAD).
+    if (r == 1)
+        gDiag.padRumbleSent++;
+    else
+        gDiag.padRumbleDropped++;
+    return r;
 }
 
 static void padRumbleArm(int durationMs)
 {
     int i;
 
-    if (!gEnableRumble)
+    // rumbleLive: never issue a libpad RPC before the main loop is polling pads -- see the boot-hang
+    // note at the top of this section. This MUST stay ahead of the gEnableRumble check.
+    if (!rumbleLive || !gEnableRumble)
         return;
 
     // Rate limit on the SAME clock readPads() ticks with, so held-direction key-repeat can't grind.
@@ -514,6 +548,8 @@ static void padRumbleArm(int durationMs)
     if (rumbleLastMs != 0 && (now - rumbleLastMs) < RUMBLE_MIN_GAP_MS)
         return;
     rumbleLastMs = now;
+
+    gDiag.padRumbleArmed++; // #172 diag: RA past gEnableRumble + the rate limit (see include/diag.h)
 
     for (i = 0; i < pad_count; ++i) {
         struct pad_data_t *pad = &pad_data[i];

--- a/src/pad.c
+++ b/src/pad.c
@@ -160,6 +160,12 @@ static int initializePad(struct pad_data_t *pad)
     pad->actAligned = 0;
     pad->rumbleOn = 0;
     pad->rumbleMsLeft = 0;
+    // Clear the HUD mirrors HERE too, not just where they are set below. Every early return between
+    // this point and the actuator block would otherwise leave AN/AK showing a PREVIOUS pad's values,
+    // and the actuators==0 branch never touches AK at all -- so a stale AK:1 could survive onto a pad
+    // that was never aligned. A diagnostic that lies is worse than no diagnostic (Gemini review, #176).
+    gDiag.padActuators = 0;
+    gDiag.padActAligned = 0;
 
     // is there any device connected to that port?
     state = waitPadReady(pad);


### PR DESCRIPTION
From @Blade1984000's hardware report in #172: RiptOPL froze at varying points during startup (**"Loading USB storage driver..."**), and rumble doesn't fire at all.

## The boot hang — this one is mine

`guiIntroLoop()` calls `handleInput()` every frame but **never calls `readPads()`**. So `paddata` is frozen on the single pre-intro read, and `oldpaddata` is still 0 from BSS. That makes `getKeyOn()` — `(paddata & key) && !(oldpaddata & key)` — return **true on every intro frame** for any button held at power-on, so `menuHandleInputMenu` fires `sfxPlay(SFX_CURSOR)` continuously for the whole boot.

**That was harmless for years:** `sfxPlay` early-returns on `!audio_initialized`, and audsrv isn't up until `deferredAudioInit` (late in the IO FIFO) — boot-time `sfxPlay` was a **no-op**. #174's rumble hook sits **above** that gate (deliberately, so haptics survive SFX being off), which turned that dormant path into a **blocking EE→IOP libpad RPC every 120ms for the entire boot**, concurrent with the IO worker's `SifLoadModuleBuffer` of USBMASS_BD/dev9/smap.

It also explains the detail that never fit: **"pressing Start during boot doesn't help"** — *holding a button is the trigger*. Every workaround he tried made it worse.

**Fix:** rumble is inert until `padRumbleActivate()`, called once from `main()` after `guiIntroLoop()` returns and before `guiMainLoop()` starts polling pads. Structurally impossible to fire a libpad RPC during boot.

### Honest scope — this is not proven to be *his* freeze

It does **not** explain his **first** freeze, which happened before he held any button. And **"MAX suddenly worked"** points at an intermittent race independent of config, which also means the config-deletion "fix" proves nothing. The known **no-timeout device-init wedge** (`bdmLoadBlockDeviceModules` → USBMASS_BD attach; nothing on that chain has a timeout; single FIFO IO worker) is still a live, separate candidate.

This fix stands on its own regardless: **firing blocking RPCs at the IOP while it's loading modules is indefensible.**

## No vibration — instrument, don't guess

He's confirmed he enabled it in General Settings and it still doesn't buzz. I can't find it by reading (the `sfxPlay` hook is correctly above both gates; the `actAligned` latch is correct), so this ships a **`RUM`** sub-line on the debug HUD (`gEnableDebug`) beside the existing `PAD` line:

| Field | Meaning |
|---|---|
| `AN` | actuators from `padInfoAct` (0 = pad claims no motors) |
| `AK` | `actAligned` — `padSetActAlign` accepted **and** observed complete |
| `RA` | taps **armed** (past `gEnableRumble` + the rate limit) |
| `RS` | `padSetActDirect` calls the IOP **accepted** |
| `RD` | `padSetActDirect` calls **dropped** (IOP discards outside `TASK_UPDATE_PAD`) |

- `RA:0` → setting off, or the hook never fired.
- `RA` climbing, `RS:0` → `padRumbleCapable()` is gating it — read `AN`/`AK`/`AC` to see which gate.
- `RS` climbing with a **still pad** → the command lands and the **engine/duration** is wrong, not our gating.

That last row is the thing no amount of source-reading can tell us, and it's why this ships instead of a third blind fix. Same observe-before-fix move as the #120 HUD and the boot-step localizer — which just named this reporter's stuck step straight off a photo.

## Testing

Builds green with **PADEMU=0 and PADEMU=1**; clang-format clean. Boot-gate behaviour is HW-only observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)