### PR TITLE
perf(boot): four modules off the boot-critical path -- POPSLoader-shape lazy tier-0

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -17,6 +17,9 @@ int sysGetDiscID(char *discID);
 void sysInitDev9(void);
 void sysShutdownDev9(void);
 void sysReset();
+// Deferred halves of the old sysReset module set (lazy boot, 2026-07-21). Idempotent one-shots.
+void sysLoadAudioModules(void);
+void sysLoadLaunchModules(void);
 void sysExecExit(void);
 int sysLaunchDisc(void); // boot the physical PS2 disc in the drive; <0 (stays in OPL) on failure
 void sysPowerOff(void);

--- a/src/opl.c
+++ b/src/opl.c
@@ -3000,6 +3000,12 @@ static void deferredInit(void)
     guiSetBootStatusSticky(_l(_STR_BOOT_BUILDING_MENU)); // boot-step localizer (IO thread) -- reaching
                                                          // here means the device init chain cleared; see gui.c
 
+    // Launch-support modules (isofs + genvmc), moved OFF sysReset's boot-critical path (lazy boot,
+    // 2026-07-21). Loaded here on the IO worker: resident long before the menu becomes interactive,
+    // so no launch ever loads a module mid-sequence (Delta-4 doctrine). The autolaunch fork, which
+    // never reaches this handler, calls the same idempotent one-shot synchronously.
+    sysLoadLaunchModules();
+
     // inform GUI main init part is over
     struct gui_update_t *id = guiOpCreate(GUI_INIT_DONE);
     if (id)
@@ -3049,6 +3055,9 @@ static void deferredAudioInit(void)
     int ret;
 
     guiSetBootStatusSticky(_l(_STR_BOOT_LOADING_SOUNDS)); // boot-step localizer (IO thread) -- see gui.c
+    // libsd + audsrv, moved OFF sysReset's boot-critical path (lazy boot, 2026-07-21): this handler
+    // is their consumers' natural seam -- audioInit binds audsrv right below.
+    sysLoadAudioModules();
     audioInit();
     ret = sfxInit(1);
     if (ret < 0)
@@ -3341,6 +3350,10 @@ int main(int argc, char *argv[])
     }
 
     if (argc >= 5) {
+        // The autolaunch legs skip deferredInit (which loads these for the GUI path), and their
+        // launch prep needs isofs (ISO probing/PS2Logo) + genvmc (per-game VMC validation) resident
+        // BEFORE the launch sequence starts -- never load modules inside it (Delta-4 doctrine).
+        sysLoadLaunchModules();
         /* argv[0] boot path
            argv[1] game->startup
            argv[2] str to u32 game->start_sector

--- a/src/system.c
+++ b/src/system.c
@@ -62,6 +62,9 @@ extern unsigned int size_eesync_irx;
 
 #define MAX_MODULES 64
 static void *g_sysLoadedModBuffer[MAX_MODULES];
+// Deferred-loader latches (audio + launch-support one-shots below); cleared by sysReset.
+static unsigned char sysAudioModsLoaded = 0;
+static unsigned char sysLaunchModsLoaded = 0;
 static s32 sysLoadModuleLock = -1;
 
 #define ELF_MAGIC   0x464c457f
@@ -240,6 +243,10 @@ void sysReset()
 
     // clears modules list
     memset(g_sysLoadedModBuffer, 0, sizeof(g_sysLoadedModBuffer));
+    // ...and the deferred-loader latches: after an IOP reboot NOTHING is resident, so the audio and
+    // launch-support one-shots below must reload on their next call (CodeRabbit review of #252).
+    sysAudioModsLoaded = 0;
+    sysLaunchModsLoaded = 0;
 
     // load modules
     LOG("[IOMANX]:\n");
@@ -286,32 +293,34 @@ void sysReset()
     poweroffSetCallback(&poweroffHandler, NULL);
 }
 
-// Deferred halves of the old sysReset module set (see the comment there). Both are idempotent:
-// sysLoadModuleBuffer dedupes an already-resident buffer, and the one-shot guards make repeat calls
-// free. Audio pair = deferredAudioInit's first act; launch pair = deferredInit (IO worker, GUI path)
-// or the autolaunch fork (synchronous -- it skips deferredInit).
+// Deferred halves of the old sysReset module set (see the comment there). Both are idempotent
+// one-shots that latch ONLY on full success (a transient load failure stays retryable -- the exact
+// latch-on-failure class the 2026-07 atad/mmce fixes eradicated; CodeRabbit review of #252), and
+// sysReset() clears the latches so an in-process IOP reboot reloads everything. Audio pair =
+// deferredAudioInit's first act; launch pair = deferredInit (IO worker, GUI path) or the autolaunch
+// fork (synchronous -- it skips deferredInit).
 void sysLoadAudioModules(void)
 {
-    static unsigned char loaded = 0;
-    if (loaded)
+    if (sysAudioModsLoaded)
         return;
     LOG("[LIBSD]:\n");
-    sysLoadModuleBuffer(&libsd_irx, size_libsd_irx, 0, NULL);
+    int r0 = sysLoadModuleBuffer(&libsd_irx, size_libsd_irx, 0, NULL);
     LOG("[AUDSRV]:\n");
-    sysLoadModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL);
-    loaded = 1;
+    int r1 = sysLoadModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL);
+    if (r0 >= 0 && r1 >= 0)
+        sysAudioModsLoaded = 1;
 }
 
 void sysLoadLaunchModules(void)
 {
-    static unsigned char loaded = 0;
-    if (loaded)
+    if (sysLaunchModsLoaded)
         return;
     LOG("[ISOFS]:\n");
-    sysLoadModuleBuffer(&isofs_irx, size_isofs_irx, 0, NULL);
+    int r0 = sysLoadModuleBuffer(&isofs_irx, size_isofs_irx, 0, NULL);
     LOG("[GENVMC]:\n");
-    sysLoadModuleBuffer(&genvmc_irx, size_genvmc_irx, 0, NULL);
-    loaded = 1;
+    int r1 = sysLoadModuleBuffer(&genvmc_irx, size_genvmc_irx, 0, NULL);
+    if (r0 >= 0 && r1 >= 0)
+        sysLaunchModsLoaded = 1;
 }
 
 static void poweroffHandler(void *arg)

--- a/src/system.c
+++ b/src/system.c
@@ -258,14 +258,13 @@ void sysReset()
     sysLoadModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL);
     LOG("[USBD]:\n");
     sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
-    LOG("[ISOFS]:\n");
-    sysLoadModuleBuffer(&isofs_irx, size_isofs_irx, 0, NULL);
-    LOG("[GENVMC]:\n");
-    sysLoadModuleBuffer(&genvmc_irx, size_genvmc_irx, 0, NULL);
-    LOG("[LIBSD]:\n");
-    sysLoadModuleBuffer(&libsd_irx, size_libsd_irx, 0, NULL);
-    LOG("[AUDSRV]:\n");
-    sysLoadModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL);
+    // isofs/genvmc/libsd/audsrv are NO LONGER loaded here (POPSLoader-shape lazy boot, maintainer
+    // directive 2026-07-21): they serialized four module DMAs onto the boot-critical path of EVERY
+    // flavor while nothing needs them before the menu. libsd+audsrv load in deferredAudioInit (their
+    // consumers' existing deferred seam); isofs+genvmc load via sysLoadLaunchModules() -- from
+    // deferredInit on the IO worker for the GUI path (resident long before any user launch, never AT
+    // launch per the Delta-4 no-module-loads-in-the-launch-sequence doctrine), and synchronously on
+    // the autolaunch fork which skips deferredInit entirely.
 
 #ifdef PADEMU
     int ds3pads = 1; // only one pad enabled
@@ -285,6 +284,34 @@ void sysReset()
     fileXioInit();
     poweroffInit();
     poweroffSetCallback(&poweroffHandler, NULL);
+}
+
+// Deferred halves of the old sysReset module set (see the comment there). Both are idempotent:
+// sysLoadModuleBuffer dedupes an already-resident buffer, and the one-shot guards make repeat calls
+// free. Audio pair = deferredAudioInit's first act; launch pair = deferredInit (IO worker, GUI path)
+// or the autolaunch fork (synchronous -- it skips deferredInit).
+void sysLoadAudioModules(void)
+{
+    static unsigned char loaded = 0;
+    if (loaded)
+        return;
+    LOG("[LIBSD]:\n");
+    sysLoadModuleBuffer(&libsd_irx, size_libsd_irx, 0, NULL);
+    LOG("[AUDSRV]:\n");
+    sysLoadModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL);
+    loaded = 1;
+}
+
+void sysLoadLaunchModules(void)
+{
+    static unsigned char loaded = 0;
+    if (loaded)
+        return;
+    LOG("[ISOFS]:\n");
+    sysLoadModuleBuffer(&isofs_irx, size_isofs_irx, 0, NULL);
+    LOG("[GENVMC]:\n");
+    sysLoadModuleBuffer(&genvmc_irx, size_genvmc_irx, 0, NULL);
+    loaded = 1;
 }
 
 static void poweroffHandler(void *arg)


### PR DESCRIPTION
## The gap analysis verdict first (both sides read from source)

**The shape you pointed at is already substantially ours**: config home is cwd-driven, `sysReset` loads zero storage transports, and mass boots already resolve their backing device via the driver-name ioctl in the resolver scan — we probe-and-confirm, not assume-USB. Two honest corrections from reading POPSLoader's actual source: **it IOP-resets at boot** (its speed is not inherited mounts — fully transferable comparison), and its "fast settings read" is a **dodge, not a solution** — it always reads settings from `mc0:` and embeds every other asset in the ELF; it never solved reading settings from an arbitrary cwd device. Ours does. Also flagged from their source, *not* copied: a fixed `sleep(2)` racing HDD spin-up (the exact hazard class behind our APA death) and a boot-device-lock ordering bug that makes their marker files a silent no-op.

## What ships here — the one clean transferable win

`sysReset` serialized four module DMAs onto the boot-critical path of **every** flavor for modules nothing needs before the menu: `libsd`+`audsrv` now load in `deferredAudioInit` (their consumers' existing seam), `isofs`+`genvmc` via an idempotent one-shot from `deferredInit` on the IO worker — resident long before the menu is interactive, never at launch time (Δ4 doctrine) — with a synchronous call on the autolaunch fork, which skips `deferredInit` and needs both.

## Deliberately not changed (ranked and rejected with reasons)
- Untyped-mass ATA escalation: stays — post-#250 failure is retryable; residual cost is corner-case boot latency.
- `mmceInit` sync: stays — deferring risks the #152 THM/LNG starvation.
- Menu-before-first-scan ordering: stays — load-bearing for the #132 boot-step localizer, and that region is under live HW triage.

## One UX decision for you
`bdmLoadBlockDeviceModules` loads **every enabled transport at boot regardless of Manual vs Auto**. Gating Manual transports to tab entry would be lazier — but a Manual page's tab could then never auto-appear on device presence (the driver that detects presence wouldn't be loaded). Current behavior: Manual gates only the scan, not the driver. Say the word if you want Manual to mean "nothing loads until I enter the tab", and I'll implement it with that explicit semantic.

Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated startup sequencing so audio and launch components are loaded lazily and only once when first required.
  * Improved launch reliability by ensuring required components are available before menu-based and automatic launch flows begin.
  * Prevented redundant initialization during deferred startup and autolaunch, including after reset-related reboot handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->