### PR TITLE
fix(gui): stop discarding presses made during a screen transition

### DIFF
--- a/include/pad.h
+++ b/include/pad.h
@@ -22,6 +22,10 @@
 
 int startPads();
 int readPads();
+// While frozen, readPads() keeps sampling but does not advance the key-on baseline, so an edge
+// raised now survives until it is consumed. Used across screen transitions, where the GUI polls
+// every frame but runs no input handler -- without this, presses made during a fade are discarded.
+void padFreezeEdgeBaseline(int freeze);
 void unloadPads();
 
 // Menu rumble (#172), gated by gEnableRumble. Tap/Bump arm a pulse on every capable pad and never

--- a/src/gui.c
+++ b/src/gui.c
@@ -2339,6 +2339,11 @@ static void guiDrawOverlays()
 
 static void guiReadPads()
 {
+    // A transition means handleInput() will not run this frame (see guiMainLoop). Hold the key-on
+    // baseline so a press made during the ~430ms fade is still pending when the new screen takes
+    // over, instead of being consumed by a poll that nobody is listening behind.
+    padFreezeEdgeBaseline(screenHandlerTarget != NULL);
+
     if (readPads())
         guiInactiveFrames = 0;
     else {

--- a/src/pad.c
+++ b/src/pad.c
@@ -186,6 +186,31 @@ static u32 oldpaddata;
 static u32 edgedata;
 static u32 oldedgedata;
 
+/*
+  While set, readPads() keeps sampling but does NOT advance the edge baseline, so a key-on raised
+  during this window survives until someone is actually listening.
+
+  guiMainLoop() polls the pads EVERY frame (gui.c) but only runs screenHandler->handleInput() when no
+  screen transition is in flight. A fade is 26 frames -- about 430 ms at 60 Hz -- and every poll in
+  that window still shifted oldedgedata, so the edge was consumed by a poll with no consumer behind
+  it. Any button pressed during a screen fade was silently discarded: press a direction right after
+  switching screens and nothing happens.
+
+  Freezing the BASELINE rather than skipping the poll is deliberate. readPads() also expires rumble
+  taps, drives the pad state machine and detects (dis)connects, so simply not calling it during a
+  transition would leave a motor spinning and a replug unnoticed.
+
+  Scope note: this is armed only while a transition is running, so it cannot affect ordinary
+  same-screen navigation -- deliberately, so it does not disturb the #271/#272 read-miss work being
+  tested on hardware.
+*/
+static int edgeBaselineFrozen = 0;
+
+void padFreezeEdgeBaseline(int freeze)
+{
+    edgeBaselineFrozen = freeze ? 1 : 0;
+}
+
 static int delaycnt[16];
 static int paddelay[16];
 
@@ -965,7 +990,10 @@ int readPads()
     paddata = 0;
     // Same one-poll lifetime as paddata, so an edge still lasts exactly one poll and cannot re-fire;
     // the difference is only in how a MISSED read contributes below (see the edgedata note above).
-    oldedgedata = edgedata;
+    // Unless the baseline is frozen -- then a pending key-on is held for whoever is not listening yet
+    // (padFreezeEdgeBaseline; screen transitions).
+    if (!edgeBaselineFrozen)
+        oldedgedata = edgedata;
     edgedata = 0;
 
     /*


### PR DESCRIPTION
Press a direction right after switching screens and nothing happens.

Found while investigating #271, verified in code, and **separate from that report** — it can only fire during a screen fade, which continuous same-screen scrolling never hits.

## The bug

`guiMainLoop()` polls the pads **every** frame ([gui.c:2448](../blob/master/src/gui.c#L2448)) but only runs `screenHandler->handleInput()` when no transition is in flight ([gui.c:2468](../blob/master/src/gui.c#L2468)). A fade is 26 frames — **~430 ms** at 60 Hz — and every poll during it still advanced the key-on baseline. The edge gets consumed by a poll with nothing listening behind it, and the press is simply gone.

## Fix

`padFreezeEdgeBaseline()` holds the edge baseline while a transition runs, so a key-on raised during the fade is still pending when the new screen takes over.

**Freezing the baseline rather than skipping the poll is deliberate.** `readPads()` also expires rumble taps, drives the pad state machine and detects (dis)connects — not calling it during a transition would leave a motor spinning and a replug unnoticed.

## Scope

Armed **only** while `screenHandlerTarget` is set. Ordinary same-screen navigation is untouched, deliberately: the #271/#272 read-miss work is on hardware test right now and this must not perturb what's being measured.

## Residual

A press that is also **released** inside the fade is still lost, because the edge view reflects the current sample by then. Fixing that needs a sticky pending-press latch — which is the correct long-term design for this input layer, and would also fix the "tap falls entirely between two polls" half of zackcage6's hang — but it changes edge consumption everywhere and should not land mid-test.

## Verification

- `make clean && make opl.elf` green on `ps2dev:latest`; `clang-format` clean
- `padFreezeEdgeBaseline` confirmed linked into `opl.elf` via `nm`
- **Not hardware-tested.** Reproduce by pressing a direction immediately after a screen switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved button presses made during screen transitions.
  * Prevented input from being missed or consumed before the next screen appears.
  * Improved key press and release detection across transition effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->