### PR TITLE
ci(neutrino-watch): slow the schedule from every 3h to ~every 10 days

### DIFF
--- a/.github/workflows/neutrino-watch.yml
+++ b/.github/workflows/neutrino-watch.yml
@@ -9,7 +9,7 @@ name: Neutrino Watch
 # for an OPL commit.
 #
 # It is only a slow safety net -- any push to master rebundles Neutrino anyway -- so it ticks about
-# once every 10 days rather than hourly; use the workflow_dispatch button for an on-demand check.
+# once every 10 days rather than the every-3h it used to; use workflow_dispatch for an on-demand check.
 #
 # Cheap + conditional: every run is two read-only API calls; it only dispatches a rebuild when the
 # upstream Neutrino version actually differs from what's already bundled (parsed from the rolling

--- a/.github/workflows/neutrino-watch.yml
+++ b/.github/workflows/neutrino-watch.yml
@@ -8,6 +8,9 @@ name: Neutrino Watch
 # re-dispatches rolling-release.yml so the package rebundles the latest Neutrino -- without waiting
 # for an OPL commit.
 #
+# It is only a slow safety net -- any push to master rebundles Neutrino anyway -- so it ticks about
+# once every 10 days rather than hourly; use the workflow_dispatch button for an on-demand check.
+#
 # Cheap + conditional: every run is two read-only API calls; it only dispatches a rebuild when the
 # upstream Neutrino version actually differs from what's already bundled (parsed from the rolling
 # release notes' "Included build:" line that rolling-release.yml writes). workflow_dispatch via the
@@ -15,7 +18,12 @@ name: Neutrino Watch
 
 on:
   schedule:
-    - cron: "41 */3 * * *" # every 3h (offset minute to dodge the top-of-hour cron backlog)
+    # ~Every 10 days. cron has no "every N days" operator that spans month boundaries, so pin the
+    # days explicitly: the 1st, 11th and 21st (gaps of 10, 10, then 8-11 into the next month).
+    # Deliberately NOT "*/10" for day-of-month -- that also fires on the 31st, one day after the
+    # 21st+10 tick, i.e. two runs back to back in the 7 long months.
+    # Off-hour + offset minute to dodge the top-of-hour cron backlog.
+    - cron: "41 5 1,11,21 * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

`neutrino-watch.yml` was scheduled on `41 */3 * * *` — **8 scheduled runs every day**. Confirmed in the run history (7 ticks on 2026-07-27 alone).

## Why that's too often

The watcher is only a safety net. Any push to master already re-fetches and rebundles the latest Neutrino via `rolling-release.yml`; this workflow exists solely to catch the case where upstream Neutrino releases while OPL sits idle. Upstream Neutrino does not release 8 times a day.

## Change

```yaml
- cron: "41 5 1,11,21 * *"   # was: "41 */3 * * *"
```

Fires on the 1st, 11th and 21st — gaps of 10, 10, then 8–11 days into the next month.

Deliberately **not** `*/10` for day-of-month: that also fires on the 31st, one day after the 21st+10 tick, giving two runs back to back in the 7 long months. cron has no "every N days" operator that spans month boundaries, so pinned days are the closest faithful expression.

`workflow_dispatch` is untouched — the manual button still gives an on-demand check whenever you want one.

No behavioural change to the job body: still two read-only API calls, still only dispatches a rebuild on a genuine version difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated workflow schedule to run about every 10 days by running on the 1st, 11th, and 21st of each month.
  * Expanded scheduling documentation to explain the month-boundary timing and avoid unintended extra runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->