### PR TITLE
fix(pad): gate the actuator self-heal out of boot -- and out of rumble-OFF

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -601,6 +601,13 @@ static int padRumbleSendNative(struct pad_data_t *pad, int on)
 // costs nothing. Runs on the GUI thread like every other libpad call here.
 static void padRumbleRealign(struct pad_data_t *pad)
 {
+    // SAME gate as padRumbleArm, and it MUST stay first. padSetActAlign below is a libpad RPC and
+    // waitPadRequestComplete blocks the GUI thread for up to PAD_REQ_WAIT_POLLS ms (150ms).
+    // readPads() runs during BOOT, so without rumbleLive this fires exactly the boot-time
+    // RPC-vs-SifLoadModuleBuffer race that #176 exists to prevent -- and without gEnableRumble it
+    // would do it for EVERY user on the DEFAULT config, for a feature they never switched on.
+    if (!rumbleLive || !gEnableRumble)
+        return;
     if (pad->actAligned)
         return;
     if (pad->realignDelay > 0) {


### PR DESCRIPTION
Regression I shipped in #179 (master `5a22bace`), caught before the tester burned a cycle on it.

## The bug

`padRumbleRealign()` is called from the `readPads()` tick **ungated** — not behind `rumbleLive`, not behind `gEnableRumble`:

```c
padRumbleRealign(pad); // self-heal the alignment
```

and it issues `padSetActAlign` (a libpad RPC) plus `waitPadRequestComplete` (**blocks the GUI thread up to 150ms**).

`readPads()` runs during **boot** (`opl.c:2850`), concurrent with the IO worker's `SifExecModuleBuffer` of the block-device drivers. That is exactly the boot-time RPC-vs-module-load race **#176 was written to prevent** — re-introduced one PR after fixing it.

Two ways it is *worse* than #176's version:

1. **Not gated on `gEnableRumble`**, so it fires for **every user on the default config**, for a feature they never switched on. #176's hazard at least only reached people who had turned rumble on.
2. **It retries.** A pad that reports actuators but never aligns re-arms on `realignDelay` forever, so the 150ms stall is not one-shot.

## The fix

Give `padRumbleRealign` the **same gate as `padRumbleArm`**, as the first statement so it cannot be forgotten at a future call site.

- Rumble **off** (the default): one branch per pad per frame, **zero RPCs**.
- Rumble **on**: cannot run until `padRumbleActivate()` has declared the boot chain done.

No behaviour change to the #179 fix once the menu is up — the only place it was ever meant to run.

## Audit of the rest of the path

`padRumbleSendNative` is not gated internally, but every path to it goes through `rumbleMsLeft`/`rumbleOn`, which only the (gated) `padRumbleArm` ever sets — **transitively safe**. `padRumbleRealign` was the only escapee.

## Verification

Builds green with `PADEMU=0` and `PADEMU=1`; clang-format clean.

The #179 rumble fix itself remains **HW-unvalidated** — this PR does not change it, it only stops it from touching boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
