### PR TITLE
fix(textures): decode Adam7-interlaced PNGs -- the stacked smaller-to-bigger cover art (HW batch S4)

### DIFF
--- a/src/textures.c
+++ b/src/textures.c
@@ -556,7 +556,7 @@ static void texReadPixels32Row(GSTEXTURE *texture, png_bytep rowData, int row)
     }
 }
 
-static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr,
+static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr, int passes,
                        void (*texPngReadRow)(GSTEXTURE *texture, png_bytep rowData, int row))
 {
     int rowBytes = png_get_rowbytes(pngPtr, infoPtr);
@@ -570,6 +570,34 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
                           // matches the rowBuffer-OOM path just below
         LOG("TEXTURES PngReadData: Failed to allocate %d bytes\n", size);
         return ERR_FILE_IO; // OOM mid-decode: the file EXISTS, this is transient -- don't memoize as absent
+    }
+
+    if (passes > 1) {
+        // Adam7-interlaced: libpng's pass merge ("sparkle" mode) revisits every row on each of the 7
+        // passes, so all rows must stay resident -- buffer the whole raw image, let libpng merge into
+        // it, then convert row-by-row. Transient rowBytes*Height (~188 KB for a 184x256 cover), freed
+        // before return; the common non-interlaced case keeps the single-row streaming loop below.
+        png_bytep raw = malloc((size_t)rowBytes * texture->Height);
+        if (!raw) {
+            texFree(texture);
+            LOG("TEXTURES PngReadData: Failed to allocate interlaced buffer (%d x %d)\n", rowBytes, texture->Height);
+            return ERR_FILE_IO; // OOM mid-decode (see above)
+        }
+        for (int pass = 0; pass < passes; pass++) {
+            for (int row = 0; row < texture->Height; row++) {
+                if (texLoadAbortRequested()) {
+                    free(raw);
+                    texFree(texture);
+                    return ERR_LOAD_ABORTED;
+                }
+                png_read_row(pngPtr, raw + (size_t)row * rowBytes, NULL);
+            }
+        }
+        for (int row = 0; row < texture->Height; row++)
+            texPngReadRow(texture, raw + (size_t)row * rowBytes, row);
+        free(raw);
+        png_read_end(pngPtr, NULL);
+        return 0;
     }
 
     rowBuffer = malloc(rowBytes);
@@ -700,6 +728,15 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
     if (colorType == PNG_COLOR_TYPE_GRAY || colorType == PNG_COLOR_TYPE_GRAY_ALPHA)
         png_set_gray_to_rgb(pngPtr);
 
+    // Adam7-interlaced PNGs: libpng must be told to MERGE the seven progressive passes, and that merge
+    // needs every row resident across passes -- the single-row streaming loop in texReadData cannot do
+    // it. Register the handling here (libpng requires it BEFORE png_read_update_info) and hand the pass
+    // count to texReadData, which buffers the whole image when passes > 1. Without this the seven
+    // passes decode as sequential rows: the cover renders as a stack of smaller-to-bigger copies of
+    // itself (maintainer HW report, 2026-07-21) -- a regression vs upstream's whole-image
+    // png_read_image, introduced with the streamed row decode.
+    int pngPasses = png_set_interlace_handling(pngPtr);
+
     png_set_filler(pngPtr, 0xff, PNG_FILLER_AFTER);
     png_read_update_info(pngPtr, infoPtr);
 
@@ -750,7 +787,7 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
         return texEnd(pngPtr, infoPtr, pFileBuffer, fd, ERR_BAD_DIMENSION);
     }
 
-    result = texReadData(texture, pngPtr, infoPtr, texPngReadRow);
+    result = texReadData(texture, pngPtr, infoPtr, pngPasses, texPngReadRow);
     return texEnd(pngPtr, infoPtr, pFileBuffer, fd, result);
 }
 

--- a/src/textures.c
+++ b/src/textures.c
@@ -557,6 +557,7 @@ static void texReadPixels32Row(GSTEXTURE *texture, png_bytep rowData, int row)
 }
 
 static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr, int passes,
+                       png_bytep volatile *bufSlot,
                        void (*texPngReadRow)(GSTEXTURE *texture, png_bytep rowData, int row))
 {
     int rowBytes = png_get_rowbytes(pngPtr, infoPtr);
@@ -572,6 +573,8 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
         return ERR_FILE_IO; // OOM mid-decode: the file EXISTS, this is transient -- don't memoize as absent
     }
 
+    // Every decode buffer is mirrored into *bufSlot (the caller's setjmp-frame slot) so a
+    // png_read_row longjmp on corrupt data cannot leak it, and cleared again before local frees.
     if (passes > 1) {
         // Adam7-interlaced: libpng's pass merge ("sparkle" mode) revisits every row on each of the 7
         // passes, so all rows must stay resident -- buffer the whole raw image, let libpng merge into
@@ -583,9 +586,11 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
             LOG("TEXTURES PngReadData: Failed to allocate interlaced buffer (%d x %d)\n", rowBytes, texture->Height);
             return ERR_FILE_IO; // OOM mid-decode (see above)
         }
+        *bufSlot = raw;
         for (int pass = 0; pass < passes; pass++) {
             for (int row = 0; row < texture->Height; row++) {
                 if (texLoadAbortRequested()) {
+                    *bufSlot = NULL;
                     free(raw);
                     texFree(texture);
                     return ERR_LOAD_ABORTED;
@@ -595,6 +600,7 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
         }
         for (int row = 0; row < texture->Height; row++)
             texPngReadRow(texture, raw + (size_t)row * rowBytes, row);
+        *bufSlot = NULL;
         free(raw);
         png_read_end(pngPtr, NULL);
         return 0;
@@ -606,9 +612,11 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
         LOG("TEXTURES PngReadData: Failed to allocate memory for PNG row\n");
         return ERR_FILE_IO; // OOM mid-decode (see above)
     }
+    *bufSlot = rowBuffer;
 
     for (int row = 0; row < texture->Height; row++) {
         if (texLoadAbortRequested()) {
+            *bufSlot = NULL;
             free(rowBuffer);
             texFree(texture);
             return ERR_LOAD_ABORTED;
@@ -618,6 +626,7 @@ static int texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr
         texPngReadRow(texture, rowBuffer, row);
     }
 
+    *bufSlot = NULL;
     free(rowBuffer);
     png_read_end(pngPtr, NULL);
 
@@ -639,6 +648,13 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
     void *PngFileBufferPtr;
     void *pFileBuffer = NULL;
     void (*texPngReadRow)(GSTEXTURE * texture, png_bytep rowData, int row);
+    // The decode buffer texReadData allocates (streaming rowBuffer OR the Adam7 whole-image buffer).
+    // Owned by THIS frame so the setjmp handler can free it: png_read_row longjmps here on corrupt
+    // data, which would otherwise skip texReadData's local free and leak the buffer -- up to
+    // rowBytes*Height for an interlaced file, one leak per corrupt PNG (CodeRabbit review of #247;
+    // the streaming rowBuffer had the same pre-existing leak). volatile: written between setjmp and
+    // longjmp, read after.
+    png_bytep volatile decodeBuf = NULL;
 
     texPrepare(texture);
 
@@ -701,6 +717,8 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
         /* Always free texture->Mem / texture->Clut on any longjmp (decode error or abort).
            Capture the abort flag once to avoid a TOCTOU between the texFree and the return. */
         int aborted = texLoadAbortRequested();
+        if (decodeBuf != NULL)
+            free((void *)decodeBuf); // texReadData's in-flight decode buffer (see declaration above)
         texFree(texture);
         return texEnd(pngPtr, infoPtr, pFileBuffer, fd, aborted ? ERR_LOAD_ABORTED : ERR_SET_JMP);
     }
@@ -787,7 +805,7 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
         return texEnd(pngPtr, infoPtr, pFileBuffer, fd, ERR_BAD_DIMENSION);
     }
 
-    result = texReadData(texture, pngPtr, infoPtr, pngPasses, texPngReadRow);
+    result = texReadData(texture, pngPtr, infoPtr, pngPasses, &decodeBuf, texPngReadRow);
     return texEnd(pngPtr, infoPtr, pFileBuffer, fd, result);
 }
 


### PR DESCRIPTION
## The report
> It takes the full cover art image, which should fill the frame, and instead it stacks itself multiple times in the frame, top to bottom, smallest to biggest.

## Root cause
That is the exact visual signature of an **Adam7-interlaced PNG decoded without interlace handling**: libpng emits the seven progressive passes as sequential rows (tiny sub-image first, growing), and our streaming row loop writes them straight into the texture. The decoder reads IHDR's `interlaceType` and then ignores it — no `png_set_interlace_handling`, single `png_read_row` pass. Upstream decodes whole-image (`png_read_image`, which merges passes internally), so upstream is fine — **the streamed row decode regressed interlaced files specifically.** Any interlaced PNG on any page is affected; APPS art is just where it was noticed.

## Fix
Register `png_set_interlace_handling` before `png_read_update_info` (libpng requires that ordering) and pass the count into `texReadData`. `passes > 1` → buffered path: the raw image stays resident while libpng's sparkle merge revisits every row across all seven passes, then rows convert exactly as before (transient ~188 KB for a 184×256 cover, freed before return; abort/OOM handling mirrors the streaming loop). `passes == 1` — every normal PNG — keeps the existing zero-cost streaming loop untouched.

Builds clean. HW-pending: the interlaced covers that showed the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and decoding of Adam7 interlaced PNG textures so they reconstruct and render correctly.
  * Ensures interlaced images are fully decoded and converted into the target texture format before display.
  * Added safer handling for stopping/canceling texture loads during interlaced decoding to prevent corrupted-load side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->