### PR TITLE
fix(gsm): make the hires pass clear actually clear (1080i/720p ghosting)

### DIFF
--- a/src/renderman.c
+++ b/src/renderman.c
@@ -226,7 +226,31 @@ int rmSetMode(int force)
         gsGlobal->OffsetY = ((4096 - gsGlobal->Height) / 2) * 16;
 
         if (hires) {
+            // PrimAlphaEnable MUST be OFF across this call, and the bracket below is a real fix, not
+            // hygiene (FifthFox's 1080i "scrolling leaves artifacts that persist", HW).
+            //
+            // gsKit_hires_init_screen -> _gsKit_create_passes bakes a gsKit_clear into each pass's
+            // PERSISTENT queue -- that baked clear is the ONLY thing that ever erases a hires frame
+            // (rmStartFrame deliberately skips clearing when hires; see there). But gsKit_clear's
+            // sprite samples the PRIM ABE bit from gsGlobal->PrimAlphaEnable AT CREATION TIME
+            // (gsPrimitive.c gsKit_prim_list_sprite_flat), and the colour gsKit bakes is
+            // GS_SETREG_RGBAQ(0,0,0,0x00,0) -- ALPHA ZERO. With PrimAlphaEnable ON (set above) and our
+            // source-over blend (gDefaultAlpha: (Cs-Cd)*As+Cd), As=0 reduces to Cd: the "clear" wrote
+            // the old destination pixel back. A no-op, baked in, replayed every pass, forever.
+            //
+            // That is why a band whose pass misses its 1/180s deadline shows STALE pixels instead of
+            // black, and why they persist across screens: nothing under the UI ever repaints. The
+            // non-hires path never had this bug for exactly one reason: rmStartFrame's per-frame
+            // clear passes gColBlack, whose alpha is 0x80 (opaque) -- same function, different alpha.
+            //
+            // With ABE=0 baked in, the clear writes opaque black regardless of the runtime blend
+            // state. Restoring PrimAlphaEnable right after is safe: it is only ever sampled when a
+            // primitive is CREATED, and no OPL primitive is created inside init_screen. The only
+            // other _gsKit_create_passes caller is gsKit_hires_set_bg, which OPL never calls (and
+            // must not casually: a bg texture replaces the baked clear entirely).
+            gsGlobal->PrimAlphaEnable = GS_SETTING_OFF;
             gsKit_hires_init_screen(gsGlobal, rm_mode_table[vmode].passes);
+            gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
         } else {
             gsKit_init_screen(gsGlobal);
             gsKit_mode_switch(gsGlobal, GS_ONESHOT);


### PR DESCRIPTION
**FifthFox** (SCPH-700012, real hardware): *"Scrolling in the menus tend to leave artifacts that persist into the game lists"* at 1080i. Nathan's prior: every artifact report he can recall has been **1080i/720p specifically**. ChatGPT ran the unprimed second investigation and found what two of our own passes missed; every claim below was re-verified against the **pinned gsKit revision** (v1.5.0 @ `9125cf89` — the exact commit the ps2dev container builds against).

## The bug: the hires renderer's only clear is a no-op under our blend state

- `rmStartFrame` deliberately skips `gsKit_clear` when hires. The **only** thing that erases a hires frame is the clear `_gsKit_create_passes` bakes into each pass's persistent queue (`gsHires.c:201-216`), replayed every frame.
- `gsKit_clear` doesn't draw an unconditional write. Its sprite samples the PRIM **ABE bit from `gsGlobal->PrimAlphaEnable` at creation time** (`gsPrimitive.c`), and it only saves/restores ZTEST — never the blend state.
- The colour gsKit bakes is `GS_SETREG_RGBAQ(0,0,0,0x00,0)` — **alpha zero**.
- `renderman.c` sets `PrimAlphaEnable = ON` *before* `gsKit_hires_init_screen`, with source-over blending (`(Cs-Cd)*As+Cd`). With As = 0, that reduces to **Cd**.

**The baked "clear" wrote every destination pixel back to itself. Forever.**

## Why only 1080i/720p

They're the only **3-pass** modes — 180 passes/s, a 5.56 ms deadline gsKit's own author calls out (*"Rendering has to finish within 1/180s or you will see artifacts"* — Rick Gaiser, upstream PR #94). A band whose pass misses the deadline keeps its old pixels — and because the clear is a no-op, **nothing under the UI ever repaints them**. Stale text and highlights survive across screen changes until something opaque happens to overdraw them. The 2-pass 704-wide modes have a 50% larger budget; 480p and below clear opaquely every frame in `rmStartFrame`.

**Why the non-hires clear never had this bug:** `rmStartFrame` passes `gColBlack`, whose alpha is `0x80` — opaque under the same equation. Same clear function, different alpha. That asymmetry is the whole defect.

## The fix

Force `PrimAlphaEnable` **off** across `gsKit_hires_init_screen`, so the baked clear's PRIM has ABE=0 — an unconditional opaque black write, immune to runtime blend state — then restore it. `PrimAlphaEnable` is only sampled at primitive **creation**, and no OPL primitive is created inside `init_screen`. The only other `_gsKit_create_passes` caller is `gsKit_hires_set_bg`, which OPL never calls. The bracket sits inside `if (hires)` — a provable no-op for every other mode.

## Scope honesty

A missed pass still shows its stale band **for that frame** (a skipped pass runs neither clear nor draw). What this removes is the **persistence** — the next completed pass wipes the band, so a deadline miss degrades to a one-frame flicker instead of standing ghosts. The deadline pressure itself (the scheduler's drain-and-reread of `__iCurrentPass`, inline texture uploads replayed once per pass) lives **inside gsKit**, which we don't vendor. If ghosting is reduced but not gone on HW, the decisive A/B is: 720p at 2 passes (identical 768-line footprint at CT16S — only the cadence changes).

## Verification

Builds green with `GSM1080P=1`; clang-format clean. **HW-unvalidated** — needs FifthFox at 1080i.

Credit: ChatGPT found the blend-state hole after our own investigation wrongly concluded the baked clear was sufficient — it proved the clear *executes* but never checked what it *paints*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved high-resolution display initialization to prevent rendering and transparency issues.
  * Preserved normal alpha rendering behavior after screen setup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->