### PR TITLE
build: retire ps2max, pin ps2dev:latest as the fallback; GameID defaults OFF

### DIFF
--- a/.github/scripts/build_rolling_extras.sh
+++ b/.github/scripts/build_rolling_extras.sh
@@ -4,7 +4,7 @@
 #   * the debug configs                          -> rolling/debug/
 #
 # Called by EACH SDK build job in rolling-release.yml. $1 is the SDK suffix appended to each
-# filename: "-PS2MAXSDK" for the pinned ps2max
+# filename: "-PS2DEVPINNEDSDK" for the digest-pinned ps2dev snapshot
 # build, "-PS2DEVLATESTSDK" for the ps2dev:latest build -- so the VARIANTS and DEBUG zips carry
 # every SDK flavour of every build. $2 is the LOCALVERSION
 # toolchain brand ("PS2MAXSDK"/"PS2DEVLATESTSDK") embedded in each ELF's version string: filenames get renamed

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ps2max/dev:v20250725-2
+    container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
     steps:
       - name: git checkout
         uses: actions/checkout@v6
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install newer-generation freepad (#254 pad death)
         # The GameID mmceman load kills pad input with these containers' stock freepad
-        # builds (PixeliGer: dead cursor, live menu, WOPLSDK+PS2MAXSDK). The ps2max job
+        # builds (PixeliGer: dead cursor, live menu). The digest-pinned job
         # in compilation.yml runs in the SAME container -- swap there too. Vendored
         # newer-generation bytes (modules/freepad/PROVENANCE.md), fail-loud checks.
         run: sh ./.github/scripts/install_coherent_freepad.sh
@@ -143,7 +143,7 @@ jobs:
         extra: [EXTRA_FEATURES=0, EXTRA_FEATURES=1]
         pademu: [PADEMU=0, PADEMU=1]
     runs-on: ubuntu-latest
-    container: ps2max/dev:v20250725-2
+    container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
     steps:
       - name: git checkout
         uses: actions/checkout@v6
@@ -157,7 +157,7 @@ jobs:
 
       - name: Install newer-generation freepad (#254 pad death)
         # The GameID mmceman load kills pad input with these containers' stock freepad
-        # builds (PixeliGer: dead cursor, live menu, WOPLSDK+PS2MAXSDK). The ps2max job
+        # builds (PixeliGer: dead cursor, live menu). The digest-pinned job
         # in compilation.yml runs in the SAME container -- swap there too. Vendored
         # newer-generation bytes (modules/freepad/PROVENANCE.md), fail-loud checks.
         run: sh ./.github/scripts/install_coherent_freepad.sh
@@ -294,7 +294,7 @@ jobs:
 
   build-lang:
     runs-on: ubuntu-latest
-    container: ps2max/dev:v20250725-2
+    container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
     steps:
       - name: git checkout
         uses: actions/checkout@v6
@@ -383,9 +383,9 @@ jobs:
       fail-fast: false
       matrix:
         debug: [iopcore_debug, ingame_debug, eesio_debug, iopcore_ppctty_debug, ingame_ppctty_debug, DTL_T10000=1]
-        container_commit: [":v20250725-2"]
+        container_commit: ["@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995"]
     runs-on: ubuntu-latest
-    container: ps2max/dev${{ matrix.container_commit }}
+    container: ps2dev/ps2dev${{ matrix.container_commit }}
     steps:
       - name: git checkout
         uses: actions/checkout@v6
@@ -399,7 +399,7 @@ jobs:
 
       - name: Install newer-generation freepad (#254 pad death)
         # The GameID mmceman load kills pad input with these containers' stock freepad
-        # builds (PixeliGer: dead cursor, live menu, WOPLSDK+PS2MAXSDK). The ps2max job
+        # builds (PixeliGer: dead cursor, live menu). The digest-pinned job
         # in compilation.yml runs in the SAME container -- swap there too. Vendored
         # newer-generation bytes (modules/freepad/PROVENANCE.md), fail-loud checks.
         run: sh ./.github/scripts/install_coherent_freepad.sh

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -15,6 +15,44 @@ jobs:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
     steps:
+      # Install git BEFORE checkout: without it, actions/checkout falls back to an API
+      # tarball (no .git directory), so git describe fails and the Makefile marks the
+      # build "-dirty" -- the version string then collapses and hardware reports cannot
+      # identify the exact commit/toolchain they ran.
+      #
+      # Required by EVERY ps2dev-image job, pinned or latest: the image is Alpine and ships
+      # no git. The old ps2max container carried these preinstalled, so the fallback jobs
+      # never needed this step -- retiring ps2max means they do now.
+      - name: Install host dependencies (Alpine only)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            # Consolidated ps2dev Alpine prerequisites: build tools, scripting, packaging, and gcc runtime libs.
+            apk add --no-cache \
+              bash \
+              make \
+              git \
+              zip \
+              unzip \
+              tar \
+              gzip \
+              xz \
+              python3 \
+              py3-pip \
+              py3-yaml \
+              gmp \
+              mpfr4 \
+              mpc1 \
+              perl \
+              cmake \
+              pkgconf \
+              coreutils \
+              findutils \
+              grep \
+              sed \
+              gawk \
+              diffutils
+          fi
+
       - name: git checkout
         uses: actions/checkout@v6
 
@@ -145,6 +183,36 @@ jobs:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
     steps:
+      # See the build job: pinned ps2dev images are Alpine and ship no git.
+      - name: Install host dependencies (Alpine only)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache \
+              bash \
+              make \
+              git \
+              zip \
+              unzip \
+              tar \
+              gzip \
+              xz \
+              python3 \
+              py3-pip \
+              py3-yaml \
+              gmp \
+              mpfr4 \
+              mpc1 \
+              perl \
+              cmake \
+              pkgconf \
+              coreutils \
+              findutils \
+              grep \
+              sed \
+              gawk \
+              diffutils
+          fi
+
       - name: git checkout
         uses: actions/checkout@v6
 
@@ -296,6 +364,36 @@ jobs:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
     steps:
+      # See the build job: pinned ps2dev images are Alpine and ship no git.
+      - name: Install host dependencies (Alpine only)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache \
+              bash \
+              make \
+              git \
+              zip \
+              unzip \
+              tar \
+              gzip \
+              xz \
+              python3 \
+              py3-pip \
+              py3-yaml \
+              gmp \
+              mpfr4 \
+              mpc1 \
+              perl \
+              cmake \
+              pkgconf \
+              coreutils \
+              findutils \
+              grep \
+              sed \
+              gawk \
+              diffutils
+          fi
+
       - name: git checkout
         uses: actions/checkout@v6
 
@@ -387,6 +485,36 @@ jobs:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev${{ matrix.container_commit }}
     steps:
+      # See the build job: pinned ps2dev images are Alpine and ship no git.
+      - name: Install host dependencies (Alpine only)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache \
+              bash \
+              make \
+              git \
+              zip \
+              unzip \
+              tar \
+              gzip \
+              xz \
+              python3 \
+              py3-pip \
+              py3-yaml \
+              gmp \
+              mpfr4 \
+              mpc1 \
+              perl \
+              cmake \
+              pkgconf \
+              coreutils \
+              findutils \
+              grep \
+              sed \
+              gawk \
+              diffutils
+          fi
+
       - name: git checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -8,8 +8,9 @@ name: Rolling Release
 # labeled APP_RIPTOPL-<SDK>/ folder + bare ELF; recommended download order is by reliability:
 #   * ps2dev/ps2dev:latest       -> -PS2DEVLATESTSDK  (current SDK, stock drivers; RECOMMENDED #1 --
 #                                                      what RiptOPL is developed and tested against)
-#   * ps2max/dev (pinned)        -> -PS2MAXSDK        (pinned 2025 SDK; SAFE FALLBACK for when the
-#                                                      moving latest tag regresses, see issue #102)
+#   * ps2dev/ps2dev@sha256 (pin) -> -PS2DEVPINNEDSDK  (a DIGEST PIN of ps2dev:latest taken on a day it
+#                                                      was known good; SAFE FALLBACK for when the moving
+#                                                      latest tag regresses, see issue #102)
 #
 # A source snapshot (RIPTOPL-<version>-src.zip) of the exact built commit is also
 # published, so every rolling build is self-preserving: testers can restore and
@@ -28,11 +29,11 @@ name: Rolling Release
 #
 # GATING: the ps2dev:latest (PS2DEVLATESTSDK) build must COMPILE -- if it fails to build the
 # publish FAILS loudly. Both flavours ship as their own labeled folder
-# (APP_RIPTOPL-PS2MAXSDK / -PS2DEVLATESTSDK) -- there is NO unlabeled default, so a
+# (APP_RIPTOPL-PS2DEVPINNEDSDK / -PS2DEVLATESTSDK) -- there is NO unlabeled default, so a
 # toolchain can never be swapped in silently. Each ELF self-identifies: the version string
-# carries "-PS2MAXSDK" / "-PS2DEVLATESTSDK" (LOCALVERSION). Note the compile gate
+# carries "-PS2DEVPINNEDSDK" / "-PS2DEVLATESTSDK" (LOCALVERSION). Note the compile gate
 # catches BUILD breakage only: ps2dev:latest tracks a MOVING tag whose ps2sdk drifts daily and
-# can yield a green-but-non-booting binary (issue #102), which is why the pinned PS2MAXSDK flavour
+# can yield a green-but-non-booting binary (issue #102), which is why the pinned PS2DEVPINNEDSDK flavour
 # is kept as the safe fallback -- see the release notes "Get started".
 
 on:
@@ -55,7 +56,7 @@ concurrency:
 jobs:
   build-rolling-pinned:
     runs-on: ubuntu-latest
-    container: ps2max/dev:v20250725-2
+    container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
     # Fallback/compatibility toolchain: best-effort, must not block the rolling publish.
     continue-on-error: true
     steps:
@@ -77,18 +78,19 @@ jobs:
         # #245 "no flavour ships the leak" directive is still honored.
         run: sh ./.github/scripts/install_coherent_mmce.sh
 
-      - name: Install newer-generation freepad (#254 pad death)
-        # The GameID mmceman load kills pad input with this container's stock freepad
-        # build (PixeliGer: dead cursor, live menu). Vendored newer-generation bytes
-        # (modules/freepad/PROVENANCE.md), fail-loud checks.
-        run: sh ./.github/scripts/install_coherent_freepad.sh
+      # NO freepad swap here any more. That step existed because the OLD fallback container
+      # (ps2max/dev) shipped a freepad generation whose pad input died under mmceman's sio2man hook
+      # (#254). This flavour is now a DIGEST PIN OF ps2dev:latest, so its freepad is the same
+      # generation the recommended build uses -- overriding it with vendored bytes would make the
+      # fallback differ from the build it is meant to fall back FROM, which defeats the purpose.
+      # The two flavours must now differ by SDK DATE ONLY.
 
       - name: Build (make clean release)
-        # LOCALVERSION brands the in-ELF version string ("-PS2MAXSDK") so hardware reports
+        # LOCALVERSION brands the in-ELF version string ("-PS2DEVPINNEDSDK") so hardware reports
         # self-identify which toolchain's binary produced them (Makefile appends it).
-        run: make --trace clean && make --trace LOCALVERSION=PS2MAXSDK release
+        run: make --trace clean && make --trace LOCALVERSION=PS2DEVPINNEDSDK release
 
-      - name: Stage rolling assets (pinned = PS2MAXSDK)
+      - name: Stage rolling assets (pinned = PS2DEVPINNEDSDK)
         run: |
           set -eu
           mkdir -p rolling
@@ -100,37 +102,37 @@ jobs:
             echo "No RIPTOPL ELF produced by the pinned build" >&2
             exit 1
           fi
-          cp -f "$MAIN_ELF" rolling/RIPTOPL-PS2MAXSDK.ELF
+          cp -f "$MAIN_ELF" rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF
           # IRX provenance manifest: hash every prebuilt module consumed from this container's SDK.
           # A silent SDK-side driver swap (the mmceman class) then shows up as a manifest diff
           # between runs instead of as a hardware mystery.
-          sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST-PS2MAXSDK.txt 2>/dev/null || true
+          sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST-PS2DEVPINNEDSDK.txt 2>/dev/null || true
           echo "Staged pinned rolling assets:"
           ls -la rolling
 
-      - name: Build + stage DualSense (DS5) loader (PS2MAXSDK)
+      - name: Build + stage DualSense (DS5) loader (PS2DEVPINNEDSDK)
         # DualSense (DS5 USB) is HW-validated (maintainer, 2026-07-06) but kept OFF in the default
         # build by choice. Ship a ready-made DUALSENSE=1 loader for THIS SDK flavour as a named
         # top-level asset so DS5 owners can pick their preferred (recommended) flavour without
         # digging in the VARIANTS zip. Best-effort: a DS5 build hiccup must not sink the main flavour.
-        # LOCALVERSION carries "-PS2MAXSDK-ds5" so hardware reports self-identify.
+        # LOCALVERSION carries "-PS2DEVPINNEDSDK-ds5" so hardware reports self-identify.
         run: |
           make --trace clean
           rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the DS5 output is unambiguous
-          if make --trace LOCALVERSION=PS2MAXSDK-ds5 DUALSENSE=1 release; then
+          if make --trace LOCALVERSION=PS2DEVPINNEDSDK-ds5 DUALSENSE=1 release; then
             DS5_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
             if [ -n "${DS5_ELF:-}" ] && [ -f "$DS5_ELF" ]; then
-              cp -f "$DS5_ELF" rolling/RIPTOPL-PS2MAXSDK-ds5.ELF
+              cp -f "$DS5_ELF" rolling/RIPTOPL-PS2DEVPINNEDSDK-ds5.ELF
             else
-              echo "WARN: PS2MAXSDK DUALSENSE=1 build produced no ELF; skipping DS5 asset this run" >&2
+              echo "WARN: PS2DEVPINNEDSDK DUALSENSE=1 build produced no ELF; skipping DS5 asset this run" >&2
             fi
           else
-            echo "WARN: PS2MAXSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
+            echo "WARN: PS2DEVPINNEDSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
           fi
 
-      - name: Build variant + debug extras (pinned = PS2MAXSDK)
+      - name: Build variant + debug extras (pinned = PS2DEVPINNEDSDK)
         # Runs AFTER staging so the per-build `make clean` can't wipe the saved main ELF.
-        run: sh ./.github/scripts/build_rolling_extras.sh "-PS2MAXSDK" "PS2MAXSDK"
+        run: sh ./.github/scripts/build_rolling_extras.sh "-PS2DEVPINNEDSDK" "PS2DEVPINNEDSDK"
 
       - name: Upload pinned rolling assets
         uses: actions/upload-artifact@v6
@@ -237,7 +239,7 @@ jobs:
       - name: Build + stage DualSense (DS5) loader (PS2DEVLATESTSDK)
         # Named DUALSENSE=1 loader on the ps2dev:latest toolchain. Like the plain PS2DEVLATESTSDK
         # build this rides the moving SDK tag (may not boot -- issue #102); DS5 owners who want a
-        # reliable build should prefer the -PS2MAXSDK-ds5 asset. Best-effort so a
+        # reliable build should prefer the -PS2DEVPINNEDSDK-ds5 asset. Best-effort so a
         # DS5 hiccup can't sink the required primary flavour. LOCALVERSION carries "-PS2DEVLATESTSDK-ds5".
         run: |
           make --trace clean
@@ -293,9 +295,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OPL_VERSION: ${{ needs.build-rolling-ps2dev-latest.outputs.version }}
-      # Pinned ps2sdk/toolchain tag of the FALLBACK (-PS2MAXSDK) build, referenced in the release
-      # notes (the -PS2MAXSDK flavour). Bump alongside the build-rolling-pinned container (ps2max/dev:...).
-      SDK_VER: "v20250725-2"
+      # Human-readable label for the FALLBACK (-PS2DEVPINNEDSDK) build, shown in the release notes.
+      # This flavour is a DIGEST PIN of ps2dev:latest, so the label is the date the pin was taken.
+      # Bump it and the container digest together in build-rolling-pinned when re-pinning.
+      SDK_VER: "ps2dev:latest pinned 2026-07-28"
       # MEGA archival credentials (repo secrets MEGA_USERNAME / MEGA_PASSWORD). Exposed under the
       # names USERNAME / PASSWORD because the upload action (Difegue/action-megacmd) reads exactly
       # those env names, and because it lets the MEGA steps gate on `env.USERNAME != ''` -- a fork
@@ -329,7 +332,7 @@ jobs:
           set -eu
           # Apply ONE authoritative version (from the primary ps2dev:latest build, which now
           # resolves full git history) to BOTH toolchains. The source commit is identical, so
-          # the only difference is the toolchain-brand suffix (-PS2MAXSDK / -PS2DEVLATESTSDK).
+          # the only difference is the toolchain-brand suffix (-PS2DEVPINNEDSDK / -PS2DEVLATESTSDK).
           VER="${OPL_VERSION:-}"
           if [ -z "$VER" ]; then
             VER="rolling-${GITHUB_SHA}"
@@ -338,11 +341,11 @@ jobs:
           if [ -f rolling/RIPTOPL.ELF ]; then
             mv -f rolling/RIPTOPL.ELF "rolling/RIPTOPL-${VER}-PS2DEVLATESTSDK.ELF"
           fi
-          if [ -f rolling/RIPTOPL-PS2MAXSDK.ELF ]; then
-            mv -f rolling/RIPTOPL-PS2MAXSDK.ELF "rolling/RIPTOPL-${VER}-PS2MAXSDK.ELF"
+          if [ -f rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF ]; then
+            mv -f rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF "rolling/RIPTOPL-${VER}-PS2DEVPINNEDSDK.ELF"
           fi
           # DualSense (DS5) named loaders, one per SDK flavour (best-effort -- any may be absent).
-          for sdk in PS2MAXSDK PS2DEVLATESTSDK; do
+          for sdk in PS2DEVPINNEDSDK PS2DEVLATESTSDK; do
             if [ -f "rolling/RIPTOPL-${sdk}-ds5.ELF" ]; then
               mv -f "rolling/RIPTOPL-${sdk}-ds5.ELF" "rolling/RIPTOPL-${VER}-${sdk}-ds5.ELF"
             fi
@@ -389,7 +392,7 @@ jobs:
           set -eu
           # Full installable package the user copies to a memory card / device:
           #                                              drivers (no coherent-mmce override); SAFE FALLBACK.
-          #   APP_RIPTOPL-PS2MAXSDK/RIPTOPL.ELF       -- pinned/stable 2025 ps2max SDK; SAFE FALLBACK.
+          #   APP_RIPTOPL-PS2DEVPINNEDSDK/RIPTOPL.ELF   -- digest pin of ps2dev:latest; SAFE FALLBACK.
           #   APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF -- ps2dev:latest (bleeding-edge MOVING tag; may not
           #                                              boot, issue #102). No unlabeled default folder.
           #   POPSTARTER/                     -- SMB network stack (popsmb/) + bdma_config.txt=fat32.
@@ -403,17 +406,17 @@ jobs:
           # the workflow); the two pinned flavours are best-effort, each in its own labeled folder.
           # This belt-and-braces check just asserts the PS2DEVLATESTSDK ELF landed before packaging.
           LATEST_ELF="rolling/${VERSIONED_BASE}-PS2DEVLATESTSDK.ELF"
-          PINNED_ELF="rolling/${VERSIONED_BASE}-PS2MAXSDK.ELF"
+          PINNED_ELF="rolling/${VERSIONED_BASE}-PS2DEVPINNEDSDK.ELF"
           if [ ! -f "$LATEST_ELF" ]; then
             echo "PS2DEVLATESTSDK (ps2dev:latest) ELF missing -- its build job failing already fails the workflow" >&2
             exit 1
           fi
           cp -f "$LATEST_ELF" "$PKG/APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF"
           if [ -f "$PINNED_ELF" ]; then
-            mkdir -p "$PKG/APP_RIPTOPL-PS2MAXSDK"
-            cp -f "$PINNED_ELF" "$PKG/APP_RIPTOPL-PS2MAXSDK/RIPTOPL.ELF"
+            mkdir -p "$PKG/APP_RIPTOPL-PS2DEVPINNEDSDK"
+            cp -f "$PINNED_ELF" "$PKG/APP_RIPTOPL-PS2DEVPINNEDSDK/RIPTOPL.ELF"
           else
-            echo "WARN: pinned fallback build missing this run; package ships without APP_RIPTOPL-PS2MAXSDK" >&2
+            echo "WARN: pinned fallback build missing this run; package ships without APP_RIPTOPL-PS2DEVPINNEDSDK" >&2
           fi
           cp -f popsmb/* "$PKG/POPSTARTER/"
           cp -f pops/* "$PKG/POPS/"
@@ -467,7 +470,7 @@ jobs:
           (
             cd "$PKG"
             zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-PS2DEVLATESTSDK POPSTARTER POPS PS2-Servers.url >/dev/null
-            if [ -d APP_RIPTOPL-PS2MAXSDK ]; then zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-PS2MAXSDK >/dev/null; fi
+            if [ -d APP_RIPTOPL-PS2DEVPINNEDSDK ]; then zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-PS2DEVPINNEDSDK >/dev/null; fi
             # the extracted neutrino/ folder (drag-and-drop; replaces the old zip-in-zip neutrino_*.7z)
             if [ -d neutrino ]; then zip -r -X "../rolling/${ZIP}" neutrino >/dev/null; fi
           )
@@ -478,7 +481,7 @@ jobs:
         run: |
           set -eu
           # The EXTRA_FEATURES x PADEMU variants and the debug builds (each in BOTH SDK flavours:
-          # standard = -PS2DEVLATESTSDK, plus -PS2MAXSDK) -> two separate release zips. Remove the
+          # standard = -PS2DEVLATESTSDK, plus -PS2DEVPINNEDSDK) -> two separate release zips. Remove the
           # loose dirs afterward so the final 'gh release upload rolling/*' stays file-only.
           REL="${OPL_VERSION:-rolling}"
           for kind in variants debug; do
@@ -497,8 +500,8 @@ jobs:
       - name: Build release notes
         run: |
           set -eu
-          HAS_PS2MAXSDK=no
-          [ -f "rolling/${VERSIONED_BASE}-PS2MAXSDK.ELF" ] && HAS_PS2MAXSDK=yes
+          HAS_PS2DEVPINNEDSDK=no
+          [ -f "rolling/${VERSIONED_BASE}-PS2DEVPINNEDSDK.ELF" ] && HAS_PS2DEVPINNEDSDK=yes
           {
             if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
               printf 'RiptOPL %s -- tagged release.\n\n' "$OPL_VERSION"
@@ -517,10 +520,11 @@ jobs:
             printf '  1. **APP_RIPTOPL-PS2DEVLATESTSDK/** -- built on the ps2dev:latest toolchain (version ends\n'
             printf '     "-PS2DEVLATESTSDK"). This is the RECOMMENDED download: it uses the current SDK, with the\n'
             printf '     stock drivers RiptOPL is developed and tested against.\n'
-            printf '  2. **APP_RIPTOPL-PS2MAXSDK/** -- pinned 2025 ps2max/dev SDK (version ends "-PS2MAXSDK").\n'
-            printf '     The SAFE FALLBACK. Because it tracks a moving SDK tag, the recommended build can\n'
-            printf '     occasionally regress on some consoles (see issue #102) -- if it black-screens at startup\n'
-            printf '     or the cursor does not respond, use this one and please say so in the report.\n'
+            printf '  2. **APP_RIPTOPL-PS2DEVPINNEDSDK/** -- the SAME ps2dev SDK, pinned by digest to a day it\n'
+            printf '     was known good (version ends "-PS2DEVPINNEDSDK").\n'
+            printf '     The SAFE FALLBACK. Because #1 tracks a MOVING tag, it can occasionally regress on some\n'
+            printf '     consoles (see issue #102) -- if it black-screens at startup or the cursor does not\n'
+            printf '     respond, use this one and please say so in the report.\n'
             printf '\n'
             printf 'When something misbehaves on hardware, please say WHICH flavour you ran (the in-app version\n'
             printf 'string suffix tells you). A PS2DEVLATESTSDK-only failure points at an SDK regression; a\n'
@@ -528,7 +532,7 @@ jobs:
             printf '\n'
             printf '**DualSense / DS5 (USB) owners:** each flavour also ships a ready-made DUALSENSE=1 loader as\n'
             printf 'a named `RIPTOPL-<version>-<SDK>-ds5.ELF` asset (see "Other downloads"). Same reliability order\n'
-            printf 'applies -- prefer `-PS2MAXSDK-ds5`. The default builds keep DualSense OFF.\n'
+            printf 'applies -- prefer `-PS2DEVPINNEDSDK-ds5`. The default builds keep DualSense OFF.\n'
             printf '\n## Bundled Neutrino core\n'
             printf 'Required for the per-game Neutrino launch mode. From the official repo:\n'
             printf '  https://github.com/rickgaiser/neutrino\n'
@@ -571,13 +575,13 @@ jobs:
             if [ -f "rolling/RIPTOPL-DEBUG-${OPL_VERSION:-rolling}.zip" ]; then
               printf -- '- RIPTOPL-DEBUG-*.zip: debug builds (iopcore/ingame/eesio/ppctty/DTL_T10000), both SDKs -- diagnostics\n'
             fi
-            if [ "$HAS_PS2MAXSDK" = yes ]; then
-              printf -- '- %s-PS2MAXSDK.ELF: bare loader, ps2max/dev %s pinned toolchain (SAFE FALLBACK -- pinned, boots reliably)\n' "$VERSIONED_BASE" "$SDK_VER"
+            if [ "$HAS_PS2DEVPINNEDSDK" = yes ]; then
+              printf -- '- %s-PS2DEVPINNEDSDK.ELF: bare loader, digest-pinned ps2dev snapshot %s (SAFE FALLBACK -- pinned, boots reliably)\n' "$VERSIONED_BASE" "$SDK_VER"
             else
-              printf -- '- (pinned %s PS2MAXSDK build FAILED this run)\n' "$SDK_VER"
+              printf -- '- (pinned %s PS2DEVPINNEDSDK build FAILED this run)\n' "$SDK_VER"
             fi
             printf -- '- %s-PS2DEVLATESTSDK.ELF: bare loader, ps2dev:latest toolchain (RECOMMENDED -- current SDK; see "Get started")\n' "$VERSIONED_BASE"
-            for sdk in PS2MAXSDK PS2DEVLATESTSDK; do
+            for sdk in PS2DEVPINNEDSDK PS2DEVLATESTSDK; do
               if [ -f "rolling/${VERSIONED_BASE}-${sdk}-ds5.ELF" ]; then
                 printf -- '- %s-%s-ds5.ELF: %s toolchain WITH DualSense (DS5 USB) pad support (same reliability as the %s bare loader above)\n' "$VERSIONED_BASE" "$sdk" "$sdk" "$sdk"
               fi
@@ -593,7 +597,7 @@ jobs:
             printf '```\n'
             printf '\nUpdated on every push to master. This is the single rolling channel; stable builds are the v* tagged releases.\n'
           } > notes.md
-          echo "PS2MAXSDK flavour present: $HAS_PS2MAXSDK"
+          echo "PS2DEVPINNEDSDK flavour present: $HAS_PS2DEVPINNEDSDK"
           cat notes.md
           echo "Assets to publish:"
           ls -la rolling

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -60,6 +60,40 @@ jobs:
     # Fallback/compatibility toolchain: best-effort, must not block the rolling publish.
     continue-on-error: true
     steps:
+      # Install git BEFORE checkout: without it, actions/checkout falls back to an API
+      # tarball (no .git directory) and git describe fails, collapsing the version string.
+      # Required by every ps2dev image, pinned or latest -- they are Alpine and ship no git.
+      # The retired ps2max container carried these preinstalled, which is why this job did
+      # not need the step before the pin.
+      - name: Install host dependencies (Alpine only)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache \
+              bash \
+              make \
+              git \
+              zip \
+              unzip \
+              tar \
+              gzip \
+              xz \
+              python3 \
+              py3-pip \
+              py3-yaml \
+              gmp \
+              mpfr4 \
+              mpc1 \
+              perl \
+              cmake \
+              pkgconf \
+              coreutils \
+              findutils \
+              grep \
+              sed \
+              gawk \
+              diffutils
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -2941,8 +2941,29 @@ static void setDefaults(void)
 
     gMMCESlot = 2; //Default to first Auto slot
     gMMCEIGRSlot = 3;
-    gMMCEEnableGameID = 1;
-    gApplyGameID = 1; // visual GameID barcode ON by default (Pixel FX/RetroGEM HDMI displays; imperceptible otherwise)
+    /*
+      Both GameID features now ship OFF (maintainer directive, 2026-07-28), matching the
+      every-device-ships-OFF doctrine above: opt in to exactly what your rig has.
+
+      gMMCEEnableGameID -- sends the game id to an MMCE card. Default-ON meant deferredInit armed the
+      transport on EVERY boot, including consoles with no MMCE hardware, which pushed a blocking
+      mmceman.irx load into the IO worker. mmceman hooks sio2man, the same bus freepad polls the PADS
+      over, and on some containers' freepad build that kills pad input AFTER the menu is already
+      drawn -- PixeliGer's "live menu, dead cursor" (#254), unrecoverable in-app because the only
+      cure is a settings toggle you need a working cursor to reach. Shipping it off removes that
+      exposure without gating the feature: enabling it still arms immediately and still works on
+      every device, which is the #51 contract.
+
+      gApplyGameID -- the visual RetroGEM / Pixel FX barcode. It was flipped on in 120045d0 on the
+      premise it is "imperceptible otherwise". That premise is unproven and is under active doubt:
+      zackcage6 reports a white bar during load that survived the clean-frame fix, so the barcode is
+      either still implicated or was never the cause. Either way it is an experimental feature for
+      specific HDMI scalers and does not belong on by default.
+
+      Existing saved configs override both, so nobody who has turned them on loses anything.
+    */
+    gMMCEEnableGameID = 0;
+    gApplyGameID = 0;
     // Restore the fork's long-standing known-good MMCE SIO2 pacing (was flipped to 0/0 in 519f520d,
     // mislabeled "safer" -- 0 cycles + alarms OFF is the aggressive/perf extreme the in-app hints warn
     // about: lower cycles = "instabilities", alarms OFF = "can cause MMCE timeouts to result in freezes").


### PR DESCRIPTION
Three directives from today.

## 1. Both GameID features ship OFF

`gMMCEEnableGameID = 0` and `gApplyGameID = 0`, matching the standing every-device-ships-OFF doctrine. Saved configs override both, and neither feature is **gated** — enabling either still works on every device, so the #51 contract stands.

This also closes the [#254](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/254) exposure *without* the code gate you rejected. Default-ON meant `deferredInit` armed the MMCE transport on **every** boot — including consoles with no MMCE hardware — pushing a blocking `mmceman.irx` load into the IO worker. `mmceman` hooks **sio2man**, the bus freepad polls the pads over, and on some containers that kills pad input *after* the menu is drawn. Unrecoverable in-app, because the only cure is a settings toggle you need a working cursor to reach.

## 2. ps2max retired; fallback is now a digest pin of `ps2dev:latest`

Both workflows move to `ps2dev/ps2dev@sha256:c64ae69c…be995`, captured 2026-07-28. Flavour rebranded `-PS2MAXSDK` → `-PS2DEVPINNEDSDK`.

The design point: the two flavours now differ by **SDK date only**. Latest stays the target and stays recommended; the pin exists purely so a bad day on the moving tag has a known-good escape hatch from the *same SDK lineage*, rather than a different vendor's 2025 snapshot.

### One consequence worth your eyes

The fallback job **no longer runs `install_coherent_freepad.sh`.**

That step existed because ps2max shipped a freepad generation whose pad input died under mmceman's hook (#254). A ps2dev pin carries the **same freepad the recommended build uses** — overriding it with vendored bytes would make the fallback differ from the build it exists to fall back *from*, which defeats the purpose.

`install_coherent_mmce.sh` is kept on both, matching what the latest job already does.

**To re-pin later:** bump the digest in `build-rolling-pinned` (both workflows) and the `SDK_VER` label in `publish-rolling` together.

Full `opl.elf` builds clean; both workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
