### PR TITLE
docs(rolling): make PS2DEVLATESTSDK the recommended build, PS2MAXSDK the fallback

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -6,10 +6,10 @@ name: Rolling Release
 # Builds with TWO toolchains so a regression in either is visible from the rolling channel
 # (and a hardware failure can be triaged by WHICH flavours reproduce it). Each ships as its own
 # labeled APP_RIPTOPL-<SDK>/ folder + bare ELF; recommended download order is by reliability:
-#   * ps2max/dev (pinned)        -> -PS2MAXSDK        (pinned 2025 SDK; RECOMMENDED #1)
-#   * ps2dev/ps2dev:latest       -> -PS2DEVLATESTSDK  (bleeding-edge MOVING tag; ps2sdk drifts
-#                                                      daily and can produce a non-booting binary,
-#                                                      see issue #102 -- least recommended)
+#   * ps2dev/ps2dev:latest       -> -PS2DEVLATESTSDK  (current SDK, stock drivers; RECOMMENDED #1 --
+#                                                      what RiptOPL is developed and tested against)
+#   * ps2max/dev (pinned)        -> -PS2MAXSDK        (pinned 2025 SDK; SAFE FALLBACK for when the
+#                                                      moving latest tag regresses, see issue #102)
 #
 # A source snapshot (RIPTOPL-<version>-src.zip) of the exact built commit is also
 # published, so every rolling build is self-preserving: testers can restore and
@@ -32,8 +32,8 @@ name: Rolling Release
 # toolchain can never be swapped in silently. Each ELF self-identifies: the version string
 # carries "-PS2MAXSDK" / "-PS2DEVLATESTSDK" (LOCALVERSION). Note the compile gate
 # catches BUILD breakage only: ps2dev:latest tracks a MOVING tag whose ps2sdk drifts daily and
-# can yield a green-but-non-booting binary (issue #102), which is why the two pinned flavours
-# are the recommended downloads -- see the release notes "Get started".
+# can yield a green-but-non-booting binary (issue #102), which is why the pinned PS2MAXSDK flavour
+# is kept as the safe fallback -- see the release notes "Get started".
 
 on:
   push:
@@ -388,8 +388,8 @@ jobs:
         run: |
           set -eu
           # Full installable package the user copies to a memory card / device:
-          #                                              drivers (no coherent-mmce override); RECOMMENDED #1.
-          #   APP_RIPTOPL-PS2MAXSDK/RIPTOPL.ELF       -- pinned/stable 2025 ps2max SDK; RECOMMENDED #2.
+          #                                              drivers (no coherent-mmce override); SAFE FALLBACK.
+          #   APP_RIPTOPL-PS2MAXSDK/RIPTOPL.ELF       -- pinned/stable 2025 ps2max SDK; SAFE FALLBACK.
           #   APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF -- ps2dev:latest (bleeding-edge MOVING tag; may not
           #                                              boot, issue #102). No unlabeled default folder.
           #   POPSTARTER/                     -- SMB network stack (popsmb/) + bdma_config.txt=fat32.
@@ -514,13 +514,13 @@ jobs:
             printf 'SDK toolchain each was built with -- the RiptOPL code in every one is identical. Pick a folder\n'
             printf 'and copy its RIPTOPL.ELF to your launch method. Recommended in this order (by reliability):\n'
             printf '\n'
-            printf '  1. **APP_RIPTOPL-PS2MAXSDK/** -- pinned 2025 ps2max/dev SDK (version ends "-PS2MAXSDK").\n'
-            printf '     Pinned and field-proven: the recommended choice.\n'
-            printf '  2. **APP_RIPTOPL-PS2DEVLATESTSDK/** -- built on the ps2dev:latest toolchain (version ends\n'
-            printf '     "-PS2DEVLATESTSDK"). It tracks a MOVING SDK tag that changes constantly, so it can\n'
-            printf '     intermittently fail to boot on some consoles -- expected volatility of a moving SDK, NOT\n'
-            printf '     a RiptOPL bug (see issue #102). Great for catching upstream SDK regressions early; if it\n'
-            printf '     black-screens at startup, use the PS2MAXSDK build instead.\n'
+            printf '  1. **APP_RIPTOPL-PS2DEVLATESTSDK/** -- built on the ps2dev:latest toolchain (version ends\n'
+            printf '     "-PS2DEVLATESTSDK"). This is the RECOMMENDED download: it uses the current SDK, with the\n'
+            printf '     stock drivers RiptOPL is developed and tested against.\n'
+            printf '  2. **APP_RIPTOPL-PS2MAXSDK/** -- pinned 2025 ps2max/dev SDK (version ends "-PS2MAXSDK").\n'
+            printf '     The SAFE FALLBACK. Because it tracks a moving SDK tag, the recommended build can\n'
+            printf '     occasionally regress on some consoles (see issue #102) -- if it black-screens at startup\n'
+            printf '     or the cursor does not respond, use this one and please say so in the report.\n'
             printf '\n'
             printf 'When something misbehaves on hardware, please say WHICH flavour you ran (the in-app version\n'
             printf 'string suffix tells you). A PS2DEVLATESTSDK-only failure points at an SDK regression; a\n'
@@ -572,11 +572,11 @@ jobs:
               printf -- '- RIPTOPL-DEBUG-*.zip: debug builds (iopcore/ingame/eesio/ppctty/DTL_T10000), both SDKs -- diagnostics\n'
             fi
             if [ "$HAS_PS2MAXSDK" = yes ]; then
-              printf -- '- %s-PS2MAXSDK.ELF: bare loader, ps2max/dev %s pinned toolchain (RECOMMENDED -- pinned, boots reliably)\n' "$VERSIONED_BASE" "$SDK_VER"
+              printf -- '- %s-PS2MAXSDK.ELF: bare loader, ps2max/dev %s pinned toolchain (SAFE FALLBACK -- pinned, boots reliably)\n' "$VERSIONED_BASE" "$SDK_VER"
             else
               printf -- '- (pinned %s PS2MAXSDK build FAILED this run)\n' "$SDK_VER"
             fi
-            printf -- '- %s-PS2DEVLATESTSDK.ELF: bare loader, ps2dev:latest toolchain (bleeding-edge -- moving SDK tag, may not boot on all consoles; see "Get started")\n' "$VERSIONED_BASE"
+            printf -- '- %s-PS2DEVLATESTSDK.ELF: bare loader, ps2dev:latest toolchain (RECOMMENDED -- current SDK; see "Get started")\n' "$VERSIONED_BASE"
             for sdk in PS2MAXSDK PS2DEVLATESTSDK; do
               if [ -f "rolling/${VERSIONED_BASE}-${sdk}-ds5.ELF" ]; then
                 printf -- '- %s-%s-ds5.ELF: %s toolchain WITH DualSense (DS5 USB) pad support (same reliability as the %s bare loader above)\n' "$VERSIONED_BASE" "$sdk" "$sdk" "$sdk"

--- a/README.md
+++ b/README.md
@@ -291,10 +291,9 @@ contains and how to pull it.
 
 > **Which rolling build?** The rolling zip ships two loader ELFs that differ only by build
 > toolchain — the RiptOPL code in each is identical. Recommended in order of reliability:
-> **`APP_RIPTOPL-PS2MAXSDK/`** (#1), built on a pinned, known-stable SDK snapshot that boots
-> reliably. **`APP_RIPTOPL-PS2DEVLATESTSDK/`** (#2) tracks
-> the bleeding-edge `ps2dev:latest` SDK, which moves constantly and can intermittently fail to
-> boot on some consoles — it exists mainly to catch upstream SDK regressions early.
+> **`APP_RIPTOPL-PS2DEVLATESTSDK/`** (#1) — the current SDK with stock drivers, which is what
+> RiptOPL is developed and tested against. **`APP_RIPTOPL-PS2MAXSDK/`** (#2) is the safe fallback:
+> a pinned 2025 SDK, for when the moving `ps2dev:latest` tag regresses on a given console.
 > (A third `WOPLSDK` flavour was dropped in 2026-07 — it crashed at the setup menu, issue #270.) See
 > [Which build should I use?](ROLLING_RELEASE.md#which-build-should-i-use).
 

--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -13,9 +13,9 @@ ELFs and supporting files are published alongside it:
 
 | Asset | What it is |
 |---|---|
-| `RIPTOPL-<rel>-<sha>.zip` | **The installable package.** Contains two loader folders that differ ONLY by the SDK toolchain they were built with (the RiptOPL code in each is identical), each explicitly labeled and recommended in this order: `APP_RIPTOPL-PS2MAXSDK/RIPTOPL.ELF` (#1), built on a **pinned, known-stable** SDK snapshot, then `APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF` (#2), built on the moving `ps2dev:latest` tag (bleeding-edge; may not boot on all consoles). There is no unlabeled default folder. Also includes the `POPSTARTER/` + `POPS/` folders for PS1 support, the bundled Neutrino core as a ready-to-use `neutrino/` folder (drag-and-drop to `mc?:/`), and `PS2-Servers.url`, a shortcut to the maintained UDPFS / SMBv1 / UDPBD all-in-one PC launcher. The old `PC-SMB-Server/` folder is no longer embedded. Extract it, pick a folder and copy its `RIPTOPL.ELF` — see [Which build should I use?](#which-build-should-i-use) below. |
-| `RIPTOPL-<version>-PS2MAXSDK.ELF` | Bare loader, `ps2max/dev` (pinned) toolchain (**recommended**; in-app version ends `-PS2MAXSDK`). |
-| `RIPTOPL-<version>-PS2DEVLATESTSDK.ELF` | Bare loader, `ps2dev/ps2dev:latest` toolchain (bleeding-edge; in-app version ends `-PS2DEVLATESTSDK`; may not boot on all consoles). |
+| `RIPTOPL-<rel>-<sha>.zip` | **The installable package.** Contains two loader folders that differ ONLY by the SDK toolchain they were built with (the RiptOPL code in each is identical), each explicitly labeled and recommended in this order: `APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF` (#1), built on the current `ps2dev:latest` SDK with stock drivers, then `APP_RIPTOPL-PS2MAXSDK/RIPTOPL.ELF` (#2), a **pinned** 2025 SDK kept as the safe fallback. There is no unlabeled default folder. Also includes the `POPSTARTER/` + `POPS/` folders for PS1 support, the bundled Neutrino core as a ready-to-use `neutrino/` folder (drag-and-drop to `mc?:/`), and `PS2-Servers.url`, a shortcut to the maintained UDPFS / SMBv1 / UDPBD all-in-one PC launcher. The old `PC-SMB-Server/` folder is no longer embedded. Extract it, pick a folder and copy its `RIPTOPL.ELF` — see [Which build should I use?](#which-build-should-i-use) below. |
+| `RIPTOPL-<version>-PS2MAXSDK.ELF` | Bare loader, `ps2max/dev` (pinned) toolchain (**safe fallback**; in-app version ends `-PS2MAXSDK`). |
+| `RIPTOPL-<version>-PS2DEVLATESTSDK.ELF` | Bare loader, `ps2dev/ps2dev:latest` toolchain (**recommended**; in-app version ends `-PS2DEVLATESTSDK`). |
 | `RIPTOPL-<version>-<SDK>-ds5.ELF` | Same as the bare loader for each SDK flavour, **with DualSense (DS5 USB) pad support** compiled in (`DUALSENSE=1`). One per flavour (`-PS2MAXSDK-ds5` / `-PS2DEVLATESTSDK-ds5`); same reliability order applies. The default builds keep DualSense OFF. Best-effort — a flavour's DS5 build may be absent if it failed that run. |
 | `RIPTOPL-<version>-PS2DEVLATESTSDK-1080p.ELF` | **Experimental** loader with the re-added forced-**1080p** GSM video mode compiled in (`GSM1080P=1`). **Latest-SDK flavour only** — the raster is hardware-unvalidated, so it is kept out of every other asset. Selecting 1080p in the per-game GSM picker requires clearing a **three-step confirmation**; the Triangle + Cross boot combo forces safe 480p if a display can't sync it. Best-effort. |
 | `RIPTOPL-<version>-src.zip` | Source snapshot to rebuild this exact commit. |
@@ -32,14 +32,17 @@ flavour carries the same version with a `-PS2MAXSDK` / `-PS2DEVLATESTSDK` suffix
 Both loaders are **the same RiptOPL code** — they differ only by the SDK toolchain that built them.
 Recommended in this order, by reliability:
 
-1. **`APP_RIPTOPL-PS2MAXSDK/` (`-PS2MAXSDK`).** Built on a pinned 2025 `ps2max/dev` SDK. Pinned and
-   field-proven — the most reliable choice.
-2. **`APP_RIPTOPL-PS2DEVLATESTSDK/` (`-PS2DEVLATESTSDK`) is the bleeding edge.** It is built against the
+1. **`APP_RIPTOPL-PS2DEVLATESTSDK/` (`-PS2DEVLATESTSDK`) — the recommended download.** Built on the
+   current `ps2dev:latest` SDK with its stock drivers, which is what RiptOPL is developed and tested
+   against.
+2. **`APP_RIPTOPL-PS2MAXSDK/` (`-PS2MAXSDK`) is the safe fallback.** A pinned 2025 `ps2max/dev` SDK.
+   Use it when the recommended build misbehaves on your console. It is built against the
    `ps2dev:latest` Docker tag, which **moves constantly** (often several times a day). That makes it the
    best early-warning signal for upstream SDK regressions, but it also means it can *intermittently fail
    to boot* on some consoles when the SDK underneath it changes — that is expected volatility of a moving
    tag, **not** a RiptOPL bug (see issue [#102](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/102)).
-   If it black-screens at startup, use the PS2MAXSDK build instead.
+   If the recommended build black-screens at startup or the cursor does not respond, use this one
+   and please say which you ran in the report.
 
 When something misbehaves on hardware, please say **which flavour you ran** — the in-app version string's
 `-PS2MAXSDK` / `-PS2DEVLATESTSDK` suffix tells you. A PS2DEVLATESTSDK-only failure points at an
@@ -80,7 +83,7 @@ whether the bleeding-edge build succeeded.
   fails loudly. Note this guards against *build* breakage only — because `ps2dev:latest` tracks a
   moving SDK tag, a green build can still produce a binary that does not boot on hardware (see
   [Which build should I use?](#which-build-should-i-use)), which is why the pinned
-  `-PS2MAXSDK` flavour is the recommended download. The pinned build is best-effort
+  `-PS2MAXSDK` flavour is kept as the safe fallback. The pinned build is best-effort
   (`continue-on-error`); when one fails, the package ships without that folder and the notes say so.
 - Publishes/updates the single `rolling` pre-release from the host runner.
 - `concurrency` cancels superseded in-flight runs, so the release reflects the newest push.


### PR DESCRIPTION
Per your directive: latest first, max as the safe fallback.

Reverses the order [#273](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/273) left behind — that promoted PS2MAXSDK to #1 purely because it was the surviving pinned flavour after WOPLSDK was dropped, which was mechanical, not a judgement.

The rationale is now stated positively instead of as "least recommended": PS2DEVLATESTSDK carries the current SDK with stock drivers, which is what RiptOPL is developed and tested against. PS2MAXSDK is there for when the moving tag regresses on a given console (#102).

Also repairs the flavour list in the workflow header, which briefly listed `ps2dev:latest` twice and dropped ps2max during the edit.

Touches `rolling-release.yml` (header, packaging comments, generated release notes, per-asset lines), `README.md`, `ROLLING_RELEASE.md`. YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)