### PR TITLE
fix(config): stop hiding that settings have nowhere to go

### DIFF
--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1001,3 +1001,7 @@ gui_strings:
   string: Controller Vibration in Menus
 - label: HINT_RUMBLE
   string: Short vibration when moving the cursor, confirming or going back -- needs a DualShock in analog mode
+- label: ERROR_SAVING_SETTINGS_TO
+  string: Could not write settings to %s (error %d)
+- label: SETTINGS_NO_HOME
+  string: No memory card found -- settings cannot be saved. OPL was booted from a network device, whose settings must live on a local card.

--- a/src/opl.c
+++ b/src/opl.c
@@ -2162,7 +2162,10 @@ int loadConfig(int types)
 
 int saveConfig(int types, int showUI)
 {
-    char notification[128];
+    // Sized for the worst message this function can now build: the failure text carries a full config
+    // home path (configGetDir -> cfgDevice, itself up to a 256-byte prefix) plus an errno, and 128
+    // truncated exactly the part that made the message worth showing (Gemini review of #187).
+    char notification[320];
     lscstatus = types;
     lscret = 0;
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -2169,14 +2169,26 @@ int saveConfig(int types, int showUI)
     guiHandleDeferedIO(&lscstatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_saveConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
 
     if (showUI) {
-        if (lscret) {
-            char *path = configGetDir();
+        char *path = configGetDir();
 
+        if (lscret) {
             snprintf(notification, sizeof(notification), _l(_STR_SETTINGS_SAVED), path);
 
             guiMsgBox(notification, 0, NULL);
-        } else
-            guiMsgBox(_l(_STR_ERROR_SAVING_SETTINGS), 0, NULL);
+        } else if (strchr(path, '?') != NULL) {
+            // The '?' only survives configGetDir() when we fell back to the "mc?:OPL" home AND
+            // checkMC() found no card to substitute -- i.e. there is nowhere to save at all, which is
+            // a standing condition, not this one write failing. Explain that instead of an errno.
+            guiMsgBox(_l(_STR_SETTINGS_NO_HOME), 0, NULL);
+        } else {
+            // Say WHERE and WHY. A bare "Error writing settings!" cost a maintainer an afternoon on a
+            // network boot: the write was failing against a home he had no way to see, and the errno
+            // was already sitting in gDiag.lastSaveErrno (latched at the real failure site in
+            // config.c) with nothing putting it on screen.
+            snprintf(notification, sizeof(notification), _l(_STR_ERROR_SAVING_SETTINGS_TO), path, gDiag.lastSaveErrno);
+
+            guiMsgBox(notification, 0, NULL);
+        }
     }
 
     return lscret;
@@ -3218,6 +3230,20 @@ int main(int argc, char *argv[])
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &deferredInit);
 
     guiIntroLoop();
+
+    // No writable config home? Say so NOW, not after the user has changed settings and lost them.
+    // The '?' only survives configGetDir() when the discovery chain fell all the way back to the
+    // "mc?:OPL" default AND checkMC() found no card to substitute into it. That is precisely the
+    // network-boot case: the config must be read before any network stack exists, so a UDPFS/UDPBD/SMB
+    // boot can never resolve its own boot device at load time (bdmResolveBootDir returns -1 for a
+    // network block device by design), the chain falls through MC -> MMCE -> BDM -> BDM-HDD, and a rig
+    // with no local card has nowhere to put settings. Reported as "settings don't save - but they
+    // claim to load", which is exactly what silence looks like from the outside.
+    //
+    // A toast, not a modal: this is a standing property of the setup, not an error the user just
+    // caused, and it must not gate a boot that otherwise works fine.
+    if (strchr(configGetDir(), '?') != NULL)
+        guiWarning(_l(_STR_SETTINGS_NO_HOME), 6);
 
     // Menu rumble goes live ONLY now: the boot is done and guiMainLoop below starts polling pads.
     // Before this point guiIntroLoop runs handleInput() against a FROZEN paddata snapshot, so a button


### PR DESCRIPTION
**Nathan, booting from UDPFS:** *"settings don't save - but they claim to load (even if they aren't present? idk)"*.

**The "idk" is the bug.** The policy was already right; the silence wasn't.

## What actually happens (unchanged by this PR)

A network boot **cannot resolve its own boot device at config-load time** — `bdmResolveBootDir` returns `-1` for a network block device **by design**, because the config must be read before any network stack exists. So `resolveBootDirToMass` drops `gBootDir`, `configInit(NULL)` runs, and the discovery chain tries **MC → boot device → MMCE → BDM → BDM-HDD** (opl.c:1367-1387 — memory card *first*). On a rig with no local card, every one fails. The home stays the literal `mc?:OPL`, `checkMC()` finds no card to substitute for the `?`, `checkFile()` refuses the open (util.c:113-127), and the write fails.

**That is exactly "save to `mc?:/`, and if no MC is detected fail to save"** — the policy Nathan proposed when asked what SMB should do. It already worked that way. It just never said so.

## Three places it lied or withheld

**1. "Error writing settings!" said neither where nor why.** The errno was already latched at the real failure site (`gDiag.lastSaveErrno`) and the path was one call away. Now: `Could not write settings to %s (error %d)`.

**2. No card at all is a *standing* condition**, not this one write failing — so it gets its own message rather than an errno the user can't action. The test is exact, not heuristic: the `?` only survives `configGetDir()` when the chain fell back to `mc?:OPL` **and** `checkMC()` found nothing. Any real home (`mass0:`, `mmce0:`, a resolved `mc0:`) has no `?` left.

**3. Nothing said it at boot.** A diskless network boot could change settings, watch them apply, and lose them — learning only on the next boot. Now a toast right after the intro: once, non-modal, because it's a property of the setup rather than an error the user just caused, and it must not gate a boot that otherwise works.

## Deliberately NOT changed

The fallback **policy**. By menu time the network *is* up (the games are listed), so we *could* write to the share — but the next boot still can't read it back before the network exists. That's a file that is only ever written and never read. **Failing honestly beats that.**

## Verification

New lang labels appended at the **end** of `_base.yml` — verified they land last, immediately before `_STR_COUNT`, **no existing ID shifted**. (That rule has bitten this fork twice.) Builds green; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved settings-save notifications with clearer outcomes: successful saves now show the destination, while failures display the target and the specific error.
  * Added an early warning toast when there’s no writable configuration home (e.g., unavailable storage), before enabling menu rumble.
  * Save failures now distinguish missing/writable storage from other write errors.
* **Documentation**
  * Added new translation strings to support the expanded settings error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->