### PR TITLE
fix(theme): raise the VCD/apps cover to center on the games cover's axis

### DIFF
--- a/misc/conf_theme_OPL.cfg
+++ b/misc/conf_theme_OPL.cfg
@@ -151,7 +151,7 @@ appsMain16:
 	type=ItemCover
 	default=coverapp
 	x=-128
-	y=-198
+	y=240
 	width=184
 	height=185
 	overlay=case


### PR DESCRIPTION
## Report (NathanNeurotic, HW)
> VCD cover art should absolutely be adjusted to raise a bit — it's sitting low on the right side, and looks off kilter as a result.

## Cause
The VCD view renders with the **apps element family**, so its cover is `appsMain16`. `ItemCover` initialises with `ALIGN_CENTER` (themes.c:2142) — x/y is the element's **centre** — and a **negative** y anchors from the bottom (`posY = (screenHeight + y)`, scaled by `usedHeight`), while a positive y is absolute.

| element | y | height | centre | spans |
|---|---|---|---|---|
| `main16` (PS2 games) | `240` | 256 | **240** | 112–368 |
| `appsMain16` (apps/VCD) | `-198` | 185 | **282** | 190–375 |

The two were roughly **bottom-aligned** — and because the VCD/apps cover is square (185 vs 256 tall), that put its centre **42px below** the games cover in the same right-hand slot. Hence "low on the right side / off kilter."

## Fix
`appsMain16: y=-198 → y=240` → centre **240**, spans 147–332: the same axis as the games cover.

Using the **positive** form also matches `main16` exactly — a negative y additionally *scales with `usedHeight`* (so it drifted differently on a 448-line theme) while a positive one doesn't. Both covers now share one anchor rule instead of two.

This affects the **Apps page** as well as the VCD view (same element, same square-vs-tall mismatch) — which is the consistent outcome: both centre on the games cover's axis.

## Validation
`conf_theme_OPL.cfg` is embedded in the ELF (`MISC_OBJS` → `conf_theme_OPL.o`), so the rebuild bakes it in. Builds clean (`make opl.elf`, exit 0).

**Geometry is computed, not rendered** — this wants your eyes on it. If 240 reads too high, the knob is just that one number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the cover’s vertical positioning for improved theme layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->