### PR TITLE
fix(mmce): session-death resilience -- distinct errno, visible bails, VCD retry, MX4SIO settle (HW batch S3/S5/S6/S7)

### DIFF
--- a/.github/patches/mmceman-fs-open-enoent.patch
+++ b/.github/patches/mmceman-fs-open-enoent.patch
@@ -1,0 +1,17 @@
+diff --git a/mmceman/src/mmce_fs.c b/mmceman/src/mmce_fs.c
+--- a/mmceman/src/mmce_fs.c
++++ b/mmceman/src/mmce_fs.c
+@@ -131,7 +131,12 @@
+     } else {
+         DPRINTF("%s ERROR: Got bad fd: %i\n", __func__, rdbuf[0x1]);
+         file->privdata = NULL;
+-        return -1;
++        // -ENOENT, not a bare -1: this is the ONLY open-failure path where the CARD ITSELF said "no
++        // such file" -- the timeouts/garbled-reply paths above stay -1 (EE sees a non-ENOENT errno)
++        // so callers can tell genuine absence from a transient bus failure. Downstream, OPL memoizes
++        // missing art per-session; before this every contended open was branded "file does not
++        // exist" and art died until reboot.
++        return -ENOENT;
+     }
+ 
+     return 0;

--- a/.github/scripts/install_coherent_mmce.sh
+++ b/.github/scripts/install_coherent_mmce.sh
@@ -57,6 +57,20 @@ fi
 echo "== Applying mmceman fd-leak fix (mmce_fs_close/dclose slot free-on-failure) =="
 git -C "$WORK/mmceman" apply --verbose "$FS_LEAK_PATCH"
 
+# Distinct-errno fix (HW batch S3): mmce_fs_open returned one bare -1 for six different failures --
+# only the card's explicit "no such file" reply actually means the file is absent. OPL memoizes
+# missing art per-session, so a contended-bus transient used to brand every browsed game's art
+# "nonexistent" until reboot. This patch makes ONLY the card's bad-fd reply return -ENOENT; the
+# transient paths stay -1, and OPL's classifier (textures.c) memoizes only on ENOENT. Same patch
+# content applies at both pins (the open tail is identical); fail LOUD if it stops applying.
+FS_ENOENT_PATCH="$SCRIPT_DIR/../patches/mmceman-fs-open-enoent.patch"
+if [ ! -f "$FS_ENOENT_PATCH" ]; then
+    echo "ERROR: expected mmceman open-ENOENT patch not found at $FS_ENOENT_PATCH" >&2
+    exit 1
+fi
+echo "== Applying mmceman open-ENOENT fix (distinct errno for genuine not-found) =="
+git -C "$WORK/mmceman" apply --verbose "$FS_ENOENT_PATCH"
+
 # Older-SDK make quirk: the per-module obj dir isn't auto-created by every Makefile.iopglobal
 # vintage -- pre-create it so the first compile step doesn't fail on a missing directory.
 mkdir -p "$WORK/mmceman/mmceman/obj"

--- a/.github/scripts/patch_stock_mmceman.sh
+++ b/.github/scripts/patch_stock_mmceman.sh
@@ -53,6 +53,16 @@ git -C "$WORK/mmceman" checkout --quiet "$MMCE_STOCK_PIN"
 echo "== Applying mmceman fd-leak fix (mmce_fs_close/dclose slot free-on-failure, v2.1.1 context) =="
 git -C "$WORK/mmceman" apply --verbose "$FS_LEAK_PATCH"
 
+# Distinct-errno fix (HW batch S3) -- see install_coherent_mmce.sh for the full rationale. The open
+# tail is identical across pins, so the SAME patch content applies here (validated at v2.1.1).
+FS_ENOENT_PATCH="$SCRIPT_DIR/../patches/mmceman-fs-open-enoent.patch"
+if [ ! -f "$FS_ENOENT_PATCH" ]; then
+    echo "ERROR: expected mmceman open-ENOENT patch not found at $FS_ENOENT_PATCH" >&2
+    exit 1
+fi
+echo "== Applying mmceman open-ENOENT fix (distinct errno for genuine not-found) =="
+git -C "$WORK/mmceman" apply --verbose "$FS_ENOENT_PATCH"
+
 # Older-SDK make quirk: pre-create the per-module obj dir (see install_coherent_mmce.sh).
 mkdir -p "$WORK/mmceman/mmceman/obj"
 

--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -27,6 +27,9 @@ void mmceLaunchGame(item_list_t *itemList, int fd, config_set_t *configSet);
 // vmcSlotMask bit N = "a -mcN Neutrino VMC arg is set for this launch": that slot's MC comes from
 // the VMC FILE, so its physical card is NOT switched (pass 0 on OPL-core paths -- mcemu, unchanged).
 int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask);
+// Bounded post-GameID settle for cross-device launches sharing SIO2 with the MMCE (MX4SIO, batch S7).
+// Polls the device the last send targeted; 0 = settled, -1 = expired. Caller warns + proceeds.
+int mmceGameIdSettle(int timeoutMs);
 // Arm the GameID transport at menu/settings time (idempotent; no-op when the feature is off).
 void mmceArmGameIDTransport(void);
 

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1005,3 +1005,5 @@ gui_strings:
   string: Could not write settings to %s (error %d)
 - label: SETTINGS_NO_HOME
   string: No memory card found -- settings cannot be saved. OPL was booted from a network device, whose settings must live on a local card.
+- label: MMCE_GAMEID_UNSETTLED
+  string: MMCE card switch not confirmed -- launching anyway

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -908,8 +908,14 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
         goto fail;
 
     // MMCE cross-device game-id (#261) with the Δ3 -mc-covered-slot guard. Before deinit (uses game).
-    mmceSendGameID(game->startup, neutrinoPath,
-                   (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0));
+    // Same MX4SIO settle gate as the native leg below (CodeRabbit review of #248, vetted): a switch
+    // still in flight through the IOP reboot can starve the SD enumeration on the shared SIO2.
+    if (mmceSendGameID(game->startup, neutrinoPath,
+                       (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)) < 0 &&
+        bdmDriverIsMx4sio(bdmCurrentDriver)) {
+        if (mmceGameIdSettle(5000) < 0)
+            guiWarning(_l(_STR_MMCE_GAMEID_UNSETTLED), 6);
+    }
 
     // game->startup lives inside bdmGames / gAutoLaunchBDMGame, both freed below (deinitEx's
     // itemCleanUp, or the explicit free in the autolaunch branch). Copy it before the teardown so

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1228,7 +1228,17 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // MMCE cross-device game-id (#261): push the disc id to a present SD2PSX/MemCard PRO2 (either slot)
     // so it switches its per-game folder, even though this game is not on the MMCE. Self-probes +
     // no-ops if no card answers / feature off. Must run BEFORE deinit frees `game`.
-    mmceSendGameID(game->startup, NULL, 0);
+    //
+    // MX4SIO settle gate (HW batch S7): MX4SIO shares SIO2 with the MMCE, and an mmce card switch
+    // still in flight during the IOP reboot can starve the SD enumeration cdvdman then waits on
+    // FOREVER (the lime-green hang -- ee_core's marker right before LoadElf from cdrom0:). When the
+    // send reports "switched but settle NOT confirmed" (-1), re-probe the exact slot it targeted for
+    // up to 5 s; on expiry, warn and LAUNCH ANYWAY (the gate mitigates, never blocks -- and other
+    // BDM transports don't share SIO2, so only the SDC leg pays it).
+    if (mmceSendGameID(game->startup, NULL, 0) < 0 && bdmDriverIsMx4sio(bdmCurrentDriver)) {
+        if (mmceGameIdSettle(5000) < 0)
+            guiWarning(_l(_STR_MMCE_GAMEID_UNSETTLED), 6);
+    }
 
     if (gAutoLaunchBDMGame == NULL) {
         deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -26,6 +26,13 @@
 static char mmcePrefix[40]; // Contains the full path to the folder where all the games are.
 static char mmceArtPrimary[40];
 static int mmceULSizePrev = -2;
+// VCD-scan self-heal (HW batch S6): vcdFillGameList cannot tell an ABSENT POPS folder from a
+// CONTENDED one (-1 both), so ONE failed scan on a busy bus used to latch an empty VCD page under
+// NOUPDATE with no rescan for the session. Bounded retry, same shape as the ISO first-scan sentinel:
+// ~15 passes at the ~2s cadence, re-armed by a fresh L3 toggle, self-quiescing on success/expiry.
+static unsigned char mmceVcdScanFailed = 0;
+static unsigned char mmceVcdScanRetries = 0;
+#define MMCE_VCD_SCAN_RETRY_MAX 15
 static time_t mmceModifiedCDPrev;
 static time_t mmceModifiedDVDPrev;
 static int mmceGameCount = 0;
@@ -71,6 +78,7 @@ static unsigned char mmceFolderRetries = 0;
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
 static int mmceModLoaded = 0; // latched by mmceLoadModules; read by mmceSendGameID's arm check
+static char mmceGameIdTarget[8] = {0}; // last device a GameID 0x8 switch was SENT to (mmceGameIdSettle polls it)
 
 int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask)
 {
@@ -146,6 +154,10 @@ int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMa
     if (fileXioDevctl(mmceDevice, 0x8, (void *)startup, (strlen(startup) + 1), NULL, 0) < 0)
         return 0;
 
+    // Remember the slot this send actually targeted -- mmceGameIdSettle() (the MX4SIO pre-launch
+    // gate, batch S7) must poll the SAME device, not a guess.
+    snprintf(mmceGameIdTarget, sizeof(mmceGameIdTarget), "%s", mmceDevice);
+
     // Wait until the busy bit clears -- i.e. until the physical card has finished switching to the
     // per-game folder. This runs on the single GUI thread BEFORE deinit, so every millisecond here is a
     // frozen loading screen. POLL FIRST, sleep only if still busy: a card that switches instantly (the
@@ -160,14 +172,41 @@ int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMa
 
         if ((status & 1) == 0) {
             LOG("Set MMCE GameID to: %s\n", startup);
-            return 1; // card finished switching
+            return 1; // card finished switching (settle CONFIRMED)
         }
 
         DelayThread(MMCE_GAMEID_POLL_US); // still busy -> wait a short interval, then re-poll
     }
 
-    LOG("MMCE GameID switch did not signal ready within %d ms; launching anyway\n", MMCE_GAMEID_WAIT_TICKS * (MMCE_GAMEID_POLL_US / 1000));
-    return 1;
+    // Tri-state (batch S7): -1 = the 0x8 switch WAS sent but the settle was never confirmed (busy
+    // query unsupported, or the budget expired). Truthy on purpose -- the mmce-launch callers test
+    // truthiness and must still run their own settle; only the MX4SIO cross-device gate
+    // (mmceGameIdSettle) distinguishes -1 from 1, because there the un-settled switch shares SIO2
+    // with the SD enumeration the launch is about to depend on.
+    LOG("MMCE GameID switch not confirmed within budget; launching anyway\n");
+    return -1;
+}
+
+// Bounded post-GameID settle for cross-device launches that share SIO2 with the MMCE (MX4SIO, batch
+// S7: the lime-green hang is cdvdman waiting forever for the SD card to enumerate; an mmce switch
+// still in flight during the IOP reboot can starve that enumeration). Polls the exact device the
+// last send targeted: settled when presence answers AND the busy bit is clear OR unavailable --
+// requiring a readable busy bit would turn every busy-devctl-less firmware into a guaranteed full
+// stall. Returns 0 settled, -1 expired. NEVER blocks the launch -- the caller toasts and proceeds.
+int mmceGameIdSettle(int timeoutMs)
+{
+    if (mmceGameIdTarget[0] == '\0')
+        return 0;
+    for (int waited = 0; waited <= timeoutMs; waited += 200) {
+        if (fileXioDevctl(mmceGameIdTarget, 0x1, NULL, 0, NULL, 0) != -1) {
+            int busy = fileXioDevctl(mmceGameIdTarget, 0x2, NULL, 0, NULL, 0);
+            if (busy < 0 || (busy & 1) == 0)
+                return 0;
+        }
+        DelayThread(200 * 1000);
+    }
+    LOG("MMCE GameID settle NOT confirmed after %d ms\n", timeoutMs);
+    return -1;
 }
 
 static void mmceGetDeviceRoot(char *root, size_t size)
@@ -412,13 +451,24 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     }
 
     // VCD view: force a rescan once on toggle, then skip the disc heuristics while showing VCDs.
-    if (vcdConsumeDirty(itemList->mode))
+    if (vcdConsumeDirty(itemList->mode)) {
+        mmceVcdScanRetries = 0; // fresh user toggle re-arms the failed-scan retry budget
         return 1;
+    }
     // Folder browsing: descend/ascend forces one rescan (consumed before the NOUPDATE latch below).
     if (folderConsumeDirty(itemList->mode))
         return 1;
-    if (vcdViewActive(itemList->mode))
+    if (vcdViewActive(itemList->mode)) {
+        // A contended scan left the VCD page empty (S6): keep the ~2s refresh alive until a scan
+        // succeeds or the bounded budget runs out (no endless bus churn -- #246 doctrine). Also
+        // revives the manual-refresh button in the failed state.
+        if (mmceVcdScanFailed && mmceVcdScanRetries < MMCE_VCD_SCAN_RETRY_MAX) {
+            mmceVcdScanRetries++;
+            mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
+            return 1;
+        }
         return 0;
+    }
 
     if (mmceULSizePrev == -2) {
         // First scan not yet successful. If it wedges on a contended SIO2 bus, sbReadList leaves
@@ -516,6 +566,8 @@ static int mmceUpdateGameList(item_list_t *itemList)
         mmceGameCount = 0;
         mmceVcdGameCount = 0;
         mmceULSizePrev = -2; // force a fresh scan when a card returns
+        mmceVcdScanFailed = 0;
+        mmceVcdScanRetries = 0;
         return 0;
     }
 
@@ -523,8 +575,13 @@ static int mmceUpdateGameList(item_list_t *itemList)
     // can never resurrect the other view's list (see the mmceVcdGames comment at the declarations).
     if (vcdViewActive(itemList->mode)) {
         int r = vcdFillGameList(mmcePrefix, &mmceVcdGames);
-        if (r >= 0) // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
+        if (r >= 0) { // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
             mmceVcdGameCount = r;
+            mmceVcdScanFailed = 0;
+            mmceVcdScanRetries = 0;
+        } else {
+            mmceVcdScanFailed = 1; // arm mmceNeedsUpdate's bounded retry (S6)
+        }
         return mmceVcdGameCount;
     }
     sbReadList(&mmceGames, mmcePrefix, folderGetSub(itemList->mode), &mmceULSizePrev, &mmceGameCount);
@@ -828,6 +885,10 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         if (detectedPort < 0) {
             // Neither slot responded; abort rather than forward port -1 to the IOP.
             LOG("MMCE slot lost, aborting launch\n");
+            // Make the bail VISIBLE (HW batch S5: "does gameID and then nothing" with no message).
+            // deinit has not run yet, mmceLaunchGame is on the GUI thread, and guiWarning self-guards
+            // for autolaunch -- same pattern as the quiesce bail above.
+            guiWarning(_l(_STR_ERR_FILE_INVALID), 8);
             // Close the VMC fds opened above so a failed launch does not leak them
             // back to the menu across repeated attempts (Codex audit, Medium 2).
             if (vmc_fds[0] >= 0)
@@ -922,14 +983,24 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         return;
     }
 
+    // Poll-first: try once; on failure retry briefly. Covers a card re-mount that completes just past
+    // the settle window (the settle's Dopen probes can burn their whole budget on a recovering channel).
+    // A healthy card pays ~0 ms (first try succeeds); a dead one pays a bounded ~2 s before a VISIBLE
+    // bail -- the old path returned to the menu with only a LOG, which read on HW as "does gameID and
+    // then nothing" (batch S5).
     int iso_file = fileXioOpen(partname, 0x1, 0666);
+    for (int isoRetry = 0; iso_file < 0 && isoRetry < 10; isoRetry++) {
+        DelayThread(200 * 1000);
+        iso_file = fileXioOpen(partname, 0x1, 0666);
+    }
     if (iso_file < 0) {
-        LOG("Failed to open iso, aborting\n");
+        LOG("Failed to open iso %s (ret %d), aborting\n", partname, iso_file);
         // Same VMC-fd leak guard as the slot-lost path above (Codex audit, Medium 2).
         if (vmc_fds[0] >= 0)
             fileXioClose(vmc_fds[0]);
         if (vmc_fds[1] >= 0)
             fileXioClose(vmc_fds[1]);
+        guiWarning(_l(_STR_ERR_FILE_INVALID), 8); // batch S5: never bail silently
         return;
     }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -84,6 +84,8 @@ int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMa
 {
     char mmceDevice[sizeof(mmcePrefix)];
 
+    mmceGameIdTarget[0] = '\0'; // no stale target: only a send made by THIS call may be settled against
+
     if (!gMMCEEnableGameID || startup == NULL || startup[0] == '\0')
         return 0;
 
@@ -421,6 +423,11 @@ static int mmceNeedsUpdate(item_list_t *itemList)
         mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
         mmceFoldersCreatedFor[0] = '\0'; // card gone: recreate folders on the next (possibly different) card
         mmceFolderRetries = 0;
+        // Card gone with an EMPTY failed VCD list never reaches mmceUpdateGameList's resets (this
+        // early return fires first), so a reinserted card would inherit an exhausted retry budget
+        // and a dead VCD page (CodeRabbit review of #248, vetted). Fresh card = fresh budget.
+        mmceVcdScanFailed = 0;
+        mmceVcdScanRetries = 0;
         // Card gone: re-arm THM/LNG registration so a swapped-in card's assets get discovered
         // (Gemini review of #153). The old card's already-registered entries stay in the pickers --
         // eviction infrastructure doesn't exist -- but picking a stale one fails gracefully

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -77,7 +77,7 @@ static unsigned char mmceFolderRetries = 0;
 // forward declaration
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
-static int mmceModLoaded = 0; // latched by mmceLoadModules; read by mmceSendGameID's arm check
+static int mmceModLoaded = 0;          // latched by mmceLoadModules; read by mmceSendGameID's arm check
 static char mmceGameIdTarget[8] = {0}; // last device a GameID 0x8 switch was SENT to (mmceGameIdSettle polls it)
 
 int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask)

--- a/src/textures.c
+++ b/src/textures.c
@@ -3,6 +3,7 @@
 #include "include/textures.h"
 #include "include/util.h"
 #include "include/ioman.h"
+#include <errno.h> // errno/ENOENT in the mmce staging-arm open classifier (transitively via opl.h, but be explicit)
 #include <kernel.h>
 #include <png.h>
 

--- a/src/textures.c
+++ b/src/textures.c
@@ -622,9 +622,23 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
         readFunction = &texReadMemBoundedFunction;
     } else if (filePath) {
         if (texShouldUseMemoryReader(filePath)) {
+            errno = 0;
             fd = open(filePath, O_RDONLY, 0);
-            if (fd < 0)
-                return ERR_BAD_FILE;
+            if (fd < 0) {
+                // Memoize as PERMANENTLY absent (ERR_BAD_FILE -> the fail-epoch memo) only on a real
+                // ENOENT. This is the MMCE staging arm, and mmceman used to return ONE bare -1 for six
+                // different open failures -- fd-pool exhausted, three packet timeouts, a garbled reply,
+                // AND the card's genuine not-found -- so a rapid-nav contention storm branded every
+                // browsed game's art "nonexistent" for the whole session (HW batch S3: art dies, never
+                // recovers). The paired mmceman patch makes the driver return -ENOENT only for the
+                // card's explicit not-found reply; every other failure lands in the EXISTING transient
+                // lane (ERR_FILE_IO, re-probed lazily once per generation) so art self-heals when the
+                // bus quiets. If the newlib glue ever maps errno unfaithfully, the degradation is a
+                // bounded once-per-generation re-probe -- never a hard failure. The generic loose-file
+                // branch below keeps its unconditional ERR_BAD_FILE (BDM/HDD semantics unchanged).
+                LOG("texLoadAll: mmce art open failed: %s (errno %d)\n", filePath, errno);
+                return (errno == ENOENT) ? ERR_BAD_FILE : ERR_FILE_IO;
+            }
 
             result = texStageExternalFileIntoMemory(fd, &pFileBuffer);
 


### PR DESCRIPTION
Four verified mechanisms from the MC-boot HW batch (10-agent triage, adversarially verified) — all pre-existing holes exposed by one degraded-MMCE session; none of yesterday's merges caused them:

- **S3 (art death): a misclassification, not a wedge.** mmceman returned one bare `-1` for six different open failures; OPL memoized every one as "file doesn't exist" for the session. New driver patch (applies at both pins, validated) makes **only the card's explicit not-found** return `-ENOENT`; the staging arm memoizes only on ENOENT — everything else takes the existing transient lane and **art self-heals when the bus quiets**. BDM/HDD branch untouched.
- **S5 ("GameID then nothing"): silent bails.** Both launch bails now toast; the iso open gets a bounded poll-first retry (~0 ms healthy / ~2 s dead); LOGs carry path+code.
- **S6 (empty VCD page): one contended scan latched forever.** Bounded ~15×2 s retry in the proven first-scan-sentinel shape, re-armed by L3, self-quiescing. Manual refresh works in the failed state again.
- **S7 (lime green): decoded** — ee_core's pre-`LoadElf` marker; cdvdman's (deliberately untimed, untouched) wait for the MX4SIO SD, starved by an MMCE GameID switch still in flight through the IOP reboot on the shared SIO2. `mmceSendGameID` is tri-state, remembers its target slot, and the **SDC leg only** runs a 5 s settle gate — warn-and-launch-anyway on expiry, never a block. Busy-bit-less firmware exits immediately on presence (no stall).

Companion PRs from the same batch: #247 (S4 interlaced-PNG art), `claude/hdd-coexist` (S1/S2 APA+ATA).

Builds clean (incl. lang regen for the one appended label). HW-pending: the same session recipe that produced the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MMCE cross-device launches by polling GameID settling (up to a timeout) and warning if confirmation isn’t reached.
  * Added bounded retries and state resets for MMCE VCD rescan failures.
  * Refined error handling to better separate “not found” (missing card/file) from transient I/O failures, reducing stale virtual-card access.
* **User Experience**
  * Added clearer on-screen warnings for MMCE port detection, GameID unsettled, and ISO/open access failures.
* **Internationalization**
  * Added a new localized message for the “GameID unsettled” warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->