### PR TITLE
fix(disc): send the game id to the MMCE on Launch Disc (#183)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -537,11 +537,18 @@ int sysLaunchDisc(void)
     // MUST stay ABOVE deinit(): the send needs the IOP transport still up, and deinit tears it down.
     {
         char gameid[16];
-        const char *s = strrchr(path, '\\');
+        // Accept EITHER separator, then the device colon. SYSTEM.CNF is a publisher-authored text file
+        // copied out verbatim by sysParseBoot2, and while the convention is "cdrom0:\NAME;1" nothing
+        // enforces it -- a disc using '/' would otherwise leave the colon fallback yielding "/SLUS_..."
+        // (a leading slash the MMCE would never match) instead of a clean id. Take whichever separator
+        // appears LAST so a mixed path still ends at the filename. (Gemini review of #185.)
+        const char *bs = strrchr(path, '\\');
+        const char *fs = strrchr(path, '/');
+        const char *s = (bs > fs) ? bs : fs; // NULL sorts lowest, so this picks whichever exists
         int i = 0;
 
         if (s == NULL)
-            s = strrchr(path, ':'); // no directory separator: fall back to the device colon
+            s = strrchr(path, ':'); // no directory separator at all: fall back to the device colon
         s = (s != NULL) ? s + 1 : path;
 
         while (s[i] != '\0' && s[i] != ';' && i < (int)sizeof(gameid) - 1) {

--- a/src/system.c
+++ b/src/system.c
@@ -524,6 +524,38 @@ int sysLaunchDisc(void)
 
     LOG("[DISC] booting %s\n", path);
 
+    // Tell the MMCE which game is about to boot (#183). EVERY other launch path already does this --
+    // bdmsupport.c:1145, ethsupport.c:801, hddsupport.c:1049 -- but Launch Disc never did, so a
+    // PSX MemCard Gen2 / MMCE never switched to the game's folder and the user simply could not save
+    // a physical disc. mmceSendGameID no-ops when the feature is off or the transport is not armed.
+    //
+    // Derive the id from the very path we are about to exec: "cdrom0:\SLUS_123.45;1" -> "SLUS_123.45".
+    // That is correct for BOTH sources above -- BOOT2 is copied verbatim from SYSTEM.CNF and the
+    // key-derived fallback is composed into the same "cdrom0:\%s;1" shape -- so the id always matches
+    // the disc we actually boot, including the case where the two disagree and BOOT2 wins.
+    //
+    // MUST stay ABOVE deinit(): the send needs the IOP transport still up, and deinit tears it down.
+    {
+        char gameid[16];
+        const char *s = strrchr(path, '\\');
+        int i = 0;
+
+        if (s == NULL)
+            s = strrchr(path, ':'); // no directory separator: fall back to the device colon
+        s = (s != NULL) ? s + 1 : path;
+
+        while (s[i] != '\0' && s[i] != ';' && i < (int)sizeof(gameid) - 1) {
+            gameid[i] = s[i];
+            i++;
+        }
+        gameid[i] = '\0';
+
+        if (gameid[0] != '\0') {
+            LOG("[DISC] sending game id '%s' to MMCE\n", gameid);
+            mmceSendGameID(gameid, NULL, 0); // no Neutrino path and no VMC slots on a disc boot
+        }
+    }
+
     deinit(NO_EXCEPTION, IO_MODE_SELECTED_ALL); // tear OPL down (mirrors sysExecExit)
 
     args[0] = path;


### PR DESCRIPTION
Fixes #183.

**AndrewBento** (SCPH-7701, PSX MemCard Gen2): a physical PS2 disc launched via *Launch Disc* boots and plays fine, but the game ID never reaches the memory card — so the card never switches to the game's folder and **he can't save**.

## Root cause

`sysLaunchDisc()` **never called `mmceSendGameID` at all.**

Every other launch path does — `bdmsupport.c:1145`, `ethsupport.c:801`, `hddsupport.c:1049` — so ISO/HDD/SMB launches all push the ID and only the physical-disc path was silent. This isn't a regression; Launch Disc has never sent it.

## Fix

Derive the ID from the very path we're about to exec (`cdrom0:\SLUS_123.45;1` → `SLUS_123.45`) and send it before teardown.

Deriving from `path` rather than `boot` is deliberate: it's correct for **both** ID sources this function already computes — BOOT2 is copied verbatim from `SYSTEM.CNF`, and the key-derived fallback is composed into the same `cdrom0:\%s;1` shape. So the ID always matches the disc we actually boot, **including the #73 case where the two disagree and BOOT2 wins**.

Placed **above `deinit()`** — the send needs the IOP transport still up, and `deinit` tears it down.

`mmceSendGameID` already no-ops when the feature is off or the transport wasn't armed at menu time (the Δ4 arm-at-menu design from #51/#157), so this costs nothing for anyone not using an MMCE.

## Verification

Builds green; clang-format clean. The `system.c:1604` const-qualifier warning is pre-existing — merely shifted down by the added lines.

**HW-unvalidated** — needs AndrewBento or any MMCE + physical-disc rig to confirm the card switches. An emulator can't exercise a real MMCE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Improved physical disc launches by extracting the MMCE game identifier from the exact boot path that will be executed, ensuring a correct handoff to MMCE.
  * MMCE now more reliably switches to the proper game folder during disc boot, including cases where the boot path can vary.
  * Detected game IDs are logged to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->