### PR TITLE
feat(pad): per-screen rumble strength + stop the save buzz (#172 HW feedback)

### DIFF
--- a/include/gui.h
+++ b/include/gui.h
@@ -63,6 +63,11 @@ extern int guiFrameId;
 
 void guiSwitchScreen(int target);
 
+/** The GUI_SCREEN_* the user is looking at right now. Lets a caller that is handed only an event id
+ *  (sfxPlay) tell the game list from the menus. Never read mid-transition -- input is gated off while
+ *  one is in flight, so no event can fire in an ambiguous state. */
+int guiGetCurrentScreen(void);
+
 void guiReloadScreenExtents();
 
 /** Initializes the GUI */

--- a/include/pad.h
+++ b/include/pad.h
@@ -32,8 +32,9 @@ void unloadPads();
 // power-on made sfxPlay fire every frame. See the long note in pad.c.
 void padRumbleActivate(void);
 
-void padRumbleTap(void);  // light tick: cursor moved
-void padRumbleBump(void); // firmer: confirm / cancel
+void padRumbleTap(void);     // light tick: cursor moved in a menu / dialog
+void padRumbleTapList(void); // light tick: cursor moved in the GAME LIST (firmer -- see pad.c)
+void padRumbleBump(void);    // firmer: confirm / cancel
 
 // Play out any in-flight pulse then stop. Call before anything that blocks the GUI thread for long,
 // since readPads() -- which ticks the decay -- stops running then; the launch path would otherwise turn

--- a/src/gui.c
+++ b/src/gui.c
@@ -954,6 +954,17 @@ reselect_video_mode:
     guiUIUpdater(1);
 
     int ret = diaExecuteDialog(diaUIConfig, -1, 1, guiUIUpdater);
+
+    // Play out the confirm bump the dialog just armed, before applyConfig() below tears down and
+    // rebuilds the GS (rmSetMode), reloads the theme and its textures, and holds guiLock over a
+    // submenu-cache rebuild -- none of which polls readPads(), so the pulse would run for all of it
+    // (#172, "really intense ... after changing the resolution"). Deliberately HERE and not at the top
+    // of applyConfig(): applyConfig is ALSO reached off the GUI thread, from _loadConfig() on the IO
+    // worker (opl.c: guiHandleDeferedIO with IO_CUSTOM_SIMPLEACTION), and every libpad call in pad.c
+    // is documented GUI-thread-only. This one site dominates BOTH applyConfig calls below, including
+    // the video-mode revert on the reselect path.
+    padRumbleFlush();
+
     if (ret) {
         diaGetInt(diaUIConfig, UICFG_LANG, &langID);
         diaGetInt(diaUIConfig, UICFG_THEME, &themeID);
@@ -2371,6 +2382,14 @@ void guiSetFrameHook(gui_callback_t cback)
     gFrameHook = cback;
 }
 
+int guiGetCurrentScreen(void)
+{
+    // screenHandler always points INTO screenHandlers[] -- it is initialised to &screenHandlers[
+    // GUI_SCREEN_MENU] and every reassignment takes its value from screenHandlerTarget, which is only
+    // ever set from &screenHandlers[target] below. So the subtraction is always a valid index.
+    return (int)(screenHandler - screenHandlers);
+}
+
 void guiSwitchScreen(int target)
 {
     // Only initiate the transition once or else we could get stuck in an infinite loop.
@@ -2460,6 +2479,15 @@ int guiMsgBox(const char *text, int addAccept, struct UIItem *ui)
 
 void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data, int timeoutMs)
 {
+    // Play out any rumble pulse BEFORE we block (#172). This function is almost always entered a few
+    // ms after an sfxPlay(SFX_CONFIRM) armed a 110ms bump, and its wait loop below renders every frame
+    // but never calls readPads() -- which is the ONLY thing that decays the pulse and the only thing
+    // that sends the "off". The IOP LATCHES the actuator value, so the motor does not need re-sending
+    // to keep spinning: it simply runs for the entire config write / device scan. That is what the
+    // hardware reporter felt as "really intense when you save a setting" -- it was never intensity,
+    // it was DURATION. Bounded by RUMBLE_BUMP_MS and inert when nothing is armed or rumble is off.
+    padRumbleFlush();
+
     // Free the shared IOP/fileXio channel before running the deferred IO. The
     // cover-art worker's queued and in-flight reads otherwise tie up that single
     // channel, so a config write (e.g. the last-played save on game launch) queues
@@ -2519,6 +2547,12 @@ void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data, int
 
 void guiGameHandleDeferedIO(int *ptr, struct UIItem *ui, int type, void *data)
 {
+    // Same rumble-vs-blocking-work trap as guiHandleDeferedIO -- see the note there. The wait loop
+    // below has the identical shape: it renders every frame and never polls readPads(), so a bump
+    // armed by the SFX_CONFIRM that got us here would run for the whole deferred load. Reached from
+    // gameMenuLoadConfig() on every per-game settings sub-dialog.
+    padRumbleFlush();
+
     if (ioPutRequest(type, data) != IO_OK) {
         *ptr = 0;
         return;

--- a/src/pad.c
+++ b/src/pad.c
@@ -27,19 +27,34 @@
 #define DEFAULT_PAD_DELAY 200
 
 // ---- Menu rumble pulse shape (#172) ---------------------------------------------------------------
-// Defined up here because readPad()'s ds34 leg needs RUMBLE_BIG_LEVEL long before the rumble section
-// further down. Calibrated against the known-working reference (Enceladus' lua_rumble, which the
-// reporter confirms buzzes on THIS console): drive BOTH engines. The small engine (act[0], on/off) is
-// the crisp attack; the big engine (act[1], 0..255) is an offset-weight ERM that needs ~50-80ms just to
-// start turning, so it mostly adds body on the longer bump -- but it is the one you actually FEEL, and
+// Defined up here because readPad()'s ds34 leg needs the levels long before the rumble section further
+// down. Calibrated against the known-working reference (Enceladus' lua_rumble, which the reporter
+// confirms buzzes on THIS console): drive BOTH engines. The small engine (act[0], on/off) is the crisp
+// attack; the big engine (act[1], 0..255) is an offset-weight ERM that needs ~50-80ms just to start
+// turning, so it mostly adds body on the longer bump -- but it is the one you actually FEEL, and
 // shipping the small engine alone gave the reporter nothing at all.
-#define RUMBLE_TAP_MS     60   // cursor tick
-#define RUMBLE_BUMP_MS    110  // confirm / cancel / notification / ready: long enough for the big engine
-#define RUMBLE_BIG_LEVEL  0x60 // ~37% on the big engine: felt through a controller, not a phone on a desk
+//
+// THE BIG ENGINE'S LEVEL IS THE ONLY REAL INTENSITY KNOB WE HAVE. The small engine is on/off IN
+// HARDWARE, not by our choice -- libpad.h:252-255 is explicit: "act_align[0] = 0/1 turns off/on 'small'
+// engine" vs "act_align[1] = 0-255 sets 'big' engine speed". So a "quieter" tap has a FLOOR: the attack
+// never softens, only the body does. Do not expect 0x48 to feel like 3/4 of 0x60.
+// Lowering a level also buys ZERO current headroom: freepad's 600mA guard (CheckAirDirectTotal,
+// padMiscFuncs.c:265-292) tests each actuator for NONZERO, not for magnitude -- 0x01 costs it exactly
+// what 0xFF does. Only switching an engine fully off counts.
+#define RUMBLE_TAP_MS      60 // cursor tick in a menu / dialog
+// Game-list cursor tick. Deliberately longer than the menu tick: the list's frames stretch while cover
+// art loads, and readPads() -- which both re-sends and decays the pulse -- only runs once per frame. A
+// 60ms tap can therefore expire inside a single slow frame before ONE re-send has landed, which is
+// consistent with the reporter feeling the same pulse as "very weak" here and "too strong" in the menu.
+#define RUMBLE_LIST_TAP_MS 75
+#define RUMBLE_BUMP_MS     110  // confirm / cancel / notification / ready: long enough for the big engine
+#define RUMBLE_LEVEL_MENU  0x48 // ~28%: menu / dialog tick -- 0x60 read as "a bit too strong" on HW
+#define RUMBLE_LEVEL_LIST  0x78 // ~47%: game-list tick -- 0x60 read as "very weak" on HW
+#define RUMBLE_LEVEL_BUMP  0x60 // ~37%: confirm / cancel / notification / ready (see padRumbleBump)
 // Floor between taps. Key-repeat is ~100ms and an ERM never fully spins down, so an unthrottled
 // tap-per-tick becomes a continuous grind. (Comment kept ABOVE the define: as a trailing comment
 // clang-format wraps it with a line-continuation backslash, which -Wcomment rightly objects to.)
-#define RUMBLE_MIN_GAP_MS 120
+#define RUMBLE_MIN_GAP_MS  120
 
 struct pad_data_t
 {
@@ -62,9 +77,10 @@ struct pad_data_t
     // or be skipped by initializePad's early returns, so latch the confirmed alignment separately and
     // require it before ever driving an actuator.
     unsigned char actAligned;
-    unsigned char rumbleOn; // 1 = an "on" was sent that still owes its matching "off"
-    int rumbleMsLeft;       // ms remaining; ticked down in readPads() (see the ms-vs-frames note there)
-    int realignDelay;       // backoff for the actuator-alignment self-heal (padRumbleRealign)
+    unsigned char rumbleOn;    // 1 = an "on" was sent that still owes its matching "off"
+    unsigned char rumbleLevel; // big-engine level for the pulse in flight (0 = none armed)
+    int rumbleMsLeft;          // ms remaining; ticked down in readPads() (see the ms-vs-frames note there)
+    int realignDelay;          // backoff for the actuator-alignment self-heal (padRumbleRealign)
 };
 
 // Pad commands are asynchronous. Keep every wait bounded so a transient SIO2/pad error cannot hang the
@@ -440,7 +456,7 @@ static int readPad(struct pad_data_t *pad)
     // only the light motor and the reporter felt nothing -- across DS3/DS4/DS5 the two motors differ in
     // kind (a DS3's light motor is on/off in hardware; a DualSense has no classic ERM at all), so
     // picking one and hoping is exactly how you ship silence.
-    u8 rum = (gEnableRumble && pad->rumbleMsLeft > 0) ? (u8)RUMBLE_BIG_LEVEL : 0;
+    u8 rum = (gEnableRumble && pad->rumbleMsLeft > 0) ? (u8)pad->rumbleLevel : 0;
 
     if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING) {
         ret = ds34bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
@@ -500,9 +516,10 @@ static int getKeyDelay(int id, int repeat)
 // locked into DualShock mode and padSetActAlign() has enabled both engines -- we simply never fired
 // padSetActDirect().
 //
-// Engine choice: the SMALL engine only (actAlign[0], on/off). The big engine (actAlign[1], 0..255) is
-// an offset-weight ERM -- it needs ~50-80ms just to start turning and then coasts well past a menu
-// tick, so it is the wrong tool for a "click".
+// Engine choice: BOTH engines. (This comment used to say "the small engine only, the big one is the
+// wrong tool for a click" -- that reasoning lost to hardware. The reporter felt NOTHING from the small
+// engine alone: a DS3's light motor is on/off in hardware and a DualSense has no classic ERM at all, so
+// the big engine is the one you actually feel. See the level table at the top of this file.)
 //
 // Cost: padSetActDirect adds ZERO SIO2 traffic -- it is a SIF RPC that latches 6 bytes on the IOP,
 // which freepad folds into the READ_DATA poll it already sends every vblank (the SIO2 frame length
@@ -563,13 +580,16 @@ static int padRumbleCapable(struct pad_data_t *pad)
 static int padRumbleSendNative(struct pad_data_t *pad, int on)
 {
     char act[6] = {0, 0, 0, 0, 0, 0};
-    act[0] = on ? 1 : 0;                      // small engine: on/off, the crisp attack
-    act[1] = on ? (char)RUMBLE_BIG_LEVEL : 0; // big engine: the part you actually feel
+    act[0] = on ? 1 : 0;                      // small engine: on/off IN HARDWARE, the crisp attack
+    act[1] = on ? (char)pad->rumbleLevel : 0; // big engine: the part you actually feel, 0..255
     // act[2..5] stay 0 -- padSetActAlign mapped only slots 0/1 to real actuators (the rest are 0xff =
     // unused), and the reference implementation passes 0 here too (a zeroed function-static).
     int r = padSetActDirect(pad->port, pad->slot, act);
     // #172 diag: RS climbing while the pad stays still means the IOP took the command and the
     // ENGINE/duration is wrong -- not our gating. RD counts IOP drops (outside TASK_UPDATE_PAD).
+    // CAVEAT: RS is not proof the motor was driven. freepad's 600mA guard (CheckAirDirectTotal,
+    // padMiscFuncs.c:265-292) can ZERO the actuator byte and still return 1, so a silent pad with RS
+    // climbing has a third possible cause besides engine/duration: the IOP zeroed it on the budget.
     if (r == 1)
         gDiag.padRumbleSent++;
     else
@@ -644,7 +664,7 @@ static void padRumbleRealign(struct pad_data_t *pad)
     pad->realignDelay = PAD_REALIGN_FAIL_DELAY;
 }
 
-static void padRumbleArm(int durationMs)
+static void padRumbleArm(int durationMs, unsigned char level)
 {
     int i;
 
@@ -668,6 +688,7 @@ static void padRumbleArm(int durationMs)
         // it never goes through padInfoAct/padSetActAlign -- and instead reads this straight off
         // readPad()'s existing every-poll re-send. Harmless on a pad that ends up rumbling nothing.
         pad->rumbleMsLeft = durationMs;
+        pad->rumbleLevel = level; // must be set BEFORE the kick below: padRumbleSendNative reads it
 
         // Kick the native actuator immediately so the tap has no perceptible latency; readPads()
         // then RE-SENDS it every frame for the life of the tap. Do NOT "optimise" that re-send away:
@@ -681,18 +702,34 @@ static void padRumbleArm(int durationMs)
     }
 }
 
-/** Light tick for a cursor move. Safe from the GUI thread; never blocks and silently no-ops when
- *  disabled, rate-limited, or the pad can't rumble. */
+/** Light tick for a cursor move in a MENU or dialog. Safe from the GUI thread; never blocks and
+ *  silently no-ops when disabled, rate-limited, or the pad can't rumble. */
 void padRumbleTap(void)
 {
-    padRumbleArm(RUMBLE_TAP_MS);
+    padRumbleArm(RUMBLE_TAP_MS, RUMBLE_LEVEL_MENU);
+}
+
+/** Light tick for a cursor move in the GAME LIST. Same event as padRumbleTap() -- both are
+ *  sfxPlay(SFX_CURSOR) -- but firmer and slightly longer, because hardware says the two screens do not
+ *  feel alike at identical settings. sound.c picks between them off the current GUI screen: sfxPlay()
+ *  is handed only an sfx id, so the screen cannot be inferred any deeper than the hook. */
+void padRumbleTapList(void)
+{
+    padRumbleArm(RUMBLE_LIST_TAP_MS, RUMBLE_LEVEL_LIST);
 }
 
 /** Slightly firmer bump for a confirm / cancel -- a decision should feel more definite than a scroll.
- *  On the LAUNCH edge the caller must follow this with padRumbleFlush(); see there for why. */
+ *  On the LAUNCH edge the caller must follow this with padRumbleFlush(); see there for why.
+ *
+ *  The level is deliberately UNCHANGED at RUMBLE_LEVEL_BUMP while the menu tick drops to 0x48. The
+ *  reporter asked for confirms "a bit lower" too, but he was judging a bump that ran for the WHOLE of a
+ *  blocking config write -- seconds, not 110ms (readPads() is the only decay tick and it does not run
+ *  during blocking work). That is fixed separately, at the guiHandleDeferedIO / guiGameHandleDeferedIO
+ *  chokepoints. Dropping the level in the same change would correct twice for one fault and risk a
+ *  confirm he cannot feel at all. Re-ask after he retests; 0x60 -> 0x50 is then one line. */
 void padRumbleBump(void)
 {
-    padRumbleArm(RUMBLE_BUMP_MS);
+    padRumbleArm(RUMBLE_BUMP_MS, RUMBLE_LEVEL_BUMP);
 }
 
 /** Play out any in-flight pulse, then stop the motors.

--- a/src/sound.c
+++ b/src/sound.c
@@ -11,7 +11,8 @@
 #include "include/opl.h"
 #include "include/ioman.h"
 #include "include/themes.h"
-#include "include/pad.h" // padRumbleTap -- menu rumble mirrors the cursor tick (#172)
+#include "include/pad.h" // padRumbleTap/padRumbleTapList -- menu rumble mirrors the cursor tick (#172)
+#include "include/gui.h" // guiGetCurrentScreen -- the game list and the menus tap differently (#172)
 
 // Silence unused variable warnings from vorbisfile.h
 static ov_callbacks OV_CALLBACKS_NOCLOSE __attribute__((unused));
@@ -269,9 +270,18 @@ void sfxPlay(int id)
     // NOTE: SFX_CONFIRM is also the LAUNCH edge, and the pulse's decay clock is ticked by readPads(),
     // which stops running during the launch handoff -- so itemExecSelect() calls padRumbleFlush()
     // before that blocking work, or this bump would run for the whole loading screen. See pad.c.
-    if (id == SFX_CURSOR)
-        padRumbleTap();
-    else if (id == SFX_CONFIRM || id == SFX_CANCEL || id == SFX_MESSAGE)
+    // The game list and the menus both move the cursor with sfxPlay(SFX_CURSOR) -- the SAME id, so an
+    // id-only hook cannot tell them apart, and on hardware they do NOT feel alike at identical
+    // settings (the reporter called one "too strong" and the other "very weak" in the same breath).
+    // GUI_SCREEN_MAIN is exclusively the game list; the START menu is GUI_SCREEN_MENU. Reading the
+    // screen here is safe: input is gated off while a screen transition is in flight, so no cursor sfx
+    // can fire while the answer is ambiguous.
+    if (id == SFX_CURSOR) {
+        if (guiGetCurrentScreen() == GUI_SCREEN_MAIN)
+            padRumbleTapList();
+        else
+            padRumbleTap();
+    } else if (id == SFX_CONFIRM || id == SFX_CANCEL || id == SFX_MESSAGE)
         padRumbleBump();
     // SFX_MESSAGE (notifications / message boxes) is safe to arm from here: every one of its sites
     // renders from a loop that polls readPads() -- the main loop for guiShowNotifications, and


### PR DESCRIPTION
Blade tested `5a22bace` (#179) on hardware: **rumble works.** *"definitely don't revert the changes!"* This is his tuning pass — plus one real bug hiding inside it.

**His report:** game list *"very weak"*, main menu *"a bit too strong"*, and *"really intense when you save a setting — for example, after changing the resolution!"*

## 1. The main menu and the game list fire the same sfx

Both are `sfxPlay(SFX_CURSOR)` — `menusys.c:1162`/`:1171` (menu) and `:961`/`:988` (list, via `menuNextV`/`menuPrevV`). **Bit-identical pulse.** `sfxPlay(int id)` is handed only an id, so the single-chokepoint hook cannot tell the screens apart even in principle, and no edit to `RUMBLE_TAP_MS`/level makes them differ — it moves both together. **His ask was unsatisfiable as designed.**

Fix: new `guiGetCurrentScreen()`. `GUI_SCREEN_MAIN` is exclusively the game list; the START menu is `GUI_SCREEN_MENU`. `sound.c` picks `padRumbleTapList` vs `padRumbleTap` off it. Safe to read — input is gated while a screen transition is in flight, so no cursor sfx fires in an ambiguous state.

| | before | after |
|---|---|---|
| game list | 0x60 / 60ms | **0x78 / 75ms** |
| menus + dialogs | 0x60 / 60ms | **0x48 / 60ms** |
| confirm / cancel | 0x60 / 110ms | 0x60 / 110ms (held — see §3) |

The list gets a **longer** tap, not just a firmer one. `readPads()` both re-sends and decays the pulse, and runs once per frame; the list's frames stretch while cover art loads, so a 60ms tap can expire inside one slow frame before a single re-send lands. That's a real candidate for why the *identical* pulse reads "weak" there and "strong" in the menu.

## 2. The save buzz is a DURATION bug, not intensity

The level on a save is identical to any cursor tick — only ON-time differs. `rumbleMsLeft` is decremented **only** in `readPads()`, and the IOP **latches** the actuator, so nothing needs to re-send for the motor to keep spinning. The 110ms bump armed by `SFX_CONFIRM` runs for the **entire blocking write** — seconds, at full level. `padRumbleFlush()` existed for exactly this and had **one** call site (`opl.c:350`, the launch edge).

Three GUI-thread flushes added:
- `guiHandleDeferedIO()` — covers saveConfig / loadConfig / compat
- `guiGameHandleDeferedIO()` — same never-polls-`readPads()` shape, reached from `gameMenuLoadConfig` on ~12 per-game settings sites, each after an `SFX_CONFIRM`
- `_guiShowUIConfig()` after `diaExecuteDialog` — covers `applyConfig`'s GS teardown + theme reload, **including the video-mode revert path**

**Not** at the top of `applyConfig()`, though that looks tempting: `applyConfig` is also reached **off the GUI thread**, from `_loadConfig()` on the IO worker (`IO_CUSTOM_SIMPLEACTION` → `ioSimpleActionHandler`), and every libpad call in `pad.c` is documented GUI-thread-only. It would have raced `readPads()` on the same `pad_data_t`.

## 3. Confirm level deliberately held at 0x60

He asked for confirms lower too — but he was judging a bump that ran for a whole blocking save, **not a 110ms bump**. Its level was never the input to that judgement. Lowering it now would correct twice for one fault and risk shipping a confirm he can't feel. Ship the flush, re-ask. `0x60` → `0x50` is one line.

## Also

`pad.c:503` still claimed *"the SMALL engine only … the big engine is the wrong tool for a click"* — stale since the both-engines fix, and it says the **opposite** of what the code does. Corrected. Documented that the big engine's level is the **only** intensity knob (`libpad.h:252-255`: the small engine is on/off **in hardware**), so a quieter tap has a floor; that lowering a level buys **zero** current headroom (freepad's 600mA guard tests nonzero, not magnitude); and that `RS` can't prove the motor ran, since that guard can zero the byte and still return 1.

## Verification

Builds green `PADEMU=0` and `PADEMU=1`, no warnings in the changed files; clang-format clean.

**HW-unvalidated** — the levels are a judgement call until Blade retests. Independent of #180 (both touch `pad.c`, no overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
