### PR TITLE
fix(pad): make the poll-time delta wrap-correct (29.13s tick rollover)

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -118,6 +118,11 @@ struct pad_data_t
 /// current time in miliseconds (last update time)
 static u32 curtime = 0;
 static u32 time_since_last = 0;
+// Raw-tick bookkeeping for the wrap-correct delta in readPads(). lastticks is the previous poll's
+// cpu_ticks(); tickrem carries the sub-millisecond remainder so dividing a delta stays drift-free.
+static u32 lastticks = 0;
+static u32 tickrem = 0;
+static int padTicksSeeded = 0;
 
 static unsigned short pad_count;
 static struct pad_data_t pad_data[MAX_PADS];
@@ -558,7 +563,10 @@ void padRumbleActivate(void)
     rumbleLive = 1;
 }
 
-static u32 rumbleLastMs = 0;
+// Previous rumble-arm timestamp in RAW ticks (see padRumbleArm) -- raw, not ms, so the
+// difference is wrap-correct on the full 32-bit counter.
+static u32 rumbleLastTicks = 0;
+static int rumbleLastTicksValid = 0;
 
 // Gate a rumble command. Deliberately as PERMISSIVE as the known-working reference.
 //
@@ -692,9 +700,13 @@ static void padRumbleArm(int durationMs, unsigned char level, int smallEngine)
     // ticks with. The interval is measured across EVERY arm attempt -- including suppressed ones --
     // so a fast held scroll stays silent for its whole run instead of strobing at the window edge.
     // Bumps (smallEngine) are decisions, not repeats: they always land at full length.
-    u32 now = cpu_ticks() / CLOCKS_PER_MILISEC;
-    u32 interval = (rumbleLastMs != 0) ? (now - rumbleLastMs) : 0xFFFFFFFFu;
-    rumbleLastMs = now;
+    // Raw ticks, differenced BEFORE dividing -- same wrap correctness as readPads(). Dividing first
+    // put both operands in 0..29127 (cpu_ticks() wraps every ~29.13 s), so once per wrap `interval`
+    // came out enormous and this arm was treated as isolated rather than a repeat.
+    u32 nowRumbleTicks = cpu_ticks();
+    u32 interval = (rumbleLastTicksValid) ? ((nowRumbleTicks - rumbleLastTicks) / CLOCKS_PER_MILISEC) : 0xFFFFFFFFu;
+    rumbleLastTicks = nowRumbleTicks;
+    rumbleLastTicksValid = 1;
     if (!smallEngine && interval < RUMBLE_REPEAT_WINDOW_MS) {
         int duty = (int)interval * RUMBLE_REPEAT_DUTY_PCT / 100;
         if (duty < RUMBLE_REPEAT_FLOOR_MS)
@@ -825,10 +837,40 @@ int readPads()
     oldpaddata = paddata;
     paddata = 0;
 
-    // in ms.
-    u32 newtime = cpu_ticks() / CLOCKS_PER_MILISEC;
-    time_since_last = newtime - curtime;
-    curtime = newtime;
+    /*
+      Elapsed time since the last poll, in ms.
+
+      Difference the RAW tick counter, then divide. The old form divided FIRST
+      (cpu_ticks() / CLOCKS_PER_MILISEC, then subtract), which put both operands in 0..29127 --
+      cpu_ticks() is a 32-bit counter at 147.456 MHz, so it wraps every ~29.13 s and the DIVIDED
+      values wrap with it. u32 modular subtraction is only wrap-correct on the full-width counter,
+      so on the rollover poll time_since_last became ~4,294,938,169 instead of ~16.
+
+      That poisoned all three consumers below:
+        - delaycnt[i] -= time_since_last  (int minus u32 promotes to unsigned) ADDED ~29,127 ms, so
+          getKey()'s only repeat exit (delaycnt <= 0) was unreachable until the key was released.
+        - rumbleMsLeft -= (int)time_since_last SUBTRACTS ~-29,127, turning a 240 ms nav tap into a
+          ~29 second continuous buzz with the motor re-asserted every frame.
+        - the same divided-value wrap in padRumbleArm (now rumbleLastTicks).
+
+      The remainder is CARRIED rather than discarded. Differencing absolute ms was drift-free by
+      construction (16/17 alternating at 60 Hz); dividing a delta and dropping the sub-ms remainder
+      would lose ~0.5 ms of every ~16.7 ms frame, i.e. make every repeat ~3% slow and every rumble
+      tap correspondingly short. Carrying it keeps the old timing exactly.
+
+      First poll: lastticks is seeded on use so an arbitrary power-on tick value cannot present as
+      one enormous delta.
+    */
+    u32 nowticks = cpu_ticks();
+    if (!padTicksSeeded) {
+        lastticks = nowticks;
+        padTicksSeeded = 1;
+    }
+    u32 dticks = (nowticks - lastticks) + tickrem; // wrap-correct: full-width counter
+    lastticks = nowticks;
+    time_since_last = dticks / CLOCKS_PER_MILISEC;
+    tickrem = dticks % CLOCKS_PER_MILISEC;
+    curtime += time_since_last;
 
     int rslt = 0;
 


### PR DESCRIPTION
A real arithmetic bug found while chasing Zack's held-scroll stall. **It is not confirmed as that bug's cause** — see the scope note — but the arithmetic is wrong regardless, so it lands on its own.

## The defect

`readPads()` divided `cpu_ticks()` by `CLOCKS_PER_MILISEC` **before** differencing, putting both operands in `0..29127`. `cpu_ticks()` is a 32-bit counter at 147.456 MHz — it wraps every ~29.13 s, and the *divided* values wrap with it. u32 modular subtraction is only wrap-correct on the full-width counter.

So once per wrap, `time_since_last` came out as **~4,294,938,169** instead of ~16.

Three consumers were poisoned:

| Consumer | Effect |
|---|---|
| `delaycnt[i] -= time_since_last` | int − u32 promotes to unsigned, **adding ~29,127 ms** — `getKey()`'s only repeat exit (`delaycnt <= 0`) unreachable until release |
| `rumbleMsLeft -= (int)time_since_last` | `(int)4294938170 == -29126`, so it **adds ~29 s** — a 240 ms nav thump becomes a **~29 second continuous buzz**, re-asserted every frame |
| `padRumbleArm` inter-arm interval | same divided-value wrap; a held repeat misread as an isolated press |

The rumble one is the ugliest, though it's opt-in (`gEnableRumble`) so few would have hit it.

## The fix

Difference **raw ticks**, divide afterwards — wrap-correct on the full 32-bit counter — and **carry the sub-millisecond remainder**.

The carry matters and I nearly got it wrong: the old code differenced absolute ms and was drift-free by construction (16/17 alternating at 60 Hz). Dividing a delta and discarding the remainder would lose ~0.5 ms of every ~16.7 ms frame — making every repeat ~3% slow and every rumble tap correspondingly short. Also seeds the first poll so an arbitrary power-on tick value can't present as one enormous delta.

## Scope — what this does NOT fix

I'm not claiming this is Zack's stall, because it doesn't fit:

- The poison window is **one frame per 29.13 s** and needs a direction held across exactly that frame. His stall recurs constantly.
- "Happens in settings too" is anti-evidence — nobody holds a direction in a settings list for 29 s.
- It **cannot** produce the coverflow "skips 2-3 games": a poisoned `delaycnt` drains at real time and *loses* repeats rather than deferring them into a burst.

**The better lead, not fixed here:** `delaycnt` is unconditionally reset to the full initial delay on **any** frame where `getKeyPressed` reads false. So a single dropped poll mid-hold suppresses the repeat leg until release — at pad-poll rates rather than once per 29 s, and it can drop *or duplicate* edges, which would also explain the skip. That's where I'd look next, but it needs to be established rather than guessed.

Full `opl.elf` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing accuracy for controller button repeat and hold behavior.
  * Fixed timing calculations for rumble effects, including extended durations and held-button repeats.
  * Improved handling of timer wraparound and very short intervals.
  * Prevented an incorrect initial timing interval when controller polling begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->