### PR TITLE
fix(theme): custom-theme info pages fall back to the theme's own main info (#213)

### DIFF
--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1419,14 +1419,24 @@ void menuHandleInputMain()
 // Info-element family for a list: mirrors menuRenderInfo's dispatch (VCD view first -- it also
 // covers the Favourites tab's L3 VCD view -- then FAV/APP, else the games family). Shared with the
 // info-art prewarm so render and prewarm can never pick different families.
+//
+// A page-specific info family (VCD / Favourites / Apps) falls back to the theme's OWN games info family
+// when the LOADED theme does not define it -- NEVER to the built-in/baked theme (gTheme is always the
+// current theme, and every theme parses its families from a blank slate, themes.c). A custom
+// conf_theme.cfg that omits e.g. the favs-info section leaves favsInfoElems EMPTY (validateBackgroundElems
+// adds a background ONLY to an already-non-empty info family), so without this the Favourites info page
+// rendered NOTHING (brenotomaz, #213: "on the favorites info page, they don't load at all"). Rule
+// (NathanNeurotic): fav info defaults to MAIN info when the custom theme doesn't provide it; a custom
+// theme uses its OWN assets entirely, just like APPS -- never our baked assets. Empty-family-gated, so a
+// theme that DOES define the page keeps its own layout byte-for-byte.
 static theme_elems_t *menuGetInfoElems(item_list_t *list)
 {
     if (list != NULL && vcdViewActive(list->mode))
-        return &gTheme->vcdInfoElems;
+        return gTheme->vcdInfoElems.first ? &gTheme->vcdInfoElems : &gTheme->infoElems;
     if (list != NULL && list->mode == FAV_MODE)
-        return &gTheme->favsInfoElems;
+        return gTheme->favsInfoElems.first ? &gTheme->favsInfoElems : &gTheme->infoElems;
     if (list != NULL && list->mode == APP_MODE)
-        return &gTheme->appsInfoElems;
+        return gTheme->appsInfoElems.first ? &gTheme->appsInfoElems : &gTheme->infoElems;
     return &gTheme->infoElems;
 }
 


### PR DESCRIPTION
## Report (brenotomaz-eng, #213)
> On the favorites info page, [custom theme assets] don't load at all.

## Cause — it's the theme cfgs, as you suspected
Every theme parses its element families from a **blank slate** (themes.c: `newT->favsInfoElems.first = NULL`, etc. — custom themes do **not** inherit the baked families). And `validateBackgroundElems` adds a background **only to an already-non-empty** info family (themes.c:1687 `if (infoElems->first)`).

So a custom `conf_theme.cfg` that omits the `favs`-info (or `apps`/`vcd`-info) section leaves that family **genuinely empty**, and `menuGetInfoElems` returned it as-is → `menuRenderInfo` drew **nothing**.

## Fix (your rule)
A page-specific info family falls back to the theme's **own** games info family (`gTheme->infoElems`) when the loaded theme doesn't define it:
- **fav info defaults to main info** when the custom theme doesn't provide it
- a custom theme uses its **own** assets entirely, **just like APPS** — never our baked/built-in theme (`gTheme` is always the current theme)

Empty-family-gated, so a theme that *does* define the page keeps its layout byte-for-byte. `menuRenderInfo` calls `menuGetInfoElems`, so render and the info-art prewarm pick up the fallback identically.

## Scope
Fixes the **"favorites info doesn't load at all"** half of #213. The other half — *"original assets load first on the game info page"* — is separate: the game info family is the terminal case here and is unchanged when the theme defines it. That one still needs brenotomaz's **photos + his `conf_theme.cfg`** to pin down (likely the async default-texture flash, or a specific element his cfg defines).

Builds clean (`make opl.elf`, exit 0). HW-pending: brenotomaz to confirm the Favourites info page now renders his theme's assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VCD, Favourites, and Apps information pages when custom themes omit page-specific content.
  * Added fallback content so these pages no longer appear empty when themed information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->