### PR TITLE
feat(defaults): every device on the Devices page ships OFF -- pure opt-in

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2903,7 +2903,7 @@ static void setDefaults(void)
     gMMCEAckWaitCycles = 5;
     gMMCEUseAlarms = 1;
 
-    gEnableUSB = 0;                    // all block-device toggles OFF by default too (same opt-in doctrine)
+    gEnableUSB = 0; // all block-device toggles OFF by default too (same opt-in doctrine)
     gEnableILK = 0;
     gEnableMX4SIO = 0;
     gEnableBdmHDD = 0;                 // exFAT BDM HDD OFF by default (the other "HDD type"; APA/PFS is gHDDStartMode above)

--- a/src/opl.c
+++ b/src/opl.c
@@ -2879,12 +2879,16 @@ static void setDefaults(void)
     gXSensitivity = 1;
     gYSensitivity = 1;
 
-    gBDMStartMode = START_MODE_MANUAL;
-    gHDDStartMode = START_MODE_DISABLED; // RiptOPL: APA/PFS HDD OFF by default (was Manual); user opts in
-    gETHStartMode = START_MODE_DISABLED; // RiptOPL: network/SMB OFF by default (was Manual); user opts in
-    gAPPStartMode = START_MODE_MANUAL;
-    gMMCEStartMode = START_MODE_MANUAL;
-    gFAVStartMode = START_MODE_MANUAL;
+    // RiptOPL doctrine (NathanNeurotic, 2026-07-20): EVERY device on the Devices page ships OFF -- the
+    // user opts in to exactly what their rig has. A fresh install boots to the start menu with no tabs
+    // (deferredInit's boot select handles the nothing-registered case explicitly) and the user enables
+    // devices in Settings. Existing saved configs override all of these on load.
+    gBDMStartMode = START_MODE_DISABLED;
+    gHDDStartMode = START_MODE_DISABLED;
+    gETHStartMode = START_MODE_DISABLED;
+    gAPPStartMode = START_MODE_DISABLED;
+    gMMCEStartMode = START_MODE_DISABLED;
+    gFAVStartMode = START_MODE_DISABLED;
 
     gMMCESlot = 2; //Default to first Auto slot
     gMMCEIGRSlot = 3;
@@ -2899,7 +2903,7 @@ static void setDefaults(void)
     gMMCEAckWaitCycles = 5;
     gMMCEUseAlarms = 1;
 
-    gEnableUSB = 1;
+    gEnableUSB = 0;                    // all block-device toggles OFF by default too (same opt-in doctrine)
     gEnableILK = 0;
     gEnableMX4SIO = 0;
     gEnableBdmHDD = 0;                 // exFAT BDM HDD OFF by default (the other "HDD type"; APA/PFS is gHDDStartMode above)


### PR DESCRIPTION
## Directive
> Set all devices to off as default on devices page.

All start modes (BDM, APA HDD, Network, Apps, MMCE, Favourites) and all block-device toggles (USB, iLink, MX4SIO, exFAT HDD, UDPBD) now default **OFF**. HDD, network, and the non-USB toggles already were; this flips BDM/Apps/MMCE/Favourites (were Manual) and USB (was on).

## Safety checked
- **Fresh install with zero tabs is a handled state**: `deferredInit`'s boot select explicitly covers nothing-registered ("the start menu stays") — the user lands on the start menu and opts in via Settings. No NULL-tab crash path.
- **Existing installs untouched**: every one of these is only a reset default; saved config keys override on load.
- **GUI-less autolaunch untouched**: `miniInit`'s BDM force-enables stay — an external argv launch has no Settings screen to opt in with.

Note this supersedes the defaults commit in #236 (which wanted Manual + Network=SMB — contradicting the shipped Network-OFF default). This PR is the maintainer's actual doctrine: everything off, pure opt-in.

Builds clean (`make opl.elf`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Defaults**
  * Device start modes now default to **Off** for all supported devices.
  * USB block-device support is now disabled by default.
  * Saved configuration settings continue to override these defaults when loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->