### PR TITLE
feat(cheats): let the user cancel the launch when cheats fail to load (#265)

### DIFF
--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -110,6 +110,14 @@ int sbLoadCheats(const char *path, const char *file);
 const char *sbGetCheatSearchLog(void);
 // Localized "no cheats found" text with the probed locations appended (#265). Static buffer.
 const char *sbCheatsNotFoundText(void);
+/*
+  Confirm dialog for a failed cheat load (#265). 1 = continue the launch, 0 = user cancelled and the
+  caller MUST return immediately. On cancel this calls sbUnprepare(pCommon) itself -- without that
+  the patch zone stays modified and the NEXT launch's sbPrepare cannot find it.
+  pCommon is NOT always &settings->common: eth/hdd/udpfs run this before `settings` is assigned and
+  must pass ((u8 *)irx + index) directly.
+*/
+int sbCheatsMissingContinue(void *pCommon, int cheatResult);
 int sbLoadImage(const char *path, const char *file);
 
 #endif

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1175,16 +1175,10 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     settings->common.zso_cache = bdmCacheSize;
 
     if ((result = sbLoadCheats(pDeviceData->bdmPrefix, game->startup)) < 0) {
-        if (gAutoLaunchBDMGame == NULL) {
-            switch (result) {
-                case -ENOENT:
-                    guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
-                    break;
-                default:
-                    guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-            }
-        } else
-            LOG("Cheats error\n");
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        if (!sbCheatsMissingContinue(&settings->common, result))
+            return;
     }
     sbLoadImage(pDeviceData->bdmPrefix, game->startup);
 

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -730,13 +730,11 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
     compatmask = sbPrepare(game, configSet, size_smb_cdvdman_irx, smb_cdvdman_irx, &i);
 
     if ((result = sbLoadCheats(ethPrefix, game->startup)) < 0) {
-        switch (result) {
-            case -ENOENT:
-                guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
-                break;
-            default:
-                guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-        }
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        // `settings` is not assigned until below, so derive the common block from the IRX base.
+        if (!sbCheatsMissingContinue((u8 *)(&smb_cdvdman_irx) + i, result))
+            return;
     }
     sbLoadImage(ethPrefix, game->startup);
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1049,16 +1049,11 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     sbPrepare(NULL, configSet, size_irx, irx, &i);
 
     if ((result = sbLoadCheats(gHDDPrefix, game->startup)) < 0) {
-        if (gAutoLaunchGame == NULL) {
-            switch (result) {
-                case -ENOENT:
-                    guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
-                    break;
-                default:
-                    guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-            }
-        } else
-            LOG("Cheats error\n");
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        // `settings` is not assigned until below, so derive the common block from the IRX base.
+        if (!sbCheatsMissingContinue((u8 *)irx + i, result))
+            return;
     }
     sbLoadImage(gHDDPrefix, game->startup);
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -866,16 +866,10 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     settings->common.layer1_start = layer1_start;
 
     if ((result = sbLoadCheats(mmcePrefix, game->startup)) < 0) {
-        if (gAutoLaunchBDMGame == NULL) {
-            switch (result) {
-                case -ENOENT:
-                    guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
-                    break;
-                default:
-                    guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-            }
-        } else
-            LOG("Cheats error\n");
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        if (!sbCheatsMissingContinue(&settings->common, result))
+            return;
     }
     sbLoadImage(mmcePrefix, game->startup);
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1515,6 +1515,46 @@ const char *sbCheatsNotFoundText(void)
     return msg;
 }
 
+/*
+  Offer the user a way OUT of the launch when cheats did not load (#265).
+
+  Previously the launch legs showed a 10-frame toast and carried straight on into the game, so a
+  user who had just noticed "no cheats found" had no choice but to sit through the load and reset
+  the console. Now it is a confirm: accept launches anyway, cancel returns to the menu.
+
+  THE UNWIND IS THE WHOLE POINT OF THIS HELPER. Every leg reaches the cheat check AFTER
+  sbPrepare(), which finds its patch zone by SEARCHING THE IRX IMAGE for the sample pattern in
+  cdvdman_settings_common_sample. Returning to the menu without restoring that pattern would leave
+  the zone unrecognisable, and the NEXT launch's sbPrepare would fail to locate it -- so a single
+  cancel would break every subsequent launch until reboot. Doing it here rather than in five call
+  sites means no leg can forget.
+
+  pCommon must be the settings' common block. NOTE it is NOT always &settings->common: in
+  ethsupport, hddsupport and udpfssupport the cheat check runs BEFORE `settings` is assigned, so
+  those legs pass the same expression sbPrepare's index yields, ((u8 *)irx + index).
+
+  Returns 1 to continue the launch, 0 if the user cancelled (caller must return immediately).
+*/
+int sbCheatsMissingContinue(void *pCommon, int cheatResult)
+{
+    const char *text = (cheatResult == -ENOENT) ? sbCheatsNotFoundText() : _l(_STR_ERR_CHEATS_LOAD_FAILED);
+
+    // Autolaunch has no user at the pad; never block an unattended boot on a prompt.
+    if ((gAutoLaunchGame != NULL) || (gAutoLaunchBDMGame != NULL)) {
+        LOG("Cheats error (autolaunch: continuing)\n");
+        return 1;
+    }
+
+    // guiMsgBox: 2 == accept (gSelectButton), 1 == the other button. addAccept draws both icons.
+    if (guiMsgBox(text, 1, NULL) == 2)
+        return 1;
+
+    sbUnprepare(pCommon);
+    LOG("Cheats error: user cancelled the launch\n");
+
+    return 0;
+}
+
 int sbLoadCheats(const char *path, const char *file)
 {
     // 64 was too small for BDM device prefixes (up to BDM_PREFIX_MAX) plus

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -273,13 +273,12 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
         return;
 
     if ((result = sbLoadCheats(udpfsPrefix, game->startup)) < 0) {
-        switch (result) {
-            case -ENOENT:
-                guiWarning(sbCheatsNotFoundText(), 10); // #265: name the paths actually probed
-                break;
-            default:
-                guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-        }
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        // udpfs never assigns `settings` (Neutrino reads the game, not an OPL cdvdman), but
+        // sbPrepare still patched smb_cdvdman_irx, so the unwind is required all the same.
+        if (!sbCheatsMissingContinue((u8 *)(&smb_cdvdman_irx) + index, result))
+            return;
     }
     sbLoadImage(udpfsPrefix, game->startup);
 


### PR DESCRIPTION
gnaomo's third ask — the one I deferred out of #277 because it needed the unwind verified per leg.

> when the error comes up there's no way to cancel booting the game, and go back to OPL menu, would be handy and save rebooting the ps2

**Stacked on [#277](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/277)** so the diff shows only this work; it will retarget to master when that merges.

## The dangerous part, and why it's in one helper

Every leg reaches the cheat check **after** `sbPrepare()`, which locates its patch zone by *searching the IRX image* for the sample pattern in `cdvdman_settings_common_sample`. Returning to the menu without restoring that pattern leaves the zone unrecognisable — so the **next** launch's `sbPrepare` can't find it, and a single cancel would break every subsequent launch until reboot.

`sbCheatsMissingContinue()` calls `sbUnprepare()` itself, so no leg can forget it.

## The pointer is not `&settings->common` everywhere

This is the trap. In three of the five legs the cheat check runs *before* `settings` is assigned, so the obvious form would dereference an uninitialised pointer:

| Leg | Pointer passed | Why |
|---|---|---|
| bdm | `&settings->common` | assigned :1106, check at :1177 |
| **eth** | `(u8 *)(&smb_cdvdman_irx) + i` | `settings` not assigned until :743 |
| **hdd** | `(u8 *)irx + i` | `settings` not assigned until :1065 |
| mmce | `&settings->common` | assigned :753, check at :868 |
| **udpfs** | `(u8 *)(&smb_cdvdman_irx) + index` | `settings` **never** assigned — Neutrino reads the game, not an OPL cdvdman — but `sbPrepare` still patched `smb_cdvdman_irx`, so the unwind is required anyway |

Each is the same expression `sbPrepare`'s out-index yields.

## Other behaviour

- **Autolaunch is exempt** — no user at the pad, so an unattended boot is never blocked on a prompt. That preserves what the old per-leg `gAutoLaunch*Game` guards did, now in one place instead of five.
- Applies to **both** failure modes (not-found and failed-to-load), since either is a reason a user might want out.

Full `opl.elf` builds clean. The two remaining warnings (`dia.c` `cur`, `supportbase.c` `re`) are pre-existing on master.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
