### PR TITLE
fix(udpbd): set the IP before smap_init, and let a never-scanned BDM device rescan

### DIFF
--- a/modules/network/smap_udpbd/src/main.c
+++ b/modules/network/smap_udpbd/src/main.c
@@ -52,12 +52,18 @@ int _start(int argc, char *argv[])
         return MODULE_NO_RESIDENT_END;
     }
 
-    if ((result = smap_init(argc, argv)) < 0) {
-        M_DEBUG("smap: smap_init -> %d\n", result);
-        ReleaseLibraryEntries(&_exp_smap);
-        return MODULE_NO_RESIDENT_END;
-    }
-
+    // Set our IP BEFORE smap_init(). This ordering is load-bearing, not style: smap_init() spawns the
+    // interrupt handler thread, which runs udpbd_init() -> udpbd_send_info() -- i.e. it TRANSMITS. Parse
+    // ip= after that and the first INFO broadcast goes out sourced from ministack.c's compiled-in
+    // default (192.168.1.10), so the server answers the address it saw in recvfrom() and the reply is
+    // delivered to nobody. Today that is survivable ONLY because this fork added a 1s reconnect
+    // watchdog (udpbd.c) that re-broadcasts from the by-then-correct ip_addr -- an addition ORIGIN.txt
+    // does not record, so a future re-vendor from upstream would silently delete it and turn this into
+    // a hard "server never answers". UDPFS cannot hit this at all: it is three serialized IRXs, so its
+    // ministack always has the IP before udpfs_bd exists. Match that guarantee here.
+    //
+    // Safe this early: ms_ip_set_ip() only assigns ministack.c's `ip_addr`, a plain static already
+    // initialised at load time -- it touches no smap state and needs no hardware.
     for (i = 1; i < argc; i++) {
         M_DEBUG("argv[%d] = %s\n", i, argv[i]);
         if (!strncmp(argv[i], "ip=", 3)) {
@@ -65,6 +71,14 @@ int _start(int argc, char *argv[])
             if (ip != 0)
                 ms_ip_set_ip(ip);
         }
+    }
+
+    // NOW bring up the adapter. Everything that transmits hangs off this call, so by the time the
+    // first udpbd_send_info() goes out, ip_addr is already ours.
+    if ((result = smap_init(argc, argv)) < 0) {
+        M_DEBUG("smap: smap_init -> %d\n", result);
+        ReleaseLibraryEntries(&_exp_smap);
+        return MODULE_NO_RESIDENT_END;
     }
 
     return MODULE_RESIDENT_END;

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -507,14 +507,31 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     if (folderConsumeDirty(itemList->mode))
         return 1;
 
-    if (pDeviceData->bdmDeviceTick == BdmGeneration) {
+    // NEVER-SCANNED (-2) DEFEATS EVERY SHORT-CIRCUIT IN HERE -- note the condition, not just the body.
+    // bdmULSizePrev starts at -2 and only leaves it once a scan has actually run, so while it is -2
+    // this device has published no list yet and must be let through, INCLUDING while the page is still
+    // invisible -- exactly the state a device sits in between attaching and being shown. (The invisible
+    // bail below used to run first, making the old `!= -2` test on the miss-count line unreachable for
+    // a never-visible page; that test is now redundant and gone.)
+    //
+    // Why this reaches far past the invisible case: the BDM list scans essentially ONCE, on the publish
+    // pass. Every later refresh hits bdmUpdateDeviceData's "no change to the device state" return 0
+    // below, so whatever the list held at that single instant is what the user has for the rest of the
+    // boot -- and sbReadList PRESERVES its last-good list on a failed read (gDiag.isoScanPreserved),
+    // which on a FIRST scan means an empty list with no error shown. A network block device (UDPBD) is
+    // precisely where that instant can be too early: the volume is mounted but the server round-trip
+    // behind the CD/DVD opendir can still fail, and the page then reads "0 games" permanently and
+    // silently. UDPFS already rescues itself with the identical idea (udpfssupport.c:134-135,
+    // `if (udpfsULSizePrev == -2) result = 1;` -- deliberately above every gate); BDM had no
+    // equivalent. Same class as the PR #151 tab bug, one layer down.
+    if (pDeviceData->bdmDeviceTick == BdmGeneration && pDeviceData->bdmULSizePrev != -2) {
         if (pOwner != NULL && pOwner->menuItem.visible == 0)
             return 0;
         // While a network page is inside its disconnect grace window (bdmMissCount > 0, set by the
         // presence-poll debounce in bdmUpdateDeviceData), keep re-polling each refresh so the debounce
         // advances to the hide threshold -- otherwise it would stall at the single disconnect event and
         // a truly-gone network page would never hide. Local devices always have bdmMissCount == 0 here.
-        if (pDeviceData->bdmULSizePrev != -2 && pDeviceData->bdmMissCount == 0)
+        if (pDeviceData->bdmMissCount == 0)
             return 0;
     }
     pDeviceData->bdmDeviceTick = BdmGeneration;

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -540,7 +540,17 @@ static int bdmNeedsUpdate(item_list_t *itemList)
         ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
 
     // Check if the device has been connected or removed.
-    if ((result = bdmUpdateDeviceData(itemList)) == 0)
+    result = bdmUpdateDeviceData(itemList);
+    // "No change to the device state" normally means there is nothing to do -- but a device that has
+    // NEVER scanned (bdmULSizePrev == -2) has no list to leave alone, and bdmUpdateDeviceData reports
+    // 0 on every poll once the device is connected and its identity is populated. Returning here would
+    // make the -2 bypass at the device-tick gate above a NO-OP, which is exactly what it was before
+    // this line changed (Gemini review of #186 -- it caught that my first cut fixed nothing).
+    //
+    // Falling through is safe and needs no new scan logic: result stays 0 past the connect/disconnect
+    // sfx branches, and the sbIsSameSize(bdmPrefix, bdmULSizePrev) check further down cannot match a
+    // sentinel of -2, so it sets result = 1 and the first scan publishes through the existing path.
+    if (result == 0 && pDeviceData->bdmULSizePrev != -2)
         return 0;
 
     // If a device was added or removed play the appropriate UI sound.


### PR DESCRIPTION
**Nathan** (real hardware, PS2-Servers with known-good UDPBD): *"UDPBD isn't working. The page doesn't show up sometimes, and when it does — it doesn't populate the list."* Server side proven good; UDPFS works. Both symptoms are ours, and **they share one window**.

## Bug 1 — the IP arrives after we've already transmitted

`smap_udpbd`'s `_start` parsed `ip=` **after** `smap_init()`. But `smap_init` spawns the interrupt handler thread, which runs `udpbd_init()` → `udpbd_send_info()` — **it transmits.**

So the first INFO broadcast went out sourced from ministack's compiled-in default **`192.168.1.10`**, the server answered the address it saw in `recvfrom()`, and the reply went **nowhere**. The link only came up when the fork's 1s reconnect watchdog re-broadcast from the by-then-correct `ip_addr`.

UDPFS structurally can't hit this — it's three serialized IRXs, so its ministack always has the IP before `udpfs_bd` exists. **That's the real asymmetry: ORDER, not argv index.** (An earlier theory that the buffer loader puts `ip=` at `argv[0]` is **dead** — `udpfs_ministack` has the identical `for (i = 1; i < argc; i++)` loop and UDPFS works.)

Safe to move: `ms_ip_set_ip()` only assigns a plain static already initialised at load time.

## Bug 2 — a BDM device scans its list essentially once, forever

`bdmULSizePrev` starts at `-2` ("never scanned") — but the `-2` test sat **below** the invisible-page bail, making it unreachable for exactly the state a device occupies between attaching and being shown. Every later refresh then hits `bdmUpdateDeviceData`'s "no change" `return 0`.

So whatever the list held at that single publish instant is what you get for the rest of the boot — and `sbReadList` **preserves its last-good list on a failed read**, which on a *first* scan means an empty list **with no error shown**.

A network block device is precisely where that instant can be too early — e.g. inside Bug 1's up-to-1s dead window — and the page then reads "0 games" permanently and silently.

UDPFS already rescues itself with the identical idea (`udpfssupport.c:134-135`, deliberately above every gate). BDM had no equivalent. Same class as the #151 tab bug, one layer down.

**Together:** Bug 1 opens a window where the device isn't connected (**no tab**); Bug 2 makes any scan landing in that window **permanent** (**empty tab**).

## Ruled out — recorded so it isn't re-litigated

- **`gBDMPrefix` leaking the USB prefix onto UDPBD** — shipped default is empty (opl.c:2757); Nathan runs defaults.
- **The udpfs_ioman NIC latch** — real fragility (load-once, never cleared), but **cannot be this case**: opl.c:646 gives UDPFS_MODE `START_MODE_DISABLED` unless the protocol *is* UDPFS, so on UDPBD the UDPFS tab never inits and never latches. Exactly one network tab is ever enabled.
- **The bdmevent registration race** — no window exists; the callback only fires inside bdm.c's mount-success branch, seconds after `SifAddCmdHandler`.

## Also worth knowing

The **1s reconnect watchdog** in `smap_udpbd/src/udpbd.c` is a **RiptOPL-local addition that `ORIGIN.txt` does not document**. Before this PR it was the only reason UDPBD worked at all — a re-vendor from upstream would have silently deleted it and turned this into a hard "server never answers".

## Verification

`smap_udpbd.irx` rebuilt **from clean** (a plain `make` doesn't pick module source up). Builds green; clang-format clean.

**HW-unvalidated** — needs Nathan's rig + PS2-Servers to confirm the tab appears reliably and the list populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured network services apply the configured IP address before bringing up UDP communications, improving correctness of initial network announcements.
  * Corrected device refresh logic for “never-scanned” devices so they can still publish/scan and populate lists even when their menu page isn’t visible.
  * Adjusted the “no state change” short-circuit so initial publish/scan can proceed for never-scanned devices after the first update attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->