### PR TITLE
fix(boot): never queue the MMCE game-ID arm ahead of the menu

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -711,11 +711,20 @@ static void initAllSupport(int force_reinit)
     initSupport(appGetObject(0), APP_MODE, force_reinit);
     initSupport(favGetObject(0), FAV_MODE, force_reinit);
 
-    // Δ4 (NHDDL parity): arm the MMCE GameID transport HERE -- at boot and on every settings apply --
-    // instead of self-arming inside mmceSendGameID during a launch (an IRX load at the launch's most
-    // fragile moment; issue #51's fix with the timing corrected). Deferred to the IO worker like
-    // udpfsInit's module load; idempotent, and a failure is a harmless LOG at menu time.
-    if (gMMCEEnableGameID)
+    // Δ4 (NHDDL parity): arm the MMCE GameID transport at boot and on every settings apply -- instead
+    // of self-arming inside mmceSendGameID during a launch (an IRX load at the launch's most fragile
+    // moment; issue #51's fix with the timing corrected). Idempotent; a failure is a harmless LOG.
+    //
+    // BUT NEVER AHEAD OF THE MENU (GZAst, HW 2026-07-16: boot stuck forever on "Arming MMCE
+    // game-ID..."). The arm is a blocking SifExecModuleBuffer of mmceman.irx with no possible EE-side
+    // timeout, and posting it here during BOOT put it in the IO FIFO ahead of deferredInit -- so
+    // GUI_INIT_DONE queued behind a wedgeable module load, and a rig where mmceman's probe hangs never
+    // reached the menu at all. GameID arming is MENU-time work by design (that is the whole Δ4 point):
+    // during boot, deferredInit posts it AFTER itself, so a wedge costs GameID on a degraded IO worker
+    // instead of the console. Post-boot (settings apply), arm immediately as before. Default-on
+    // exposure note: gMMCEEnableGameID ships 1, so EVERY rig pays this load -- including ones with no
+    // MMCE hardware anywhere, like the reporter's network-only setup.
+    if (gMMCEEnableGameID && !gBootInProgress)
         ioPutRequest(IO_CUSTOM_SIMPLEACTION, &mmceArmGameIDTransport);
 }
 
@@ -2893,6 +2902,15 @@ static void deferredInit(void)
     struct gui_update_t *id = guiOpCreate(GUI_INIT_DONE);
     if (id)
         guiDeferUpdate(id);
+
+    // MMCE GameID arming, boot leg: posted HERE -- after GUI_INIT_DONE is on its way to the GUI
+    // thread -- and not from initAllSupport, so the blocking, untimeoutable mmceman.irx load can never
+    // hold the menu hostage again (GZAst's boot froze forever on "Arming MMCE game-ID..."). This
+    // appends the arm after this handler in the IO FIFO: worst case a wedged probe degrades the IO
+    // worker POST-boot (visible, diagnosable, menu alive) instead of killing the boot. The
+    // settings-apply leg still arms immediately from initAllSupport.
+    if (gMMCEEnableGameID)
+        ioPutRequest(IO_CUSTOM_SIMPLEACTION, &mmceArmGameIDTransport);
 
     // Nad #6: never silently SKIP the boot select -- doing so left the GUI on the start-menu screen
     // with the first-appended tab (a BDM instance, typically MX4SIO) as the implicit selection. If


### PR DESCRIPTION
**GZAst (HW, network-only rig, no MMCE hardware):** boot stuck forever on *"Arming MMCE game-ID..."* — the boot-step localizer naming the exact wedge, as designed.

**Mechanism:** the arm is a blocking `SifExecModuleBuffer` of `mmceman.irx` with **no possible EE-side timeout**. `initAllSupport` posted it to the IO FIFO *during boot*, ahead of `deferredInit` — so `GUI_INIT_DONE` queued behind a wedgeable module load, and a rig where mmcemans probe hangs never reaches the menu. `gMMCEEnableGameID` ships default-on, so **every** rig pays this load, MMCE hardware or not.

**Ruled out:** the Launch Disc game-ID update (#185, suspected in the report) — it touched only `sysLaunchDisc`, launch-time; the boot arm is unchanged since Δ4. Pre-existing exposure, first rig to hit it.

**Fix — ordering, not a timeout (none is possible):** during boot, `deferredInit` posts the arm *after* `GUI_INIT_DONE` is on its way, so a wedged probe degrades the IO worker post-boot (menu alive, diagnosable) instead of killing the console. Settings-apply still arms immediately. Same decouple-menu-from-device-chain principle the brenotomaz analysis called for.

Builds green. **HW-pending — GZAsts rig is the repro.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by deferring MMCE GameID transport initialization until the boot interface is ready.
  * Prevented potential boot menu freezes caused by initialization occurring too early.
  * Preserved immediate transport initialization when applying settings after startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->