### PR TITLE
fix(vcd): sort by the visible title when game IDs are hidden (#195)

### DIFF
--- a/include/menusys.h
+++ b/include/menusys.h
@@ -109,7 +109,10 @@ submenu_list_t *submenuAppendItem(submenu_list_t **submenu, int icon_id, char *t
 submenu_list_t *submenuFindItemByIdAndText(submenu_list_t *submenu, int id, const char *text);
 void submenuRemoveItem(submenu_list_t **submenu, int id);
 void submenuDestroy(submenu_list_t **submenu);
-void submenuSort(submenu_list_t **submenu);
+// `mode` = the owning device's list mode (menuItem.userdata->mode), so a VCD view with "hide game ID"
+// on sorts by the RENDERED title instead of the raw filename's invisible game-ID prefix (#195).
+// Pass -1 when no mode applies (non-device submenus).
+void submenuSort(submenu_list_t **submenu, int mode);
 
 char *submenuItemGetText(submenu_item_t *it);
 char *menuItemGetText(menu_item_t *it);

--- a/src/gui.c
+++ b/src/gui.c
@@ -1691,8 +1691,7 @@ static void guiHandleOp(struct gui_update_t *item)
             cacheAdvanceGeneration();
             break;
 
-        case GUI_OP_SORT:
-        {
+        case GUI_OP_SORT: {
             // Sort by the on-screen title: hand the owning device's mode down so a VCD view with "hide
             // game ID" on orders by the rendered name, not the raw filename's game-ID prefix (#195).
             // userdata is the item_list_t (opl.c: menuItem.userdata = mod->support); -1 if unset.

--- a/src/gui.c
+++ b/src/gui.c
@@ -684,7 +684,21 @@ void guiShowVcdConfig(void)
                 snprintf(gPopstarterPath, sizeof(gPopstarterPath), "%s", tmpPop);
         }
         diaGetInt(diaVcdConfig, CFG_BDMA_APPLY, &gBdmaApplyOnLaunch);
-        diaGetInt(diaVcdConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId); // display-only; next list draw reflects it, no rebuild needed
+        {
+            // #195: hide-gameid is NO LONGER purely cosmetic -- it is now a SORT KEY. Both the VCD scan
+            // sort (vcdEntryCmp) and the menu sort (submenuSort) order by the DISPLAYED title, i.e. past
+            // the hidden prefix, so a change must re-sort every VCD-capable page. Without this the rows
+            // keep the PREVIOUS key's order while rendering the new text = visibly mis-alphabetised until
+            // something else happens to force a rescan (CodeRabbit review of #200). Mirrors the
+            // first-disc-only handling below.
+            int previousHideGameId = gVcdHideGameId;
+            diaGetInt(diaVcdConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId);
+            if (gVcdHideGameId != previousHideGameId) {
+                vcdMarkAllDirty();
+                hddVcdInvalidateCache(); // the cached HDD VCD list was sorted with the old key
+                rebuildVcdLists = 1;
+            }
+        }
         {
             // #118: first-disc-only changes the VCD list CONTENTS (discs hidden/shown), so unlike the
             // cosmetic hide-gameid it must rebuild every VCD-capable device page when toggled. Device

--- a/src/gui.c
+++ b/src/gui.c
@@ -1678,7 +1678,13 @@ static void guiHandleOp(struct gui_update_t *item)
             break;
 
         case GUI_OP_SORT:
-            submenuSort(item->menu.subMenu);
+        {
+            // Sort by the on-screen title: hand the owning device's mode down so a VCD view with "hide
+            // game ID" on orders by the rendered name, not the raw filename's game-ID prefix (#195).
+            // userdata is the item_list_t (opl.c: menuItem.userdata = mod->support); -1 if unset.
+            item_list_t *sortSupport = (item_list_t *)item->menu.menu->userdata;
+            submenuSort(item->menu.subMenu, sortSupport ? sortSupport->mode : -1);
+        }
             item->menu.menu->submenu = *item->menu.subMenu;
 
             { // recompute the coverflow wrap tail after the sort reorders the list

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -820,8 +820,15 @@ static void swap(submenu_list_t *a, submenu_list_t *b)
         nb->prev = a;
 }
 
-// Sorts the given submenu by comparing the on-screen titles
-void submenuSort(submenu_list_t **submenu)
+// Sorts the given submenu by comparing the ON-SCREEN titles. `mode` is the owning device's list mode
+// (menuItem.userdata->mode) so a VCD view with "hide game ID" on sorts by what is actually RENDERED:
+// vcdDisplayName() skips the leading "SLES_123.45." prefix at draw time, so comparing the raw stored
+// filenames here ordered the list by an invisible publisher code -- alphabetical to nobody (#195). It
+// returns `text` unchanged for every non-VCD list (and when the prefix is shown), so this is a no-op
+// for PS2/apps/folders. Pass -1 when no mode applies. MUST stay in the same collation the VCD scan
+// sort uses (vcdEntryCmp, strcasecmp on the same display-adjusted key) or the two disagree and this
+// menu-level pass -- which runs LAST -- silently undoes the backing array's order.
+void submenuSort(submenu_list_t **submenu, int mode)
 {
     // a simple bubblesort
     // *submenu = mergeSort(*submenu);
@@ -841,8 +848,12 @@ void submenuSort(submenu_list_t **submenu)
         while (tip->next) {
             submenu_list_t *nxt = tip->next;
 
-            char *txt1 = submenuItemGetText(&tip->item);
-            char *txt2 = submenuItemGetText(&nxt->item);
+            // Compare the RENDERED text, not the stored name (see the header comment): a VCD view with
+            // "hide game ID" on draws each row past its game-ID prefix, so the raw filename is the wrong
+            // sort key. vcdDisplayName is a pure pointer-bump (no copy) and returns the input unchanged
+            // for every other list.
+            const char *txt1 = vcdDisplayName(mode, submenuItemGetText(&tip->item));
+            const char *txt2 = vcdDisplayName(mode, submenuItemGetText(&nxt->item));
 
             // Folder browsing: folders group ahead of games; within each group sort by title.
             int cmp;

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -79,8 +79,10 @@ const char *vcdDisplayName(int mode, const char *text)
     return n ? text + n : text;
 }
 
-// Case-insensitive name order for the scan sort below -- the same collation submenuSort uses
-// (strcasecmp), so a menu-level sort (gAutosort) can never disagree with the backing array's order.
+// Case-insensitive name order for the scan sort below. MUST stay in the same collation submenuSort
+// uses (strcasecmp on the SAME display-adjusted key -- menusys.c was updated alongside this to sort by
+// vcdDisplayName), or the two disagree and the menu-level gAutosort pass, which runs LAST, silently
+// undoes this backing array's order.
 static int vcdEntryCmp(const void *a, const void *b)
 {
     const char *na = ((const vcd_entry_t *)a)->name;

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -83,7 +83,19 @@ const char *vcdDisplayName(int mode, const char *text)
 // (strcasecmp), so a menu-level sort (gAutosort) can never disagree with the backing array's order.
 static int vcdEntryCmp(const void *a, const void *b)
 {
-    return strcasecmp(((const vcd_entry_t *)a)->name, ((const vcd_entry_t *)b)->name);
+    const char *na = ((const vcd_entry_t *)a)->name;
+    const char *nb = ((const vcd_entry_t *)b)->name;
+    // Sort by the TITLE the user actually sees. With "hide game ID" on (gVcdHideGameId), the list
+    // renders each name past its "SLES_123.45." prefix (vcdDisplayName), so sorting the raw filenames
+    // ordered by the invisible publisher code -- alphabetical to nobody (Blade, HW, #195: "omit that
+    // part in the alphabet"). Skip the same prefix here so the visible order matches the visible text.
+    // With hide off, the prefix IS shown, so it stays part of the sort key. vcdGameIdPrefixLen returns
+    // 0 for a name without a strict game-ID prefix, so untagged titles are unaffected either way.
+    if (gVcdHideGameId) {
+        na += vcdGameIdPrefixLen(na);
+        nb += vcdGameIdPrefixLen(nb);
+    }
+    return strcasecmp(na, nb);
 }
 
 // Core scan: opendir `dirPath` and collect *.VCD basenames into a fresh vcd_entry_t list. POSIX dir


### PR DESCRIPTION
**Blade (HW):** the alphabetical VCD sort (#196) *"didnt work"* — with a photo showing **hide game ID** enabled.

The sort compared the raw filename (`SLES_123.45.Title.VCD`), but with `gVcdHideGameId` on the list **renders** each name past its `SLES_123.45.` prefix. So it was ordered by the **invisible publisher code** — alphabetical to nobody. Nathan nailed it: *"omit that part in the alphabet."*

**Fix:** `vcdEntryCmp` skips the same game-ID prefix (`vcdGameIdPrefixLen`) before comparing **when hide is on**, so the sort key matches the visible text. Hide off -> the prefix is shown, so it stays in the key. `vcdGameIdPrefixLen` returns 0 for any name without a strict `AAAA_NNN.NN` prefix, so untagged titles are unaffected.

Builds green. **HW-pending** — Blade with hide-ID on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed VCD submenu sorting so ordering remains consistent when the “hide game ID” option is enabled.
  - Sorting now uses the rendered (visible) title text instead of the raw underlying filename, avoiding order mismatches.
  - When the hide game ID setting is changed, VCD lists are refreshed so the updated sort behavior applies immediately.
  - Submenu sorting now respects the owning device’s sort mode when available, with a fallback for non-device menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->