### PR TITLE
fix(menu): select the first-ever tab when it's enabled from the start menu (#254 follow-up)

### DIFF
--- a/include/menusys.h
+++ b/include/menusys.h
@@ -133,7 +133,7 @@ void menuHandleInputInfo();
 void menuHandleInputGameMenu();
 void menuHandleInputAppMenu();
 
-// True while no device/mode tab has ever been appended this session (menu list still empty).
+// True once the menu list contains a registered device/mode tab (false while it is still empty).
 int menuHasRegisteredItems(void);
 
 // Sets the selected item if it is found in the menu list

--- a/include/menusys.h
+++ b/include/menusys.h
@@ -133,6 +133,9 @@ void menuHandleInputInfo();
 void menuHandleInputGameMenu();
 void menuHandleInputAppMenu();
 
+// True while no device/mode tab has ever been appended this session (menu list still empty).
+int menuHasRegisteredItems(void);
+
 // Sets the selected item if it is found in the menu list
 void menuSetSelectedItem(menu_item_t *item);
 

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1074,6 +1074,14 @@ static void menuPrevPage()
     // issue #48 (the prior #48 fix only clamped R1, leaving this L1 wrap behind).
 }
 
+// True while no device/mode tab has ever been appended this session (the global menu list is
+// still empty). initSupport uses this to spot "user enabled the FIRST tab from the start menu",
+// where nothing would otherwise take them to it (#254).
+int menuHasRegisteredItems(void)
+{
+    return menu != NULL;
+}
+
 void menuSetSelectedItem(menu_item_t *item)
 {
     menu_list_t *itm = menu;

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1074,8 +1074,8 @@ static void menuPrevPage()
     // issue #48 (the prior #48 fix only clamped R1, leaving this L1 wrap behind).
 }
 
-// True while no device/mode tab has ever been appended this session (the global menu list is
-// still empty). initSupport uses this to spot "user enabled the FIRST tab from the start menu",
+// True once the global menu list contains a registered device/mode tab (returns menu != NULL).
+// initSupport uses the FALSE case to spot "user enabled the FIRST tab from the start menu",
 // where nothing would otherwise take them to it (#254).
 int menuHasRegisteredItems(void)
 {

--- a/src/opl.c
+++ b/src/opl.c
@@ -652,6 +652,21 @@ void initSupport(item_list_t *itemList, int mode, int force_reinit)
             mod->support = itemList;
             mod->support->owner = mod;
             initMenuForListSupport(mod);
+
+            // First-ever tab while the GUI sits on the start menu (fresh/default config, every
+            // mode OFF): take the user TO the new tab, or they stay on the "default interface"
+            // with no visible way to it -- exactly how PixeliGer's #254 follow-up presented
+            // ("Apps section does not appear in the default interface even if enabled, until a
+            // theme is applied" -- the theme apply was just the thing that returned them to the
+            // tab screen). Boot is unaffected: deferredInit's default-device select queues AFTER
+            // this one and wins; multi-mode enables land on the last registered tab.
+            if (!menuHasRegisteredItems()) {
+                struct gui_update_t *sel = guiOpCreate(GUI_OP_SELECT_MENU);
+                if (sel) {
+                    sel->menu.menu = &mod->menuItem;
+                    guiDeferUpdate(sel);
+                }
+            }
         } else {
             // Re-enable after a prior disable: the support + its menu item already exist (registered on
             // an earlier enable), so the !mod->support branch above -- the ONLY place that sets


### PR DESCRIPTION
PixeliGer: "the Apps section does not appear in the default interface — even if enabled — and can only be accessed once a Theme is applied."

**Root cause (both candidate mechanisms covered, per maintainer call):** the tab registers correctly on enable (`initSupport` → `GUI_OP_ADD_MENU`), but with a fresh/default config every mode is OFF at boot, so nothing ever runs a menu select — the GUI stays on the start menu with no visible path to the new tab. The theme apply only "fixed" it because it returns to the tab screen.

**Fix:** when `initSupport` registers a NEW tab while the menu list is still empty (first-ever tab this session), queue `GUI_OP_SELECT_MENU` for it — the user lands on the tab they just enabled instead of being stranded. Boot is unaffected (`deferredInit`'s default-device select queues later and wins); enabling several modes in one apply lands on the last registered tab.

Behaviour change is deliberately narrow: only first-ever-tab mid-session enables (the exact reporter scenario). Flavour-independent (EE code is identical across flavours — the WOPLSDK/PS2MAXSDK framing was the fresh-config GameID-workaround flow).

Build green (PS2DEVLATESTSDK release); clang-format 12 clean. HW-pending: PixeliGer confirms the Apps tab appears on enable without touching themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newly enabled device modes now automatically open their menu tab when it’s the first menu item registered in the current session.

* **Bug Fixes**
  * Resolved an issue where the interface could remain on the default screen, preventing users from easily accessing a newly enabled mode’s tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->