### PR TITLE
fix: fail-loud rename diagnostics + review-driven hardening (#257)

### DIFF
--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -650,8 +650,15 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
         if (o->itemGetStartup == NULL || o->itemGetImage == NULL || !favOwnerHasId(o, favArray[i].id))
             continue;
         char *s = o->itemGetStartup(o, favArray[i].id);
-        if (s != NULL && strcmp(s, value) == 0)
-            return o->itemGetImage(o, folder, isRelative, value, suffix, resultTex, psm);
+        if (s != NULL && strcmp(s, value) == 0) {
+            int r = o->itemGetImage(o, folder, isRelative, value, suffix, resultTex, psm);
+            // Relative (ART) requests return as-is -- the matched owner IS the item's owner. For an
+            // absolute (theme-folder) request a bare -1 may only mean this owner can't key the path
+            // (e.g. appsupport's startup-keyed lookup with an unresolved artMode); fall through to
+            // the passthrough loop below, same as an unmatched request (CodeRabbit review of #255).
+            if (isRelative || r != -1)
+                return r;
+        }
     }
     // Attribute-image passthrough (#213): theme attribute caches (Rating/Vmode/Scan/Players...) are
     // created with an ABSOLUTE prefix (the theme path, isPrefixRelative=0, themes.c) and key their

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -18,6 +18,7 @@
 
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioMount("iso:", ***), fileXioUmount("iso:")
+#include <errno.h>       // sbRename failure logging (#257/#259)
 #include <io_common.h>   // FIO_MT_RDONLY
 #include <ps2sdkapi.h>   // lseek64
 #include <string.h>      // strtok/strncmp/strlen/memset (Neutrino args parse)
@@ -1223,17 +1224,20 @@ void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int 
     base_game_info_t *game = &(*list)[id];
 
     for (part = 0; part < game->parts; part++) {
-        int rr;
+        int rr, re;
 
         sbCreatePath_name(game, oldpath, prefix, sep, part, game->name);
         sbCreatePath_name(game, newpath, prefix, sep, part, newname);
         rr = rename(oldpath, newpath);
+        re = errno; // capture BEFORE anything else can clobber it (CodeRabbit review of #259)
         // Fail LOUD (#257): an unsupported/failed rename must not be silent -- on the WOPLSDK and
         // PS2MAXSDK flavours the v2.1.1-generation mmceman registered NOT_SUPPORTED_OP for rename,
         // so MMCE game renames no-op'd with zero trace (fixed by the coherent-mmceman switch in
-        // PR #255; this log is the tripwire if a transport ever lacks rename again).
+        // PR #255; this log is the tripwire if a transport ever lacks rename again). rename() only
+        // returns 0/-1, so the errno is what discriminates ENOTSUP/ENOENT/EIO -- the same "surface
+        // the write errno" convention as the #245 save-path fix.
         if (rr < 0)
-            LOG("sbRename: rename(%s -> %s) failed: %d\n", oldpath, newpath, rr);
+            LOG("sbRename: rename(%s -> %s) failed, errno=%d\n", oldpath, newpath, re);
     }
 
     if (game->format == GAME_FORMAT_USBLD) {

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1223,9 +1223,17 @@ void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int 
     base_game_info_t *game = &(*list)[id];
 
     for (part = 0; part < game->parts; part++) {
+        int rr;
+
         sbCreatePath_name(game, oldpath, prefix, sep, part, game->name);
         sbCreatePath_name(game, newpath, prefix, sep, part, newname);
-        rename(oldpath, newpath);
+        rr = rename(oldpath, newpath);
+        // Fail LOUD (#257): an unsupported/failed rename must not be silent -- on the WOPLSDK and
+        // PS2MAXSDK flavours the v2.1.1-generation mmceman registered NOT_SUPPORTED_OP for rename,
+        // so MMCE game renames no-op'd with zero trace (fixed by the coherent-mmceman switch in
+        // PR #255; this log is the tripwire if a transport ever lacks rename again).
+        if (rr < 0)
+            LOG("sbRename: rename(%s -> %s) failed: %d\n", oldpath, newpath, rr);
     }
 
     if (game->format == GAME_FORMAT_USBLD) {

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1222,6 +1222,7 @@ void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int 
     int part;
     char oldpath[256], newpath[256];
     base_game_info_t *game = &(*list)[id];
+    int renameFailed = 0;
 
     for (part = 0; part < game->parts; part++) {
         int rr, re;
@@ -1236,11 +1237,23 @@ void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int 
         // PR #255; this log is the tripwire if a transport ever lacks rename again). rename() only
         // returns 0/-1, so the errno is what discriminates ENOTSUP/ENOENT/EIO -- the same "surface
         // the write errno" convention as the #245 save-path fix.
-        if (rr < 0)
+        if (rr < 0) {
             LOG("sbRename: rename(%s -> %s) failed, errno=%d\n", oldpath, newpath, re);
+            renameFailed = 1;
+        }
     }
 
+    // Never commit metadata the files no longer match (CodeRabbit review of #259): for USBLD games
+    // the on-disk part paths derive from the NAME (ul.<crc>.<name>.N), so updating game->name and
+    // rebuilding ul.cfg after a failed rename would point the entry at paths that do not exist.
+    // Skipping the commit keeps the entry bound to the real (old) files; the next list refresh is
+    // consistent either way. In the #257 ENOTSUP case every part fails, so this also stops the
+    // "name changed on screen, file unchanged" desync.
     if (game->format == GAME_FORMAT_USBLD) {
+        if (renameFailed) {
+            LOG("sbRename: keeping old name/metadata for '%s' -- rename failed\n", game->name);
+            return;
+        }
         memset(game->name, 0, UL_GAME_NAME_MAX + 1);
         memcpy(game->name, newname, UL_GAME_NAME_MAX);
         sbRebuildULCfg(list, prefix, gamecount, -1);


### PR DESCRIPTION
Follow-up to #255 (the `sbRename` commit missed the merge) plus all CodeRabbit review findings on it, each verified against the code before taking:

1. `f03f1a78` — `sbRename` ignored `rename()`'s return: how #257 presented silently on the v2.1.1-generation mmceman (NOT_SUPPORTED_OP for rename). The driver-side fix merged in #255; this is the tripwire log.
2. `daf21d3f` — (review, valid) `rename()` only returns 0/-1; capture and log `errno` instead, matching the #245 "surface the write errno" convention.
3. `0dea8218` — (review, valid) metadata was committed even when a part failed to rename, desyncing `game->name`/ul.cfg from the on-disk files (USBLD part paths derive from the title). Skip the commit on any failure; no rollback by design (next refresh is consistent).
4. `39a982d8` — (review, valid-but-unreachable) the fav-image startup-match branch returned -1 immediately for absolute requests, bypassing the #213 passthrough loop; now follows the same fallthrough rule. Practically unreachable (an attribute value can't equal a startup), taken for path consistency.

Rejected: full rename rollback (over-engineering for same-dir renames; skipped commit keeps all later state coherent).

clang-format 12 clean; PS2MAXSDK build green on the branch.

Addresses #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rename reliability by detecting per-part rename failures, logging the affected old/new paths with the relevant error code, and preventing stale metadata from being applied when updates can’t be completed.
  * Fixed image retrieval behavior for theme-folder (absolute) requests so previously skipped matches are now properly returned when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->