### PR TITLE
feat(vcd): sort the VCD scan alphabetically (#195)

### DIFF
--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -149,7 +149,7 @@ gui_strings:
 - label: ERROR_LOADING_ID
   string: Error while loading the Game ID.
 - label: AUTOSORT
-  string: Automatic Sorting
+  string: Sort Games Alphabetically
 - label: ERR_LOADING_LANGFILE
   string: Error loading the language file.
 - label: DEBUG

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -79,6 +79,13 @@ const char *vcdDisplayName(int mode, const char *text)
     return n ? text + n : text;
 }
 
+// Case-insensitive name order for the scan sort below -- the same collation submenuSort uses
+// (strcasecmp), so a menu-level sort (gAutosort) can never disagree with the backing array's order.
+static int vcdEntryCmp(const void *a, const void *b)
+{
+    return strcasecmp(((const vcd_entry_t *)a)->name, ((const vcd_entry_t *)b)->name);
+}
+
 // Core scan: opendir `dirPath` and collect *.VCD basenames into a fresh vcd_entry_t list. POSIX dir
 // IO only (newlib-port rule). Shared by vcdScanDir (POPS subfolder) and vcdScanDirRoot (path as-is).
 static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
@@ -132,6 +139,17 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
         free(list);
         return 0;
     }
+
+    // #195 (Blade, HW): VCD lists arrived in readdir order -- i.e. FAT directory-entry order, which is
+    // effectively random after any add/delete churn -- while every other list reads alphabetical. Sort
+    // the BACKING array here at the scan, not the menu rows: every consumer then agrees (device pages,
+    // the FAV VCD view, art prewarm), ids stay in lockstep with parallel arrays (the HDD path keeps a
+    // per-id partition-label array), and it holds no matter which publish path builds the rows.
+    // Gated on the same Automatic Sorting switch the game lists honour: Autosort off = raw dir order,
+    // as for every other list. Launch/favourites are unaffected either way -- VCDs resolve BY NAME.
+    if (gAutosort && count > 1)
+        qsort(list, count, sizeof(vcd_entry_t), &vcdEntryCmp);
+
     *outList = list;
     return count;
 }


### PR DESCRIPTION
Fixes #195.

**Blade (HW):** *"The .ELF files are sorted alphabetically, which is correct! The .VCDs, however, are just jumbled up."*

VCD lists arrived in **readdir order** — FAT directory-entry order, effectively random after add/delete churn. The sort lives at the **scan** (`vcdScanOpenDir`), not the menu rows, deliberately:

- **every consumer agrees at once** — device pages, FAV VCD view, art prewarm — and it holds no matter which publish path builds the rows;
- **ids stay in lockstep with parallel arrays** — the APA-HDD path keeps a per-id partition-label array that a display-layer fix could never touch safely;
- **launch + favourites unaffected** — VCDs resolve by name end to end.

Collation is `strcasecmp` (same as `submenuSort`), gated on the same **Automatic Sorting** switch the game lists honour — Autosort off keeps raw order, consistent with every other list.

Bonus in the same issue: Blades HW verdict on #191 — *"you improved the vibration — its good to go now, feels great."* **The RETRO rumble retune is hardware-confirmed.**

Builds green; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional alphabetical sorting for VCD directory entries when autosort is enabled.
  * Sorting is case-insensitive for consistent ordering across different filesystem scan results.
* **UI / Copy Updates**
  * Updated the on-screen AUTOSORT label text to reflect “Sort Games Alphabetically” for clearer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->