### PR TITLE
fix(vcd): don't re-walk the APA HDD on a hide-gameid toggle (audit of the #200 fix)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -701,17 +701,20 @@ void guiShowVcdConfig(void)
         }
         diaGetInt(diaVcdConfig, CFG_BDMA_APPLY, &gBdmaApplyOnLaunch);
         {
-            // #195: hide-gameid is NO LONGER purely cosmetic -- it is now a SORT KEY. Both the VCD scan
-            // sort (vcdEntryCmp) and the menu sort (submenuSort) order by the DISPLAYED title, i.e. past
-            // the hidden prefix, so a change must re-sort every VCD-capable page. Without this the rows
-            // keep the PREVIOUS key's order while rendering the new text = visibly mis-alphabetised until
-            // something else happens to force a rescan (CodeRabbit review of #200). Mirrors the
-            // first-disc-only handling below.
+            // #195: hide-gameid is NO LONGER purely cosmetic -- it is now a SORT KEY. The menu sort
+            // (submenuSort) orders by the DISPLAYED title, i.e. past the hidden prefix, so a change must
+            // re-sort every VCD-capable page. vcdMarkAllDirty() + rebuildVcdLists forces that menu rebuild
+            // and its submenuSort re-runs against the new vcdDisplayName key -- WITHOUT re-reading any
+            // device. Do NOT invalidate the HDD VCD cache here (unlike first-disc-only below): this toggle
+            // changes only the DISPLAY ORDER, not the list CONTENTS, and submenuSort reorders the cached
+            // rows in place. hddVcdInvalidateCache() would force an unnecessary full re-walk of every
+            // __.POPS partition (pfs1: remount) plus a transient empty HDD VCD page on every flip (audit
+            // 2026-07-17 of the CodeRabbit #200 fix -- my "sorted with the old key" note was true but
+            // irrelevant, the menu sort fixes the order regardless of the backing array).
             int previousHideGameId = gVcdHideGameId;
             diaGetInt(diaVcdConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId);
             if (gVcdHideGameId != previousHideGameId) {
                 vcdMarkAllDirty();
-                hddVcdInvalidateCache(); // the cached HDD VCD list was sorted with the old key
                 rebuildVcdLists = 1;
             }
         }


### PR DESCRIPTION
## Found by auditing my own bot-review fixes

You flagged that bot review claims need vetting. I ran an adversarial audit over **every** CodeRabbit/Gemini-driven change I merged this session, each one checked by an independent agent trying to *break* it. Verdict: **no correctness regressions** — but one **SUSPECT**, confirmed against the code, and this fixes it.

## The issue
The #200 CodeRabbit fix made a hide-gameid toggle re-sort every VCD page. I mirrored the first-disc-only handler and included `hddVcdInvalidateCache()` — wrong for *this* case.

- hide-gameid changes only the **display order** (`vcdDisplayName` is cosmetic; the scanned list contents are identical).
- The menu rebuild's `submenuSort` already re-orders the cached rows by the new `vcdDisplayName` key **without touching any device**.
- `hddVcdInvalidateCache()` (`hddVcdListBuilt = 0`) forced an unnecessary **full re-walk of every `__.POPS` partition (pfs1: remount)** plus a **transient empty HDD VCD page** on every flip.

My "sorted with the old key" comment was true but irrelevant — the backing array's order doesn't drive the display; `submenuSort` does.

## The fix
Drop `hddVcdInvalidateCache()` from the hide-gameid block; keep `vcdMarkAllDirty()` + `rebuildVcdLists`. **Leave it in the first-disc-only block**, where it's *required* (that filter changes the built list's contents).

Not a correctness bug — an efficiency/UX regression on APA-HDD PS1 users. Builds clean (`make opl.elf`, exit 0).

## Audit summary (the rest came back SAFE)
- **#202** boot BDM type — SAFE (byte-identical for untyped massN:; closest call is +one re-resolve scan when a *typed* boot device is physically removed mid-session — added latency, not a break)
- **#199** Off-wins reconcile + localized enum — SAFE (forcing DISABLED under OFF has zero runtime effect; enum indices/lifetime intact)
- **#210** fail-epoch — SAFE (downgrade is the safe direction; normal browsing byte-identical) — *unmerged*
- **#49** cache slots (32) — SAFE (bounded, deduped by suffix)
- **#203 / #201 / #200-brace** — SAFE (no-op to behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VCD configuration handling so changing the Game ID display/sort setting refreshes VCD menus correctly without unnecessarily rebuilding cached HDD VCD data.
  * Preserved full cache invalidation for settings that affect which discs are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->