### PR TITLE
fix(bdm): never create the OPL library tree at an EMPTY device prefix (#214)

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -552,7 +552,14 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     // Falling through is safe and needs no new scan logic: result stays 0 past the connect/disconnect
     // sfx branches, and the sbIsSameSize(bdmPrefix, bdmULSizePrev) check further down cannot match a
     // sentinel of -2, so it sets result = 1 and the first scan publishes through the existing path.
-    if (result == 0 && pDeviceData->bdmULSizePrev != -2)
+    // ... but ONLY for a slot that has actually CONNECTED (bdmPrefix populated by the connect pass).
+    // A NEVER-connected slot also sits at the -2 sentinel with result == 0, and letting it fall
+    // through reached sbCreateFolders() with an EMPTY prefix -- mkdir("CFG")/mkdir("THM")/... resolve
+    // relative to the CWD, i.e. the BOOT FOLDER, so an enabled-but-absent BDM device recreated the
+    // whole OPL library tree inside mmce0:/RIPTOPL/ (or wherever OPL lives) on every startup
+    // (AndrewBento, #214; FifthFox reported the same class). The #186 first-scan rescue only ever
+    // needed MOUNTED devices, which always have bdmPrefix set before any 0-result poll.
+    if (result == 0 && (pDeviceData->bdmULSizePrev != -2 || pDeviceData->bdmPrefix[0] == '\0'))
         return 0;
 
     // If a device was added or removed play the appropriate UI sound.
@@ -562,7 +569,8 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     } else if (result == 1)
         sfxPlay(SFX_BD_CONNECT);
 
-    if (!pDeviceData->FoldersCreated) {
+    // Belt-and-suspenders: never create the library tree at an empty prefix (= the CWD/boot folder).
+    if (!pDeviceData->FoldersCreated && pDeviceData->bdmPrefix[0] != '\0') {
         sbCreateFolders(pDeviceData->bdmPrefix, 1);
         pDeviceData->FoldersCreated = 1;
     }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -559,8 +559,22 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     // whole OPL library tree inside mmce0:/RIPTOPL/ (or wherever OPL lives) on every startup
     // (AndrewBento, #214; FifthFox reported the same class). The #186 first-scan rescue only ever
     // needed MOUNTED devices, which always have bdmPrefix set before any 0-result poll.
-    if (result == 0 && (pDeviceData->bdmULSizePrev != -2 || pDeviceData->bdmPrefix[0] == '\0'))
-        return 0;
+    if (result == 0) {
+        // The -2 rescue applies ONLY to a device that is CONNECTED **and PUBLISHED**. Two #214-class
+        // holes otherwise: a NEVER-connected slot (bdmPrefix empty) reached sbCreateFolders("") --
+        // bare mkdir("CFG")/mkdir("THM")/... resolve against the CWD, i.e. the BOOT FOLDER
+        // (AndrewBento, #214); and a PRESENT but transport-WITHHELD device would get folders + scans
+        // on a page the user disabled, because bdmUpdateDeviceData populates bdmPrefix BEFORE its
+        // explicit-BDM-off/transport-disabled 0-returns (CodeRabbit review of #239 -- vetted against
+        // bdmUpdateDeviceData: the withhold paths run after bdmBuildGamePrefix). The #186 first-scan
+        // rescue only ever needed MOUNTED devices, whose connect pass sets BOTH the prefix and
+        // menuItem.visible before any 0-result poll.
+        int neverScanned = (pDeviceData->bdmULSizePrev == -2);
+        int connectedAndPublished = pDeviceData->bdmPrefix[0] != '\0' &&
+                                    itemList->owner != NULL && ((opl_io_module_t *)itemList->owner)->menuItem.visible;
+        if (!(neverScanned && connectedAndPublished))
+            return 0;
+    }
 
     // If a device was added or removed play the appropriate UI sound.
     if (result == -1) {


### PR DESCRIPTION
Fixes #214 (AndrewBento) + FifthFox's earlier same-class report. Root cause: my 1742728a (applying Gemini's #186 review) let NEVER-CONNECTED BDM slots (bdmULSizePrev == -2, bdmPrefix still empty) fall through to sbCreateFolders("", 1) — bare mkdir("CFG")/mkdir("THM")/... resolve against the CWD = the BOOT FOLDER, so an enabled-but-absent BDM device recreated the whole OPL library tree inside mmce0:/RIPTOPL/ once per slot per boot. Fix: gate the -2 rescue on a populated bdmPrefix (the #186 UDPBD first-scan rescue only ever needed MOUNTED devices, which always have it) + belt-and-suspenders on the sbCreateFolders call. Adversarially verified CONFIRMED; a live example of the vet-every-bot-finding rule. Builds clean. HW-pending: Andrew's rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-update behavior for devices that have never been scanned, allowing the update path only when the device is actually present and available.
  * Prevented unintended library folder creation when no valid device prefix is available, avoiding directory creation in the current working directory.
  * Added additional safeguards to ensure only complete, relevant device information is processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->