### PR TITLE
fix(vcd): restore the POPSLoader cover fallback (ART primary, POPS/<name>.png fallback)

### DIFF
--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -46,6 +46,12 @@ int vcdResolvePopstarter(const char *devPrefix, char *out, int outSize);
 // Build the POPSTARTER argv[0] selector "<devPrefix>POPS/<prefix><name>.ELF" into out.
 void vcdBuildSelector(const char *devPrefix, const char *prefix, const char *name, char *out, int outSize);
 
+// VCD (PS1) cover FALLBACK to the POPSLoader-style "<scanPrefix>POPS/<value>.png" (suffixless, next to
+// the .VCD). Cover/icon suffixes only; a device getImage calls this ONLY after its own <dev>ART/<name>_
+// <suffix>.png misses, and only in the VCD view. `scanPrefix` = the prefix passed to vcdFillGameList.
+// Returns texDiscoverLoad's result (>= 0 hit, negative miss).
+int vcdLoadPopsCover(const char *scanPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex);
+
 // ---- per-device VCD view (L3 toggle) ----------------------------------------------
 // Does this device class get a VCD view? (BDM range, MMCE, ETH, and the APA/PFS HDD.)
 int vcdModeSupported(int mode);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1212,13 +1212,22 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    // PS1 (VCD) art uses this same ART path as PS2. The cache supplies the filename first and may retry
-    // once with a strict PS1 ID after a genuine miss; no alternate VCD art directories are probed.
+    // OPL's own ART/<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
+    // with a strict PS1 ID).
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", pDeviceData->bdmPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1);
+    int r = texDiscoverLoad(resultTex, path, -1);
+    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD --
+    // ROOT-anchored (bdmBuildVcdPrefix), the SAME prefix the VCD scan uses, since the POPS layout lives at
+    // the device root, outside gBDMPrefix. Cover/icon only, VCD view only.
+    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode)) {
+        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
+        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
+        r = vcdLoadPopsCover(vcdPrefix, value, suffix, resultTex);
+    }
+    return r;
 }
 
 static int bdmGetTextId(item_list_t *itemList)

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -819,13 +819,18 @@ static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char
 {
     char path[256];
 
-    // PS1 (VCD) art uses this same ART path as PS2. The cache supplies the filename first and may retry
-    // once with a strict PS1 ID after a genuine miss; no alternate VCD art directories are probed.
+    // OPL's own ART\<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
+    // with a strict PS1 ID).
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s\\%s_%s", ethPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1);
+    int r = texDiscoverLoad(resultTex, path, -1);
+    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD.
+    // ethPrefix ends in '\\', so vcdLoadPopsCover auto-detects the SMB separator. Cover/icon, VCD view only.
+    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode))
+        r = vcdLoadPopsCover(ethPrefix, value, suffix, resultTex);
+    return r;
 }
 
 static int ethGetTextId(item_list_t *itemList)

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -935,9 +935,14 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
-    // PS1 (VCD) art uses this same ART path as PS2. The cache supplies the filename first and may retry
-    // once with a strict PS1 ID after a genuine miss; no alternate paths or miss-memo are reintroduced.
-    return mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
+    // OPL's own ART/<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
+    // with a strict PS1 ID). On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless
+    // cover named exactly like the .VCD, next to it in the POPS/ folder (mmceArtPrimary IS the VCD scan
+    // prefix). Cover/icon only, VCD view only -- a PS2 list and any hit never pay the extra probe.
+    int r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
+    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode))
+        r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
+    return r;
 }
 
 static int mmceGetTextId(item_list_t *itemList)

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -355,13 +355,18 @@ static int udpfsGetImage(item_list_t *itemList, char *folder, int isRelative, ch
 {
     char path[256];
 
-    // PS1 (VCD) art uses this same ART path as PS2. The cache supplies the filename first and may retry
-    // once with a strict PS1 ID after a genuine miss; no alternate VCD art directories are probed.
+    // OPL's own ART/<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
+    // with a strict PS1 ID).
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", udpfsPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1);
+    int r = texDiscoverLoad(resultTex, path, -1);
+    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD.
+    // Cover/icon only, VCD view only.
+    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode))
+        r = vcdLoadPopsCover(udpfsPrefix, value, suffix, resultTex);
+    return r;
 }
 
 static int udpfsGetTextId(item_list_t *itemList)

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -204,8 +204,8 @@ int vcdLoadPopsCover(const char *scanPrefix, const char *value, const char *suff
 {
     char path[256];
 
-    if (scanPrefix == NULL || value == NULL || suffix == NULL)
-        return ERR_BAD_FILE;
+    if (scanPrefix == NULL || value == NULL || suffix == NULL || resultTex == NULL)
+        return ERR_BAD_FILE; // resultTex too: texDiscoverLoad dereferences it (CodeRabbit review of #203)
     if (strcmp(suffix, "COV") != 0 && strcmp(suffix, "ICO") != 0)
         return ERR_BAD_FILE; // only the cover/icon fall back to the suffixless POPS name
 

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -23,6 +23,7 @@
 #include "include/mmcesupport.h" // mmceLoadModules (ensure mmceman for the MMCE BDMA source)
 #include "include/gui.h"         // guiWarning (passing toast on a failed launch-path BDMA equip)
 #include "include/lang.h"        // _l + _STR_BDMA_ERR_* (same texts the Settings-screen equip shows)
+#include "include/textures.h"    // texDiscoverLoad + ERR_BAD_FILE (VCD POPS cover fallback)
 #include "include/vcdsupport.h"
 
 int vcdExtractGameId(const char *name, char *idOut, int idSize)
@@ -187,6 +188,30 @@ static char vcdSep(const char *devPrefix)
 {
     int n = (devPrefix != NULL) ? (int)strlen(devPrefix) : 0;
     return (n > 0 && devPrefix[n - 1] == '\\') ? '\\' : '/';
+}
+
+// VCD (PS1) cover FALLBACK. OPL's own art (<dev>ART/<name>_COV.png) is the PRIMARY -- each device's
+// getImage tries it first; this only runs on a genuine miss. It loads the POPSLoader-style cover named
+// exactly like the .VCD (suffixless "<name>.png"), sitting NEXT TO the game in the same POPS/ folder the
+// VCD scan reads -- so a cover whose name matches the VCD minus the extension still shows (FifthFox, HW
+// 2026-07-16; the tier removed by 86da2023's #120 single-lookup simplification). `scanPrefix` MUST be the
+// SAME prefix the device passes to vcdFillGameList (the device root for BDM, mmcePrefix for MMCE, etc.),
+// so the cover is looked up beside the .VCD. COVER/ICON ONLY -- background/logo/screenshot must never
+// fall back to the single suffixless file or each would render the cover instead. Returns
+// texDiscoverLoad's result (>= 0 hit, negative miss). No miss-memo: kept deliberately simple -- callers
+// gate this on a genuine ERR_BAD_FILE + the VCD view, so a PS2 list and a hit never pay the extra probe.
+int vcdLoadPopsCover(const char *scanPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex)
+{
+    char path[256];
+
+    if (scanPrefix == NULL || value == NULL || suffix == NULL)
+        return ERR_BAD_FILE;
+    if (strcmp(suffix, "COV") != 0 && strcmp(suffix, "ICO") != 0)
+        return ERR_BAD_FILE; // only the cover/icon fall back to the suffixless POPS name
+
+    // Same directory the scan reads: "<scanPrefix>POPS<sep><value>"; texDiscoverLoad appends the extension.
+    snprintf(path, sizeof(path), "%s%s%c%s", scanPrefix, POPS_FOLDER, vcdSep(scanPrefix), value);
+    return texDiscoverLoad(resultTex, path, -1);
 }
 
 // Probe POPS/POPSTARTER.ELF on a device root given WITHOUT a trailing separator ("mass0", "mc0", "pfs0").


### PR DESCRIPTION
## Bug (FifthFox, HW 2026-07-16)
VCD (PS1) covers stopped loading. His covers are named exactly like the .VCD **minus the extension** (`Game.VCD` → `Game.png`), sitting next to the game in the **POPS/ folder** — the canonical POPSLoader layout. gameID-named covers still loaded (via the kept strict-ID tier), which is how the cause was isolated. Confirmed **not** looking on `mc`.

## Root cause
`86da2023` ("load PS1 art with a single filename lookup" — a #120 MMCE-bus anti-wedge fix) + `c43c56de` dropped the 3-tier `vcdLoadArt`, keeping only `<dev>ART/<name>_COV.png` (+ the gameID retry in the texcache). The removed **tier 3** was `<dev>POPS/<name>.png` — the suffixless cover next to the .VCD — which is *exactly* FifthFox's layout. Clinching logic: 86da2023 removed **only** that tier, and his art broke → his covers were served by it. Not #196 (the alphabetical sort) — that's a red herring in the timeline.

## Fix
Per maintainer direction — *"OPL reads `ART/<name>_COV.png` with `POPS/` as the fallback, keep it simple"*:

- OPL's own `ART/<name>_COV.png` stays the **primary** lookup (unchanged).
- On a genuine miss **in the VCD view**, each device's `getImage` falls back to `<scanPrefix>POPS/<name>.png` via a new `vcdLoadPopsCover()` helper. `scanPrefix` is the **same** prefix the device passes to `vcdFillGameList`, so the cover is found beside the .VCD (root-anchored for BDM, `mmcePrefix` for MMCE, `ethPrefix`/`\` for SMB, `udpfsPrefix` for UDPFS).

**Kept deliberately simple — no miss-memo resurrection.** The probe is gated on a genuine `ERR_BAD_FILE` **and** `vcdViewActive()`, so a PS2 list, an ART hit, or a transient bus error never pays it; cover/icon suffixes only (bg/logo/screenshot never fall back to the single suffixless file). This keeps the #120 exposure tightly bounded (VCD pages, genuine misses only).

Wired into **MMCE / BDM / ETH / UDPFS**. **HDD (APA) is left as-is** on purpose: its VCDs scan from a per-partition pfs root (`vcdScanDirRoot`), not a `POPS/` subfolder, so its cover layout differs and needs separate handling — out of scope here.

## Files
`vcdsupport.c/.h` (helper), `mmcesupport.c`, `bdmsupport.c`, `ethsupport.c`, `udpfssupport.c` — +67/−12.

## Validation
Builds clean locally (ps2dev, `make opl.elf`, exit 0). HW-pending: FifthFox to confirm his MMCE VCD covers load, and to watch for any MMCE-bus regression on cover-less PS1 lists (the #120 concern the original change addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback loading for VCD/PS1 cover and icon textures from POPS-compatible locations when standard ART artwork is missing.
  * Fallback is only attempted in the VCD view for relative cover requests, and only for cover/icon suffixes.
* **Bug Fixes**
  * Improved cover/icon retrieval consistency across supported image sources by retrying with the POPS-style path after a genuine “file not found” result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->