### PR TITLE
feat(display): default overscan compensation to Off (0)

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2820,7 +2820,12 @@ static void setDefaults(void)
     gVMode = 0;
     gXOff = 0;
     gYOff = 0;
-    gOverscan = 100;
+    // Overscan compensation defaults OFF (was 100 = a 5%-per-side inset; Nathan 2026-07-16, from
+    // FifthFox's HW report). The inset shifts ALL rendering inward, but scrolled dialog text was not
+    // clipped to the inset viewport, so rows bled outside the background ("scrolled text moves out of
+    // the background image"). Modern displays don't need the inset; anyone on a CRT that does can
+    // still raise it in Display Settings. Saved configs override this, as with every default.
+    gOverscan = 0;
 
     setDefaultColors();
 


### PR DESCRIPTION
**FifthFox (HW):** with overscan active, scrolled dialog text bleeds *outside* the background image. `rmSetOverscan` insets all rendering by `overscan/2000` per side (100 = ~5%/side), but scrolled rows arent clipped to that inset viewport, so they draw past the backgrounds edge. **Nathan, from his report: default it off.**

Modern displays show the full raster without an inset, so the default no longer pays a visual cost — and the specific bleed — for a compensation most users dont need. CRT users who *do* overscan can still raise it in Display Settings (option and range unchanged). Saved configs override the default.

**This does not itself CLIP the bleed** for someone who raises overscan — that is a separate render-viewport fix (a GS scissor around the dialog), tracked as a follow-up. It needs hardware validation an emulator cant give, so its not rushed in here.

Builds green; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled overscan compensation by default to prevent dialog text from extending beyond its background.
  * Existing saved configurations continue to override the default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->