### PR TITLE
feat(apps): debug-gated discovery dump (apps-dump.txt) for #253 triage

### DIFF
--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -170,8 +170,10 @@ static int appStartupKeyEqual(const char *a, const char *b)
 // donates its argv1 (title.cfg-only metadata) to an empty-handed legacy survivor. Legacy-vs-legacy
 // collisions (two conf_apps.cfg keys pointing at the same ELF) are KEPT: dropping one would shift
 // the config-node mapping, and a duplicated hand-edited entry is the user's own data.
+static int appDroppedCount;
 static void appDedupList(void)
 {
+    appDroppedCount = 0;
     if (appsList == NULL || appItemCount <= 1)
         return;
 
@@ -185,6 +187,7 @@ static void appDedupList(void)
             }
         }
         if (dup >= 0 && !appsList[i].legacy) {
+            appDroppedCount++;
             LOG("APPSUPPORT dedup: dropping scanned '%s' (%s) -- already listed as '%s' (%s)\n",
                 appsList[i].title, appsList[i].startup, appsList[dup].title, appsList[dup].startup);
             if (appsList[dup].argv1[0] == '\0' && appsList[i].argv1[0] != '\0') {
@@ -198,6 +201,33 @@ static void appDedupList(void)
         kept++;
     }
     appItemCount = kept;
+}
+
+// #253 diagnostics: write every entry's resolved identity to <config home>/apps-dump.txt so a
+// reporter's file answers "which two prefixes did this app come in through" without a serial
+// cable. Called only with debug enabled (gEnableDebug); small text file, rewritten per rebuild.
+static void appDumpDiscovery(void)
+{
+    char path[300];
+    FILE *f;
+
+    if (appsList == NULL)
+        return;
+    snprintf(path, sizeof(path), "%sapps-dump.txt", configGetDir());
+    f = fopen(path, "w");
+    if (f == NULL) {
+        LOG("APPSUPPORT unable to write %s\n", path);
+        return;
+    }
+    fprintf(f, "# RiptOPL app discovery dump: %d apps, %d duplicate(s) dropped by dedup\n", appItemCount, appDroppedCount);
+    fprintf(f, "# [index] [source] title | path | boot | resolved startup\n");
+    for (int i = 0; i < appItemCount; i++) {
+        fprintf(f, "%3d [%s] %s | %s | %s | %s\n",
+                i, appsList[i].legacy ? "legacy" : "scan", appsList[i].title,
+                appsList[i].path, appsList[i].boot, appsList[i].startup);
+    }
+    fclose(f);
+    LOG("APPSUPPORT discovery dump written to %s\n", path);
 }
 
 
@@ -561,6 +591,12 @@ static int appUpdateItemList(item_list_t *itemList)
             // must appear ONCE (#253). Runs before the art table is built so its startup hashes map
             // to the deduped rows.
             appDedupList();
+
+            // #253 diagnostics: with debug enabled, dump every entry's resolved identity so a
+            // reporter's file answers "which two prefixes did this app come in through" without a
+            // serial cable. Tiny text file at the config home, rewritten each rebuild.
+            if (gEnableDebug)
+                appDumpDiscovery();
         } else {
             LOG("APPSUPPORT unable to allocate memory.\n");
             appItemCount = 0;

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -211,8 +211,6 @@ static void appDumpDiscovery(void)
     char path[300];
     FILE *f;
 
-    if (appsList == NULL)
-        return;
     snprintf(path, sizeof(path), "%sapps-dump.txt", configGetDir());
     f = fopen(path, "w");
     if (f == NULL) {
@@ -221,13 +219,17 @@ static void appDumpDiscovery(void)
     }
     fprintf(f, "# RiptOPL app discovery dump: %d apps, %d duplicate(s) dropped by dedup\n", appItemCount, appDroppedCount);
     fprintf(f, "# [index] [source] title | path | boot | resolved startup\n");
-    for (int i = 0; i < appItemCount; i++) {
+    for (int i = 0; appsList != NULL && i < appItemCount; i++) {
         fprintf(f, "%3d [%s] %s | %s | %s | %s\n",
                 i, appsList[i].legacy ? "legacy" : "scan", appsList[i].title,
                 appsList[i].path, appsList[i].boot, appsList[i].startup);
     }
-    fclose(f);
-    LOG("APPSUPPORT discovery dump written to %s\n", path);
+    // Claim success only when the whole file is confirmed on disk -- the same
+    // evidence-over-status-codes rule as the config save path (#245).
+    if (fclose(f) == 0)
+        LOG("APPSUPPORT discovery dump written to %s\n", path);
+    else
+        LOG("APPSUPPORT discovery dump write FAILED on close: %s\n", path);
 }
 
 
@@ -591,17 +593,18 @@ static int appUpdateItemList(item_list_t *itemList)
             // must appear ONCE (#253). Runs before the art table is built so its startup hashes map
             // to the deduped rows.
             appDedupList();
-
-            // #253 diagnostics: with debug enabled, dump every entry's resolved identity so a
-            // reporter's file answers "which two prefixes did this app come in through" without a
-            // serial cable. Tiny text file at the config home, rewritten each rebuild.
-            if (gEnableDebug)
-                appDumpDiscovery();
         } else {
             LOG("APPSUPPORT unable to allocate memory.\n");
             appItemCount = 0;
         }
     }
+
+    // #253 diagnostics: with debug enabled, dump every entry's resolved identity so a
+    // reporter's file answers "which two prefixes did this app come in through" without a
+    // serial cable. Tiny text file at the config home, rewritten each rebuild -- including
+    // the zero-app rebuild, or a stale dump would outlive the truth (CodeRabbit #262).
+    if (gEnableDebug)
+        appDumpDiscovery();
 
     if (appBuildArtLookup() < 0)
         LOG("APPSUPPORT unable to allocate art lookup table.\n");


### PR DESCRIPTION
PixeliGer's remaining duplicates are **not** the conf_apps.cfg+title.cfg collision #253's dedup fixed (they have no conf_apps.cfg) — so the pair must enter through two different prefixes of one stick, which the startup-keyed dedup deliberately keeps apart ("don't merge different devices").

With debug enabled, `appUpdateItemList` now writes `<config home>/apps-dump.txt` listing every entry's source (legacy/scan), title, path, boot and resolved startup, plus the dedup drop count. One upload answers which two prefixes are duplicating — no serial cable needed. No behavior change with debug off.

Build green (PS2DEVLATESTSDK release); clang-format 12 clean. After the reporter's dump, the actual fix lands as a follow-up (device-identity-aware canonicalization or wildcard matching, depending on which pair it shows).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional, debug-only diagnostics for application discovery and deduplication.
  - When debug mode is enabled, the system generates an `apps-dump.txt` report in the config directory during the rebuild process.
  - The report includes total discovered apps, how many duplicate *scanned* entries were dropped, and per-entry details such as legacy vs scan status, title/path, boot state, and resolved startup info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->