### PR TITLE
fix(gui): clear the GameID barcode before the ELF handoff (#269)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2685,9 +2685,14 @@ void guiRenderTextScreen(const char *message)
 // Renders the CosmicScale "GameID" barcode just before a game is handed to its core, so an HDMI
 // scaler can auto-load that game's per-title display profile. Encoding is the canonical CosmicScale
 // scheme (start word 0xA5 / end word 0xD5 / length byte / additive 0x100-sum checksum), drawn with
-// rmDrawRect exactly as CosmicScale's own OPL fork does. Gated behind gApplyGameID (default OFF) --
-// the pattern is meaningless to non-GameID displays, and the actual HDMI latch is only verifiable on
-// real GameID hardware (experimental until a tester confirms).
+// rmDrawRect exactly as CosmicScale's own OPL fork does. Gated behind gApplyGameID, which has been
+// default ON since 120045d0 -- the pattern is meaningless to non-GameID displays, and the actual HDMI
+// latch is only verifiable on real GameID hardware (experimental until a tester confirms).
+//
+// NOTE (#269): "imperceptible on other displays" was only true once guiShowGameID stopped LEAVING the
+// barcode on screen. It is the last thing OPL draws before the ELF handoff, and on composite the
+// 1-pixel-pitch strip averages to a solid white bar that the GS scans out for the whole game load.
+// The trailing clean-frame loop at the end of guiShowGameID is what makes that premise hold.
 
 #define GAMEID_HOLD_FRAMES 45 // ~0.75s @ 60fps -- enough stable frames for a scaler to sample
 
@@ -2782,6 +2787,31 @@ void guiShowGameID(const char *startup)
         guiStartFrame();
         rmDrawRect(0, 0, screenWidth, screenHeight, GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x80));
         gameIDDrawBars(startup);
+        guiEndFrame();
+    }
+
+    /*
+      Leave a CLEAN black frame behind (#269).
+
+      This is the last thing OPL renders: itemExecSelect() calls us and then goes straight into
+      itemLaunch() -> deinit() -> ExecPS2(), and on a default config nothing in between draws
+      anything (gRememberLastPlayed is off, so there is no save toast; no cheats, no VMC, no
+      MX4SIO warning). Neither deinit() nor sysLaunchLoaderElf() reprograms a GS display register,
+      so whatever buffer rmEndFrame last pointed DISPFB2 at keeps being scanned out until the GAME
+      programs the GS -- which on USB is minutes away.
+
+      Without this, that buffer is "black field + barcode strip", and the strip is drawn at
+      1-virtual-pixel pitch (magenta column immediately followed by cyan/yellow). That is below the
+      chroma bandwidth of composite output, so the columns average to near-white and the user sees
+      a solid ~288x2 white bar, ~71% down an otherwise black screen, for the entire load. Exactly
+      the report: every game, unrelated to Debug Colors, lasting as long as the media takes.
+
+      Two frames because rendering is double-buffered -- one alone leaves the barcode in the OTHER
+      buffer, which is the one a scaler may resync to across the video-mode change.
+    */
+    for (frame = 0; frame < 2; frame++) {
+        guiStartFrame();
+        rmDrawRect(0, 0, screenWidth, screenHeight, GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x80));
         guiEndFrame();
     }
 }


### PR DESCRIPTION
Fixes the persistent white bar Zack reports during game boot. Root-caused, then independently verified against the source before any code was written.

## Root cause

`guiShowGameID()` is the **last thing OPL renders**. `itemExecSelect()` calls it, then goes straight into `itemLaunch()` → `deinit()` → `ExecPS2()`. On a default config nothing in between draws anything — `gRememberLastPlayed` is off so there's no save toast, no cheats, no VMC, and USB isn't MX4SIO so none of those warnings fire.

Neither `deinit()` nor `sysLaunchLoaderElf()` reprograms a GS display register, so whatever buffer `rmEndFrame` last pointed `DISPFB2` at **keeps being scanned out until the game itself programs the GS** — minutes later on USB.

That buffer was "black field + barcode strip". The strip is drawn at 1-virtual-pixel pitch (magenta column immediately followed by cyan/yellow), which is below the chroma bandwidth of composite output on an SCPH-30001R, so the columns average to near-white. The geometry works out to **~288×2, centred horizontally, ~71% down an otherwise black screen** — precisely "a solid white bar".

It accounts for every detail of the report:

| Reported | Explained by |
|---|---|
| Happens on **all** games | Global flag, single launch chokepoint every device leg funnels through |
| **Debug Colors is OFF** and irrelevant | ee_core's colour writes are all gated on `EnableDebug`; the one ungated write is black |
| Lasts ~2 min, i.e. exactly the load time | The GS scans that buffer until the game reprograms it — Zack's own guess that it "would flash by on a faster drive" is right |

The feature shipped **default-OFF** in `7bc0f117` and was flipped ON in `120045d0` on the stated premise that it's *"imperceptible otherwise"*. That premise was never hardware-validated, and it was false.

## Fix

Leave two clean black frames behind after the hold loop. Two because rendering is double-buffered — clearing one leaves the barcode in the other, which is the buffer a scaler may resync to across the video-mode change.

This makes the feature **harmless on its own** rather than masking it by flipping the default back. Whether `gApplyGameID` should still default ON is a separate policy call and is deliberately **not** changed here — the fork's doctrine is to ship opinionated defaults, and with this fix the default is no longer harmful. Say the word if you'd rather flip it too.

Also corrects the header comment, which still claimed "default OFF".

## Hardware caveat — worth one tester's confirmation

Clearing immediately after the 45-frame hold could in principle break the latch on real **Pixel FX / RetroGEM** hardware, if the scaler samples the bars across the video-mode transition rather than only during the hold. Nobody here has that hardware to check.

Zack's bug is fixed either way. If a GameID owner reports a regression, the answer is to *lengthen the hold*, not to remove the clear.

Full `opl.elf` builds clean.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
