### PR TITLE
fix(gui): only show "Config loaded" when a config file was actually read

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1852,7 +1852,12 @@ static void _loadConfig()
 
     lscret = result;
     lscstatus = 0;
-    showCfgPopup = 1;
+    // Only claim "Config loaded from ..." when a config file was actually READ (#254 follow-up:
+    // the toast used to fire unconditionally, so with no conf_opl.cfg anywhere it still said
+    // "Config loaded from mass0:" -- which read exactly like the freeze screen on reporters'
+    // photos (brenotomaz, PixeliGer), when the real state was the DEFAULT start menu (every
+    // device OFF). Defaults are not a load; stay silent then.
+    showCfgPopup = (result & CONFIG_OPL) ? 1 : 0;
 }
 
 static int trySaveConfigBDM(int types)


### PR DESCRIPTION
Follow-up to the #254 triage. `_loadConfig` set `showCfgPopup` unconditionally, so a boot with no `settings_riptopl.cfg` anywhere still toasted "Config loaded from mass0:". On both reporters' photos that read exactly like the #254 freeze ("stuck after config loaded") when the real state was the DEFAULT start menu — every device OFF by default, no tabs registered. Defaults are not a load; the toast now fires only when `configReadMulti`'s result carries `CONFIG_OPL`.

One-line behavioral change, clang-format clean. Addresses part of the #254 confusion (the freeze itself was fixed in #255).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the “Config loaded from …” notification from appearing unless a configuration file was successfully read.
  * The UI now stays quiet when only default settings are used (for example, when no config file is available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


> **Correction (2026-07-25):** earlier discussion referenced `conf_opl.cfg`; the fork's settings file is `settings_riptopl.cfg` (legacy `conf_riptopl.cfg`, auto-migrated). The fix is filename-agnostic — only the wording was wrong. Commit message amended accordingly.
