### PR TITLE
fix(theme): stop the AttributeImage badge thrashing a one-slot cache (#49)

### DIFF
--- a/src/themes.c
+++ b/src/themes.c
@@ -23,11 +23,13 @@
 
 // Cache slots per AttributeImage element. An AttributeImage is NOT a per-game image -- it is a small FIXED
 // SET of glyphs keyed by the attribute's value, so the cache only ever needs to hold that attribute's whole
-// value set to be thrash-free. Sized to the LARGEST set we emit, #Format (ISO/ZSO/VCD/UL/ELF/HDL = 6), with
-// headroom; #DiscType is 3 (PS1CD/PS2CD/PS2DVD), #Media and #System are 2 each. Cheap: cacheInitCache
-// allocates empty entry structs, and a slot costs texture memory only once a glyph is actually loaded into
-// it -- so a #DiscType cache still only ever holds its 3.
-#define ATTR_IMAGE_CACHE_SLOTS   8
+// value set to be thrash-free. Our built-in attributes are tiny (#Format = ISO/ZSO/VCD/UL/ELF/HDL = 6,
+// #DiscType = 3, #Media/#System = 2), but a theme can bind AttributeImage to a CUSTOM per-game config key
+// (Genre, Developer, Publisher, ...) whose value set is open-ended (Gemini review of #49), so size for that:
+// 32 covers any realistic custom attribute with headroom. Genuinely cheap -- cacheInitCache allocates only
+// `count` empty cache_entry_t structs (no texture memory until a glyph is actually loaded into a slot), so
+// 32 slots is ~2-3 KB of EE RAM and a #DiscType cache still only ever HOLDS its 3.
+#define ATTR_IMAGE_CACHE_SLOTS 32
 
 extern const char conf_theme_OPL_cfg;
 extern u16 size_conf_theme_OPL_cfg;

--- a/src/themes.c
+++ b/src/themes.c
@@ -21,6 +21,14 @@
 #define DECORATOR_SIZE           20
 #define APP_PREFETCH_IDLE_FRAMES 10
 
+// Cache slots per AttributeImage element. An AttributeImage is NOT a per-game image -- it is a small FIXED
+// SET of glyphs keyed by the attribute's value, so the cache only ever needs to hold that attribute's whole
+// value set to be thrash-free. Sized to the LARGEST set we emit, #Format (ISO/ZSO/VCD/UL/ELF/HDL = 6), with
+// headroom; #DiscType is 3 (PS1CD/PS2CD/PS2DVD), #Media and #System are 2 each. Cheap: cacheInitCache
+// allocates empty entry structs, and a slot costs texture memory only once a glyph is actually loaded into
+// it -- so a #DiscType cache still only ever holds its 3.
+#define ATTR_IMAGE_CACHE_SLOTS   8
+
 extern const char conf_theme_OPL_cfg;
 extern u16 size_conf_theme_OPL_cfg;
 extern const char theme_coverflow_cfg;
@@ -727,7 +735,17 @@ static mutable_image_t *initMutableImage(const char *themePath, config_set_t *th
 
     if (cachePattern && !mutableImage->cache) {
         if (type == ELEM_TYPE_ATTRIBUTE_IMAGE)
-            mutableImage->cache = cacheInitCache(-1, themePath, 0, cachePattern, 1);
+            // An AttributeImage is a small FIXED SET of glyphs keyed by the attribute's value, not a
+            // per-game image: #DiscType has three (PS1CD/PS2CD/PS2DVD), #Media two (CD/DVD), #System two
+            // (PS1/PS2), #Format a handful. With ONE slot the cache could hold exactly one of them, so
+            // every move between a DVD game and a CD game EVICTED it and re-read the PNG off the device --
+            // and that re-read rides the single art worker, queued BEHIND the whole interactive art set
+            // (the cover shows in ~0.2s but the rest drains for seconds). That is AcidReach's #49 report
+            // exactly: ~5s on a slow step to a new game, ~0.5s back to a previous one, and -- the tell --
+            // ~0.2s when scrolling FAST, because scrolling defers the art set and the badge jumps a clear
+            // queue. ATTR_IMAGE_CACHE_SLOTS covers the largest attribute's value set, so each glyph is read
+            // ONCE per session and every later selection is a RAM hit with zero device IO.
+            mutableImage->cache = cacheInitCache(-1, themePath, 0, cachePattern, ATTR_IMAGE_CACHE_SLOTS);
         else
             mutableImage->cache = cacheInitCache(theme->gameCacheCount++, "ART", 1, cachePattern, cacheCount);
     }


### PR DESCRIPTION
## The report (AcidReach, HW, `hdd0:/+OPL/THM/`)
The `#DiscType` disc badge **works** — it's just slow, in a very specific pattern:

| | |
|---|---|
| step slowly to a **new** game | **~5 s** |
| step back to a **previous** game | **~0.5 s** |
| scroll **rapidly** across several games | **~0.2 s — instant**, seen before or not |

**Observation 3 is the tell**, and it refutes every settle/idle-timer theory outright — those all predict rapid input makes the badge *slower*. It's faster because rapid scrolling **starves whatever was blocking it**.

## Root cause
```c
mutableImage->cache = cacheInitCache(-1, themePath, 0, cachePattern, 1);
//                                                                   ^^^ ONE slot
```
…for an attribute with **three** values (`#DiscType` = PS1CD/PS2CD/PS2DVD).

An AttributeImage isn't a per-game image — it's a small **fixed set** of glyphs keyed by the value. With one slot the cache holds exactly one, so **every move between a DVD game and a CD game evicts it and re-reads the PNG off the device**. That re-read rides the **single art worker**, queued **behind the whole interactive art set**: the cover appears in ~0.2s but the rest drains for seconds, and the badge waits for all of it.

All three observations, one cause:
- **~5s** — evicted → re-read → stuck behind the draining art set
- **~0.5s** — that disc type still resident in the 1 slot
- **~0.2s** — scrolling defers/aborts the art set → badge jumps a clear queue

## Fix
Size the cache to the attribute's value set: `ATTR_IMAGE_CACHE_SLOTS = 8` — covers the largest set we emit (`#Format` = ISO/ZSO/VCD/UL/ELF/HDL = 6) with headroom; `#DiscType` is 3, `#Media`/`#System` are 2. Each glyph is read **once per session**; every later selection is a RAM hit with zero device IO.

Cheap: `cacheInitCache` allocates empty entry structs, and a slot costs texture memory only once a glyph is actually loaded into it — so a `#DiscType` cache still only ever holds its 3.

## Ruled out (recorded so it isn't re-chased)
The per-item **config** wait. `menuCanRequestItemConfig` already returns 1 for BDM/ETH/HDD/FAV (his device), and its own comment describes this exact symptom as the *old* behaviour PR #155 removed. The MMCE non-COV `delay++` settle is MMCE-only and can't apply to him.

Pairs with #206: that made **failed** badge lookups memoize; this keeps the **successful** ones resident.

**AcidReach was right, and his report was never stale.** The feature resolves correctly — `#DiscType` maps to PS1CD/PS2CD/PS2DVD and the theme's `PS1CD_#DiscType.png` is found at `<themePath>`. It just thrashed.

## Validation
Builds clean (`make opl.elf`, exit 0). **HW-pending**: AcidReach to confirm all three cases are now instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute-related image caching by allocating more cache capacity for embedded glyph variants.
  * Reduces cache evictions during quick switching between attribute values, minimizing visual “thrashing.”
  * Results in more stable visuals and smoother transitions during fast navigation and gameplay updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->