### PR TITLE
Closed experiment: isolate APA from disabled ATA-BDM probing

### DIFF
--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,0 +1,1 @@
+Trigger CI for the final Copilot comparison branch.

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,1 +1,0 @@
-Trigger CI for the final Copilot comparison branch.

--- a/modules/hdd/xhdd/xhdd.c
+++ b/modules/hdd/xhdd/xhdd.c
@@ -112,12 +112,21 @@ static iop_device_t xhddDevice = {
 int _start(int argc, char *argv[])
 {
     int i;
+    int noBdm = 0;
 
     isHDPro = 0;
     for (i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-hdpro"))
             isHDPro = 1;
+        else if (!strcmp(argv[i], "-nobdm"))
+            noBdm = 1;
     }
+
+    // Keep xhdd0: available for APA devctl calls, but do not advertise it as a
+    // block device when ATA-BDM support is disabled. This prevents bdmfs_fatfs
+    // from probing an APA disk through the BDM path while USB BDM remains active.
+    if (noBdm)
+        xhddDevice.type = IOP_DT_CHAR | IOP_DT_FSEXT;
 
     return AddDrv(&xhddDevice) == 0 ? MODULE_RESIDENT_END : MODULE_NO_RESIDENT_END;
 }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -263,7 +263,13 @@ retry:
         if (retLoadModule >= 0)
             DelayThread(1000 * 1000);
         LOG("[XHDD]:\n");
-        sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
+        // General BDM can remain enabled for USB/MX4SIO/iLink without exposing the
+        // internal APA disk to bdmfs_fatfs. Only register xhdd as a block device
+        // when the dedicated ATA-BDM backend is actually enabled.
+        if (gEnableBdmHDD)
+            sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
+        else
+            sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-nobdm");
     }
 
     if (retLoadModule < 0) {


### PR DESCRIPTION
## Closed after transcript verification

This draft was created from an incomplete reconstruction of the Copilot share. The supplied transcript shows that Copilot later abandoned this `xhdd -nobdm` diagnosis after the internal ATA-BDM versus native APA distinction was clarified.

The branch is preserved for reference, but this PR should not be used as the Copilot solution or merged for issue #217.

For the actual simultaneous native APA + ATA-BDM configuration, this branch also leaves `xhdd` in normal block-device mode, so it does not test the reported coexistence failure.