### PR TITLE
fix(dia): clip scrolled dialog rows to the viewport (overscan stray text)

### DIFF
--- a/src/dia.c
+++ b/src/dia.c
@@ -664,7 +664,28 @@ void diaRenderUI(struct UIItem *ui, short inMenu, struct UIItem *cur, int haveFo
             hmax = 0;
         }
 
-        diaRenderItem(x, y, rc, rc == cur, haveFocus, &w, &h);
+        // Viewport clip for scrolled dialogs (FifthFox HW: "scrolled text moves out of the background
+        // image ... clearing the entire screen removes the stray text"). diaScrollOffset shifts rows
+        // above y0 (and below the hint bar); nothing else stops them drawing there, and since the
+        // dialog re-paints its background rather than full-clearing, a row that scrolled outside the
+        // background stays behind as stray text. So SKIP entirely any row fully outside the item
+        // viewport -- there is then nothing to leave behind. It is an APP-LAYER skip on purpose: a GS
+        // scissor cannot survive the 720p/1080i multi-pass render (its per-pass band scissor gets
+        // overwritten), so this works in every video mode where a scissor would not.
+        //
+        // A skipped row is not measured; advance the layout by its declared height (fixedHeight, or a
+        // small default) so the on-screen rows below keep their positions. Exactness is not needed for
+        // an invisible row -- w/h only feed the y advance and the maxScroll clamp, which the
+        // cursor-follow logic re-clamps every frame. The FOCUSED row is never skipped (that clamp keeps
+        // it inside the viewport by construction), so cursor tracking stays exact.
+        int viewBottom = gTheme->usedHeight - 40; // the same bound the scroll clamp below uses
+        int estH = (rc->fixedHeight > 0) ? rc->fixedHeight : 24;
+        if (rc != cur && (y + estH <= y0 || y >= viewBottom)) {
+            w = 0;
+            h = estH;
+        } else {
+            diaRenderItem(x, y, rc, rc == cur, haveFocus, &w, &h);
+        }
 
         if (rc == cur) {
             curTop = y;

--- a/src/dia.c
+++ b/src/dia.c
@@ -458,6 +458,34 @@ static void diaDrawHint(int text_id)
 
 /// renders an ui item (either selected or not)
 /// sets width and height of the render into the parameters
+// The height diaRenderItem WOULD set for this item, computed without drawing. Kept byte-for-byte in
+// step with diaRenderItem's *h logic below: the default is UI_SPACING_H, UI_SPACER is 0, UI_COLOUR is
+// 17, an invisible controllable item is 0 (diaRenderItem early-returns leaving the caller's h=0), and
+// any non-zero fixedHeight overrides upward (negative = percent of screenHeight). *h never depends on
+// x/y or the text, so this is exact -- used to advance layout past a row the viewport clip skips (#195
+// scroll-bleed fix) so the on-screen rows below it keep their true positions.
+static int diaItemHeight(struct UIItem *item)
+{
+    int h;
+
+    if (!item->visible && item->type >= UI_LABEL)
+        return 0;
+
+    if (item->type == UI_SPACER)
+        h = 0;
+    else if (item->type == UI_COLOUR)
+        h = 17;
+    else
+        h = UI_SPACING_H;
+
+    if (item->fixedHeight != 0) {
+        int newSize = (item->fixedHeight < 0) ? item->fixedHeight * screenHeight / -100 : item->fixedHeight;
+        if (h < newSize)
+            h = newSize;
+    }
+    return h;
+}
+
 static void diaRenderItem(int x, int y, struct UIItem *item, int selected, int haveFocus, int *w, int *h)
 {
     // Don't draw controllable items that are not visible.
@@ -673,16 +701,16 @@ void diaRenderUI(struct UIItem *ui, short inMenu, struct UIItem *cur, int haveFo
         // scissor cannot survive the 720p/1080i multi-pass render (its per-pass band scissor gets
         // overwritten), so this works in every video mode where a scissor would not.
         //
-        // A skipped row is not measured; advance the layout by its declared height (fixedHeight, or a
-        // small default) so the on-screen rows below keep their positions. Exactness is not needed for
-        // an invisible row -- w/h only feed the y advance and the maxScroll clamp, which the
-        // cursor-follow logic re-clamps every frame. The FOCUSED row is never skipped (that clamp keeps
-        // it inside the viewport by construction), so cursor tracking stays exact.
+        // A skipped row is not drawn, but the layout must advance by its EXACT height (diaItemHeight,
+        // which mirrors diaRenderItem's *h logic) so the on-screen rows below it keep their true
+        // positions and contentBottom/cursor-follow stay correct. Width is irrelevant for an unshown
+        // row -- x resets on the next line break -- so w=0. The FOCUSED row is never skipped (the
+        // cursor-follow clamp keeps it inside the viewport by construction), so cursor tracking is exact.
+        int rowH = diaItemHeight(rc);
         int viewBottom = gTheme->usedHeight - 40; // the same bound the scroll clamp below uses
-        int estH = (rc->fixedHeight > 0) ? rc->fixedHeight : 24;
-        if (rc != cur && (y + estH <= y0 || y >= viewBottom)) {
+        if (rc != cur && (y + rowH <= y0 || y >= viewBottom)) {
             w = 0;
-            h = estH;
+            h = rowH;
         } else {
             diaRenderItem(x, y, rc, rc == cur, haveFocus, &w, &h);
         }


### PR DESCRIPTION
**FifthFox (HW):** *"Scrolled text moves out of the background image. Clearing the entire screen ... removes the stray text."* The overscan default→0 (#192) reduced this; a residual remained (*"I still see text above the background"*).

**Cause:** a scrolling dialog shifts rows by `diaScrollOffset`, and a row pushed above `y0` still rendered there — but the dialog re-paints its **background image** each frame rather than full-clearing, so a row scrolled outside that image is left behind as stray text (FifthFoxs own diagnosis).

**Fix:** skip drawing any row fully outside the item viewport `[y0, usedHeight-40]`. A skipped row isnt measured; layout advances by its declared height so on-screen rows keep position. The **focused row is never skipped**, so cursor tracking stays exact.

**App-layer on purpose.** A GS scissor is the textbook fix but **cannot survive the 720p/1080i multi-pass render** — gsKit writes a per-pass band scissor our app scissor would overwrite, corrupting the exact hires modes FifthFox uses. Skipping needs no scissor and works in every mode. (An off-canvas render was also rejected: gsKit packs vertices `px*16+OffsetX`, so a coord past ~-1728 in a 640-wide mode underflows and **wraps back on-screen** as garbage.)

**Note:** restores a clip written alongside #192 but lost when the branch was cut — #192 shipped only the default change.

Builds green. **HW-pending:** FifthFox scrolls a long settings dialog at 1080i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stray text and visual artifacts when dialogs are scrolled.
  * Improved viewport clipping so rows fully outside the visible area are no longer drawn.
  * Maintained correct scrolling and layout positioning while content is clipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->