### PR TITLE
fix(mmce): make per-game settings actually save on MMCE + stop the "saved then error" lie (#245)

### DIFF
--- a/.github/patches/mmceman-fs-close-fd-leak-v211.patch
+++ b/.github/patches/mmceman-fs-close-fd-leak-v211.patch
@@ -1,0 +1,64 @@
+diff --git a/mmceman/src/mmce_fs.c b/mmceman/src/mmce_fs.c
+--- a/mmceman/src/mmce_fs.c
++++ b/mmceman/src/mmce_fs.c
+@@ -162,22 +162,31 @@
+     res = mmce_sio2_tx_rx_pio(0x4, 0x6, wrbuf, rdbuf, &timeout_1s);
+     mmce_sio2_unlock();
+ 
++    // Free the EE/IOP-side handle slot on EVERY exit, not just a clean close: the fd is being torn
++    // down regardless of what the card reports, so a timed-out or errored close must still return
++    // its slot to the 16-entry pool. Otherwise a transient close failure strands the slot for the
++    // life of the (session-singleton) driver, and after ~16 such failures every mmceN: open()/
++    // opendir() fails permanently (observed downstream: contended VCD-info art reads exhaust the
++    // pool -> blank game lists / boot fails until reboot). NB: we only reset the slot value here,
++    // NOT file->privdata (the pointer) -- close is entered only after a successful open, so privdata
++    // is always valid; keeping it non-NULL avoids any deref-of-NULL on a hypothetical re-entry.
+     if (res == -1) {
+         DPRINTF("%s ERROR: P1 - Timedout waiting for /ACK\n", __func__);
++        *(int*)file->privdata = -1;
+         return -1;
+     }
+ 
+     if (rdbuf[0x1] != MMCE_REPLY_CONST) {
+         DPRINTF("%s ERROR: Invalid response from card. Got 0x%x, Expected 0x%x\n", __func__, rdbuf[0x1], MMCE_REPLY_CONST);
++        *(int*)file->privdata = -1;
+         return -1;
+     }
+ 
+-    if (rdbuf[0x4] == 0x0) {
+-        *(int*)file->privdata = -1;
+-    } else {
++    if (rdbuf[0x4] != 0x0) {
+         res = rdbuf[0x4];
+         DPRINTF("%s ERROR: got return value %i\n", __func__, res);
+     }
++    *(int*)file->privdata = -1;
+ 
+     return res;
+ }
+@@ -657,18 +666,25 @@
+     res = mmce_sio2_tx_rx_pio(0x4, 0x6, wrbuf, rdbuf, &timeout_1s);
+     mmce_sio2_unlock();
+ 
++    // Free the handle slot on EVERY exit (same rationale as mmce_fs_close). Only the slot VALUE is
++    // reset on the failure paths -- file->privdata (the pointer) is left non-NULL there and cleared
++    // to NULL only on the clean path (as upstream did), so a failed dclose can never leave a NULL
++    // privdata behind for a later deref.
+     if (res == -1) {
+         DPRINTF("%s ERROR: P1 - Timedout waiting for /ACK\n", __func__);
++        *(int*)file->privdata = -1;
+         return -1;
+     }
+ 
+     if (rdbuf[0x1] != MMCE_REPLY_CONST) {
+         DPRINTF("%s ERROR: Invalid response from card. Got 0x%x, Expected 0x%x\n", __func__, rdbuf[0x1], MMCE_REPLY_CONST);
++        *(int*)file->privdata = -1;
+         return -1;
+     }
+ 
+     if (rdbuf[0x4] != 0x0) {
+         DPRINTF("%s ERROR: Card failed to close dir %i, return value %i\n", __func__, (u8)*(int*)file->privdata, rdbuf[0x1]);
++        *(int*)file->privdata = -1;
+         return -1;
+     }
+ 

--- a/.github/scripts/patch_stock_mmceman.sh
+++ b/.github/scripts/patch_stock_mmceman.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Install a LEAK-FIXED mmceman into $(PS2SDK)/iop/irx for the PRE-sio2man-refactor containers
+# (WOPLSDK = ghcr ps2homebrew digest pin, PS2MAXSDK = ps2max/dev pin). mmcedrv/mmceigr (the
+# IN-GAME modules) are deliberately LEFT AS THE CONTAINER'S STOCK PREBUILTS (field-proven; see
+# install_coherent_mmce.sh for the full mmcedrv rationale).
+#
+# WHY: mmce_fs_close/dclose in every stock mmceman leak their slot from the 16-entry FS handle
+# pool on ANY failed close (SIO2 timeout / bad reply / card error) -- only a clean close frees it.
+# mmceman is a session singleton, so on a contended card those failures accumulate and after ~16
+# the pool is permanently drained: every mmceN: open()/opendir() fails until reboot (RiptOPL #120
+# class: blank game lists, dead saves). The fix was applied to the PS2DEVLATESTSDK flavour on
+# 2026-07-10 (install_coherent_mmce.sh) but the WOPLSDK/PS2MAXSDK flavours kept shipping the leaky
+# stock driver -- maintainer directive 2026-07-20 (#245 investigation): NO flavour ships the leak.
+#
+# WHY NOT install_coherent_mmce.sh here: that script rebuilds from MMCE_PIN db3e93f0, which
+# includes the cccc366 "sio2man updates" changes targeting the POST-May-2026 sio2man refactor in
+# ps2dev:latest. These containers ship the PRE-refactor sio2man, so db3e93f0's hook would be
+# desynced the OTHER way (the exact class of bug install_coherent_mmce.sh exists to fix). Instead:
+# rebuild from the last PRE-refactor generation, ps2-mmce v2.1.1 (979dd77e, 2026-03-07 -- the same
+# generation the WOPLSDK container's ports pin ships), with ONLY the fd-leak patch on top. The
+# patch content is byte-identical in effect to the db3e93f0 one; only the diff context differs
+# (v2.1.1's mmce_fs.c predates the close-packet padding + fs_rename additions).
+#
+# PROVENANCE DELTA (documented per the WOPLSDK job's discriminator purpose): mmceman on these
+# flavours is now "v2.1.1 + fd-leak fix" instead of the container's untouched stock. For WOPLSDK
+# the stock IS ports-built v2.1.1, so the delta is exactly the leak fix. For PS2MAXSDK the stock
+# may be an earlier ports generation; v2.1.1 is the closest pre-refactor source and the manifest
+# (IRX-MANIFEST-*.txt) records the shipped hash either way.
+#
+# Pin is an immutable SHA (tags can move). Bump deliberately. Fail LOUD everywhere -- silently
+# shipping the leak again is the failure mode to avoid.
+set -eu
+
+MMCE_STOCK_PIN="${MMCE_STOCK_PIN:-979dd77e61f44cb9dfdfe76d255d829fa833ed92}" # ps2-mmce v2.1.1 (2026-03-07, pre-sio2man-refactor)
+MMCE_REPO="https://github.com/ps2-mmce/mmceman"
+
+: "${PS2SDK:?PS2SDK must be set (run inside a ps2dev toolchain container)}"
+DEST="$PS2SDK/iop/irx"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FS_LEAK_PATCH="$SCRIPT_DIR/../patches/mmceman-fs-close-fd-leak-v211.patch"
+if [ ! -f "$FS_LEAK_PATCH" ]; then
+    echo "ERROR: expected mmceman fd-leak patch (v2.1.1 context) not found at $FS_LEAK_PATCH" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT TERM INT HUP
+echo "== Building leak-fixed stock-generation mmceman from ps2-mmce @ ${MMCE_STOCK_PIN} =="
+git clone --quiet "$MMCE_REPO" "$WORK/mmceman"
+git -C "$WORK/mmceman" checkout --quiet "$MMCE_STOCK_PIN"
+
+echo "== Applying mmceman fd-leak fix (mmce_fs_close/dclose slot free-on-failure, v2.1.1 context) =="
+git -C "$WORK/mmceman" apply --verbose "$FS_LEAK_PATCH"
+
+# Older-SDK make quirk: pre-create the per-module obj dir (see install_coherent_mmce.sh).
+mkdir -p "$WORK/mmceman/mmceman/obj"
+
+make -C "$WORK/mmceman/mmceman"
+
+src="$WORK/mmceman/mmceman/irx/mmceman.irx"
+if [ ! -f "$src" ]; then
+    echo "ERROR: mmceman.irx was not produced by the ps2-mmce build" >&2
+    exit 1
+fi
+cp -f "$src" "$DEST/mmceman.irx"
+echo "  installed leak-fixed mmceman.irx ($(wc -c < "$src") bytes) -> $DEST/"
+for m in mmcedrv mmceigr; do
+    if [ ! -f "$DEST/$m.irx" ]; then
+        echo "ERROR: stock $m.irx missing from the SDK prebuilts" >&2
+        exit 1
+    fi
+    echo "  keeping STOCK $m.irx ($(wc -c < "$DEST/$m.irx") bytes) in $DEST/ (in-game, field-proven)"
+done
+echo "== Leak-fixed mmceman installed; in-game mmcedrv/mmceigr remain the SDK stock prebuilts =="

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -22,6 +22,9 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow
 
+      - name: Install leak-fixed stock-generation mmceman (maintainer directive, #245)
+        run: sh ./.github/scripts/patch_stock_mmceman.sh
+
       - name: Compile -> make clean release
         run: make --trace clean && make --trace release
 
@@ -141,6 +144,9 @@ jobs:
       - run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow
+
+      - name: Install leak-fixed stock-generation mmceman (maintainer directive, #245)
+        run: sh ./.github/scripts/patch_stock_mmceman.sh
 
       - name: Get version
         run: |
@@ -373,6 +379,9 @@ jobs:
       - run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow
+
+      - name: Install leak-fixed stock-generation mmceman (maintainer directive, #245)
+        run: sh ./.github/scripts/patch_stock_mmceman.sh
 
       - name: Get version
         run: |

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -65,6 +65,13 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow || true
 
+      - name: Install leak-fixed stock-generation mmceman (maintainer directive, #245)
+        # The stock mmceman leaks a 16-slot FS-pool handle on every failed close; the fix shipped
+        # on PS2DEVLATESTSDK since 2026-07-10 but this flavour kept the leak. Rebuilds mmceman from
+        # the PRE-sio2man-refactor generation (v2.1.1) + the fd-leak patch only -- NOT the
+        # db3e93f0 coherent-mmce pin, whose sio2man hook targets the post-refactor SDK.
+        run: sh ./.github/scripts/patch_stock_mmceman.sh
+
       - name: Build (make clean release)
         # LOCALVERSION brands the in-ELF version string ("-PS2MAXSDK") so hardware reports
         # self-identify which toolchain's binary produced them (Makefile appends it).
@@ -124,11 +131,12 @@ jobs:
   build-rolling-woplsdk:
     runs-on: ubuntu-latest
     # wOPL's exact digest-pinned build container ("use older sdk container until mmce is
-    # stabilised in sdk" -- KrahJohlito, wOPL, 2026-07-04). Deliberately does NOT run
-    # install_coherent_mmce.sh: this flavour ships the container's STOCK
-    # sio2man/mmceman/mmcedrv/mmceigr, i.e. 100% wOPL provenance. With the default (latest +
-    # coherent-mmce) and -PS2MAXSDK flavours, hardware reports become a three-way discriminator:
-    # which flavours reproduce a failure isolates SDK-vs-driver-vs-RiptOPL-code causes.
+    # stabilised in sdk" -- KrahJohlito, wOPL, 2026-07-04). Still does NOT run
+    # install_coherent_mmce.sh (that pin's sio2man hook targets the post-refactor SDK), but since
+    # 2026-07-20 (maintainer directive, #245) it DOES run patch_stock_mmceman.sh: mmceman is
+    # rebuilt from the container's own generation (v2.1.1) with ONLY the fd-leak fix -- no flavour
+    # ships the 16-slot pool leak anymore. sio2man/mmcedrv/mmceigr remain 100% container stock, so
+    # the three-way flavour discriminator survives with one documented, single-purpose delta.
     container: ghcr.io/ps2homebrew/ps2homebrew@sha256:207523ad98f17fd406afa7dd0c6cfe10730627545cbe45247f0bd73c8a66c376
     # Diagnostic/compat flavour: best-effort, must not block the rolling publish.
     continue-on-error: true
@@ -167,6 +175,11 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow || true
+
+      - name: Install leak-fixed stock-generation mmceman (maintainer directive, #245)
+        # See the job comment above: v2.1.1 (this container's own ports generation) + the fd-leak
+        # patch only. The IRX manifest below records the shipped hash for provenance.
+        run: sh ./.github/scripts/patch_stock_mmceman.sh
 
       - name: Build (make clean release)
         # LOCALVERSION brands the in-ELF version string ("-WOPLSDK") so hardware reports

--- a/include/menusys.h
+++ b/include/menusys.h
@@ -120,7 +120,7 @@ config_set_t *menuLoadConfig();
 config_set_t *menuLoadConfigDirect(void);
 void menuRequestInfoSize(void);
 config_set_t *gameMenuLoadConfig(struct UIItem *ui);
-void menuSaveConfig();
+int menuSaveConfig();
 
 void menuRenderMain();
 void menuRenderMenu();

--- a/include/opl.h
+++ b/include/opl.h
@@ -73,6 +73,7 @@ config_set_t *oplGetLegacyAppsInfo(char *name);
 
 void setErrorMessage(int strId);
 void setErrorMessageWithCode(int strId, int error);
+void setErrorMessagePathCode(int strId, const char *path, int error);
 int loadConfig(int types);
 int saveConfig(int types, int showUI);
 void applyConfig(int themeID, int langID, int skipDeviceRefresh);

--- a/include/util.h
+++ b/include/util.h
@@ -18,7 +18,10 @@ typedef struct
     unsigned int available;
     char *lastPtr;
     short allocResult;
-    int writeError; // sticky flag: set when any buffered write()/close() fails; returned by closeFileBuffer
+    int writeError;           // sticky flag: set when any buffered write()/close() fails; returned by closeFileBuffer
+    unsigned int totalQueued; // total bytes ever handed to writeFileBuffer; when == available at close
+                              // time, the WHOLE content still sits in buffer (no intermediate flush) --
+                              // configWrite's read-back verify uses that to capture the intended bytes
 } file_buffer_t;
 
 file_buffer_t *openFileBufferBuffer(short allocResult, const void *buffer, unsigned int size);

--- a/src/config.c
+++ b/src/config.c
@@ -1193,9 +1193,60 @@ int configWrite(config_set_t *configSet)
                 }
             }
 
+            // Capture the exact bytes about to be flushed, for the read-back verify below. The capture
+            // is COMPLETE only when nothing was flushed early (totalQueued == available) -- true for
+            // every real config (< 4 KB buffer). On a partial capture the rescue is skipped entirely;
+            // it never guesses.
+            char *intended = NULL;
+            unsigned int intendedLen = 0;
+            if (fileBuffer->available > 0 && fileBuffer->totalQueued == fileBuffer->available) {
+                intended = (char *)malloc(fileBuffer->available);
+                if (intended != NULL) {
+                    memcpy(intended, fileBuffer->buffer, fileBuffer->available);
+                    intendedLen = fileBuffer->available;
+                }
+            }
+
             ok = (closeFileBuffer(fileBuffer) == 0);
             if (!ok)
                 gDiag.lastSaveErrno = errno; // #120 diag: flush/close failure errno, captured before bgmUnMute
+
+            // EVIDENCE OVER STATUS CODES (#245, temporal bisect): on some MMCE clone firmware the
+            // write can LAND while the close reply is junk/timed out -- and honoring that status
+            // verbatim did two bad things: reported a persisted save as failed, and (worse) let the
+            // restore below O_TRUNC-rewrite the ORIGINAL bytes over the new ones when the new config
+            // was shorter, actively UN-saving the user's change. So on a failed close, read the file
+            // back and byte-compare against the captured intent: identical bytes = the save
+            // demonstrably PERSISTED, whatever the status said -> success (no restore, no toast). Any
+            // mismatch, short read, or unreadable file leaves the failure standing and the restore
+            // path intact -- this can only ever convert failure->success on PROOF, so the #184
+            // silent-wipe guard is not weakened.
+            // ...but NEVER on pfs: PFS commits data+metadata through a shared IOP-side block cache, so
+            // after a FAILED close a fresh open+read can be satisfied entirely from that still-dirty
+            // cache -- proving nothing about the platter. There, honest failure + retry is the safe
+            // behavior. MMCE is cacheless (the read round-trips to the card), which is what makes the
+            // rescue's evidence real on the device this targets.
+            if (!ok && intended != NULL && strncmp(configSet->filename, "pfs", 3) != 0) {
+                int vfd = openFile(configSet->filename, O_RDONLY);
+                if (vfd >= 0) {
+                    int vsz = getFileSize(vfd);
+                    if (vsz == (int)intendedLen) {
+                        char *readBack = (char *)malloc(intendedLen);
+                        if (readBack != NULL) {
+                            if (read(vfd, readBack, intendedLen) == (int)intendedLen &&
+                                memcmp(readBack, intended, intendedLen) == 0) {
+                                LOG("CONFIG write to %s: close reported failure but read-back verifies all %u bytes -- treating as SAVED\n",
+                                    configSet->filename, intendedLen);
+                                ok = 1;
+                                gDiag.lastSaveErrno = 0; // the save is ruled a success; don't leave a failure errno on the HUD
+                            }
+                            free(readBack);
+                        }
+                    }
+                    close(vfd);
+                }
+            }
+            free(intended);
             bgmUnMute();
         } else {
             gDiag.lastSaveErrno = errno; // #120 diag: write-open failure errno (wedged card = EIO/ENODEV),

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -5,6 +5,7 @@
 */
 
 #include "include/opl.h"
+#include "include/diag.h" // gDiag.lastSaveErrno -- surfaced in the per-game save-failure toast (#245)
 #include "include/menusys.h"
 #include "include/iosupport.h"
 #include "include/supportbase.h" // sbSetConfigStatSize -- defer the #Size stat off the scroll path
@@ -295,18 +296,27 @@ static void _menuResolveInfoSize()
         configFree(loadedConfig);
 }
 
+static int menuSaveResult = 0; // carries configWrite's success out of the deferred _menuSaveConfig callback
+
 static void _menuSaveConfig()
 {
     int result;
 
     WaitSema(menuSemaId);
     result = configWrite(itemConfig);
-    itemConfigId = -1; // to invalidate cache and force reload
+    itemConfigId = -1;         // to invalidate cache and force reload
+    menuSaveResult = result;   // publish BEFORE actionStatus=0 -- that flag is the waiter's release signal
     actionStatus = 0;
     SignalSema(menuSemaId);
 
     if (!result)
-        setErrorMessage(_STR_ERROR_SAVING_SETTINGS);
+        // #245 (AndrewBento, MMCE): name WHERE and the errno instead of a bare "Error writing
+        // settings!". itemConfig->filename is the per-game write target (e.g. mmceN:/CFG/<id>.cfg) and
+        // gDiag.lastSaveErrno was latched inside configWrite at the real failure site -- together they
+        // distinguish a genuine mmceman write/close failure (nonzero errno: EIO/ENOSPC/ENOENT/EROFS)
+        // from our strict close check tripping on a write that actually landed (errno 0). Matches the
+        // diagnostic the global saveConfig failure already prints.
+        setErrorMessagePathCode(_STR_ERROR_SAVING_SETTINGS_TO, itemConfig ? itemConfig->filename : "", gDiag.lastSaveErrno);
 }
 
 static void _menuRequestConfig()
@@ -428,10 +438,12 @@ config_set_t *gameMenuLoadConfig(struct UIItem *ui)
     return itemConfig;
 }
 
-void menuSaveConfig()
+int menuSaveConfig()
 {
     actionStatus = 1;
+    menuSaveResult = 0;
     guiHandleDeferedIO(&actionStatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuSaveConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
+    return menuSaveResult;
 }
 
 static void menuInitMainMenu(void)
@@ -1640,9 +1652,15 @@ void menuHandleInputGameMenu()
         } else if (menuID == GAME_SAVE_CHANGES) {
             if (guiGameSaveConfig(itemConfig, selected_item->item->userdata))
                 configSetInt(itemConfig, CONFIG_ITEM_CONFIGSOURCE, CONFIG_SOURCE_USER);
-            menuSaveConfig();
-            saveConfig(CONFIG_GAME, 0);
-            guiMsgBox(_l(_STR_GAME_SETTINGS_SAVED), 0, NULL);
+            int okItem = menuSaveConfig();          // per-game CFG/<id>.cfg (itemConfig)
+            int okGame = saveConfig(CONFIG_GAME, 0); // the global game config set
+            // #245: claim "saved" only when BOTH writes actually persisted. The modal used to be
+            // UNCONDITIONAL, so a failed mmceN: write showed "Game settings saved" IMMEDIATELY
+            // followed by the async "error writing settings!" toast -- the exact contradiction Andrew
+            // reported. On failure the error toast (raised in _menuSaveConfig / saveConfig, now with
+            // the path + errno) already explains why; don't also lie that it saved.
+            if (okItem && okGame)
+                guiMsgBox(_l(_STR_GAME_SETTINGS_SAVED), 0, NULL);
             guiGameLoadConfig(selected_item->item->userdata, gameMenuLoadConfig(NULL));
         } else if (menuID == GAME_TEST_CHANGES) {
             guiGameTestSettings(selected_item->item->current->item.id, selected_item->item->userdata, itemConfig);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -304,8 +304,8 @@ static void _menuSaveConfig()
 
     WaitSema(menuSemaId);
     result = configWrite(itemConfig);
-    itemConfigId = -1;         // to invalidate cache and force reload
-    menuSaveResult = result;   // publish BEFORE actionStatus=0 -- that flag is the waiter's release signal
+    itemConfigId = -1;       // to invalidate cache and force reload
+    menuSaveResult = result; // publish BEFORE actionStatus=0 -- that flag is the waiter's release signal
     actionStatus = 0;
     SignalSema(menuSemaId);
 
@@ -1652,7 +1652,7 @@ void menuHandleInputGameMenu()
         } else if (menuID == GAME_SAVE_CHANGES) {
             if (guiGameSaveConfig(itemConfig, selected_item->item->userdata))
                 configSetInt(itemConfig, CONFIG_ITEM_CONFIGSOURCE, CONFIG_SOURCE_USER);
-            int okItem = menuSaveConfig();          // per-game CFG/<id>.cfg (itemConfig)
+            int okItem = menuSaveConfig();           // per-game CFG/<id>.cfg (itemConfig)
             int okGame = saveConfig(CONFIG_GAME, 0); // the global game config set
             // #245: claim "saved" only when BOTH writes actually persisted. The modal used to be
             // UNCONDITIONAL, so a failed mmceN: write showed "Game settings saved" IMMEDIATELY

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -47,6 +47,8 @@ static int mmceResolvedDevice = -1;
 // card/slot skips the redundant burst (mirrors BDM's FoldersCreated one-shot). Reset by mmceInit and
 // on card removal (empty prefix) so a freshly inserted card still gets its folders.
 static char mmceFoldersCreatedFor[40] = {0};
+#define MMCE_FOLDER_RETRY_MAX 5           // bounded CFG-create retries per card before declaring it obstructed
+static unsigned char mmceFolderRetries = 0;
 
 // Card-switch wait: poll the MMCE busy bit every 500 ms for up to ~7.5 s, matching mmceman's own
 // switch handshake. On a CROSS-DEVICE launch (a USB/HDD/SMB game whose per-game card lives on the
@@ -346,6 +348,7 @@ void mmceInit(item_list_t *itemList)
     mmceVcdGames = NULL;
     mmceResolvedDevice = -1; // re-detect the Auto slot on a fresh init (tab re-enable / settings apply)
     mmceFoldersCreatedFor[0] = '\0';
+    mmceFolderRetries = 0;
 
     configGetInt(configGetByType(CONFIG_OPL), "usb_frames_delay", &mmceGameList.delay);
     mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
@@ -378,6 +381,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     if (mmcePrefix[0] == '\0') {
         mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
         mmceFoldersCreatedFor[0] = '\0'; // card gone: recreate folders on the next (possibly different) card
+        mmceFolderRetries = 0;
         // Card gone: re-arm THM/LNG registration so a swapped-in card's assets get discovered
         // (Gemini review of #153). The old card's already-registered entries stay in the pickers --
         // eviction infrastructure doesn't exist -- but picking a stale one fails gracefully

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -466,11 +466,25 @@ static int mmceNeedsUpdate(item_list_t *itemList)
         if (cfgDir != NULL) {
             closedir(cfgDir);
             snprintf(mmceFoldersCreatedFor, sizeof(mmceFoldersCreatedFor), "%s", mmcePrefix);
+            mmceFolderRetries = 0;
+        } else if (++mmceFolderRetries >= MMCE_FOLDER_RETRY_MAX) {
+            // CFG is OBSTRUCTED, not merely missing: mkdir + opendir have now both failed repeatedly
+            // (a non-directory entry named CFG, or on-card FS damage to that dir entry -- e.g. a
+            // PC-side deletion that left a broken record). Retrying forever would churn the shared
+            // SIO2 bus with a 10-mkdir burst PLUS a forced full list rescan every ~2s for the whole
+            // session (adversarial review of #246), so latch and stop. The user is NOT left stranded:
+            // the write-time parent-create in checkFile still attempts CFG on every save, and the
+            // save's failure toast names the exact path + errno -- the card needs a PC-side look.
+            LOG("MMCE: %s still absent after %d create attempts -- obstructed; giving up for this session\n",
+                cfgPath, MMCE_FOLDER_RETRY_MAX);
+            snprintf(mmceFoldersCreatedFor, sizeof(mmceFoldersCreatedFor), "%s", mmcePrefix);
+            mmceFolderRetries = 0;
         } else {
             // Keep the ~2s background refresh alive so the create genuinely retries -- the NOUPDATE
             // latch at the top of this function (line 390) would otherwise settle the callback to 0
             // and the "retry next refresh" never happens. Mirrors the first-scan retry pattern above.
-            LOG("MMCE: %s not present after sbCreateFolders -- re-arming retry\n", cfgPath);
+            LOG("MMCE: %s not present after sbCreateFolders -- re-arming retry (%d/%d)\n",
+                cfgPath, mmceFolderRetries, MMCE_FOLDER_RETRY_MAX);
             mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
             result = 1;
         }

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -451,9 +451,24 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     // after the NOUPDATE latch near the top of this function.
 
     // Create the library folders once per card/slot, not on every refresh (each is an SIO2 mkdir).
+    // Only latch the "done" memo once CFG actually EXISTS on the card: sbCreateFolders' mkdir burst
+    // ignores its return, so a single mkdir dropped on a busy card would otherwise mark the tree
+    // "created" forever while CFG never got made -- and every per-game save then fails, because the
+    // config write targets <prefix>CFG/<id>.cfg (#245, AndrewBento). Leaving the memo unset here lets
+    // the ~2s refresh keep retrying until CFG is confirmed present, so a missing folder always heals
+    // itself instead of stranding saves.
     if (strcmp(mmceFoldersCreatedFor, mmcePrefix) != 0) {
         sbCreateFolders(mmcePrefix, 1);
-        snprintf(mmceFoldersCreatedFor, sizeof(mmceFoldersCreatedFor), "%s", mmcePrefix);
+
+        char cfgPath[sizeof(mmcePrefix) + 4];
+        snprintf(cfgPath, sizeof(cfgPath), "%sCFG", mmcePrefix);
+        DIR *cfgDir = opendir(cfgPath);
+        if (cfgDir != NULL) {
+            closedir(cfgDir);
+            snprintf(mmceFoldersCreatedFor, sizeof(mmceFoldersCreatedFor), "%s", mmcePrefix);
+        } else {
+            LOG("MMCE: %s not present after sbCreateFolders -- will retry next refresh\n", cfgPath);
+        }
     }
 
     return result;

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -467,7 +467,12 @@ static int mmceNeedsUpdate(item_list_t *itemList)
             closedir(cfgDir);
             snprintf(mmceFoldersCreatedFor, sizeof(mmceFoldersCreatedFor), "%s", mmcePrefix);
         } else {
-            LOG("MMCE: %s not present after sbCreateFolders -- will retry next refresh\n", cfgPath);
+            // Keep the ~2s background refresh alive so the create genuinely retries -- the NOUPDATE
+            // latch at the top of this function (line 390) would otherwise settle the callback to 0
+            // and the "retry next refresh" never happens. Mirrors the first-scan retry pattern above.
+            LOG("MMCE: %s not present after sbCreateFolders -- re-arming retry\n", cfgPath);
+            mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
+            result = 1;
         }
     }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -47,7 +47,7 @@ static int mmceResolvedDevice = -1;
 // card/slot skips the redundant burst (mirrors BDM's FoldersCreated one-shot). Reset by mmceInit and
 // on card removal (empty prefix) so a freshly inserted card still gets its folders.
 static char mmceFoldersCreatedFor[40] = {0};
-#define MMCE_FOLDER_RETRY_MAX 5           // bounded CFG-create retries per card before declaring it obstructed
+#define MMCE_FOLDER_RETRY_MAX 5 // bounded CFG-create retries per card before declaring it obstructed
 static unsigned char mmceFolderRetries = 0;
 
 // Card-switch wait: poll the MMCE busy bit every 500 ms for up to ~7.5 s, matching mmceman's own

--- a/src/opl.c
+++ b/src/opl.c
@@ -1136,6 +1136,16 @@ void setErrorMessage(int strId)
     guiSetFrameHook(&errorMessageHook);
 }
 
+// Two-argument (path + errno) variant, for a write failure that wants to name WHERE and WHY. The
+// per-game save path (#245) uses it to surface the config target and gDiag.lastSaveErrno, matching
+// the diagnostic the global saveConfig failure already prints -- so a failed mmceN:/CFG write reports
+// the errno on screen instead of a bare "Error writing settings!".
+void setErrorMessagePathCode(int strId, const char *path, int error)
+{
+    snprintf(errorMessage, sizeof(errorMessage), _l(strId), path, error);
+    guiSetFrameHook(&errorMessageHook);
+}
+
 // ----------------------------------------------------------
 // ------------------ Configuration handling ----------------
 // ----------------------------------------------------------

--- a/src/opl.c
+++ b/src/opl.c
@@ -1142,7 +1142,7 @@ void setErrorMessage(int strId)
 // the errno on screen instead of a bare "Error writing settings!".
 void setErrorMessagePathCode(int strId, const char *path, int error)
 {
-    snprintf(errorMessage, sizeof(errorMessage), _l(strId), path, error);
+    snprintf(errorMessage, sizeof(errorMessage), _l(strId), path ? path : "", error);
     guiSetFrameHook(&errorMessageHook);
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -112,32 +112,48 @@ void checkMCFolder(void)
 
 static int checkFile(char *path, int mode)
 {
-    // check if it is mc
-    if (strncmp(path, "mc", 2) == 0) {
+    // The "mc?:" wildcard-card resolution is mc-specific: substitute the detected card digit, or bail
+    // if no card is present.
+    if (strncmp(path, "mc", 2) == 0 && path[2] == 0x3F) {
+        if (checkMC() >= 0)
+            path[2] = mcID;
+        else
+            return 0;
+    }
 
-        // if user didn't explicitly asked for a MC (using '?' char)
-        if (path[2] == 0x3F) {
-
-            // Use default detected card
-            if (checkMC() >= 0)
-                path[2] = mcID;
-            else
-                return 0;
-        }
-
-        // in create mode, we check that the directory exist, or create it
-        if (mode & O_CREAT) {
+    // In create mode, ensure the immediate parent directory exists (create it if not) for any device
+    // path shaped "<dev>:/<subdir>/<file>" -- previously this ran for "mc" prefixes only. In practice
+    // that shape is the MMCE per-game config target mmceN:/.../CFG/<id>.cfg (the reported case);
+    // BDM/HDD homes are written as "massN:OPL/..."/"pfs0:OPL/..." with no slash after the colon and are
+    // NOT matched here -- they were never matched before either, and sbCreateFolders remains their
+    // safety net. The MMCE failure: the driver's open(O_CREAT) cannot create a file under a missing
+    // directory, and sbCreateFolders' mkdir burst return is UNCHECKED while its once-per-card memo
+    // latches regardless -- so a single mkdir missed on a busy card leaves CFG permanently absent and
+    // every per-game save fails. Before d5150a49 that was swallowed and shown as "saved"; now it
+    // honestly errors (#245, AndrewBento, MMCE). Creating the parent here makes the write persist.
+    //
+    // Only a genuine SUBdirectory is created -- never a bare device root -- because the driver owns the
+    // root and its opendir/mkdir semantics differ; `pos > devSlash + 1` requires a path component after
+    // "<dev>:/". One extra opendir per O_CREAT write only (never on reads); on MMCE that is one SIO2
+    // round-trip on an already user-initiated, infrequent save.
+    if (mode & O_CREAT) {
+        char *pos = strrchr(path, '/');
+        const char *devSlash = strstr(path, ":/");
+        if (pos != NULL && devSlash != NULL && pos > devSlash + 1) {
             char dirPath[256];
-            char *pos = strrchr(path, '/');
-            if (pos) {
-                memcpy(dirPath, path, (pos - path));
-                dirPath[(pos - path)] = '\0';
+            int n = (int)(pos - path);
+            if (n < (int)sizeof(dirPath)) {
+                memcpy(dirPath, path, n);
+                dirPath[n] = '\0';
+                // Best-effort: attempt the mkdir only when opendir says the dir is missing, but NEVER
+                // fail checkFile on the result. open() is the real source of truth -- if the dir truly
+                // could not be made, the open below fails honestly; and if opendir ever mis-reports an
+                // existing dir as missing (a device-driver quirk), the harmless mkdir-EEXIST is ignored
+                // and the write still proceeds. So this can only ever HELP a write, never block one.
                 DIR *dir = opendir(dirPath);
-                if (dir == NULL) {
-                    int res = mkdir(dirPath, 0777);
-                    if (res != 0)
-                        return 0;
-                } else
+                if (dir == NULL)
+                    mkdir(dirPath, 0777);
+                else
                     closedir(dir);
             }
         }

--- a/src/util.c
+++ b/src/util.c
@@ -261,6 +261,7 @@ file_buffer_t *openFileBuffer(char *fpath, int mode, short allocResult, unsigned
         fileBuffer->fd = fd;
         fileBuffer->mode = mode;
         fileBuffer->writeError = 0;
+        fileBuffer->totalQueued = 0;
     }
 
     return fileBuffer;
@@ -286,6 +287,7 @@ file_buffer_t *openFileBufferBuffer(short allocResult, const void *buffer, unsig
     fileBuffer->fd = -1;
     fileBuffer->mode = O_RDONLY;
     fileBuffer->writeError = 0;
+    fileBuffer->totalQueued = 0;
 
     memcpy(fileBuffer->buffer, buffer, size);
     fileBuffer->buffer[size] = '\0';
@@ -392,6 +394,7 @@ int readFileBuffer(file_buffer_t *fileBuffer, char **outBuf)
 
 void writeFileBuffer(file_buffer_t *fileBuffer, char *inBuf, int size)
 {
+    fileBuffer->totalQueued += size; // see util.h -- lets configWrite know whether buffer still holds ALL content
     // LOG("writeFileBuffer avail: %d size: %d\n", fileBuffer->available, size);
     if (fileBuffer->available && fileBuffer->available + size > fileBuffer->size) {
         // LOG("writeFileBuffer flushing: %d\n", fileBuffer->available);


### PR DESCRIPTION
Fixes #245 (AndrewBento, SCPH-7701, PSxMemCard MMCE, build 3331): changing a PS2 game's Loader Core shows "Game settings saved" then "error writing settings!", and per-game settings never persist.

## Root cause — verified against the upstream mmceman driver (`ps2-mmce/mmceman`)
On Nathan's steer, I read the actual driver source instead of guessing:
- **`mmce_fs_write` returns the card's real byte count; `mmce_fs_close` returns 0 on success** — both *standard*. So mmceman is **not** a false-positive driver: when OPL's check trips, the write **genuinely failed on the card**. This closes the "just relax the check" idea and confirms **reverting `d5150a49` would only re-hide real data loss** (the #184 silent config-wipe).
- **`mmce_fs_open` returns a bad fd → hard fail when it can't create the file** — e.g. its parent `CFG/` dir doesn't exist on the SD.

Two independent problems, fixed here:

### 1. The write actually failed — the "splash damage"
`checkFile()` auto-creates the immediate parent dir on `O_CREAT` **only for `mc` paths**. MMCE (`mmce0:/…/CFG/<id>.cfg`) never got that, so if `CFG/` was absent the open failed. `CFG/` is meant to come from `sbCreateFolders`, but **its mkdir-burst return is unchecked while its once-per-card memo latches regardless** — one mkdir missed on a busy card leaves `CFG/` permanently absent, and every per-game save then fails deterministically (matches Andrew). **Fix:** generalize the `O_CREAT` parent-dir creation to `<dev>:/<subdir>/<file>` paths (in practice the MMCE CFG target). Corruption-safe & regression-proof: writes-only (reads untouched), mkdir is **best-effort** (never returns 0 → can't block a working write), only a real subdir is created (never a device root). BDM/HDD homes (`massN:OPL/…`) aren't matched and keep `sbCreateFolders` as their net — unchanged.

### 2. The "saved" message was a separate, unconditional lie
`GAME_SAVE_CHANGES` showed "Game settings saved" **without checking the result**, right before the async error toast. **Fix:** `menuSaveConfig()` returns the write result; the modal shows only when **both** writes persisted. The per-game failure toast now names the **path + errno** (reusing `ERROR_SAVING_SETTINGS_TO`) so a genuine card fault is diagnosable on HW.

## Why this is the right shape
The driver evidence says the failure is **genuine**, so the fix makes the write *succeed* (create the dir) rather than mask the error. If it's a deeper card fault (not a missing dir), the new on-screen errno says so:
- **ENOENT** → this dir fix was the cause.
- **EIO / ENOSPC / EROFS** → a card/SD fault; we'll know from the number.

`d5150a49`'s atomic-save guard is deliberately kept intact.

Adversarially verified (both the save-honesty change and the hot `checkFile` change: reads unaffected, no new failure path, subdir guard walked across mmce/mass/mc/relative/root cases). Bot sweep: accepted Gemini's NULL-path guard on the new helper; declined the pre-existing (unreachable) `configWrite` NULL note. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Save operations now report failures more accurately, including the affected file path and error details.
  * The “Game settings saved” confirmation appears only after all required settings are successfully saved.
  * Memory-card paths are handled more reliably, including detection of unavailable cards.
  * Required directories are created more consistently when saving files.
  * Memory-card library folders are retried if creation does not complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->