### PR TITLE
fix(theme): give AttributeImage a persistent cacheId -- the uncut #120 info-page read storm (#154)

### DIFF
--- a/include/themes.h
+++ b/include/themes.h
@@ -28,6 +28,15 @@ typedef struct
 typedef struct
 {
     // Attributes for: AttributeImage
+    // currentCacheId + currentUid are ONE logical pair -- cacheGetTexture's two out-params must BOTH
+    // persist across frames or its negative (FAILED) memo cannot work: a failed load writes
+    // *cacheId = -2 and *UID = gCacheGeneration, and the skip gate is (*cacheId == -2 && *UID ==
+    // gCacheGeneration). drawAttributeImage used to pass a STACK-LOCAL for the cacheId, so the -2 was
+    // thrown away every frame and each frame re-enqueued a fresh FAILING device open -- an unbounded
+    // read storm on whatever device the theme lives on. That was the "baseline info-entry read burst"
+    // (86da2023) behind the #120/#154 MMCE wedge. Every other cacheGetTexture caller already passes a
+    // persistent field/array (see getGameImageTexture).
+    int currentCacheId;
     int currentUid;
     u32 currentConfigId;
     char *currentValue;

--- a/src/themes.c
+++ b/src/themes.c
@@ -673,6 +673,7 @@ static void endMutableImage(struct theme_element *elem)
 static mutable_image_t *initMutableImage(const char *themePath, config_set_t *themeConfig, theme_t *theme, const char *name, int type, const char *cachePattern, int cacheCount, const char *defaultTexture, const char *overlayTexture)
 {
     mutable_image_t *mutableImage = (mutable_image_t *)malloc(sizeof(mutable_image_t));
+    mutableImage->currentCacheId = -1; // -1 = the cache API's "no entry" sentinel (see themes.h)
     mutableImage->currentUid = -1;
     mutableImage->currentConfigId = 0;
     mutableImage->currentValue = NULL;
@@ -1199,6 +1200,13 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
     if (config) {
         if (attributeImage->currentConfigId != config->uid) {
             // force refresh
+            // Reset the cacheId TOO, and note this is mandatory rather than tidiness: the -2 memo gate
+            // in cacheGetTexture short-circuits WITHOUT comparing the value string (unlike the identity
+            // gate below it, which does strcmp entry->value). A -2 left over from the previous game
+            // would therefore suppress THIS game's badge for the rest of the generation -- i.e. the
+            // badge would stop updating / keep the old glyph. currentValue can only change inside this
+            // same branch, so clearing both here is airtight.
+            attributeImage->currentCacheId = -1;
             attributeImage->currentUid = -1;
             attributeImage->currentConfigId = config->uid;
             attributeImage->currentValue = NULL;
@@ -1212,8 +1220,15 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
 
                 return;
             } else {
-                int posZ = 0;
-                GSTEXTURE *texture = cacheGetTexture(attributeImage->cache, menu->item->userdata, &posZ, &attributeImage->currentUid, attributeImage->currentValue);
+                // Pass the PERSISTENT cacheId, not a stack local: cacheGetTexture's FAILED memo writes
+                // *cacheId = -2 (+ *UID = gCacheGeneration) and its skip gate reads BOTH back next
+                // frame. With a per-frame `int posZ = 0` the -2 was discarded, the gate was
+                // unreachable, and every frame re-enqueued a fresh FAILING open -- the unbounded
+                // info-page read storm behind #120/#154 (a badge whose glyph the theme does not ship
+                // is the NORMAL case; that is why the embedded-glyph fallback above exists). This is
+                // the same pattern getGameImageTexture has always used, which is exactly why main-page
+                // covers/screenshots never wedged (AndrewBento's bisect, #154).
+                GSTEXTURE *texture = cacheGetTexture(attributeImage->cache, menu->item->userdata, &attributeImage->currentCacheId, &attributeImage->currentUid, attributeImage->currentValue);
                 if (texture && texture->Mem) {
                     if (attributeImage->overlayTexture) {
                         rmDrawOverlayPixmap(&attributeImage->overlayTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,


### PR DESCRIPTION
## The bisect that cracked it (AndrewBento, HW, #154)
> I tested Riptopl with a theme where game screenshots appear on the main screen without having to go to the game information page, and everything loaded and worked normally... I didn't access the game information page... all screenshots loaded every time. **The problem isn't with the screenshots or the image loading, but with the game information page itself.**

He's right — and the bisect doesn't exonerate the art pipeline, it **indicts one caller**.

## Root cause
`cacheGetTexture`'s negative (FAILED) memo requires **both** out-params to persist. A failed load writes `*cacheId = -2; *UID = gCacheGeneration;` and the skip gate is `(*cacheId == -2 && *UID == gCacheGeneration)`.

```c
// themes.c — drawAttributeImage (INFO badges)   ❌ stack local, re-zeroed every frame
int posZ = 0;
cacheGetTexture(..., &posZ, &attributeImage->currentUid, ...);

// themes.c — getGameImageTexture (MAIN covers)  ✅ persistent
cacheGetTexture(..., &item->cache_id[...], &item->cache_uid[...], ...);
```

So the `-2` was **thrown away every frame**, the skip gate was structurally unreachable, and **every frame re-enqueued a fresh failing device open** for as long as the info page rendered. `AttributeImage` was the *only* art consumer in the tree doing this — which is exactly why Andrew's main-page screenshots cost ~1 open per generation and survived indefinitely.

Info-page-exclusive **by layout, not by engine**: `conf_theme_OPL.cfg` puts all seven AttributeImage elements on `info7..info13`, none on `main`. It only fires on a **disk theme** (the cache branch is gated on `thmGetGuiValue() != 0`; the built-in theme short-circuits to embedded glyphs with zero card reads), and only for badges whose glyph the theme doesn't ship — which the embedded-glyph fallback right above it exists for *because that's the normal case*.

**This is the "BASELINE info-entry read burst that desyncs the card in the first place" that 86da2023 admitted it never cut.** No #120 attempt ever went near it — all of them sanded `ELEM_TYPE_GAME_IMAGE` or the VCD cover loader, i.e. the paths that *already had a working memo*. That's why every beta made it "take longer to happen" and none fixed it.

## Fix (4 lines, mirrors the proven GameImage pattern)
`mutable_image_t` gains `currentCacheId`, init `-1`, passed instead of the stack local. A missing glyph now costs **one open per generation** instead of one per frame.

It also resets in the force-refresh branch — **mandatory, not tidiness**: the `-2` gate short-circuits *without* comparing the value string, so a leftover `-2` from the previous game would suppress the new badge for the rest of the generation.

## Scope — honest
This is the **trigger**, verified line-by-line. The **persistence** (all art dead afterward) has *no code-side explanation* — no global art-kill flag exists, request accounting balances. It rests on the fork's own HW conclusion (01aa6d3e) that the card desyncs **card-side** under read load. So this is a **prevention** fix; an already-desynced card needs a power cycle. **HW must confirm before #154/#120 is called closed.**

## Also refuted (worth recording)
The TerminateThread/RPC-corruption theory is **dead on reachability**. `cacheEnd()`'s only caller is gated to Exit / Power Off / Boot Disc, and `gDiag.artTerminate` (**TK**) increments inside that same branch — so **TK is mathematically 0 for any session you're still browsing in**. Every "TK:0" HW reading was *vacuous*. Info exit issues no abort at all (`guiSwitchScreen` only calls `cacheAdvanceGeneration`, whose invalidate runs `preserveLoaded=1` and never sets `abortRequested`).

## Validation
Struct changed → validated with a full `make clean` rebuild (the Makefile doesn't track header deps). Builds clean, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture caching for attribute images to prevent repeated failed texture loads across frames.
  * Cache state now resets correctly when the active configuration changes.
  * Improved rendering consistency by keeping image cache state synchronized with the active image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->