### PR TITLE
fix(art): default the .tar cover loader ON (wOPL parity) + 4 real tar-engine defects (#54)

### DIFF
--- a/include/tar.h
+++ b/include/tar.h
@@ -32,7 +32,16 @@ typedef struct
 typedef struct
 {
     TarEntryBase base;
-    char filename[41]; // ART: filename up to 40 chars + null
+    // [48], not [41]: the parser derives its copy length from the entry STRIDE, not from this array --
+    // nameMax = entrySize - sizeof(TarEntryBase) - 1 = 64 - 16 - 1 = 47 -- so it memcpy'd 47 bytes and
+    // NUL-terminated at [47], i.e. 7 bytes past the declared size. It landed in this struct's own tail
+    // padding (the stride is exactly 64), so it was benign in practice, but it is out of bounds on the
+    // declared type and would corrupt the next entry the moment anyone resizes this array or grows
+    // TarEntryBase. [48] keeps sizeof(TarEntryArt) == 64, so entrySize, nameMax, copyLen, the on-disk
+    // art_cache.bin layout and wOPL cache compatibility are all unchanged (do NOT widen further without
+    // bumping ARC_VERSION -- 47 is also wOPL-base's cap, and real keys are far shorter,
+    // e.g. "SLUS_203.70_COV.png" = 19).
+    char filename[48]; // ART: filename up to 47 chars + null
 } TarEntryArt;
 
 typedef struct

--- a/src/gui.c
+++ b/src/gui.c
@@ -29,6 +29,7 @@
 #include "include/sound.h"
 #include "include/guigame.h"
 #include "include/texcache.h"
+#include "include/tar.h" // tarInvalidate -- re-arm the .tar probe when the toggle flips
 
 #include <limits.h>
 #include <stdlib.h>
@@ -1008,7 +1009,16 @@ reselect_video_mode:
         diaGetInt(diaUIConfig, UICFG_AUTOREFRESH, &gAutoRefresh);
         diaGetInt(diaUIConfig, UICFG_NOTIFICATIONS, &gEnableNotifications);
         diaGetInt(diaUIConfig, UICFG_COVERART, &gEnableArt);
-        diaGetInt(diaUIConfig, UICFG_ENABLE_ART_TAR, &gEnableArtTar);
+        {
+            // Re-arm the .tar probe when the toggle actually flips. tarFind's "no archive anywhere"
+            // latch is write-once and process-wide, and NOTHING was clearing it (tarInvalidate had no
+            // callers at all) -- so a user who turned the loader on after boot kept getting nothing
+            // until a reboot, which looks exactly like "the toggle does nothing".
+            int previousArtTar = gEnableArtTar;
+            diaGetInt(diaUIConfig, UICFG_ENABLE_ART_TAR, &gEnableArtTar);
+            if (gEnableArtTar != previousArtTar)
+                tarInvalidate(TAR_KIND_ART);
+        }
         diaGetInt(diaUIConfig, UICFG_WIDESCREEN, &gWideScreen);
         diaGetInt(diaUIConfig, CFG_APPLYGAMEID, &gApplyGameID);
         diaGetInt(diaUIConfig, UICFG_VMODE, &gVMode);

--- a/src/opl.c
+++ b/src/opl.c
@@ -2827,7 +2827,13 @@ static void setDefaults(void)
     gETHPrefix[0] = '\0';
     gEnableNotifications = 1;
     gEnableArt = 1;
-    gEnableArtTar = 0; // .tar cover-art loader is opt-in (default OFF)
+    // .tar cover-art loader ON by default = wOPL parity (#54). wOPL has NO equivalent gate on either
+    // branch -- it tries ART/art.tar FIRST and falls back to the loose ART/ file -- so shipping this OFF
+    // was the whole of "art.tar covers don't work": the reporter had the feature and could not find the
+    // switch ("I looked for an activation option but couldn't find it"). The toggle stays as an escape
+    // hatch. Cost on a setup with no art.tar is one failed open() per session, then zero (the tarFind
+    // inactive latch), which is exactly why wOPL's author added that latch rather than a user toggle.
+    gEnableArtTar = 1;
     gWideScreen = 1;
     gDefaultGameView = GAME_VIEW_BOTH;
     gEnableSFX = 1;

--- a/src/tar.c
+++ b/src/tar.c
@@ -17,6 +17,9 @@
 #include <string.h>
 
 #include "include/tar.h"
+#include "include/ioman.h" // LOG -- this engine shipped with ZERO tracing, which made every "art.tar
+                           // doesn't work" report unfalsifiable (the CHT path announces its hit at
+                           // supportbase.c; ART said nothing at all).
 
 typedef struct
 {
@@ -219,10 +222,11 @@ static int tarWriteCache(const char *cachePath, const char *tarPath, TarKind kin
 
 static int tarParseFile(TarKind kind, const char *path)
 {
-    struct stat st;
-    if (stat(path, &st) < 0)
-        return -1;
-
+    // No stat() existence probe here. It was pure redundancy -- the caller has already proven the file
+    // OPENS, and this function opens it again below -- but its failure latched s_inactive[kind], which is
+    // a process-wide, write-once kill switch with no live way to clear it. Any device driver where open()
+    // succeeds but stat() fails therefore killed art.tar for the whole session with the archive sitting
+    // right there. Let the open() below be the single arbiter of existence.
     char dirPath[256];
     strncpy(dirPath, path, sizeof(dirPath));
     dirPath[sizeof(dirPath) - 1] = '\0';
@@ -269,15 +273,27 @@ static int tarParseFile(TarKind kind, const char *path)
         if (isZeroBlock(header))
             break;
 
+        // Derive the seek distance from the UNCAPPED header size. Clamping rawSize FIRST and computing
+        // paddedSize from the clamped value made any member larger than MAX_FILE_SIZE seek SHORT, so the
+        // walk landed mid-data and indexed every SUBSEQUENT entry at a garbage offset -- and tarWriteCache
+        // then PERSISTED that corrupt index to art_cache.bin, where it passes revalidation (which only
+        // rejects rawSize > MAX_FILE_SIZE, and the clamped value is exactly ==) and survives reboots until
+        // the archive's size changes. wOPL refuses such an archive outright; skipping just the oversized
+        // member keeps the rest of the archive usable while never desynchronising the walk.
         u64 rawSize = parseOctal((char *)header + 124, 12);
-        if (rawSize > MAX_FILE_SIZE)
-            rawSize = MAX_FILE_SIZE;
-
         u64 paddedSize = ((rawSize + 511) / 512) * 512;
+        int oversized = (rawSize > MAX_FILE_SIZE); // too big to serve (rawSize/paddedSize are u32) -> don't index it
 
         u64 dataOffset = lseek64(fd, 0, SEEK_CUR);
         if (dataOffset == (u64)-1)
             goto fail;
+
+        if (oversized) {
+            LOG("TAR skip oversized entry (%lu bytes > %d) in %s\n", (unsigned long)rawSize, MAX_FILE_SIZE, path);
+            if (lseek64(fd, paddedSize, SEEK_CUR) == (u64)-1)
+                goto fail;
+            continue;
+        }
 
         if (s_count[kind] >= s_cap[kind]) {
             u32 newCap = s_cap[kind] ? (s_cap[kind] + 64) : 64;
@@ -356,15 +372,22 @@ int tarLoadFromAnyDevice(TarKind kind)
 
         s_dev[kind] = dev;
         if (tarParseFile(kind, tarPath) == 0) {
+            LOG("TAR indexed %s (%u entries)\n", tarPath, (unsigned int)s_count[kind]);
             found = 1;
             break;
         }
+        LOG("TAR parse FAILED for %s -- trying the next device\n", tarPath);
 
         tarCloseInternal(kind);
     }
 
-    if (!found)
+    // Latch: no archive on any device -> stop probing for the rest of the session (this is what makes
+    // the loader cheap by default on setups that ship no .tar -- one failed open per device, then zero).
+    // It is write-once and process-wide, so LOG it: a silent latch made every HW report unfalsifiable.
+    if (!found) {
+        LOG("TAR no archive found for kind %d -- probing disabled for this session\n", (int)kind);
         s_inactive[kind] = 1;
+    }
 
     return found ? 0 : -1;
 }


### PR DESCRIPTION
## The report (brenotomaz-eng, #54)
> I used to use Wopl and the .tar covers worked perfectly, but in this fork RiptOPL they don't load. **I looked for an activation option but couldn't find it in the display tab.**

## Root cause — it's one line
`gEnableArtTar = 0;`

wOPL has **no equivalent gate on either branch** — verified against the real source, not from memory:
```
git grep -iE 'gEnableArtTar|ENABLE_ART_TAR' wopl/wOPL-base wopl/wOPL-release   → (nothing)
```
Both wOPL branches try the archive **first, unconditionally**, with the loose `ART/` file as fallback. We shipped exactly the feature he asked for, switched off — and he told us in the report that he went looking for the switch and couldn't find it.

Worth noting **#54 was never HW-confirmed**: he tried to retest, and his console hung at boot — that's the *separate* exFAT-USB/WOPLSDK boot hang, not art.tar.

### Settled negatives (checked against wOPL — don't re-litigate)
- In-archive entry name is **byte-for-byte correct** (`<value>_<suffix>.png`, no folder prefix, no `./`).
- ustar parser **matches** (size@124, 12 octal digits, 512-byte blocks, zero-block terminator).
- `art_cache.bin` header is **byte-identical**; a version mismatch is rejected and self-heals.

The engine was never the problem.

## What else this fixes (default-ON makes these load-bearing)

**1. Index corruption — we were *less* robust than wOPL.** `tarParseFile` clamped `rawSize` to `MAX_FILE_SIZE` then derived `paddedSize` **from the clamped value**, so any member >4 MiB seeked **short**: the walk landed mid-data and indexed every subsequent entry at a garbage offset — and `tarWriteCache` **persisted that to art_cache.bin**, where it passes revalidation (which only rejects `> MAX_FILE_SIZE`, and the clamped value is exactly `==`) and **survives reboots**. Now the seek always uses the uncapped padded size and oversized members are skipped.

**2. Silent session-wide kill switch.** A redundant `stat()` existence probe latched `s_inactive[kind]` — write-once, process-wide, and **nothing live cleared it** (`tarInvalidate` had zero callers). The probe was pointless: the caller already proved the file opens and the function opens it again two lines later. Any driver where `open()` works but `stat()` doesn't killed art.tar **for the whole session** with the archive sitting right there.

**3. The toggle couldn't re-arm.** Because that latch is write-once and `tarInvalidate` was dead code, turning the loader on *after* boot returned nothing until a reboot — i.e. the toggle looked broken. Now wired on change.

**4. OOB on the declared type.** `filename[41]`, but the parser derives its copy length from the entry **stride**: `nameMax = 64-16-1 = 47` → memcpy 47 + NUL at `[47]` = 7 bytes past. Benign (landed in tail padding) but out of bounds and one refactor from corrupting the next entry. Verified `[48]` keeps `sizeof(TarEntryArt) == 64`:

```
base=16
OLD filename[41]: sizeof=64 nameMax=47 (NUL at [47] -> OUT OF BOUNDS)
NEW filename[48]: sizeof=64 nameMax=47 (NUL at [47] -> in bounds)
stride unchanged (64 == 64)? YES - art_cache.bin layout + wOPL compat preserved
```

**Plus tracing:** `src/tar.c` shipped with **zero `LOG()` calls**, so every "art.tar doesn't work" report was unfalsifiable (the CHT path announces its hit + device). Added logging for the index hit, per-device parse failure, the oversized skip, and the latch arming.

## Why default-ON is safe
wOPL's own author answered the perf objection — commit `dcf273bd` *"Fix tar device probing ... Fixes lag on game selection when tar files aren't present"*: a setup with no art.tar costs **one failed open per device per session, then zero**. That latch is precisely why wOPL needs no user toggle. Ours stays as an escape hatch.

## Validation
Struct changed → full `make clean` rebuild, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)