### PR TITLE
fix(boot): never re-home config to a plain mc when a real boot device is slow to mount

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1748,8 +1748,15 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
     char stem[16];
     int unit;
 
-    // *ioBdmType is only written on success -- a failed resolve must not erase the caller's knowledge
-    // of the boot device's type (the save-path retry keys on it).
+    // *ioBdmType must never ERASE the caller's knowledge of the boot device's type -- the save-path
+    // retry keys on it. It is written on success, and also on the -1 (never-mounted) paths with the
+    // PREFIX CLASSIFICATION: that is not an erase (for an untyped massN: boot filterType IS knownType,
+    // so it round-trips unchanged; for a typed usb0:/ata0:/... boot the prefix is authoritative). This
+    // matters now that a failed resolve KEEPS the boot dir instead of dropping it to legacy discovery:
+    // the caller zeroes this to UNKNOWN before every call, so without writing it back a slow-to-mount
+    // boot device left gBootDirBdmType == UNKNOWN and _saveConfig's re-resolve-and-retry -- gated on
+    // exactly that -- could never fire, so the settings never reached the device once it did mount
+    // (CodeRabbit review of #202).
     int knownType = *ioBdmType;
 
     if (!bdmParseBootStem(bootDir, stem, sizeof(stem), &unit))
@@ -1759,8 +1766,10 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
     int filterType = isMass ? knownType : bdmDetermineDeviceType(stem);
     if (!isMass && filterType == BDM_TYPE_UNKNOWN)
         return 0; // mc/mmce/host/pfs/hdd/cdrom/... -- not a BDM boot path, leave it alone
-    if (filterType == BDM_TYPE_UDPBD)
-        return -1; // network block device: no local mount to resolve at config-load time
+    if (filterType == BDM_TYPE_UDPBD) {
+        *ioBdmType = filterType; // keep the classification so a later save retry stays pinned to it
+        return -1;               // network block device: no local mount to resolve at config-load time
+    }
 
     const char *tail = strchr(bootDir, ':') + 1; // "" | "/APPS" | "APPS" (bdmParseBootStem proved the ':')
     // The boot token's unit digit doubles as the scan-order hint for BOTH families: mass1: names the
@@ -1852,6 +1861,9 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
                 budgetMs += 8000;
                 continue;
             }
+            *ioBdmType = filterType; // never mounted in time, but keep the classification: the caller
+                                     // now KEEPS the boot dir, and _saveConfig's retry is gated on this
+                                     // being != UNKNOWN (see the header comment)
             return -1;
         }
         DelayThread(100 * 1000);

--- a/src/opl.c
+++ b/src/opl.c
@@ -1458,7 +1458,7 @@ static void resolveBootDirToMass(void)
     // MMCE boot: the mmceman driver is likewise not loaded at boot time (sysReset loads none of the
     // device stacks), so mmceN: is unreadable exactly when settings must load. Load it (idempotent)
     // and give the card a moment to register its filesystem. mmceN: IS the readable namespace, so no
-    // prefix rewrite is needed; if the card never shows, drop to legacy discovery like the BDM case.
+    // prefix rewrite is needed.
     if (!strncmp(gBootDir, "mmce", 4)) {
         mmceLoadModules();
         char devRoot[8];
@@ -1476,10 +1476,16 @@ static void resolveBootDirToMass(void)
                 delay(1);
             }
         }
-        LOG("BOOT MMCE boot device for %s never mounted -> legacy discovery\n", gBootDir);
-        gBootDir[0] = '\0';
-        configEnd();
-        configInit(NULL);
+        // Card still settling after the wait. It served this very ELF milliseconds ago, so it IS present
+        // -- it just has not re-registered its mmceman filesystem yet. Do NOT blank gBootDir and re-home
+        // the config to a plain memory card here (the old configInit(NULL) fallback): with an empty boot
+        // dir, configGetDir() returns the legacy mc?: default, so _saveConfig's checkMCFolder() + the
+        // per-file O_CREAT stamped an unwanted mc?:OPL folder and settings onto a SEPARATE plain mc card
+        // (FifthFox, HW 2026-07-16). mc is never an MMCE user's config home. Keep mmce as the home: this
+        // boot falls back to defaults if the card is still settling, and the first save lands on mmce
+        // once it has mounted (a truly dead card fails the save visibly -- the same contract the BDM boot
+        // device honours below). mc stays untouched.
+        LOG("BOOT MMCE boot device %s not mounted after wait -> keep as config home (mc untouched)\n", gBootDir);
         return;
     }
 
@@ -1488,13 +1494,17 @@ static void resolveBootDirToMass(void)
     gBootDirBdmType = BDM_TYPE_UNKNOWN; // classify fresh from the prefix
     int ret = bdmResolveBootDir(gBootDir, sizeof(gBootDir), gBootElfName, &gBootDirBdmType);
     if (ret < 0) {
-        // The boot device did not mount in time. Drop the dead identity so the existing empty-gBootDir
-        // discovery/alternate-save can still find a home for the config, rather than every read/save
-        // silently failing against an unopenable prefix.
-        LOG("BOOT boot device for %s never mounted -> legacy discovery\n", before);
-        gBootDir[0] = '\0';
-        configEnd();
-        configInit(NULL);
+        // The boot device's BDM stack did not mount within the resolve budget. It served this ELF, so it
+        // IS present -- do NOT blank gBootDir and re-home the config to a plain mc here (the old
+        // configInit(NULL)). An empty boot dir makes configGetDir() fall to the legacy mc?: default, and
+        // _saveConfig's checkMCFolder() + the per-file O_CREAT then stamp an mc?:OPL folder + settings
+        // onto a plain memory card (FifthFox, HW 2026-07-16 -- extended from the MMCE case above at
+        // NathanNeurotic's request). mc is never the boot device's config home. Keep the boot identity as
+        // the home (the config sets were already homed there by init()'s configInit): this boot reads
+        // defaults if the stack is still coming up, and a save targets the boot device -- failing visibly
+        // if it is genuinely gone -- never a plain mc. bdmResolveBootDir leaves gBootDir UNCHANGED on a
+        // failed resolve (it only rewrites on success), so the identity here is intact.
+        LOG("BOOT boot device %s not mounted after resolve -> keep as config home (mc untouched)\n", before);
         return;
     }
     if (ret > 0 && strcmp(before, gBootDir) != 0) {


### PR DESCRIPTION
## Bug (FifthFox, HW 2026-07-16)
Booting OPL from an **MMCE** storage device, OPL created its OPL config folder + `settings_riptopl.cfg` on a **separate plain `mc` memory card** — which should never hold OPL folders. (`mc` ≠ MMCE: MMCE is a game/art storage device; `mc` is just a memory card.)

## Root cause
`resolveBootDirToMass()` gives an MMCE (and BDM) boot device only a bounded window to re-register its filesystem after the IOP reset — the mmceman/BDM stacks aren't loaded at config-load time. On timeout it did `gBootDir=""; configInit(NULL)`, which **re-homes the config to the legacy `mc?:` default**. The next save then fires `checkMCFolder()` (→ `mc?:OPL/`) and writes the `.cfg` files there via each `O_CREAT`.

What lands on `mc` is the OPL **config** folder + `.cfg` files (+ `favourites.bin`) — **not** the full CD/DVD/ART game tree (that only comes from `sbCreateFolders`, never called with an `mc` prefix).

**Not a recent code regression** — the MMCE branch dates to `af8be2d6` (2026-07-03), the mc-touch guard's `gBootDir` gate to `07e32f63`. It surfaced now because the card's mount timing crossed the ~2s threshold with a plain `mc` inserted.

## Fix
In both the MMCE and BDM mount-timeout branches, **keep the boot identity as the config home** instead of blanking to `mc?:`. The device served this ELF milliseconds ago, so it's present — just settling. This boot falls back to defaults if the stack is still coming up, and the first save lands on the real boot device once it mounts (a genuinely dead device fails the save visibly — the same contract already accepted for BDM). `mc` stays untouched.

- MMCE case = FifthFox's confirmed report.
- BDM case = extended at maintainer request (same latent flaw; `bdmResolveBootDir` leaves `gBootDir` unchanged on a failed resolve, so the identity is intact).
- **Deliberately untouched:** the uLE APA-HDD branch (`hdd0:...pfs`), which drops to legacy discovery on purpose so `checkLoadConfigHDD` can find the APA `+OPL` config — keeping that unreadable launch identity would break APA config loading.

## Validation
Builds clean locally (ps2dev, `make opl.elf`, exit 0). HW-pending: FifthFox to confirm no `mc?:OPL` folder appears when booting from his MMCE with a plain `mc` inserted (boot log line `keep as config home (mc untouched)` fires on the timeout path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot recovery when storage devices aren’t ready and require re-registration or additional resolve time.
  * Preserves the chosen boot location as the configuration home across MMCE and BDM/boot-dir resolution delays or failures.
  * Prevents unnecessary fallback to legacy memory-card configuration discovery when boot-dir resolution doesn’t complete in time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->