### PR TITLE
feat(net): 3-row Network setting -- Start / Protocol / Access

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -151,6 +151,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_ENABLE_UDPBD         "enable_udpbd"
 #define CONFIG_OPL_NET_BOOT_PROTOCOL    "net_boot_protocol"
 #define CONFIG_OPL_NETWORK_PROTOCOL     "network_protocol"
+#define CONFIG_OPL_NET_START_MODE       "net_start_mode"
 #define CONFIG_OPL_SWAP_SEL_BUTTON      "swap_select_btn"
 #define CONFIG_OPL_PARENTAL_LOCK_PWD    "parental_lock_password"
 #define CONFIG_OPL_SFX                  "enable_sfx"

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -55,8 +55,9 @@ enum UI_ITEMS {
     CFG_ENABLEBDMHDD,
     CFG_ENABLEUDPBD,     // legacy: kept as an unused placeholder (superseded by CFG_NETPROTOCOL)
     CFG_NETBOOTPROTOCOL, // legacy: kept as an unused placeholder (superseded by CFG_NETPROTOCOL)
-    CFG_NETPROTOCOL,     // unified network-protocol selector (Off/SMB/UDPFS)
-    CFG_UDPFSMODE,       // when UDPFS is selected: Files (udpfs_ioman filesystem) vs Image (udpfs_bd block/massN:)
+    CFG_NETSTART,        // network start mode row: Off / Manual / Auto (== START_MODE_*)
+    CFG_NETPROTOCOL,     // protocol row: SMB / UDPFS / UDPBD (Off moved to CFG_NETSTART)
+    CFG_UDPFSMODE,       // access row: Files (udpfs_ioman filesystem) vs IMG (udpfs_bd block/massN:); locked per protocol
     CFG_LASTPLAYED,
     CFG_FOLDERNAV,
     CFG_RUMBLE,

--- a/include/opl.h
+++ b/include/opl.h
@@ -170,7 +170,8 @@ enum NETWORK_PROTOCOL {
     NET_PROTO_UDPFSBD = 3, // udpfs BLOCK device (udpfs_bd -> massN:, UDPRDMA) -- picker "UDPFS", access=Image
     NET_PROTO_UDPBD = 4,   // smap_udpbd / SUDPBDv2 monolith -- picker "UDPBD"; server = udpbd-server (0xBDBD)
 };
-extern int gNetworkProtocol; // enum NETWORK_PROTOCOL -- authoritative; the three above are derived shadows
+extern int gNetworkProtocol; // enum NETWORK_PROTOCOL -- authoritative backend; the three above are derived shadows
+extern int gNetStartMode;    // START_MODE_* -- network start row (Off/Manual/Auto); DISABLED <=> protocol OFF
 
 extern int gAutosort;
 extern int gAutoRefresh;

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -306,17 +306,23 @@ struct UIItem diaDeviceConfig[] = {
     {UI_BREAK},
 
     // Unified network-protocol selector (Off/SMB/UDPFS) -- one exclusive enum replaces the old
-    // ETH-start-mode + Network-Boot toggle + Net-Boot-Protocol picker (the single NIC carries one
-    // transport). The legacy CFG_ETHMODE/CFG_ENABLEUDPBD/CFG_NETBOOTPROTOCOL ids are retired placeholders.
+    // Network -- THREE orthogonal rows (the single NIC carries one transport). Row 1 Start
+    // (Off/Manual/Auto) gates whether/when the stack loads; Row 2 Protocol (SMB/UDPFS/UDPBD); Row 3
+    // Access (Files/IMG). guiDeviceUpdater greys Protocol+Access while Start=Off, and locks Access to
+    // Files for SMB / IMG for UDPBD (only UDPFS offers the free toggle). The legacy CFG_ENABLEUDPBD/
+    // CFG_NETBOOTPROTOCOL ids stay retired placeholders. Enum value strings are literals, as before --
+    // no new lang labels.
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_NET_PROTOCOL}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_NETSTART, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Protocol", -1}}},
     {UI_SPACER},
     {UI_ENUM, CFG_NETPROTOCOL, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    // UDPFS access mode (shown only when UDPFS is the selected protocol): Files = the udpfs_ioman
-    // filesystem (loose ISOs from a served folder); Image = the udpfs_bd block device (a served disk
-    // image, massN:). The PC server can't be probed live, so the mode is a config-time choice.
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_UDPFS_MODE}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Access", -1}}},
     {UI_SPACER},
     {UI_ENUM, CFG_UDPFSMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -227,6 +227,37 @@ struct UIItem diaConfig[] = {
     {UI_STRING, CFG_MMCEPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
     {UI_BREAK},
 
+    // Cache & Storage -- moved here from Device Settings so that screen is strictly device selection
+    // (Nathan 2026-07-16). Same CFG_* ids, same defaults; guiShowConfig now does the diaGet/diaSet.
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Cache & Storage", -1}}},
+    {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HDD_SPINDOWN}}},
+    {UI_SPACER},
+    {UI_INT, CFG_HDDSPINDOWN, 1, 1, _STR_HINT_SPINDOWN, 0, 0, {.intvalue = {20, 20, 0, 20}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_CACHE_HDD_GAME_LIST}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_HDDGAMELISTCACHE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"BDM Cache", -1}}},
+    {UI_SPACER},
+    {UI_INT, CFG_BDMCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 8, 0, 32, NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD Cache", -1}}},
+    {UI_SPACER},
+    {UI_INT, CFG_HDDCACHE, 1, 1, -1, 0, 0, {.intvalue = {8, 0, 0, 32, NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"SMB Cache", -1}}},
+    {UI_SPACER},
+    {UI_INT, CFG_SMBCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 4, 0, 32, NULL}}},
+    {UI_BREAK},
+
     // buttons
     {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
     {UI_BREAK},
@@ -305,34 +336,9 @@ struct UIItem diaDeviceConfig[] = {
     {UI_ENUM, CFG_MMCEMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"Cache & Storage", -1}}},
-    {UI_SPLITTER},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HDD_SPINDOWN}}},
-    {UI_SPACER},
-    {UI_INT, CFG_HDDSPINDOWN, 1, 1, _STR_HINT_SPINDOWN, 0, 0, {.intvalue = {20, 20, 0, 20}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_CACHE_HDD_GAME_LIST}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_HDDGAMELISTCACHE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"BDM Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_BDMCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 8, 0, 32, NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_HDDCACHE, 1, 1, -1, 0, 0, {.intvalue = {8, 0, 0, 32, NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"SMB Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_SMBCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 4, 0, 32, NULL}}},
-    {UI_BREAK},
+    // Cache & Storage moved to General Settings (diaConfig) -- Device Settings is now strictly device
+    // selection/mode. The CFG_* ids are unchanged, so guiShowDeviceConfig's old cache diaGet/diaSet
+    // calls were relocated to guiShowConfig alongside them.
 
     // buttons
     {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},

--- a/src/gui.c
+++ b/src/gui.c
@@ -1212,12 +1212,27 @@ static int guiDeviceUpdater(int modified)
         diaSetEnabled(diaDeviceConfig, CFG_HDDMODE, !bdmHdd);
         diaSetEnabled(diaDeviceConfig, CFG_ENABLEBDMHDD, hddMode == 0);
 
-        // Network transport is a single exclusive enum (CFG_NETPROTOCOL) now, so the old live
-        // ETH<->UDPBD NIC interlock is gone -- one selector cannot pick two transports at once.
-        // Reveal the UDPFS Files/Image sub-mode only while UDPFS (picker index 2) is selected.
-        int netPickerVal;
-        diaGetInt(diaDeviceConfig, CFG_NETPROTOCOL, &netPickerVal);
-        diaSetVisible(diaDeviceConfig, CFG_UDPFSMODE, netPickerVal == 2);
+        // Network 3-row live logic. Row 1 Start (Off/Manual/Auto), Row 2 Protocol (SMB/UDPFS/UDPBD),
+        // Row 3 Access (Files/IMG). While Start=Off, grey Protocol + Access. Lock Access to Files for
+        // SMB and to IMG for UDPBD (only UDPFS offers the free toggle) -- snap the value so a stale IMG
+        // left over from UDPFS can never mis-derive to UDPFSBD under SMB, AND grey the control so the
+        // lock is visible. (The OK read-back is protocol-first too, so this is belt-and-braces.)
+        int netStart = 0, netProto = 0;
+        diaGetInt(diaDeviceConfig, CFG_NETSTART, &netStart);
+        diaGetInt(diaDeviceConfig, CFG_NETPROTOCOL, &netProto);
+        int netOn = (netStart != START_MODE_DISABLED);
+        diaSetEnabled(diaDeviceConfig, CFG_NETPROTOCOL, netOn);
+        if (!netOn) {
+            diaSetEnabled(diaDeviceConfig, CFG_UDPFSMODE, 0);
+        } else if (netProto == 0) { // SMB -> Files, locked
+            diaSetInt(diaDeviceConfig, CFG_UDPFSMODE, 0);
+            diaSetEnabled(diaDeviceConfig, CFG_UDPFSMODE, 0);
+        } else if (netProto == 2) { // UDPBD -> IMG, locked
+            diaSetInt(diaDeviceConfig, CFG_UDPFSMODE, 1);
+            diaSetEnabled(diaDeviceConfig, CFG_UDPFSMODE, 0);
+        } else { // UDPFS -> Files/IMG free
+            diaSetEnabled(diaDeviceConfig, CFG_UDPFSMODE, 1);
+        }
     }
 
     return 0;
@@ -1227,8 +1242,9 @@ void guiShowDeviceConfig(void)
 {
     const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), _l(_STR_FAV), NULL};
     const char *deviceModes[] = {_l(_STR_OFF), _l(_STR_MANUAL), _l(_STR_AUTO), NULL};
-    const char *netProtocols[] = {"Off", "SMB", "UDPFS", "UDPBD", NULL}; // UDPBD kept for users on the older SUDPBDv2 server
-    const char *udpfsModes[] = {"Files", "Image", NULL};                 // Files=udpfs_ioman filesystem, Image=udpfs_bd block
+    const char *netStartModes[] = {"Off", "Manual", "Auto", NULL}; // Row 1: == START_MODE_DISABLED/MANUAL/AUTO
+    const char *netProtocols[] = {"SMB", "UDPFS", "UDPBD", NULL};  // Row 2 (Off moved to Row 1); UDPBD = SUDPBDv2 server
+    const char *udpfsModes[] = {"Files", "IMG", NULL};             // Row 3: Files=udpfs_ioman filesystem, IMG=udpfs_bd block
 
     // Devices & modes
     diaSetEnum(diaDeviceConfig, CFG_DEFDEVICE, deviceNames);
@@ -1251,24 +1267,29 @@ void guiShowDeviceConfig(void)
     diaSetInt(diaDeviceConfig, CFG_ENABLEBDMHDD, gEnableBdmHDD);
     diaSetEnabled(diaDeviceConfig, CFG_ENABLEBDMHDD, !gHDDStartMode);
     diaSetEnabled(diaDeviceConfig, CFG_HDDMODE, !gEnableBdmHDD);
-    // Unified network selector: Off / SMB / UDPFS / UDPBD. gNetworkProtocol keeps distinct internal
-    // values (UDPFS=filesystem/udpfs_ioman, UDPFSBD=block/udpfs_bd, UDPBD=smap_udpbd/SUDPBDv2) as the
-    // backend discriminators; the picker maps them onto Off/SMB/UDPFS/UDPBD and the Files/Image sub-mode
-    // picks the UDPFS backend. UDPBD is retained as a first-class option: the SUDPBDv2 wire protocol is
-    // NOT interchangeable with UDPRDMA, so users on the older udpbd-server must keep selecting it.
-    int netPickerVal = (gNetworkProtocol == NET_PROTO_OFF)   ? 0 :
-                       (gNetworkProtocol == NET_PROTO_SMB)   ? 1 :
-                       (gNetworkProtocol == NET_PROTO_UDPBD) ? 3 :
-                                                               2; // UDPFS/UDPFSBD -> "UDPFS"
-    // Files is the default for everything EXCEPT an actual block (UDPFSBD) config, so a user switching
-    // Off/SMB -> UDPFS lands on the loose-ISO filesystem (the intended default), not the disk-image
-    // backend. guiDeviceUpdater only reveals this control, never re-seeds it, so the seed must be right.
-    int udpfsModeVal = (gNetworkProtocol == NET_PROTO_UDPFSBD) ? 1 : 0; // Image only for the block config; else Files
+    // Network: 3 orthogonal rows seeded from the authoritative gNetworkProtocol + gNetStartMode.
+    //   Row 1 Start:    Off/Manual/Auto == gNetStartMode (START_MODE_*)
+    //   Row 2 Protocol: SMB(0)/UDPFS(1)/UDPBD(2)  -- OFF and UDPFSBD both collapse to their protocol
+    //   Row 3 Access:   Files(0)/IMG(1); IMG only distinct for UDPFS (-> UDPFSBD backend)
+    // guiDeviceUpdater does the greying + the Access lock (SMB->Files, UDPBD->IMG). A NET_PROTO_OFF
+    // backend has no protocol memory, so seed the protocol row to SMB -- the common default a user
+    // reaches when they switch Start from Off to Manual/Auto.
+    int netStartVal = gNetStartMode;
+    int netProtoVal = (gNetworkProtocol == NET_PROTO_UDPBD)                                          ? 2 :
+                      (gNetworkProtocol == NET_PROTO_UDPFS || gNetworkProtocol == NET_PROTO_UDPFSBD) ? 1 :
+                                                                                                       0; // SMB / OFF
+    // IMG for the udpfs block backend AND UDPBD (IMG-locked), so the seed already matches the lock.
+    int netAccessVal = (gNetworkProtocol == NET_PROTO_UDPFSBD || gNetworkProtocol == NET_PROTO_UDPBD) ? 1 : 0;
+    diaSetEnum(diaDeviceConfig, CFG_NETSTART, netStartModes);
+    diaSetInt(diaDeviceConfig, CFG_NETSTART, netStartVal);
     diaSetEnum(diaDeviceConfig, CFG_NETPROTOCOL, netProtocols);
-    diaSetInt(diaDeviceConfig, CFG_NETPROTOCOL, netPickerVal);
+    diaSetInt(diaDeviceConfig, CFG_NETPROTOCOL, netProtoVal);
     diaSetEnum(diaDeviceConfig, CFG_UDPFSMODE, udpfsModes);
-    diaSetInt(diaDeviceConfig, CFG_UDPFSMODE, udpfsModeVal);
-    diaSetVisible(diaDeviceConfig, CFG_UDPFSMODE, netPickerVal == 2); // Files/Image only meaningful for UDPFS
+    diaSetInt(diaDeviceConfig, CFG_UDPFSMODE, netAccessVal);
+    // Seed the initial grey/lock: diaExecuteDialog renders the FIRST frame before it calls
+    // guiDeviceUpdater, so without this the first frame flashes every row enabled.
+    diaSetEnabled(diaDeviceConfig, CFG_NETPROTOCOL, netStartVal != START_MODE_DISABLED);
+    diaSetEnabled(diaDeviceConfig, CFG_UDPFSMODE, netStartVal != START_MODE_DISABLED && netProtoVal == 1);
 
     // Cache & storage (spindown, game-list cache, BDM/HDD/SMB caches) moved to General Settings
     // (guiShowConfig / diaConfig) -- Device Settings is now strictly device selection.
@@ -1292,26 +1313,25 @@ void guiShowDeviceConfig(void)
         diaGetInt(diaDeviceConfig, CFG_ENABLEILK, &gEnableILK);
         diaGetInt(diaDeviceConfig, CFG_ENABLEMX4SIO, &gEnableMX4SIO);
         diaGetInt(diaDeviceConfig, CFG_ENABLEBDMHDD, &gEnableBdmHDD);
-        // Read the unified selector (Off/SMB/UDPFS) + the Files/Image sub-mode, and fold them back into
-        // gNetworkProtocol (UDPFS Files -> NET_PROTO_UDPFS filesystem; UDPFS Image -> NET_PROTO_UDPFSBD
-        // block). Then re-derive the legacy shadows (gEnableUDPBD / gNetBootProtocol / gETHStartMode) that
-        // downstream consumers still read. SMB keeps its live start-mode; any non-SMB protocol forces it off.
-        int netPickerVal = 0, udpfsModeVal = 0;
-        diaGetInt(diaDeviceConfig, CFG_NETPROTOCOL, &netPickerVal);
-        diaGetInt(diaDeviceConfig, CFG_UDPFSMODE, &udpfsModeVal);
-        gNetworkProtocol = (netPickerVal == 0) ? NET_PROTO_OFF :
-                           (netPickerVal == 1) ? NET_PROTO_SMB :
-                           (netPickerVal == 3) ? NET_PROTO_UDPBD :
-                           (udpfsModeVal == 1) ? NET_PROTO_UDPFSBD :
-                                                 NET_PROTO_UDPFS;
+        // Fold the 3 rows back into the authoritative gNetworkProtocol + gNetStartMode. PROTOCOL-FIRST:
+        // the Access value is consulted ONLY for UDPFS, so a stale IMG under SMB/UDPBD can never
+        // mis-derive. Start=Off -> OFF regardless of the (greyed) protocol/access. Then re-derive the
+        // legacy shadows (gEnableUDPBD / gNetBootProtocol / gETHStartMode) downstream consumers read.
+        int netStartVal = 0, netProtoVal = 0, netAccessVal = 0;
+        diaGetInt(diaDeviceConfig, CFG_NETSTART, &netStartVal);
+        diaGetInt(diaDeviceConfig, CFG_NETPROTOCOL, &netProtoVal);
+        diaGetInt(diaDeviceConfig, CFG_UDPFSMODE, &netAccessVal);
+        gNetStartMode = netStartVal; // 0/1/2 == START_MODE_DISABLED/MANUAL/AUTO
+        gNetworkProtocol = (netStartVal == START_MODE_DISABLED) ? NET_PROTO_OFF :
+                           (netProtoVal == 0)                   ? NET_PROTO_SMB :
+                           (netProtoVal == 2)                   ? NET_PROTO_UDPBD :
+                           (netAccessVal == 1)                  ? NET_PROTO_UDPFSBD :
+                                                                  NET_PROTO_UDPFS; // UDPFS + Files
         gEnableUDPBD = (gNetworkProtocol == NET_PROTO_UDPBD || gNetworkProtocol == NET_PROTO_UDPFSBD);
         gNetBootProtocol = (gNetworkProtocol == NET_PROTO_UDPFSBD) ? NET_BOOT_UDPFS : NET_BOOT_UDPBD;
-        if (gNetworkProtocol == NET_PROTO_SMB) {
-            if (gETHStartMode == START_MODE_DISABLED)
-                gETHStartMode = START_MODE_MANUAL;
-        } else {
-            gETHStartMode = START_MODE_DISABLED;
-        }
+        // SMB's start mode IS the network start row now (Auto = boot connect, Manual = on-entry);
+        // every non-SMB protocol forces the SMB/ETH stack off so only one transport claims the NIC.
+        gETHStartMode = (gNetworkProtocol == NET_PROTO_SMB) ? gNetStartMode : START_MODE_DISABLED;
 
         // Cache & storage read-back now lives in guiShowConfig (moved to General Settings).
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -1242,9 +1242,8 @@ void guiShowDeviceConfig(void)
 {
     const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), _l(_STR_FAV), NULL};
     const char *deviceModes[] = {_l(_STR_OFF), _l(_STR_MANUAL), _l(_STR_AUTO), NULL};
-    const char *netStartModes[] = {"Off", "Manual", "Auto", NULL}; // Row 1: == START_MODE_DISABLED/MANUAL/AUTO
-    const char *netProtocols[] = {"SMB", "UDPFS", "UDPBD", NULL};  // Row 2 (Off moved to Row 1); UDPBD = SUDPBDv2 server
-    const char *udpfsModes[] = {"Files", "IMG", NULL};             // Row 3: Files=udpfs_ioman filesystem, IMG=udpfs_bd block
+    const char *netProtocols[] = {"SMB", "UDPFS", "UDPBD", NULL}; // Row 2 (Off moved to Row 1); UDPBD = SUDPBDv2 server -- protocol names, not translated
+    const char *udpfsModes[] = {"Files", "IMG", NULL};            // Row 3: Files=udpfs_ioman filesystem, IMG=udpfs_bd block
 
     // Devices & modes
     diaSetEnum(diaDeviceConfig, CFG_DEFDEVICE, deviceNames);
@@ -1280,7 +1279,11 @@ void guiShowDeviceConfig(void)
                                                                                                        0; // SMB / OFF
     // IMG for the udpfs block backend AND UDPBD (IMG-locked), so the seed already matches the lock.
     int netAccessVal = (gNetworkProtocol == NET_PROTO_UDPFSBD || gNetworkProtocol == NET_PROTO_UDPBD) ? 1 : 0;
-    diaSetEnum(diaDeviceConfig, CFG_NETSTART, netStartModes);
+    // Row 1 == START_MODE_DISABLED/MANUAL/AUTO -- the SAME three options (and indices) as every other
+    // device's start row, so reuse the localized deviceModes rather than a hardcoded English duplicate
+    // (Gemini review of #199). Same function scope as the dialog it feeds, so the diaSetEnum raw-pointer
+    // rule (#154) still holds.
+    diaSetEnum(diaDeviceConfig, CFG_NETSTART, deviceModes);
     diaSetInt(diaDeviceConfig, CFG_NETSTART, netStartVal);
     diaSetEnum(diaDeviceConfig, CFG_NETPROTOCOL, netProtocols);
     diaSetInt(diaDeviceConfig, CFG_NETPROTOCOL, netProtoVal);

--- a/src/gui.c
+++ b/src/gui.c
@@ -605,6 +605,13 @@ void guiShowConfig()
     diaSetString(diaConfig, CFG_ETHPREFIX, gETHPrefix);
     diaSetString(diaConfig, CFG_MMCEPREFIX, gMMCEPrefix);
 
+    // Cache & Storage -- relocated here from Device Settings (same CFG ids + globals)
+    diaSetInt(diaConfig, CFG_HDDSPINDOWN, gHDDSpindown);
+    diaSetInt(diaConfig, CFG_HDDGAMELISTCACHE, gHDDGameListCache);
+    diaSetInt(diaConfig, CFG_BDMCACHE, bdmCacheSize);
+    diaSetInt(diaConfig, CFG_HDDCACHE, hddCacheSize);
+    diaSetInt(diaConfig, CFG_SMBCACHE, smbCacheSize);
+
     guiUpdater(1); // apply the initial comp-half grey before the dialog is drawn
 
     int ret;
@@ -631,6 +638,14 @@ reshow_config:
         diaGetString(diaConfig, CFG_BDMPREFIX, gBDMPrefix, sizeof(gBDMPrefix));
         diaGetString(diaConfig, CFG_ETHPREFIX, gETHPrefix, sizeof(gETHPrefix));
         diaGetString(diaConfig, CFG_MMCEPREFIX, gMMCEPrefix, sizeof(gMMCEPrefix));
+
+        // Cache & Storage -- relocated here from Device Settings (same CFG ids + globals)
+        diaGetInt(diaConfig, CFG_HDDSPINDOWN, &gHDDSpindown);
+        diaGetInt(diaConfig, CFG_HDDGAMELISTCACHE, &gHDDGameListCache);
+        diaGetInt(diaConfig, CFG_BDMCACHE, &bdmCacheSize);
+        diaGetInt(diaConfig, CFG_HDDCACHE, &hddCacheSize);
+        diaGetInt(diaConfig, CFG_SMBCACHE, &smbCacheSize);
+
         DisableCron = 1; // Disable Auto Start Last Played counter (we don't want to call it right after enable it on GUI)
 
         applyConfig(-1, -1, 0);
@@ -1255,12 +1270,8 @@ void guiShowDeviceConfig(void)
     diaSetInt(diaDeviceConfig, CFG_UDPFSMODE, udpfsModeVal);
     diaSetVisible(diaDeviceConfig, CFG_UDPFSMODE, netPickerVal == 2); // Files/Image only meaningful for UDPFS
 
-    // Cache & storage
-    diaSetInt(diaDeviceConfig, CFG_HDDSPINDOWN, gHDDSpindown);
-    diaSetInt(diaDeviceConfig, CFG_HDDGAMELISTCACHE, gHDDGameListCache);
-    diaSetInt(diaDeviceConfig, CFG_BDMCACHE, bdmCacheSize);
-    diaSetInt(diaDeviceConfig, CFG_HDDCACHE, hddCacheSize);
-    diaSetInt(diaDeviceConfig, CFG_SMBCACHE, smbCacheSize);
+    // Cache & storage (spindown, game-list cache, BDM/HDD/SMB caches) moved to General Settings
+    // (guiShowConfig / diaConfig) -- Device Settings is now strictly device selection.
 
     // MMCE Start Mode stays with the other device start modes; the MMCE game-config (slot / IGR slot /
     // GameID / ack-wait / alarms) moved to its own "MMCE Settings" page -- see guiShowMmceConfig.
@@ -1302,11 +1313,7 @@ void guiShowDeviceConfig(void)
             gETHStartMode = START_MODE_DISABLED;
         }
 
-        diaGetInt(diaDeviceConfig, CFG_HDDSPINDOWN, &gHDDSpindown);
-        diaGetInt(diaDeviceConfig, CFG_HDDGAMELISTCACHE, &gHDDGameListCache);
-        diaGetInt(diaDeviceConfig, CFG_BDMCACHE, &bdmCacheSize);
-        diaGetInt(diaDeviceConfig, CFG_HDDCACHE, &hddCacheSize);
-        diaGetInt(diaDeviceConfig, CFG_SMBCACHE, &smbCacheSize);
+        // Cache & storage read-back now lives in guiShowConfig (moved to General Settings).
 
         diaGetInt(diaDeviceConfig, CFG_MMCEMODE, &gMMCEStartMode);
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1746,10 +1746,18 @@ static void _loadConfig()
                 else
                     gNetStartMode = START_MODE_AUTO; // UDPFSBD / UDPBD block
             }
-            // A live protocol with an Off start row is contradictory (hand-edited config) -- make it
-            // start; and keep the SMB start-mode shadow in lockstep with the authoritative row.
-            if (gNetworkProtocol != NET_PROTO_OFF && gNetStartMode == START_MODE_DISABLED)
+            // Reconcile the two persisted halves; a hand-edited/stale config can disagree either way
+            // (CodeRabbit review of #199):
+            //  - Protocol Off + a live start row is contradictory the OTHER direction: the dialog would
+            //    show that start mode against its SMB fallback protocol, so accepting ANY change would
+            //    silently enable SMB. Off wins -- it is the authoritative "network is off".
+            //  - A live protocol with an Off row (or a value outside the enum -- an out-of-range int can
+            //    reach here from a hand-edited file) must start: floor it to Manual.
+            if (gNetworkProtocol == NET_PROTO_OFF)
+                gNetStartMode = START_MODE_DISABLED;
+            else if (gNetStartMode < START_MODE_MANUAL || gNetStartMode > START_MODE_AUTO)
                 gNetStartMode = START_MODE_MANUAL;
+            // Keep the SMB start-mode shadow in lockstep with the authoritative row.
             if (gNetworkProtocol == NET_PROTO_SMB)
                 gETHStartMode = gNetStartMode;
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -166,7 +166,8 @@ int gEnableMX4SIO;
 int gEnableBdmHDD;
 int gEnableUDPBD;
 int gNetBootProtocol; // NET_BOOT_UDPBD | NET_BOOT_UDPFS (legacy shadow, derived from gNetworkProtocol)
-int gNetworkProtocol; // enum NETWORK_PROTOCOL -- authoritative unified selector (Off/SMB/UDPBD/UDPFSBD/UDPFS)
+int gNetworkProtocol; // enum NETWORK_PROTOCOL -- authoritative backend selector (Off/SMB/UDPBD/UDPFSBD/UDPFS)
+int gNetStartMode;    // START_MODE_* -- the Off/Manual/Auto network start row (see the 3-row Network setting)
 int gAutosort;
 int gAutoRefresh;
 int gEnableNotifications;
@@ -643,7 +644,9 @@ void initSupport(item_list_t *itemList, int mode, int force_reinit)
         // The UDPFS filesystem tab lives only while its protocol is selected. It has no Auto/Manual
         // sub-mode (the unified selector is Off/on); treat "selected" as Manual so the IRX chain + mount
         // happen when the user enters the tab, mirroring SMB's default start behavior.
-        startMode = (gNetworkProtocol == NET_PROTO_UDPFS) ? START_MODE_MANUAL : START_MODE_DISABLED;
+        // UDPFS filesystem tab honours the network start row: Auto loads the udpfs IRX chain + mount at
+        // boot, Manual defers it to tab-entry. (Was a hardcoded MANUAL before the 3-row Network setting.)
+        startMode = (gNetworkProtocol == NET_PROTO_UDPFS) ? gNetStartMode : START_MODE_DISABLED;
 
     if (startMode) {
         if (!mod->support) {
@@ -1727,6 +1730,29 @@ static void _loadConfig()
             } else {
                 gETHStartMode = START_MODE_DISABLED;
             }
+
+            // Network start row (Off/Manual/Auto). A config predating this field has no net_start_mode
+            // key -- derive it from the protocol we just resolved so an existing user keeps working:
+            //   OFF   -> Off (Row 1); SMB -> its persisted eth_mode (so a prior SMB=Auto survives);
+            //   UDPFS -> Manual (matches the old hardcoded UDPFS_MODE start gate); block -> Auto
+            //   (matches the old bdm boot-connect for UDPBD/UDPFSBD, where start mode is cosmetic).
+            if (!configGetInt(configOPL, CONFIG_OPL_NET_START_MODE, &gNetStartMode)) {
+                if (gNetworkProtocol == NET_PROTO_OFF)
+                    gNetStartMode = START_MODE_DISABLED;
+                else if (gNetworkProtocol == NET_PROTO_SMB)
+                    gNetStartMode = gETHStartMode;
+                else if (gNetworkProtocol == NET_PROTO_UDPFS)
+                    gNetStartMode = START_MODE_MANUAL;
+                else
+                    gNetStartMode = START_MODE_AUTO; // UDPFSBD / UDPBD block
+            }
+            // A live protocol with an Off start row is contradictory (hand-edited config) -- make it
+            // start; and keep the SMB start-mode shadow in lockstep with the authoritative row.
+            if (gNetworkProtocol != NET_PROTO_OFF && gNetStartMode == START_MODE_DISABLED)
+                gNetStartMode = START_MODE_MANUAL;
+            if (gNetworkProtocol == NET_PROTO_SMB)
+                gETHStartMode = gNetStartMode;
+
             configGetInt(configOPL, CONFIG_OPL_SFX, &gEnableSFX);
             configGetInt(configOPL, CONFIG_OPL_BOOT_SND, &gEnableBootSND);
             configGetInt(configOPL, CONFIG_OPL_BGM, &gEnableBGM);
@@ -2007,6 +2033,7 @@ static void _saveConfig()
         // Dual-write: the authoritative unified selector PLUS the three legacy keys (derived shadows),
         // so a config saved by this build still boots correctly on an older OPL that only reads the legacy keys.
         configSetInt(configOPL, CONFIG_OPL_NETWORK_PROTOCOL, gNetworkProtocol);
+        configSetInt(configOPL, CONFIG_OPL_NET_START_MODE, gNetStartMode);
         configSetInt(configOPL, CONFIG_OPL_SFX, gEnableSFX);
         configSetInt(configOPL, CONFIG_OPL_BOOT_SND, gEnableBootSND);
         configSetInt(configOPL, CONFIG_OPL_BGM, gEnableBGM);
@@ -2831,6 +2858,7 @@ static void setDefaults(void)
     // path re-derives the gEnableUDPBD/gNetBootProtocol shadows and forces a device refresh already.
     // Existing installs are unaffected: a saved net protocol in settings_riptopl.cfg overrides this.
     gNetworkProtocol = NET_PROTO_OFF;
+    gNetStartMode = START_MODE_DISABLED; // Off in the 3-row Network setting; migration reconciles old configs
 
     frameCounter = 0;
 


### PR DESCRIPTION
Splits the single Network picker into three orthogonal rows (owner-confirmed model). **Stacks on #198** (Cache move) — both edit guiShowDeviceConfig; rebased on it so there is no merge conflict. **Roll #198 first**, then this shows only the network diff.

| Row | Values | Locking |
|---|---|---|
| **Network** | Off / Manual / Auto | start mode |
| **Protocol** | SMB / UDPFS / UDPBD | greyed while Start=Off |
| **Access** | Files / IMG | SMB->Files, UDPBD->IMG (locked); UDPFS free |

**Off** = no network. **Manual** = tab appears, connects when opened. **Auto** = connects at boot.

## What made this careful

The three protocols init through **three different subsystems**, so init-gating + migration were **adversarially verified before implementation** (build-verify only, no HW):

- **SMB** -> `gETHStartMode = gNetStartMode`. ETH already honours Auto(boot)/Manual(on-entry); this restores the Auto the unified picker had no UI to set.
- **UDPFS** -> the `UDPFS_MODE` start gate changes from a hardcoded MANUAL to `gNetStartMode`, so Auto loads the udpfs chain at boot (ps2_ip is ready pre-deferred-init; static-IP ministack; load-once latch protects it).
- **UDPBD / UDPFSBD (block)** -> **honest collapse.** These ride `gEnableUDPBD` into the BDM block device, and `bdmEffectiveStartMode` floors BDM to Auto for block net protocols. `gBDMStartMode` is shared across all five BDM transports, so UDPBD has no private start global — **Manual behaves as Auto** for block. Documented, not pretended; no bdmsupport change.

## Safety

- **gNetworkProtocol stays the sole backend** — every routing site untouched. One new global `gNetStartMode`.
- **Derivation is protocol-first** — a stale IMG under SMB/UDPBD can never mis-derive to UDPFSBD. Verified **16/16** derivation + round-trip cases.
- **Migration**: new `net_start_mode` key; a legacy config derives it from the resolved protocol (SMB reuses its `eth_mode`, so a prior SMB=Auto survives). `eth_mode` still dual-written -> an older OPL still boots SMB. Fresh config -> Off.
- **No new lang labels** — enum strings stay literals as the old picker did, so zero append-only exposure.

Builds green; clang-format clean. **HW-unvalidated** (per your build-verify call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate Network settings for Start mode, Protocol, and Access.
  * Network options now dynamically enable, grey out, or lock based on the selected protocol.
  * Added persistent network start-mode configuration (with compatibility handling for older settings).
  * Moved Cache & Storage controls to General Settings, including HDD, BDM, and SMB cache.
* **Bug Fixes**
  * Network startup and access selections now remain synchronized across configuration changes.
  * UDPFS startup now follows the configured start mode instead of a fixed default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->