### PR TITLE
perf(vcd): stop re-equipping BDMA on every launch when the card already carries a driver pair

### DIFF
--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -878,6 +878,38 @@ int vcdEquipBdma(int source, int mode, char *diag, int diagSize)
     return (mr != 0) ? mr : 0;
 }
 
+// 1.0.1-style fast path for the launch equip: a card with NO marker but BOTH driver modules present is
+// a pair the user (or an install predating the marker file) manages MANUALLY. vcdReadBdmaMode()
+// collapses "marker absent" into VCD_BDMA_FAT32, so before this check every launch on such a card read
+// as a MISMATCH and paid the FULL equip -- source-device module loads with bounded waits plus two module
+// copies onto the memory card -- on EVERY VCD launch (NathanNeurotic: "unnecessary over work... extended
+// wait on game launch... unnecessary MC transfer"). Trust the card and hand off. An EXPLICIT different
+// marker (a real variant switch, checked by the caller before this) or a missing/partial pair still does
+// the copy work -- ONCE -- after which the marker matches and every later launch takes the cheap path.
+static int vcdBdmaManualPairPresent(void)
+{
+    char mcDir[64];
+    char path[96];
+    int fd, i;
+
+    if (!vcdResolvePopstarterMc(mcDir, sizeof(mcDir)))
+        return 0;
+    snprintf(path, sizeof(path), "%s/%s", mcDir, VCD_BDMA_MARKER);
+    fd = open(path, O_RDONLY);
+    if (fd >= 0) {
+        close(fd);
+        return 0; // marker PRESENT -> its verdict stands (the caller already compared it)
+    }
+    for (i = 0; i < 2; i++) {
+        snprintf(path, sizeof(path), "%s/%s", mcDir, vcdBdmaModule[i]);
+        fd = open(path, O_RDONLY);
+        if (fd < 0)
+            return 0; // pair incomplete -> a real equip is useful work
+        close(fd);
+    }
+    return 1;
+}
+
 // Best-effort auto-equip of the device-matching BDMA driver before a VCD launch (POPSLoader's
 // ApplyBdmaMode parity). POPSTARTER does its OWN SifIopReset, then reloads its block-device drivers
 // from the FIXED memory-card files mc?:/POPSTARTER/usbd.irx + usbhdfsd.irx; equipping copies the
@@ -901,6 +933,8 @@ void vcdEnsureBdmaForLaunch(int source, int mode)
         return; // FAT32 / invalid -> POPSTARTER's built-in driver, nothing to equip
     if (vcdReadBdmaMode() == mode)
         return; // the matching variant is already on the card
+    if (vcdBdmaManualPairPresent())
+        return; // no marker but a full pair on the card -- manually managed; dumb 1.0.1-style handoff
 
     int er = vcdEquipBdma(source, mode, diag, sizeof(diag));
     if (er == 0)


### PR DESCRIPTION
## The complaint
> BDMA operations are overboard... especially when the user already has the right one equipped. It feels like we are doing unnecessary over work, causing extended wait on game launch (handing over to POPSTARTER waiting on unnecessary MC transfer method?)

With the 1.0.1 anchor: MMCE VCD launches there were a **dumb, fast handoff** — everything slow is machinery we added in front of it.

## The trap — found exactly where you pointed
`vcdReadBdmaMode()` collapses "marker file **absent**" into `VCD_BDMA_FAT32`. So a card that **already has the right `usbd.irx` + `usbhdfsd.irx` pair** but no `bdma_config.txt` (manual setup, or any install predating the marker) read as a *mismatch* — and the launch prep ran the **full equip on every single VCD launch**: source-device module force-loads with bounded waits, POPS/ probes, **two module copies onto the memory card**, and a marker write. That's the extended pre-handoff wait — and it also **clobbered the user's manually-placed pair every launch**.

## Fix
New no-marker fast path: **marker absent + both driver modules present = manually managed pair → trust it, touch nothing, hand off.** An *explicit* different marker (a real variant switch) or a missing/partial pair still does the copy work — **once** — after which the marker matches and every later launch takes the existing cheap path. Fast-path cost: ~4–5 mc metadata ops, replacing bounded-wait module loads + 4 file copies.

## Adversarially verified (SHIP)
Gate matrix walked: corrupt-marker self-heal survives; an explicit-FAT32 marker still equips; a partial pair still repairs; no-card behavior unchanged. Settings-screen equip path untouched (the helper is static; sole call site is the launch prep). POSIX-only IO rule kept; no interaction with the POPSTARTER net/SMB co-tenants.

## Known trade-offs (deliberate, per the dumb-handoff doctrine)
- A manual pair of the **wrong variant** now launches uncorrected — previously it was overwritten every launch. The modules carry no variant identity (undetectable without hashing); one Settings-screen equip writes the marker and restores auto-correction forever.
- The fast path writes **no marker** (it can't know which variant the pair is — writing one would lie), so Settings' BDMA MODE keeps showing FAT32 for manually-managed cards.

Builds clean. HW-pending: FifthFox's MMCE VCD launch time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BDMA driver detection when manually installed drivers are present on a PS2 memory card.
  * Prevented unnecessary automatic setup when both required driver modules are already installed and no configuration marker is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->