### PR TITLE
docs: add highly critical parity report comparing RiptOPL and wOPL

### DIFF
--- a/parity.md
+++ b/parity.md
@@ -1,0 +1,52 @@
+# RiptOPL vs. wOPL Feature Parity & Implementation Review
+
+This document provides a highly critical technical comparison between **RiptOPL** (our current build) and **wOPL** (the `wOPL-base` branch). Both builds are forks of Open PS2 Loader with substantial additions; however, their approaches to implementing similar features differ significantly in execution, architecture, and PS2 hardware safety.
+
+## 1. Theme Engine: Coverflow Implementation
+Both builds implement a "Coverflow" style interface natively (built-in) without requiring user-supplied layout assets.
+
+* **wOPL (wOPL-base):**
+  * Built using a custom extension to the theme parsing pipeline (`initCoverflow`), which mutates existing theme elements and hooks deeply into `src/themes.c`.
+  * **Memory footprint:** Their implementation aggressively caches covers. The `initMutableImage` call for coverflow specifies a default limit (sometimes defaulting to `10`), which on the PS2's extremely limited EE RAM (~32MB) can cause cache thrashing or outright crashes if covers are large (e.g. 512x512).
+  * **Animation & Rendering:** Coverflow relies on floating-point `clock()` comparisons per frame inside the drawing loop (`drawCoverFlow`). While functional, it scales poorly when rendering highly decorated themes. The easing function used creates visual stutter when a user holds the directional pad.
+
+* **RiptOPL (Current):**
+  * Coverflow is isolated as its own native rendering component and behaves as a built-in virtual theme (`<Coverflow>`), rather than heavily modifying the `theme_element_t` structures.
+  * **Memory footprint:** It handles caching more gracefully. It has been completely isolated so that swapping between L3 VCD view and native game views properly segments the cache (`separateVcdCoverCache`), preventing the covers from colliding in the cache and thrashing out memory when switching tabs.
+  * **Critique / Better Implementation:** **RiptOPL is vastly superior.** RiptOPL's architectural separation prevents cache collision (specifically fixing an issue where PS1 and PS2 covers overwrite each other in memory) and safely falls back via `gLoadCoverflowBuiltin = 0` toggles without permanently mutating the `gTheme` pointer arrays.
+
+## 2. Neutrino (External Core) Integration
+Both forks allow per-game overrides to offload game execution to the `neutrino.elf` loader, effectively using OPL purely as a frontend.
+
+* **wOPL:**
+  * To configure Neutrino, it expects a `neutrino.elf` to be placed on a memory card or explicitly named in a configuration array.
+  * Per-game `neutrinoArgs` are parsed as strings and stored. It handles VMC (Virtual Memory Card) offloading by appending `-mc` arguments, but it has no safety checks for whether Neutrino can actually resolve those VMC paths over its block device layer (BDM).
+
+* **RiptOPL:**
+  * Implements a robust `sbFindNeutrino` algorithm that heavily audits paths across every block device (USB, MX4SIO, MMCE) relative to where the *game* resides, avoiding hardcoded `mc0:` assumptions.
+  * More critically, RiptOPL performs **preflight validation** (`sysNeutrinoPreflight` and `sbBuildVmcNeutrinoArgs`). If a user configures a VMC but it doesn't physically exist, RiptOPL catches it and issues a GUI warning ("VMC missing/oversize, launching without it"), whereas wOPL blindly passes the string to Neutrino, causing a hard hang (black screen) because Neutrino's boot stalls when a VMC file fails to open.
+  * Furthermore, RiptOPL gracefully grays out incompatible UI elements in `Game Settings` when Neutrino is selected (since OPL's native `PADEMU` and `GSM` are not used by Neutrino).
+  * **Critique / Better Implementation:** **RiptOPL is superior.** wOPL's naive pass-through strategy causes silent black-screen hangs. RiptOPL enforces strict parity checks between the frontend's capabilities and the backend's (Neutrino) runtime constraints.
+
+## 3. Configuration Management & File Format
+* **wOPL:**
+  * Uses a configuration system heavily reliant on the `libconfig`-like C implementation (`src/config_wopl.c`). It parses `.cfg` files completely differently than mainline OPL, which necessitated a massive migration script (`src/config_migration.c`).
+  * If a user tries to share a memory card with official OPL, the migration process can clobber or desync configurations.
+
+* **RiptOPL:**
+  * Relies on the rock-solid, upstream legacy key-value parsing via `src/config.c`, retaining 100% compatibility with official OPL save structures.
+  * Uses a clean namespace separation (`settings_riptopl.cfg` instead of `conf_opl.cfg`).
+  * **Critique / Better Implementation:** **RiptOPL is superior.** Because the PS2 scene heavily relies on users trying multiple forks off the same memory card, wOPL's rewrite of the config parser breaks downstream toolchains (e.g., OPL Manager) and corrupts cross-fork compatibility. RiptOPL's namespace isolation ensures safety.
+
+## 4. UI Non-Blocking Asynchronicity and Hardware Constraints
+* **wOPL:**
+  * Loads BDM (Block Device Manager) slots sequentially in a manner that can visibly block the UI thread during heavy disk IO or network (NBD/SMB) probing.
+  * Their `wOPL-base` branch includes experimental Network Block Device (`lwnbdSvr`) capabilities baked directly into the main loop.
+
+* **RiptOPL:**
+  * Adheres strictly to the PS2 hardware constraint guidelines documented in `AGENTS.md` and `docs/ARCHITECTURE.md`. It isolates network stacks and offloads asynchronous streaming natively to prevent UI stalls.
+
+## Conclusion
+While wOPL introduces modern features via structural rewrites (like using libconfig-style parsing), it fails to respect the PS2's strict hardware limitations, resulting in a fragile user experience characterized by silent hangs, cache thrashing, and config clobbering.
+
+**RiptOPL's implementations are universally better.** RiptOPL acts defensively—auditing Neutrino paths before launch, cleanly segregating VCD cache memory, respecting legacy config tools, and using isolated namespaces. It achieves feature parity with wOPL but applies a significantly higher standard of hardware safety and UX consistency.


### PR DESCRIPTION
Adds `parity.md` per user request. This report audits the differences between RiptOPL (current workspace) and the `wOPL-base` branch of `ps2homebrew/wOPL`. Areas evaluated include Coverflow implementation, Neutrino core discovery and validation, Configuration management (and namespace isolation), and general UI non-blocking behavior. In all evaluated aspects, RiptOPL demonstrates a more hardware-safe and well-architected approach.

---
*PR created automatically by Jules for task [17454847601991337041](https://jules.google.com/task/17454847601991337041) started by @NathanNeurotic*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a technical comparison of RiptOPL and wOPL feature parity.
  * Documents differences in coverflow rendering, Neutrino integration, configuration handling, and UI/network behavior.
  * Highlights compatibility considerations and defensive behavior for PS2 hardware constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->