### PR TITLE
fix(texcache): fail-epoch for genuine-absence art — Andrew's #154 info-page wedge

### DIFF
--- a/include/texcache.h
+++ b/include/texcache.h
@@ -23,6 +23,14 @@ typedef struct
 
     int UID;
 
+    // Set when this entry's load FAILED with ERR_BAD_FILE -- a GENUINE ABSENCE (open() found no file),
+    // as opposed to a transient read error on a contended bus (ERR_FILE_IO). cacheGetTextureInternal
+    // memoizes a genuine absence on gCacheFailEpoch (which survives the per-screen-switch generation
+    // bump, so the info page stops re-running the same failing opens every visit -- #154/#120) and a
+    // transient on gCacheGeneration (re-probed next generation, in case the bus recovered). 0 on a
+    // fresh/cleared entry (memset) -- treated as transient, the conservative default.
+    unsigned char failAbsent;
+
     // Identity of the art this entry holds (heap copy of the request value, e.g. the game's
     // startup). The instant-return path validates it against the caller's value so a poisoned or
     // stale per-item (cacheId, UID) pair self-heals in one frame instead of permanently rendering
@@ -89,6 +97,8 @@ int cacheAbortMmceImageLoadsTimed(int timeoutTicks);
  *  Never blocks on the IO worker.
  */
 void cacheAdvanceGeneration(void);
+// Drop the genuine-absence art memos (see texcache.c). Call only on a deliberate settings/theme apply.
+void cacheInvalidateFailMemo(void);
 
 /** Advances the failure-retry generation without canceling queued art loads.
  */

--- a/src/opl.c
+++ b/src/opl.c
@@ -2177,6 +2177,12 @@ static void _saveConfig()
 
 void applyConfig(int themeID, int langID, int skipDeviceRefresh)
 {
+    // A deliberate settings/theme apply is the one moment art the user just added (or a theme they just
+    // switched to) could newly exist, so clear the genuine-absence art memo and let cover-less items be
+    // probed once more. This is NOT cacheAdvanceGeneration (screen-switch/scroll churn -- the very thing
+    // the fail epoch ignores) and NOT the background rescan poll (re-hammering that reintroduces #120).
+    cacheInvalidateFailMemo();
+
     if (gDefaultDevice < 0 || gDefaultDevice > FAV_MODE)
         gDefaultDevice = MMCE_MODE;
     // Favourites (issue #54) is a valid startup page only while the FAV tab is enabled; otherwise fall

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -58,6 +58,7 @@ typedef struct load_image_request
     int cacheUID;
     int effectiveMode;
     int generation;
+    int failEpoch; // gCacheFailEpoch when this request was ENQUEUED -- see the completion path
     volatile int abortRequested;
     unsigned char priority;
     unsigned char vcdFallback;
@@ -900,7 +901,16 @@ static void cacheCompleteRequest(load_image_request_t *req, int result)
             // (result >= 0 but Mem == NULL) are transient/present-but-broken -> re-probe next generation,
             // so a real file is never permanently hidden by a one-off bus hiccup (the reason the earlier
             // gCacheFailEpoch attempt was rejected -- PR #134's ERR_FILE_IO split is what makes it safe).
-            req->entry->failAbsent = (result == ERR_BAD_FILE);
+            //
+            // AND require the fail-epoch to be UNCHANGED since this request started (req->failEpoch ==
+            // gCacheFailEpoch). cacheInvalidateFailMemo() (settings/theme apply) bumps the epoch precisely
+            // to force cover-less items to re-probe -- e.g. the user just copied a cover onto the card.
+            // A request already IN FLIGHT across that apply must NOT be allowed to write a genuine-absence
+            // memo under the NEW epoch: that would re-suppress the very re-probe the apply asked for, so
+            // the freshly-added art would not appear until a SECOND apply (CodeRabbit review of #154).
+            // Downgrading a stale-epoch absence to transient (failAbsent = 0) re-probes it next generation
+            // -- imminent, and exactly the item most likely to have just gained art.
+            req->entry->failAbsent = (result == ERR_BAD_FILE && req->failEpoch == gCacheFailEpoch);
         } else {
             req->entry->texture = req->texture;
             cacheResetTextureState(&req->texture);
@@ -1318,9 +1328,14 @@ void cacheAdvanceGeneration(void)
 void cacheInvalidateFailMemo(void)
 {
     cacheLock();
-    gCacheFailEpoch++;
-    if (gCacheFailEpoch <= 0)
+    // Wrap BEFORE overflowing: gCacheFailEpoch++ at INT_MAX is signed-overflow UB, and -O2 may then
+    // prove the (<= 0) guard dead and delete it (Gemini review of #154). Practically unreachable (one
+    // bump per settings/theme apply), but keep it defined. (gCacheGeneration uses the older <=0 idiom
+    // above; left as-is -- pre-existing, out of this change's scope.)
+    if (gCacheFailEpoch == 0x7FFFFFFF)
         gCacheFailEpoch = 1;
+    else
+        gCacheFailEpoch++;
     cacheUnlock();
 }
 
@@ -1696,6 +1711,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     req->vcdFallback = vcdViewActive(effectiveMode);
     req->priority = priority;
     req->generation = gCacheGeneration;
+    req->failEpoch = gCacheFailEpoch; // pin the absence epoch to when the load STARTED, not when it finishes
     req->value = (char *)req + sizeof(load_image_request_t);
     strcpy(req->value, value);
     req->cacheUID = cache->nextUID;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -125,6 +125,14 @@ static int gArtQueuedCount = 0;
 static int gArtActiveCount = 0;
 static int gArtInteractiveActiveCount = 0;
 static int gCacheGeneration = 1;
+// Separate epoch for GENUINE-ABSENCE art memos. gCacheGeneration bumps on every screen switch and cursor
+// move (cacheAdvanceGeneration), which is correct for scroll/nav churn but WRONG for a known-missing file:
+// keying an absence on it made every info-page entry re-run the same ~6 failing opens for a PS1 game with
+// no art, wedging the slow MMCE SIO2 bus (#154, the "baseline info-entry read burst" #120 never cut). This
+// epoch bumps ONLY on a deliberate settings/theme apply (cacheInvalidateFailMemo, from applyConfig) -- NOT
+// on generation advance and NEVER on the background rescan poll (that re-hammer is exactly what reintroduces
+// #120) -- so a genuine absence is probed ONCE and then costs zero opens until the user changes something.
+static int gCacheFailEpoch = 1;
 static load_image_request_t *gArtCurrentReq = NULL;
 /* Navigation-active snapshot. getKey() mutates GUI-thread-only pad-repeat state,
  * so the art worker thread must not call it; the GUI thread refreshes this flag
@@ -887,6 +895,12 @@ static void cacheCompleteRequest(load_image_request_t *req, int result)
         } else if (result < 0 || req->texture.Mem == NULL) {
             req->entry->lastUsed = 0;
             req->entry->state = CACHE_ENTRY_FAILED;
+            // ONLY ERR_BAD_FILE is a genuine absence (open() failed = no such file) -> long-term memo.
+            // ERR_FILE_IO (contended-bus read/stage error) and a decode that yielded no pixels
+            // (result >= 0 but Mem == NULL) are transient/present-but-broken -> re-probe next generation,
+            // so a real file is never permanently hidden by a one-off bus hiccup (the reason the earlier
+            // gCacheFailEpoch attempt was rejected -- PR #134's ERR_FILE_IO split is what makes it safe).
+            req->entry->failAbsent = (result == ERR_BAD_FILE);
         } else {
             req->entry->texture = req->texture;
             cacheResetTextureState(&req->texture);
@@ -1004,6 +1018,7 @@ void cacheInit()
     gArtActiveCount = 0;
     gArtInteractiveActiveCount = 0;
     gCacheGeneration = 1;
+    gCacheFailEpoch = 1;
     gArtInteractiveReqList = NULL;
     gArtInteractiveReqEnd = NULL;
     gArtPrefetchReqList = NULL;
@@ -1294,6 +1309,21 @@ void cacheAdvanceGeneration(void)
     cacheWakeWorker();
 }
 
+// Drop the GENUINE-ABSENCE art memos so cover-less items are probed once more. Call ONLY on a deliberate
+// settings/theme apply (from applyConfig) -- never on cacheAdvanceGeneration (that fires on every screen
+// switch, which is the churn this epoch exists to ignore) and never on the background rescan poll (that
+// re-hammer is what reintroduces the #120 wedge). A cover copied onto the card mid-session appears after
+// the next settings apply or reboot; a real device change already rebuilds the lists (fresh caches +
+// re-zeroed per-item cacheIds), so this is belt-and-braces for the settings/theme case.
+void cacheInvalidateFailMemo(void)
+{
+    cacheLock();
+    gCacheFailEpoch++;
+    if (gCacheFailEpoch <= 0)
+        gCacheFailEpoch = 1;
+    cacheUnlock();
+}
+
 void cacheBumpGeneration(void)
 {
     cacheLock();
@@ -1453,7 +1483,19 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     cacheLock();
     effectiveMode = cacheGetEffectiveMode(list, value);
 
+    // Failure memos. -2 = a GENUINE ABSENCE, keyed on gCacheFailEpoch: it survives the per-screen-switch
+    // generation bump, so the info page no longer re-runs the same failing opens on every visit (#154).
+    // -3 = a TRANSIENT failure, keyed on gCacheGeneration: re-probed on the next generation in case the
+    // bus recovered. A mismatch (epoch/generation advanced) drops the memo so the load is re-attempted.
     if (*cacheId == -2) {
+        if (*UID == gCacheFailEpoch) {
+            cacheUnlock();
+            return NULL;
+        }
+
+        *cacheId = -1;
+        *UID = -1;
+    } else if (*cacheId == -3) {
         if (*UID == gCacheGeneration) {
             cacheUnlock();
             return NULL;
@@ -1505,8 +1547,16 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
                     cacheUnlock();
                     return result;
                 case CACHE_ENTRY_FAILED:
-                    *cacheId = -2;
-                    *UID = gCacheGeneration;
+                    // Memo this failure so it is not reopened every frame. A genuine absence is keyed on
+                    // gCacheFailEpoch (long-lived: no re-probe until settings/theme apply); a transient on
+                    // gCacheGeneration (re-probed next generation, in case the bus recovered).
+                    if (entry->failAbsent) {
+                        *cacheId = -2;
+                        *UID = gCacheFailEpoch;
+                    } else {
+                        *cacheId = -3;
+                        *UID = gCacheGeneration;
+                    }
                     cacheUnlock();
                     return NULL;
                 default:


### PR DESCRIPTION
## This is Andrew's actual #154 fix — **not** #206
Nathan confirmed Andrew wedges on the **built-in `<OPL>` theme**, where `drawAttributeImage` returns at the embedded-glyph branch *before* touching the cache — so the #206 badge storm is structurally unreachable for him. (#206 is a real fix, but for **disk-theme** users like FifthFox.)

## Root cause — fits every fact Andrew has ever given us
The FAILED-art memo is keyed on `gCacheGeneration`:
```c
case CACHE_ENTRY_FAILED:  *cacheId = -2; *UID = gCacheGeneration;   // write
if (*cacheId == -2 && *UID == gCacheGeneration) return NULL;         // skip
```
But `guiSwitchScreen` calls `cacheAdvanceGeneration` on **every screen switch**. Enter info → bump; leave → bump. So **every info visit re-runs the same ~6 failing opens** (BG/COV/SCR/SCR2…), back-to-back with no settle, on PS1 games that have **no art at all** — every open a not-found on the slow MMCE SIO2 bus. That's the *"baseline info-entry read burst that desyncs the card"* 86da2023 named and never cut.

It explains all of it:
| fact | why |
|---|---|
| art-OFF fixes it | these are GameImage requests, which **are** `gEnableArt`-gated |
| built-in theme still wedges | nothing here is theme-dependent |
| main page hammers fine | 1–2 elements at user-paced scroll, not ~6 back-to-back ×2/visit |
| PS2 info never wedges | PS2 art **exists** → opens succeed → memoize |
| #137/#138 didn't fix it | they trimmed lookup **tiers**, never the per-visit **re-run** |

## Fix — split the memo by failure kind (PR #134's `ERR_FILE_IO`/`ERR_BAD_FILE`)
- **Genuine absence** (`ERR_BAD_FILE`, open() found no file) → memo on a new **`gCacheFailEpoch`** that does **not** bump on generation advance, only on a deliberate settings/theme apply. A cover-less item is probed **once**, then zero opens across every screen switch and info re-entry. Sentinel `-2`.
- **Transient** (`ERR_FILE_IO`, opened but the read stalled; or a decode with no pixels) → memo on `gCacheGeneration` **exactly as before**, re-probing next generation so a *present* file is never permanently hidden by a one-off bus hiccup. New sentinel `-3`, distinct so the two epoch spaces can't collide (that overload is literally the #206 bug — not repeated).

`cache_entry_t` gains `failAbsent`, set at completion from the result code.

## Why safe to do now (we rejected this exact design before)
We built the fail-epoch once and **rejected** it: a transient error was indistinguishable from a genuine absence, so it would latch a *present* cover blank. **PR #134's `ERR_FILE_IO` split removed that blocker** — this is the first build where the two can be told apart.

## Landmine avoided
The epoch bumps **only** from `applyConfig` (deliberate, low-frequency) — never from `cacheAdvanceGeneration` (the churn it exists to ignore) and **never from the background rescan poll** (re-hammering that is exactly what reintroduces #120). A device change already rebuilds the lists (fresh caches + re-zeroed per-item cacheIds), so the `applyConfig` bump is belt-and-braces for add-art-mid-session / theme-swap.

## Scope — honest
This cuts the **trigger** (the unbounded failing-open burst), verified in code. The **persistence** (all art dead until reboot) is still inferred from HW (01aa6d3e), not proven in code — so this is a **prevention** fix: a card already desynced mid-session needs a power cycle. If Andrew *still* wedges, the burst wasn't sufficient and the next suspects are the bounded amplifiers on top (per-settled CFG open, VCD strict-ID retry, the POPS probe). `TK`/`MH`/`MM` on his HUD remain non-signals.

## Validation
Struct changed → full `make clean` rebuild, exit 0. **HW-pending on Andrew's rig** — this is the one that should actually hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-artwork handling so cover-less items aren’t repeatedly re-checked during screen navigation and cursor movement.
  * Added clearer separation between genuinely absent artwork and transient loading/decoding failures to prevent incorrect memoization.
  * Artwork is re-probed after applying settings or switching themes, ensuring newly added covers show up without requiring a full rescan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->