### PR TITLE
docs(bdma): record the USB-always-usbexfat doctrine

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -767,6 +767,10 @@ static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     // toasts its diagnostic in passing. iLink/UDPBD/unknown have no BDMA variant and are left as-is.
     switch (pDeviceData->bdmDeviceType) {
         case BDM_TYPE_USB:
+            // AUTO (gBdmaApplyOnLaunch) always equips the USBEXFAT pair for USB (maintainer
+            // directive 2026-07-25): that driver reads FAT32 too, so ONE variant plays every
+            // USB stick and nobody has to guess the filesystem. FAT32/no-BDMA (POPSTARTER's
+            // built-in USB stack) is a MANUAL-only choice (VCD Settings, apply-on-launch OFF).
             vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_USB, VCD_BDMA_USBEXFAT);
             break;
         case BDM_TYPE_SDC:


### PR DESCRIPTION
No behavior change — RiptOPL's launch path already equips `VCD_BDMA_USBEXFAT` for every `BDM_TYPE_USB` launch under auto-apply (`bdmsupport.c`), which is exactly the requested doctrine: the exFAT BDMA pair reads FAT32 too, so one variant plays every USB stick; FAT32/no-BDMA stays manual-only (VCD Settings with apply-on-launch OFF). POPSLoader got the matching behavior change in EXP70 (`ResolveAdaptiveBdmaTarget("USB")` now returns USBEXFAT unconditionally). This just records the doctrine at the decision point so the next reader doesn't 'fix' it into a preference gate. clang-format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified USB launch behavior for automatic driver selection.
  * Documented support for FAT32-formatted USB sticks.
  * Clarified that FAT32 without BDMA requires manual configuration with apply-on-launch disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->