### PR TITLE
refactor(settings): move Cache & Storage to General Settings

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -227,6 +227,37 @@ struct UIItem diaConfig[] = {
     {UI_STRING, CFG_MMCEPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
     {UI_BREAK},
 
+    // Cache & Storage -- moved here from Device Settings so that screen is strictly device selection
+    // (Nathan 2026-07-16). Same CFG_* ids, same defaults; guiShowConfig now does the diaGet/diaSet.
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Cache & Storage", -1}}},
+    {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HDD_SPINDOWN}}},
+    {UI_SPACER},
+    {UI_INT, CFG_HDDSPINDOWN, 1, 1, _STR_HINT_SPINDOWN, 0, 0, {.intvalue = {20, 20, 0, 20}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_CACHE_HDD_GAME_LIST}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_HDDGAMELISTCACHE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"BDM Cache", -1}}},
+    {UI_SPACER},
+    {UI_INT, CFG_BDMCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 8, 0, 32, NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD Cache", -1}}},
+    {UI_SPACER},
+    {UI_INT, CFG_HDDCACHE, 1, 1, -1, 0, 0, {.intvalue = {8, 0, 0, 32, NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"SMB Cache", -1}}},
+    {UI_SPACER},
+    {UI_INT, CFG_SMBCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 4, 0, 32, NULL}}},
+    {UI_BREAK},
+
     // buttons
     {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
     {UI_BREAK},
@@ -305,34 +336,9 @@ struct UIItem diaDeviceConfig[] = {
     {UI_ENUM, CFG_MMCEMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Cache & Storage", -1}}},
-    {UI_SPLITTER},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HDD_SPINDOWN}}},
-    {UI_SPACER},
-    {UI_INT, CFG_HDDSPINDOWN, 1, 1, _STR_HINT_SPINDOWN, 0, 0, {.intvalue = {20, 20, 0, 20}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_CACHE_HDD_GAME_LIST}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_HDDGAMELISTCACHE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"BDM Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_BDMCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 8, 0, 32, NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_HDDCACHE, 1, 1, -1, 0, 0, {.intvalue = {8, 0, 0, 32, NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"SMB Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_SMBCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 4, 0, 32, NULL}}},
-    {UI_BREAK},
+    // Cache & Storage moved to General Settings (diaConfig) -- Device Settings is now strictly device
+    // selection/mode. The CFG_* ids are unchanged, so guiShowDeviceConfig's old cache diaGet/diaSet
+    // calls were relocated to guiShowConfig alongside them.
 
     // buttons
     {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},

--- a/src/gui.c
+++ b/src/gui.c
@@ -605,6 +605,13 @@ void guiShowConfig()
     diaSetString(diaConfig, CFG_ETHPREFIX, gETHPrefix);
     diaSetString(diaConfig, CFG_MMCEPREFIX, gMMCEPrefix);
 
+    // Cache & Storage -- relocated here from Device Settings (same CFG ids + globals)
+    diaSetInt(diaConfig, CFG_HDDSPINDOWN, gHDDSpindown);
+    diaSetInt(diaConfig, CFG_HDDGAMELISTCACHE, gHDDGameListCache);
+    diaSetInt(diaConfig, CFG_BDMCACHE, bdmCacheSize);
+    diaSetInt(diaConfig, CFG_HDDCACHE, hddCacheSize);
+    diaSetInt(diaConfig, CFG_SMBCACHE, smbCacheSize);
+
     guiUpdater(1); // apply the initial comp-half grey before the dialog is drawn
 
     int ret;
@@ -631,6 +638,14 @@ reshow_config:
         diaGetString(diaConfig, CFG_BDMPREFIX, gBDMPrefix, sizeof(gBDMPrefix));
         diaGetString(diaConfig, CFG_ETHPREFIX, gETHPrefix, sizeof(gETHPrefix));
         diaGetString(diaConfig, CFG_MMCEPREFIX, gMMCEPrefix, sizeof(gMMCEPrefix));
+
+        // Cache & Storage -- relocated here from Device Settings (same CFG ids + globals)
+        diaGetInt(diaConfig, CFG_HDDSPINDOWN, &gHDDSpindown);
+        diaGetInt(diaConfig, CFG_HDDGAMELISTCACHE, &gHDDGameListCache);
+        diaGetInt(diaConfig, CFG_BDMCACHE, &bdmCacheSize);
+        diaGetInt(diaConfig, CFG_HDDCACHE, &hddCacheSize);
+        diaGetInt(diaConfig, CFG_SMBCACHE, &smbCacheSize);
+
         DisableCron = 1; // Disable Auto Start Last Played counter (we don't want to call it right after enable it on GUI)
 
         applyConfig(-1, -1, 0);
@@ -1255,12 +1270,8 @@ void guiShowDeviceConfig(void)
     diaSetInt(diaDeviceConfig, CFG_UDPFSMODE, udpfsModeVal);
     diaSetVisible(diaDeviceConfig, CFG_UDPFSMODE, netPickerVal == 2); // Files/Image only meaningful for UDPFS
 
-    // Cache & storage
-    diaSetInt(diaDeviceConfig, CFG_HDDSPINDOWN, gHDDSpindown);
-    diaSetInt(diaDeviceConfig, CFG_HDDGAMELISTCACHE, gHDDGameListCache);
-    diaSetInt(diaDeviceConfig, CFG_BDMCACHE, bdmCacheSize);
-    diaSetInt(diaDeviceConfig, CFG_HDDCACHE, hddCacheSize);
-    diaSetInt(diaDeviceConfig, CFG_SMBCACHE, smbCacheSize);
+    // Cache & storage (spindown, game-list cache, BDM/HDD/SMB caches) moved to General Settings
+    // (guiShowConfig / diaConfig) -- Device Settings is now strictly device selection.
 
     // MMCE Start Mode stays with the other device start modes; the MMCE game-config (slot / IGR slot /
     // GameID / ack-wait / alarms) moved to its own "MMCE Settings" page -- see guiShowMmceConfig.
@@ -1302,11 +1313,7 @@ void guiShowDeviceConfig(void)
             gETHStartMode = START_MODE_DISABLED;
         }
 
-        diaGetInt(diaDeviceConfig, CFG_HDDSPINDOWN, &gHDDSpindown);
-        diaGetInt(diaDeviceConfig, CFG_HDDGAMELISTCACHE, &gHDDGameListCache);
-        diaGetInt(diaDeviceConfig, CFG_BDMCACHE, &bdmCacheSize);
-        diaGetInt(diaDeviceConfig, CFG_HDDCACHE, &hddCacheSize);
-        diaGetInt(diaDeviceConfig, CFG_SMBCACHE, &smbCacheSize);
+        // Cache & storage read-back now lives in guiShowConfig (moved to General Settings).
 
         diaGetInt(diaDeviceConfig, CFG_MMCEMODE, &gMMCEStartMode);
 


### PR DESCRIPTION
**Nathan:** *"move the device caches from Device Settings to General Settings instead. Device Settings will become strictly the devices then."*

The whole **Cache & Storage** section — HDD Spindown, Cache HDD Game List, and the BDM/HDD/SMB read caches — moves from `diaDeviceConfig` to `diaConfig` (General Settings). Device Settings is now strictly device selection: default menu, per-device start modes, USB/iLink/MX4SIO/HDD enables, the network row, and APP/FAV/MMCE modes.

**Pure relocation** — identical CFG ids, defaults, ranges, and globals. The five `diaSetInt` seeds and five `diaGetInt` read-backs moved with the rows from `guiShowDeviceConfig` to `guiShowConfig`, so saved configs map through unchanged and OK in either screen writes the right globals. (`diaGetInt` no-ops on an absent id, so nothing could have zeroed a cache — but the dead calls are removed anyway.)

The recent dialog viewport-clip fix means the extra General-Settings rows scroll cleanly.

Builds green; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Moved cache and storage settings from Device Settings to General Settings.
  * Added controls for HDD spindown, game-list caching, and cache sizes for BDM, HDD, and SMB storage.
  * Updated the settings layout to make cache-related options easier to find in one location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->