### PR TITLE
docs(credits): credit Blade1984 for real-hardware testing

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -101,7 +101,7 @@ BDMA-ATA (exFAT internal-HDD block-device support), plus fixes, feedback and ove
 by saildot4k
 
 Testing, bug reports and real-hardware feedback
-by eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573
+by eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz, nuno6573 and Blade1984
 
 Financial support
 by Akilluminati47

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ work it is built on:
 ### Real-hardware testing (this fork)
 
 Enormous thanks to the testers who run every rolling build on real consoles and file the
-reports that shape the fixes — **eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz
-and nuno6573**.
+reports that shape the fixes — **eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz,
+nuno6573 and Blade1984**.
 
 ### Financial support (this fork)
 

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1104,7 +1104,12 @@ struct UIItem diaAbout[] = {
     {UI_BREAK},
 
     {UI_SPACER},
-    {UI_LABEL, 0, 1, 1, -1, 0, 15, {.label = {"algol - Berion - El_Patas - EP - gledson999 - jolek - lee4", -1}}},
+    // Blade1984 sits here rather than in a fork-testers block of his own: the About cannot scroll
+    // (its only navigable control is the trailing OK, and diaRenderUI pins diaScrollOffset to 0 while
+    // focus is on the first control), so a new heading + name row pushed the content bottom from
+    // 367px to 442px -- past visibleBottom (gTheme->usedHeight - 40 = 440, and only 408 on a
+    // 448-line theme). That would have rendered the credit, and the OK button, off-screen.
+    {UI_LABEL, 0, 1, 1, -1, 0, 15, {.label = {"algol - Berion - Blade1984 - El_Patas - EP - gledson999 - jolek - lee4", -1}}},
     {UI_BREAK},
 
     {UI_SPACER},


### PR DESCRIPTION
Blade1984 reported the menu-rumble FR (#172) and then ran **every** build of it on real hardware — including the round that proved the actuator alignment was silently never landing (#179). He was asked what name he wanted in the credits; this is it.

Added to all four surfaces: **CREDITS**, **README**, the **docs site** (pushed separately to `gh-pages` — [live](https://nathanneurotic.github.io/Open-PS2-Loader/credits.html)), and the **in-app About**.

## In-app placement — and why he's on the QA line

He goes on the existing **Quality Assurance** line rather than in a fork-testers block of his own, because **the About dialog cannot scroll.**

Its only navigable control is the trailing `UI_OK`, and `diaRenderUI` pins `diaScrollOffset = 0` whenever focus is on the first control (`dia.c:707-711` — the #48 fix). Nothing below the fold is ever reachable.

I built the fork-testers section first, then measured it:

| | content bottom | 480-theme (limit 440) | 448-theme (limit 408) |
|---|---|---|---|
| before | 367px | fits | fits |
| new heading + 2 name rows | **442px** | **overflows** | **overflows** |
| **shipped (QA line)** | **367px** | fits | fits |

`visibleBottom = gTheme->usedHeight - 40`, and `themes.c:2443` sets `usedHeight = screenHeight` — so on a 448-line theme the limit is only 408. The new section would have rendered the credit **and the OK button** off-screen: a credit nobody can see. On the QA line he costs **zero rows**, and the line lands at 70 chars, under the existing 74-char maximum.

Quality Assurance is also simply accurate for what he does.

## Known gap, deliberately not smuggled in

This fork's **other** testers (eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz, nuno6573) are credited in CREDITS/README/docs but **have never appeared in the app at all** — the About's QA list is upstream OPL's. Fixing that needs either a scrollable About or a compacted list. It isn't free, so it isn't in this PR.

## Verification

About content bottom is **367px — byte-identical to before**. `lang_autogen.h` tail unchanged (`_STR_HINT_RUMBLE` still last, **no ID shifted** — the append-only rule). Builds green; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
