### PR TITLE
feat(net): default the network protocol to Off so the first pick loads live

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ It supports six categories of devices:
 6. ATA/IDE HDDs, including internal exFAT configurations (MBR/GPT).
 
 Plus an optional **network-block-device boot** (UDPBD / UDPFS, via Neutrino) that streams games
-from a PC over the LAN as their own game list — the network protocol defaults to **Off**; pick
-UDPFS, UDPBD or SMB in Device Settings and it comes up live, no restart needed (network stacks
-share the one adapter, so only the first protocol loaded per boot can own it).
+from a PC over the LAN as their own game list — the network protocol defaults to **Off**; the
+first protocol you pick in Device Settings comes up live. (Network stacks share the one adapter
+and stay loaded for the whole boot, so *switching away* from a loaded protocol still needs a
+restart — OPL says so when it applies.)
 See [This Fork's Additions](#this-forks-additions).
 
 All of the devices mentioned above support multiple file formats, including:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ It supports six categories of devices:
 6. ATA/IDE HDDs, including internal exFAT configurations (MBR/GPT).
 
 Plus an optional **network-block-device boot** (UDPBD / UDPFS, via Neutrino) that streams games
-from a PC over the LAN as their own game list — UDPFS is the pre-selected network protocol (an
-inert no-op until a network adapter and PC server are present) and is mutually exclusive with SMB.
+from a PC over the LAN as their own game list — the network protocol defaults to **Off**; pick
+UDPFS, UDPBD or SMB in Device Settings and it comes up live, no restart needed (network stacks
+share the one adapter, so only the first protocol loaded per boot can own it).
 See [This Fork's Additions](#this-forks-additions).
 
 All of the devices mentioned above support multiple file formats, including:
@@ -144,7 +145,8 @@ This build layers several features on top of upstream OPL:
   device — they show up as a **UDPBD Games** list with full covers and per-game settings, just
   like a local drive. UDPBD launches via Neutrino, is mutually exclusive with SMB (they share
   the one network adapter), and needs a static PS2 IP (the default is `192.168.1.10`); the
-  fork's **pre-selected network protocol is UDPFS** (switch to UDPBD in Device Settings). Run it from the
+  fork's **network protocol defaults to Off** — pick UDPFS or UDPBD in Device Settings and it
+  loads live (a restart is only needed to *switch away* from a protocol already loaded). Run it from the
   **[PS2 Servers](https://github.com/NathanNeurotic/PS2-Servers)** all-in-one PC launcher. See the
   network-boot section of **[docs/NEUTRINO.md](docs/NEUTRINO.md#4-network-boot--udpbd--udpfs-neutrino-only)**.
 - **UDPFS network boot (Neutrino):** a newer network transport (Neutrino's UDPRDMA) offered

--- a/src/opl.c
+++ b/src/opl.c
@@ -2809,11 +2809,19 @@ static void setDefaults(void)
     gEnableUSB = 1;
     gEnableILK = 0;
     gEnableMX4SIO = 0;
-    gEnableBdmHDD = 0;                  // exFAT BDM HDD OFF by default (the other "HDD type"; APA/PFS is gHDDStartMode above)
-    gEnableUDPBD = 0;                   // the UDPBD BLOCK device stays opt-in; the default protocol below is UDPFS
-    gNetBootProtocol = NET_BOOT_UDPBD;  // default transport when network boot is enabled (back-compat)
-    gNetworkProtocol = NET_PROTO_UDPFS; // unified selector: UDPFS (UDPRDMA filesystem) by default -- inert
-                                        // without a NIC + PC server; NIC-exclusive with SMB as before
+    gEnableBdmHDD = 0;                 // exFAT BDM HDD OFF by default (the other "HDD type"; APA/PFS is gHDDStartMode above)
+    gEnableUDPBD = 0;                  // the UDPBD BLOCK device stays opt-in
+    gNetBootProtocol = NET_BOOT_UDPBD; // default transport when network boot is enabled (back-compat)
+    // Unified network selector defaults to OFF (was UDPFS, Nathan 2026-07-16). The reason is the NIC
+    // latch: every network stack loads its IOP chain ONCE per boot and never unloads (re-binding the
+    // UDPRDMA socket bricks UDPFS; smap registers a single SMAP_driver), so whichever protocol is
+    // active FIRST owns the adapter until a restart -- the settings page even tells you so
+    // (NETBOOT_RESTART). With UDPFS pre-selected, a user who wanted UDPBD or SMB had to change the
+    // setting and REBOOT before their choice could load. Defaulting to Off means nothing claims the
+    // NIC at boot, so the first protocol the user picks in Device Settings comes up live -- the apply
+    // path re-derives the gEnableUDPBD/gNetBootProtocol shadows and forces a device refresh already.
+    // Existing installs are unaffected: a saved net protocol in settings_riptopl.cfg overrides this.
+    gNetworkProtocol = NET_PROTO_OFF;
 
     frameCounter = 0;
 


### PR DESCRIPTION
**Nathan (HW, 2026-07-16):** *"Switch network default to off, so that the user can pick their mode without having to restart OPL."*

His UDPBD test was confounded by exactly this: the boot default was UDPFS, and every network stack loads its IOP chain **once per boot** and never unloads (re-binding the UDPRDMA socket bricks UDPFS; smap registers a single `SMAP_driver`). Whichever protocol is active first owns the NIC until a restart — the settings page even says so (`NETBOOT_RESTART`). With UDPFS pre-selected, wanting UDPBD or SMB meant change-setting-then-reboot.

**Off at boot = nothing claims the NIC = the first pick loads live.** The apply path already re-derives the `gEnableUDPBD`/`gNetBootProtocol` shadows (gui.c:1296-1297) and forces a device refresh — no new plumbing. The `NET_PROTO_OFF` enum comment (opl.h:167) already read "fork default"; the code now matches it.

**Existing installs unaffected** — a saved protocol in `settings_riptopl.cfg` overrides the default. README updated in the same change.

Builds green; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Updates**
  * Network boot is now disabled by default (protocol set to Off).
  * Selecting UDPFS or UDPBD in Device Settings activates network boot live, without restarting.
  * Restart is only required when switching away from a protocol that was already loaded during the current boot.
* **Documentation**
  * Updated network-block-device boot instructions to reflect the new default behavior and restart conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->