### PR TITLE
Closed experiment: xhdd isolation plus raw APA enumeration

### DIFF
--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,1 +1,0 @@
-Trigger CI for the final hybrid comparison branch.

--- a/.ci-trigger
+++ b/.ci-trigger
@@ -1,0 +1,1 @@
+Trigger CI for the final hybrid comparison branch.

--- a/modules/hdd/xhdd/xhdd.c
+++ b/modules/hdd/xhdd/xhdd.c
@@ -112,12 +112,21 @@ static iop_device_t xhddDevice = {
 int _start(int argc, char *argv[])
 {
     int i;
+    int noBdm = 0;
 
     isHDPro = 0;
     for (i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-hdpro"))
             isHDPro = 1;
+        else if (!strcmp(argv[i], "-nobdm"))
+            noBdm = 1;
     }
+
+    // Keep xhdd0: available for APA devctl calls, but do not advertise it as a
+    // block device when ATA-BDM support is disabled. This prevents bdmfs_fatfs
+    // from probing an APA disk through the BDM path while USB BDM remains active.
+    if (noBdm)
+        xhddDevice.type = IOP_DT_CHAR | IOP_DT_FSEXT;
 
     return AddDrv(&xhddDevice) == 0 ? MODULE_RESIDENT_END : MODULE_NO_RESIDENT_END;
 }

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -133,6 +133,10 @@ static int hddWriteSectors(u32 lba, u32 nsectors, const void *buf)
 }
 
 //-------------------------------------------------------------------------
+#define HDD_APA_HEADER_MAGIC      0x00415041
+#define HDD_APA_CHAIN_MAX_ENTRIES 2048
+#define HDD_HDL_HEADER_LBA_OFFSET ((HDL_GAME_DATA_OFFSET + 4096) / 512)
+
 struct GameDataEntry
 {
     u32 lba, size;
@@ -140,13 +144,70 @@ struct GameDataEntry
     char id[APA_IDMAX + 1];
 };
 
+static void hddFreeGameDataList(struct GameDataEntry *head)
+{
+    while (head != NULL) {
+        struct GameDataEntry *next = head->next;
+        free(head);
+        head = next;
+    }
+}
+
+static struct GameDataEntry *hddFindGameListRecord(struct GameDataEntry *head, const char *partition)
+{
+    struct GameDataEntry *current;
+
+    for (current = head; current != NULL; current = current->next) {
+        if (!strncmp(current->id, partition, APA_IDMAX))
+            return current;
+    }
+
+    return NULL;
+}
+
+static struct GameDataEntry *hddGetOrCreateGameListRecord(struct GameDataEntry **head, struct GameDataEntry **tail, unsigned int *count, const char *partition)
+{
+    struct GameDataEntry *record = hddFindGameListRecord(*head, partition);
+
+    if (record != NULL)
+        return record;
+
+    record = malloc(sizeof(*record));
+    if (record == NULL)
+        return NULL;
+
+    memset(record, 0, sizeof(*record));
+    strncpy(record->id, partition, APA_IDMAX);
+    record->id[APA_IDMAX] = '\0';
+
+    if (*tail != NULL)
+        (*tail)->next = record;
+    else
+        *head = record;
+
+    *tail = record;
+    (*count)++;
+    return record;
+}
+
+static int hddReadApaHeader(u32 lba, apa_header_t *header)
+{
+    if (hddReadSectors(lba, sizeof(*header) / 512, IOBuffer) != 0)
+        return -EIO;
+
+    memcpy(header, IOBuffer, sizeof(*header));
+    if (header->magic != HDD_APA_HEADER_MAGIC || header->start != lba || header->length == 0)
+        return -EINVAL;
+
+    return 0;
+}
+
 static int hddGetHDLGameInfo(struct GameDataEntry *game, hdl_game_info_t *ginfo)
 {
     int ret;
 
     ret = hddReadSectors(game->lba, 2, IOBuffer);
     if (ret == 0) {
-
         hdl_apa_header *hdl_header = (hdl_apa_header *)IOBuffer;
 
         strncpy(ginfo->partition_name, game->id, APA_IDMAX);
@@ -162,106 +223,143 @@ static int hddGetHDLGameInfo(struct GameDataEntry *game, hdl_game_info_t *ginfo)
         ginfo->layer_break = hdl_header->layer1_start;
         ginfo->disctype = (u8)hdl_header->discType;
         ginfo->start_sector = game->lba;
-        ginfo->total_size_in_kb = game->size * 2; // size * 2048 / 1024 = 2x
-    } else
-        ret = -1;
+        ginfo->total_size_in_kb = game->size * 2;
+    } else {
+        ret = -EIO;
+    }
 
     return ret;
 }
 
-//-------------------------------------------------------------------------
-static struct GameDataEntry *GetGameListRecord(struct GameDataEntry *head, const char *partition)
+static int hddPopulateHDLGameList(struct GameDataEntry *head, unsigned int count, hdl_games_list_t *game_list)
 {
     struct GameDataEntry *current;
+    unsigned int valid = 0;
+    int lastError = -EIO;
+
+    if (count == 0)
+        return 0;
+
+    game_list->games = calloc(count, sizeof(*game_list->games));
+    if (game_list->games == NULL)
+        return -ENOMEM;
 
     for (current = head; current != NULL; current = current->next) {
-        if (!strncmp(current->id, partition, APA_IDMAX)) {
-            return current;
+        int result = current->lba == 0 ? -EINVAL : hddGetHDLGameInfo(current, &game_list->games[valid]);
+
+        if (result != 0) {
+            LOG("HDD HDL raw scan: skipped '%s' at LBA %lu (%d)\n", current->id, (unsigned long)current->lba, result);
+            lastError = result;
+            continue;
         }
+        valid++;
     }
 
-    return NULL;
+    if (valid == 0) {
+        free(game_list->games);
+        game_list->games = NULL;
+        return lastError;
+    }
+
+    game_list->count = valid;
+    return 0;
 }
 
+// ps2hdd-osd can expose PFS records through dread while omitting HDL type 0x1337.
+// Walk the authoritative on-disk APA header chain through ps2hdd's serialized
+// HDIOC_READSECTOR path instead, without loading another ATA driver or mounting data.
 int hddGetHDLGamelist(hdl_games_list_t *game_list)
 {
-    struct GameDataEntry *head, *current, *next, *pGameEntry;
-    unsigned int count, i;
-    iox_dirent_t dirent;
-    int fd, ret;
+    struct GameDataEntry *head = NULL;
+    struct GameDataEntry *tail = NULL;
+    unsigned int count = 0;
+    unsigned int guard;
+    u32 lba = 0;
+    u32 totalSectors;
+    int totalKnown;
+    int result = 0;
 
     hddFreeHDLGamelist(game_list);
 
-    ret = 0;
-    if ((fd = fileXioDopen("hdd0:")) >= 0) {
-        head = current = NULL;
-        count = 0;
-        int saw_hdl = 0;
-        while (fileXioDread(fd, &dirent) > 0) {
-            if (dirent.stat.mode == HDL_FS_MAGIC) {
-                saw_hdl = 1;
-                if ((pGameEntry = GetGameListRecord(head, dirent.name)) == NULL) {
-                    if (head == NULL) {
-                        current = head = malloc(sizeof(struct GameDataEntry));
-                    } else {
-                        current = current->next = malloc(sizeof(struct GameDataEntry));
-                    }
+    totalSectors = hddGetTotalSectors();
+    totalKnown = totalSectors != 0 && totalSectors != (u32)-1;
 
-                    if (current == NULL)
-                        break;
+    for (guard = 0; guard < HDD_APA_CHAIN_MAX_ENTRIES; guard++) {
+        apa_header_t header;
+        u32 next;
 
-                    strncpy(current->id, dirent.name, APA_IDMAX);
-                    current->id[APA_IDMAX] = '\0';
-                    count++;
-                    current->next = NULL;
-                    current->size = 0;
-                    current->lba = 0;
-                    pGameEntry = current;
-                }
-
-                if (!(dirent.stat.attr & APA_FLAG_SUB)) {
-                    // Note: The APA specification states that there is a 4KB area used for storing the partition's information, before the extended attribute area.
-                    pGameEntry->lba = dirent.stat.private_5 + (HDL_GAME_DATA_OFFSET + 4096) / 512;
-                }
-
-                pGameEntry->size += (dirent.stat.size / 4); // size in HDD sectors * (512 / 2048) = 0.25x
-            }
+        result = hddReadApaHeader(lba, &header);
+        if (result != 0) {
+            LOG("HDD HDL raw scan: invalid APA header at LBA %lu (%d)\n", (unsigned long)lba, result);
+            break;
         }
 
-        fileXioDclose(fd);
+        next = header.next;
+        if (header.type == HDL_FS_MAGIC) {
+            apa_header_t mainHeader;
+            const apa_header_t *identity = &header;
+            char partition[APA_IDMAX + 1];
+            struct GameDataEntry *record;
 
-        if (saw_hdl && head == NULL)
-            ret = -ENOMEM;
-
-        if (head != NULL) {
-            if ((game_list->games = malloc(sizeof(hdl_game_info_t) * count)) != NULL) {
-                memset(game_list->games, 0, sizeof(hdl_game_info_t) * count);
-
-                for (i = 0, current = head; i < count; i++, current = current->next) {
-                    if ((ret = hddGetHDLGameInfo(current, &game_list->games[i])) != 0)
-                        break;
+            if (header.flags & APA_FLAG_SUB) {
+                if (header.main == lba || (totalKnown && header.main >= totalSectors)) {
+                    result = -EINVAL;
+                    break;
                 }
 
-                if (ret) {
-                    free(game_list->games);
-                    game_list->games = NULL;
-                } else {
-                    game_list->count = count;
+                result = hddReadApaHeader(header.main, &mainHeader);
+                if (result != 0 || mainHeader.type != HDL_FS_MAGIC || (mainHeader.flags & APA_FLAG_SUB)) {
+                    result = -EINVAL;
+                    break;
                 }
-            } else {
-                ret = ENOMEM;
+                identity = &mainHeader;
             }
 
-            for (current = head; current != NULL; current = next) {
-                next = current->next;
-                free(current);
+            memcpy(partition, identity->id, APA_IDMAX);
+            partition[APA_IDMAX] = '\0';
+            if (partition[0] == '\0') {
+                result = -EINVAL;
+                break;
             }
+
+            record = hddGetOrCreateGameListRecord(&head, &tail, &count, partition);
+            if (record == NULL) {
+                result = -ENOMEM;
+                break;
+            }
+
+            if (!(header.flags & APA_FLAG_SUB)) {
+                u32 metadataLba = header.start + HDD_HDL_HEADER_LBA_OFFSET;
+
+                if (metadataLba < header.start || (totalKnown && metadataLba >= totalSectors)) {
+                    result = -EINVAL;
+                    break;
+                }
+                record->lba = metadataLba;
+            }
+
+            record->size += header.length / 4;
         }
-    } else {
-        ret = fd;
+
+        if (next == 0) {
+            result = 0;
+            break;
+        }
+        if (next == lba || (totalKnown && next >= totalSectors)) {
+            result = -EINVAL;
+            break;
+        }
+        lba = next;
     }
 
-    return ret;
+    if (guard == HDD_APA_CHAIN_MAX_ENTRIES)
+        result = -EINVAL;
+
+    if (result == 0)
+        result = hddPopulateHDLGameList(head, count, game_list);
+
+    hddFreeGameDataList(head);
+    return result;
 }
 
 //-------------------------------------------------------------------------

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -263,7 +263,13 @@ retry:
         if (retLoadModule >= 0)
             DelayThread(1000 * 1000);
         LOG("[XHDD]:\n");
-        sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
+        // General BDM can remain enabled for USB/MX4SIO/iLink without exposing the
+        // internal APA disk to bdmfs_fatfs. Only register xhdd as a block device
+        // when the dedicated ATA-BDM backend is actually enabled.
+        if (gEnableBdmHDD)
+            sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
+        else
+            sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-nobdm");
     }
 
     if (retLoadModule < 0) {


### PR DESCRIPTION
## Closed after transcript verification

This draft combined Kimi's raw APA enumeration with an `xhdd -nobdm` change that was incorrectly attributed to Copilot's final recommendation.

The supplied Copilot transcript shows that Copilot abandoned the BDM-contention diagnosis after the native APA versus internal ATA-BDM distinction was clarified. In the simultaneous APA + ATA-BDM configuration, the `-nobdm` path is inactive anyway, making this branch effectively redundant with the isolated raw-APA experiment while adding unrelated module changes.

The branch is preserved for reference and should not be merged for issue #217.