### PR TITLE
fix(udpbd): dead ARP cache, and describe the transport that actually loaded

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -97,7 +97,11 @@ int bdmEnsureSourceModules(int bdmType, u32 timeoutMs);
 int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType);
 
 int bdmFindPartition(char *target, const char *name, int write);
-int bdmIsUDPBDLoaded(void);                  // 1 if the UDPBD NIC stack is loaded (the SMB stack must not load on top)
+int bdmIsUDPBDLoaded(void); // 1 if the UDPBD NIC stack is loaded (the SMB stack must not load on top)
+// Which network block transport is actually resident (NET_BOOT_UDPBD / NET_BOOT_UDPFS). Use this,
+// not gNetBootProtocol, for anything DESCRIBING the live device -- the picker can change without a
+// reboot while the loaded IRX cannot.
+int bdmGetLoadedNetProtocol(void);
 int bdmSupportIsUDPBD(item_list_t *support); // 1 if this support is the UDPBD block device (its games are Neutrino-only)
 
 // Re-evaluate every BDM device's presence + page visibility on the next refresh (bumps the latch

--- a/modules/network/smap_udpbd/src/ministack.c
+++ b/modules/network/smap_udpbd/src/ministack.c
@@ -136,7 +136,17 @@ int arp_add_entry(uint32_t ip, uint8_t mac[6])
 
     // Add new entry
     for (i = 0; i < MS_ARP_ENTRIES; i++) {
-        if (ip == 0) {
+        // Test the SLOT, not the argument. This read `if (ip == 0)`, i.e. it checked the peer IP
+        // being added rather than whether arp_table[i] was free -- so for any real peer (ip != 0)
+        // no free slot was ever found and arp_add_entry always returned -1, leaving the ARP cache
+        // permanently empty. udpfs_ministack (ministack_arp.c) has always had this right, which is
+        // why only the UDPBD monolith is affected.
+        //
+        // The consequence is not a hard failure, which is why it went unnoticed: every send site in
+        // this driver targets the broadcast MAC anyway, so traffic still flows -- as a BROADCAST to
+        // every host on the LAN, on every frame. On a busy network that is both a throughput
+        // problem and a good way to look like "UDPBD isn't working right".
+        if (arp_table[i].ip == 0) {
             arp_table[i].ip = ip;
             arp_table[i].mac[0] = mac[0];
             arp_table[i].mac[1] = mac[1];

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -33,6 +33,20 @@ static int ieee1394ModLoaded = 0;
 static int mx4sioModLoaded = 0;
 static int hddModLoaded = 0;
 static int udpbdModLoaded = 0;
+/*
+  WHICH network block transport is actually resident, as NET_BOOT_UDPBD / NET_BOOT_UDPFS, or -1
+  when none is loaded.
+
+  udpbdModLoaded alone is protocol-agnostic: both branches of the loader set it to 1, so once
+  either chain is up the module gate short-circuits. But the tab label, the tab icon and the
+  Neutrino -bsd backend all read the LIVE gNetBootProtocol. Change the picker without rebooting and
+  those three start describing a transport that is NOT the one loaded -- e.g. a tab labelled UDPFSBD
+  and a "-bsd=udpfsbd" launch arg while the smap_udpbd monolith is what is actually resident.
+  (A restart notice is shown on protocol change, but nothing enforces it.)
+
+  Consumers below use this instead, so they always describe what is really loaded.
+*/
+static int udpbdLoadedProtocol = -1;
 static s32 bdmLoadModuleLock;
 int bdmDeviceModeStarted;
 
@@ -264,6 +278,15 @@ int bdmIsUDPBDLoaded(void)
     return udpbdModLoaded;
 }
 
+/*
+  The network block transport actually resident (NET_BOOT_UDPBD / NET_BOOT_UDPFS). Falls back to the
+  live gNetBootProtocol before anything has loaded, so first-boot labelling is unchanged.
+*/
+int bdmGetLoadedNetProtocol(void)
+{
+    return (udpbdLoadedProtocol >= 0) ? udpbdLoadedProtocol : gNetBootProtocol;
+}
+
 // True when this support's device is the UDPBD block device (its games are Neutrino-only).
 // Returns 0 for non-BDM supports (incl. FAV-wrapped items, which have no source lookup here).
 int bdmSupportIsUDPBD(item_list_t *support)
@@ -369,12 +392,16 @@ static void bdmLoadBlockDeviceModules(void)
             // ministack (gets the ip= arg, exports to bd), then udpfs_bd (registers the "udp" BDM device).
             if (bdmLoadOptionalModule("UDPFS_SMAP", &udpfs_smap_irx, size_udpfs_smap_irx) >= 0 &&
                 bdmLoadOptionalModuleArgs("UDPFS_MINISTACK", &udpfs_ministack_irx, size_udpfs_ministack_irx, (int)strlen(ipArg) + 1, ipArg) >= 0 &&
-                bdmLoadOptionalModule("UDPFS_BD", &udpfs_bd_irx, size_udpfs_bd_irx) >= 0)
+                bdmLoadOptionalModule("UDPFS_BD", &udpfs_bd_irx, size_udpfs_bd_irx) >= 0) {
                 udpbdModLoaded = 1;
+                udpbdLoadedProtocol = NET_BOOT_UDPFS;
+            }
         } else {
             // UDPBD: the self-contained smap_udpbd monolith (smap + ministack + udpbd in one irx).
-            if (bdmLoadOptionalModuleArgs("SMAP_UDPBD", &smap_udpbd_irx, size_smap_udpbd_irx, (int)strlen(ipArg) + 1, ipArg) >= 0)
+            if (bdmLoadOptionalModuleArgs("SMAP_UDPBD", &smap_udpbd_irx, size_smap_udpbd_irx, (int)strlen(ipArg) + 1, ipArg) >= 0) {
                 udpbdModLoaded = 1;
+                udpbdLoadedProtocol = NET_BOOT_UDPBD;
+            }
         }
         // Release the dev9 reference taken above if the load failed -- otherwise a failing/retrying
         // UDPBD/UDPFS (both gates re-enter on every device refresh while !udpbdModLoaded) inflates the
@@ -1320,7 +1347,7 @@ static int bdmGetTextId(item_list_t *itemList)
     else if (bdmDriverIsATA(pDeviceData->bdmDriver))
         mode = _STR_HDD_GAMES;
     else if (bdmDriverIsUDPBD(pDeviceData->bdmDriver))
-        mode = (gNetBootProtocol == NET_BOOT_UDPFS) ? _STR_UDPFSBD_GAMES : _STR_UDPBD_GAMES; // BLOCK: UDPFSBD vs UDPBD (the udpfs FILESYSTEM tab is _STR_UDPFS_GAMES, a separate device); mirror bdmGetIconId
+        mode = (bdmGetLoadedNetProtocol() == NET_BOOT_UDPFS) ? _STR_UDPFSBD_GAMES : _STR_UDPBD_GAMES; // BLOCK: UDPFSBD vs UDPBD (the udpfs FILESYSTEM tab is _STR_UDPFS_GAMES, a separate device); mirror bdmGetIconId
 
     return mode;
 }
@@ -1340,7 +1367,7 @@ static int bdmGetIconId(item_list_t *itemList)
     else if (bdmDriverIsATA(pDeviceData->bdmDriver))
         mode = HDD_BD_ICON;
     else if (bdmDriverIsUDPBD(pDeviceData->bdmDriver))
-        mode = (gNetBootProtocol == NET_BOOT_UDPFS) ? UDPFS_ICON : UDP_ICON;
+        mode = (bdmGetLoadedNetProtocol() == NET_BOOT_UDPFS) ? UDPFS_ICON : UDP_ICON;
 
     return mode;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -1027,7 +1027,7 @@ static const char *getDeviceName(const char *driver)
     if (!strcmp(driver, "udp"))
         // Both BLOCK transports register the "udp" BDM token; gNetBootProtocol picks the Neutrino backing
         // store: -bsd=udpbd (smap_udpbd / SUDPBDv2) vs -bsd=udpfsbd (the udpfs_bd UDPRDMA toml).
-        return (gNetBootProtocol == NET_BOOT_UDPFS) ? "udpfsbd" : "udpbd";
+        return (bdmGetLoadedNetProtocol() == NET_BOOT_UDPFS) ? "udpfsbd" : "udpbd";
     if (!strcmp(driver, "udpfs"))
         // UDPFS *filesystem* device (udpfssupport / udpfs_ioman): the stock Neutrino -bsd token loads
         // config/bsd-udpfs.toml (the FHI filesystem driver), then opens -dvd=udpfs:<path> by name -- no


### PR DESCRIPTION
Two real defects behind *"I don't think our UDPBD page, or its piping, are working right. UDPFS is fine."*

No single smoking gun was confirmed — an investigation raised six candidates and **all six were refuted**. These two are facts that survived *from* the refutations, and both are places where `smap_udpbd` is the **old** code while the `udpfs_*` chain got the fix. That fits the reported split exactly.

## 1. The ARP cache was permanently empty

`modules/network/smap_udpbd/src/ministack.c` — the "add new entry" loop tested the **argument** instead of the **slot**:

```c
for (i = 0; i < MS_ARP_ENTRIES; i++)
    if (ip == 0)              // <- the peer IP being added
```

For any real peer (`ip != 0`) no free slot is ever found, so `arp_add_entry` always returned `-1` and the table stayed empty for the whole boot. `udpfs_ministack`'s `ministack_arp.c` has always had `arp_table[i].ip == 0` — which is precisely why only the UDPBD monolith is affected.

It isn't a hard failure, which is how it survived: every send site in this driver targets the broadcast MAC anyway. The cost is that **every PS2→server frame goes out as an Ethernet broadcast to every host on the LAN**, on every frame of every read. On a busy network that's both a throughput problem and an excellent way to look flaky.

## 2. Tab label, icon and `-bsd` arg could describe the wrong transport

`udpbdModLoaded` is protocol-agnostic — both loader branches set it to `1`, so once either chain is up the gate short-circuits. But the tab label, the tab icon and the Neutrino `-bsd` backend all read the **live** `gNetBootProtocol`.

Change the picker without rebooting and all three describe a transport that isn't resident: a tab labelled UDPFSBD and a `-bsd=udpfsbd` launch arg while the `smap_udpbd` monolith is what's actually loaded. There *is* a restart notice on protocol change, but nothing enforces it — and a launch built on the wrong `-bsd` backend fails in a way that looks like the transport is broken.

Now records which protocol loaded and exposes `bdmGetLoadedNetProtocol()`; the three describing consumers use that. Falls back to the live global before anything loads, so first-boot labelling is unchanged.

## Not claimed

Neither is proven to be *the* thing you noticed — that needs hardware. Four other candidates were refuted outright, including one worth recording: `smap_udpbd` calls `bdm_disconnect_bd()` **inside its own read callback** (`udpbd.c:174`), which is re-entrancy this fork's own UDPFS driver documents as forbidden. It was refuted as the cause here, but it's a latent hazard someone should look at deliberately.

`smap_udpbd.irx` and a full `opl.elf` both build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
