### PR TITLE
feat(cheats): name the paths probed, and accept .CHT as well as .cht (#265)

### DIFF
--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -106,6 +106,10 @@ void neutrinoArgsParse(const char *in, neutrino_args_t *na);
 void neutrinoArgsAssemble(const neutrino_args_t *na, char *out, int outSize);
 
 int sbLoadCheats(const char *path, const char *file);
+// Newline-separated list of every location the last sbLoadCheats() call probed (#265).
+const char *sbGetCheatSearchLog(void);
+// Localized "no cheats found" text with the probed locations appended (#265). Static buffer.
+const char *sbCheatsNotFoundText(void);
 int sbLoadImage(const char *path, const char *file);
 
 #endif

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1178,7 +1178,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         if (gAutoLaunchBDMGame == NULL) {
             switch (result) {
                 case -ENOENT:
-                    guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
+                    guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
                     break;
                 default:
                     guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -732,7 +732,7 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
     if ((result = sbLoadCheats(ethPrefix, game->startup)) < 0) {
         switch (result) {
             case -ENOENT:
-                guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
+                guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
                 break;
             default:
                 guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1052,7 +1052,7 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         if (gAutoLaunchGame == NULL) {
             switch (result) {
                 case -ENOENT:
-                    guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
+                    guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
                     break;
                 default:
                     guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -869,7 +869,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         if (gAutoLaunchBDMGame == NULL) {
             switch (result) {
                 case -ENOENT:
-                    guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
+                    guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
                     break;
                 default:
                     guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1468,6 +1468,53 @@ void sbCreateFolders(const char *path, int createDiscImgFolders)
 // 4 MiB at the launch's most heap-tight moment. Over-cap members fall through to the loose file.
 #define CHT_TAR_MEMBER_MAX (1024 * 1024)
 
+/*
+  Human-readable record of every location sbLoadCheats actually looked in, for the "no cheats found"
+  message (#265). "No cheats found" on its own gave the user nothing to act on -- they could not
+  tell whether OPL wanted CHT/<id>.cht on the game's own device, a cht.tar, or a different
+  startup id entirely.
+
+  Paths are not translatable text, so the launch legs append this to the localized string rather
+  than needing a new .lng label (which would have to go at the END of _base.yml under the
+  append-only rule, and would need translating in 31 languages to say nothing extra).
+*/
+static char cheatSearchLog[512];
+
+static void sbCheatLogAppend(const char *what)
+{
+    size_t used = strlen(cheatSearchLog);
+
+    if (used + 2 >= sizeof(cheatSearchLog))
+        return; // full: drop rather than truncate mid-path, which would mislead
+
+    snprintf(cheatSearchLog + used, sizeof(cheatSearchLog) - used, "%s%s", used ? "\n" : "", what);
+}
+
+const char *sbGetCheatSearchLog(void)
+{
+    return cheatSearchLog;
+}
+
+/*
+  Build the "no cheats found" text with the locations actually probed appended (#265).
+
+  Returns a pointer to a static buffer, valid until the next call -- the launch legs use it
+  immediately. If the search log is somehow empty the localized string is returned unchanged, so
+  this can never render a bare "Checked:" header with nothing under it.
+*/
+const char *sbCheatsNotFoundText(void)
+{
+    static char msg[640];
+    const char *log = sbGetCheatSearchLog();
+
+    if (log == NULL || log[0] == 0)
+        return _l(_STR_NO_CHEATS_FOUND);
+
+    snprintf(msg, sizeof(msg), "%s\n\n%s", _l(_STR_NO_CHEATS_FOUND), log);
+
+    return msg;
+}
+
 int sbLoadCheats(const char *path, const char *file)
 {
     // 64 was too small for BDM device prefixes (up to BDM_PREFIX_MAX) plus
@@ -1475,6 +1522,8 @@ int sbLoadCheats(const char *path, const char *file)
     // 256-byte path convention used elsewhere in this file.
     char cheatfile[256];
     int cheatMode = 0;
+
+    cheatSearchLog[0] = 0;
 
     if (GetCheatsEnabled()) {
         // wOPL 1.2 parity (#154, Blade1984000's widescreen packs): CHT/cht.tar -- a flat ustar of
@@ -1484,6 +1533,14 @@ int sbLoadCheats(const char *path, const char *file)
         char member[64];
         if (snprintf(member, sizeof(member), "%s.cht", file) < (int)sizeof(member)) {
             const TarEntryBase *entry = tarFind(TAR_KIND_CHT, member);
+            sbCheatLogAppend("CHT/cht.tar");
+            /*
+              Retry the member in UPPERCASE (#265). tarFind matches the archived name byte-for-byte,
+              so a pack built with "<ID>.CHT" members missed entirely. Only the EXTENSION is
+              re-cased -- the startup id is already canonical uppercase (SLUS_123.45).
+            */
+            if (entry == NULL && snprintf(member, sizeof(member), "%s.CHT", file) < (int)sizeof(member))
+                entry = tarFind(TAR_KIND_CHT, member);
             // rawSize == 0 counts as a miss (wOPL parity: its size check rejects empty members) so
             // an empty tar member never shadows a possibly-valid loose CHT/<id>.cht below; over-cap
             // members likewise fall through (CHT_TAR_MEMBER_MAX above).
@@ -1509,10 +1566,27 @@ int sbLoadCheats(const char *path, const char *file)
             }
         }
 
-        snprintf(cheatfile, sizeof(cheatfile), "%sCHT/%s.cht", path, file);
-        LOG("Loading Cheat File %s\n", cheatfile);
+        /*
+          Try lowercase then UPPERCASE (#265). PFS (HDD) is case-sensitive, and the BDM FAT drivers
+          do not fold case on lookup either, so a file saved as "<ID>.CHT" -- which is what several
+          published cheat packs ship -- was simply invisible. Both spellings go into the search log
+          so the user is told exactly what was looked for.
+        */
+        static const char *chtExt[] = {"cht", "CHT"};
+        unsigned int ext;
 
-        if ((cheatMode = load_cheats(cheatfile)) < 0) {
+        cheatMode = -1;
+
+        for (ext = 0; ext < sizeof(chtExt) / sizeof(chtExt[0]); ext++) {
+            snprintf(cheatfile, sizeof(cheatfile), "%sCHT/%s.%s", path, file, chtExt[ext]);
+            LOG("Loading Cheat File %s\n", cheatfile);
+            sbCheatLogAppend(cheatfile);
+
+            if ((cheatMode = load_cheats(cheatfile)) >= 0)
+                break;
+        }
+
+        if (cheatMode < 0) {
             // Distinguish absent from unreadable so the launch legs' 'No cheats found' branch --
             // dead code until now (load_cheats never returned -ENOENT; an upstream errno-propagation
             // attempt wrote to the pointer and was reverted) -- fires for a merely-missing file

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -275,7 +275,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     if ((result = sbLoadCheats(udpfsPrefix, game->startup)) < 0) {
         switch (result) {
             case -ENOENT:
-                guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
+                guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
                 break;
             default:
                 guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);


### PR DESCRIPTION
Covers two of gnaomo's three asks in [#265](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/265). The third is deferred with a reason rather than rushed.

## 1. Verbose "No cheats found"

The message alone gave no way to act on it — you couldn't tell whether OPL wanted `CHT/<id>.cht` on the game's own device, a `cht.tar`, or a different startup id. `sbLoadCheats` now records every location it probes, and all five launch legs render it:

```
No cheats found.

CHT/cht.tar
mass0:CHT/SLUS_123.45.cht
mass0:CHT/SLUS_123.45.CHT
```

Paths aren't translatable text, so they're appended to the existing localized string rather than adding a `.lng` label — which under the append-only rule would have to go at the *end* of `_base.yml` and be translated into 31 languages to convey nothing extra.

## 2. `.CHT` as well as `.cht` (gnaomo's follow-up comment)

PFS (HDD) is case-sensitive, and the BDM FAT drivers don't fold case on lookup either — so a file saved as `<ID>.CHT`, which is what several published cheat packs ship, was simply invisible.

Both spellings are now tried for the loose file **and** for `cht.tar` members — `tarFind` matches the archived name byte-for-byte, so an uppercase pack missed there too. Only the extension is re-cased; the startup id is already canonical uppercase.

## 3. Cancel the boot from the error — deliberately NOT done here

It's a bigger change than it looks, and worth explaining rather than silently skipping.

All five legs reach this point **after** `sbPrepare()`, which locates its patch zone by *searching the IRX image for a sample pattern*; `sbUnprepare()` restores that pattern. Returning early without the correct unwind would leave the zone modified and **break every subsequent launch** — a far worse bug than the papercut it fixes. On top of that, in `ethsupport.c` the `settings` pointer isn't even assigned yet at that point, so the obvious `sbUnprepare(&settings->common)` would dereference garbage.

It's very doable, but it wants its own change with the unwind verified per leg — five different launch paths, none testable locally.

Full `opl.elf` builds clean.

Refs #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
