### PR TITLE
fix(art): revert the .tar loader to default OFF (keep the #207 engine fixes)

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2855,13 +2855,12 @@ static void setDefaults(void)
     gETHPrefix[0] = '\0';
     gEnableNotifications = 1;
     gEnableArt = 1;
-    // .tar cover-art loader ON by default = wOPL parity (#54). wOPL has NO equivalent gate on either
-    // branch -- it tries ART/art.tar FIRST and falls back to the loose ART/ file -- so shipping this OFF
-    // was the whole of "art.tar covers don't work": the reporter had the feature and could not find the
-    // switch ("I looked for an activation option but couldn't find it"). The toggle stays as an escape
-    // hatch. Cost on a setup with no art.tar is one failed open() per session, then zero (the tarFind
-    // inactive latch), which is exactly why wOPL's author added that latch rather than a user toggle.
-    gEnableArtTar = 1;
+    // .tar cover-art loader is OPT-IN (default OFF) -- the fork's deliberate opinionated default (#54).
+    // The reporter's "art.tar doesn't work" was DISCOVERABILITY, not the default: the toggle lives in
+    // Display Settings ("Cover Art .tar Archive"). PR #207 briefly flipped this ON for wOPL parity;
+    // reverted at NathanNeurotic's call -- users who want the archive turn it on. The engine fixes from
+    // #207 (uncapped-seek index integrity, no stat()-latch, toggle re-arm, the [48] filename bound) stay.
+    gEnableArtTar = 0;
     gWideScreen = 1;
     gDefaultGameView = GAME_VIEW_BOTH;
     gEnableSFX = 1;


### PR DESCRIPTION
## Revert the default; keep the fixes

PR #207 flipped `gEnableArtTar` **ON** for wOPL parity. **Your call: keep it OFF.**

The reporter's "art.tar doesn't work" (#54) was **discoverability** — the toggle is in Display Settings ("Cover Art .tar Archive") — not the default. That opt-in, opinionated default is the fork's posture, not upstream/wOPL parity. Users who want the archive turn it on.

**This keeps every engine fix from #207** (they're what make the feature correct *when* enabled):
- uncapped-seek index integrity (no persisted-corrupt `art_cache.bin`)
- removal of the `stat()`-existence session-wide kill switch
- `tarInvalidate` re-arm when the toggle flips
- the `[48]` filename bound
- the added `LOG` tracing

Only `gEnableArtTar` goes back to `0`.

Builds clean (`make opl.elf`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cover art `.tar` archive loading is now disabled by default.
  - Existing cover art behavior remains unchanged when the option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->