### PR TITLE
fix(gui): stop the loading spinner flashing for background rescans (#290)

### DIFF
--- a/include/ioman.h
+++ b/include/ioman.h
@@ -28,6 +28,10 @@ int ioRegisterHandler(int type, io_request_handler_t handler);
 /** schedules a new request into the pending request list
  * @note The data are not freed! */
 int ioPutRequest(int type, void *data);
+// Same queue and drain semantics as ioPutRequest, but excluded from the busy-spinner count (#290).
+// BACKGROUND MAINTENANCE only -- work the user did not ask for, whose usual outcome is "nothing
+// changed" (menuUpdateHook's periodic device rescans). User-initiated work must stay visible.
+int ioPutRequestQuiet(int type, void *data);
 
 /** removes all requests of a given type from the queue
  * @param type the type of the requests to remove
@@ -39,6 +43,10 @@ int ioGetPendingRequestCount(void);
 
 /** returns nonzero if there are any pending io requests */
 int ioHasPendingRequests(void);
+// Pending requests excluding quiet background maintenance -- what the loading spinner keys off.
+// Queue drains/throttles must keep using ioHasPendingRequests (a quiet request still occupies the
+// worker and still delays a launch).
+int ioHasVisiblePendingRequests(void);
 
 /** returns nonzero if the io thread is running */
 int ioIsRunning(void);

--- a/src/gui.c
+++ b/src/gui.c
@@ -2230,8 +2230,12 @@ static void guiDrawOverlays()
 {
     static int busyAlpha = 0x00; // Fully transparant
 
-    // are there any pending operations?
-    int pending = ioHasPendingRequests();
+    // Any pending operations the user should SEE? Visible-only on purpose (#290): the raw queue
+    // also carries menuUpdateHook's periodic background device rescans, and on a device where one
+    // presence scan takes a few hundred ms (MMCE SIO2 round-trips), keying the spinner off the raw
+    // queue made it fade in "every few seconds" while the console sat idle. Real work -- list
+    // loads, config saves, module loads, theme switches -- is still counted.
+    int pending = ioHasVisiblePendingRequests();
 
     // During the boot intro, when an animated boot logo is shown, suppress the
     // loading spinner -- the animated logo is the boot activity indicator there.
@@ -2292,7 +2296,11 @@ static void guiDrawOverlays()
 #endif
 
     // Last Played Auto Start
-    if (!pending && DisableCron == 0 && endIntro) {
+    // FULL queue check here, not the spinner's visible-only `pending` (#290): this gate previously
+    // shared that variable, and quieting the background rescans would otherwise have let the
+    // auto-start countdown run -- and fire the launch -- while a rescan still occupied the IO
+    // worker. Freezing the countdown during ANY in-flight work is the pre-#290 behaviour; keep it.
+    if (!ioHasPendingRequests() && DisableCron == 0 && endIntro) {
         if (CronStart == 0) {
             CronStart = clock() / CLOCKS_PER_SEC;
         } else {

--- a/src/ioman.c
+++ b/src/ioman.c
@@ -24,6 +24,9 @@ struct io_request_t
 {
     int type;
     void *data;
+    // Nonzero = background maintenance (periodic device rescans): excluded from the busy-spinner
+    // count below, still counted by everything that DRAINS the queue. See ioPutRequestQuiet.
+    int quiet;
     struct io_request_t *next;
 };
 
@@ -39,6 +42,28 @@ static struct io_request_t *gReqEnd;
 
 // Total number of queued requests currently stored in the list.
 static int gReqCount;
+
+/*
+  Number of NON-QUIET requests between enqueue and processing-complete -- what the GUI busy spinner
+  keys off (#290).
+
+  The spinner used to key off the raw queue (ioHasPendingRequests), which also counts the periodic
+  background device rescans menuUpdateHook enqueues every MENU_GENERAL_UPDATE_DELAY frames. On a
+  device where one presence scan takes a few hundred ms (MMCE's SIO2 round-trips, a busy USB stick),
+  each rescan held the queue non-empty long enough for the fade-in to become visible -- the loading
+  spinner "reappearing every few seconds" while the console sat idle, doing maintenance the user
+  never asked for and cannot see the result of. Upstream OPL and wOPL share this (same hook, same
+  raw-queue spinner, none of our scheduling gates), which is why the reporter reproduces it on the
+  main branch.
+
+  A request is visible from ioPutRequest until the worker has FINISHED processing it (the node is
+  unlinked only after its handler returns), so the spinner still spans the whole duration of real
+  work, exactly as before. Only who gets counted changed.
+
+  Updated under gEndSemaId in every path that links or unlinks a node; read without the sema by the
+  render loop, same single-word-read discipline as ioHasPendingRequests' pointer peek.
+*/
+static int gVisibleCount;
 
 static struct io_handler_t gRequestHandlers[MAX_IO_HANDLERS];
 
@@ -150,6 +175,8 @@ static void ioWorkerThread(void *arg)
 
             // can't be sure if the request was
             gReqList = req->next;
+            if (!req->quiet && gVisibleCount > 0)
+                gVisibleCount--; // processing done only now, so visibility spans the handler run
             free(req);
             if (gReqCount > 0)
                 gReqCount--;
@@ -166,6 +193,8 @@ static void ioWorkerThread(void *arg)
     while (gReqList) {
         struct io_request_t *req = gReqList;
         gReqList = gReqList->next;
+        if (!req->quiet && gVisibleCount > 0)
+            gVisibleCount--;
         free(req);
         if (gReqCount > 0)
             gReqCount--;
@@ -196,6 +225,7 @@ void ioInit(void)
     gReqList = NULL;
     gReqEnd = NULL;
     gReqCount = 0;
+    gVisibleCount = 0;
 
     gIOThreadId = 0;
 
@@ -222,7 +252,7 @@ void ioInit(void)
     StartThread(gIOThreadId, NULL);
 }
 
-int ioPutRequest(int type, void *data)
+static int ioPutRequestInternal(int type, void *data, int quiet)
 {
     if (isIOBlocked)
         return IO_ERR_IO_BLOCKED;
@@ -246,6 +276,7 @@ int ioPutRequest(int type, void *data)
     req->next = NULL;
     req->type = type;
     req->data = data;
+    req->quiet = quiet;
 
     if (!gReqEnd)
         gReqList = req;
@@ -253,12 +284,28 @@ int ioPutRequest(int type, void *data)
         gReqEnd->next = req;
     gReqEnd = req;
     gReqCount++;
+    if (!quiet)
+        gVisibleCount++;
 
     SignalSema(gEndSemaId);
 
     // Worker thread cannot wake itself up (WakeupThread will return an error), but it will find the new request before sleeping.
     WakeupThread(gIOThreadId);
     return IO_OK;
+}
+
+int ioPutRequest(int type, void *data)
+{
+    return ioPutRequestInternal(type, data, 0);
+}
+
+// Same queue, same handlers, same drain semantics -- but excluded from the busy-spinner count
+// (ioHasVisiblePendingRequests). For BACKGROUND MAINTENANCE only: work the user did not ask for and
+// whose usual outcome is "nothing changed", like menuUpdateHook's periodic device rescans. Anything
+// user-initiated (device enable, manual refresh, config save, module loads) must stay visible.
+int ioPutRequestQuiet(int type, void *data)
+{
+    return ioPutRequestInternal(type, data, 1);
 }
 
 int ioRemoveRequests(int type)
@@ -285,6 +332,8 @@ int ioRemoveRequests(int type)
                 gReqEnd = last;
 
             count++;
+            if (!req->quiet && gVisibleCount > 0)
+                gVisibleCount--;
             free(req);
             if (gReqCount > 0)
                 gReqCount--;
@@ -339,6 +388,15 @@ int ioGetPendingRequestCount(void)
 int ioHasPendingRequests(void)
 {
     return gReqList != NULL ? 1 : 0;
+}
+
+// Pending requests EXCLUDING quiet background maintenance -- what the loading spinner shows (#290).
+// Everything that drains or throttles the queue must keep using ioHasPendingRequests: a quiet
+// request still occupies the worker, still delays a launch, and must still hold off the next
+// background rescan.
+int ioHasVisiblePendingRequests(void)
+{
+    return gVisibleCount > 0 ? 1 : 0;
 }
 
 #ifdef __EESIO_DEBUG

--- a/src/opl.c
+++ b/src/opl.c
@@ -1110,10 +1110,17 @@ static void menuUpdateHook()
         return;
 
     // schedule updates of all the list handlers
+    // Quiet on purpose (#290): these are periodic background rescans the user never asked for, and
+    // their usual outcome is "nothing changed". Enqueued visibly, each slow presence scan faded the
+    // loading spinner in while the console sat idle -- the "spinner reappears every few seconds"
+    // report. A rescan that DOES find a change still rebuilds the list (the list itself changing is
+    // the signal; there was never a toast for it), it just does so without the spinner. Known
+    // residual: work a quiet rescan enqueues ONWARD (bdm module-load retries, favourites reload) is
+    // still visible and can flash the spinner on rigs where those persistently re-fire.
     if (gAutoRefresh) {
         for (i = 0; i < MODE_COUNT; i++) {
             if ((list_support[i].support && list_support[i].support->enabled) && ((list_support[i].support->updateDelay > 0) && (frameCounter % list_support[i].support->updateDelay == 0)))
-                ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+                ioPutRequestQuiet(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
         }
     }
 
@@ -1134,7 +1141,15 @@ static void menuUpdateHook()
                 int mode = list_support[i].support->mode;
                 // elapsed form is single-wrap-safe; zero-initialized timestamp allows one immediate rescan
                 if (genChanged || (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS) {
-                    ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+                    // Quiet ONLY for the steady-state throttled rescan (#290). The genChanged branch
+                    // fires precisely BECAUSE a device changed (hotplug / Device-Settings apply) --
+                    // that scan populates a page the user is waiting on and can take seconds, so it
+                    // stays visible. The quiet rationale ("usual outcome is nothing changed") is
+                    // false by construction on that branch.
+                    if (genChanged)
+                        ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+                    else
+                        ioPutRequestQuiet(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
                     lastBgRescan[mode] = now;
                 }
             }


### PR DESCRIPTION
Fixes #290.

## Root cause

The spinner keys off `ioHasPendingRequests()` — the **raw** IO queue — and `menuUpdateHook` enqueues periodic background device rescans into that same queue. Cover art has its **own** worker thread and never rides this queue, so while the console sits idle the rescans are the *only* periodic enqueuer. On a device where one presence scan takes a few hundred ms (MMCE's SIO2 round-trips, a busy USB stick), each rescan held the queue non-empty long enough for the 0x02/frame fade-in to become clearly visible: the spinner surfacing "every few seconds" for maintenance the user never asked for and cannot see the result of.

## Reference-tree comparison (per request)

Checked **four** trees: upstream `ps2homebrew/Open-PS2-Loader`, `KrahJohlito/wOPL` (cb7a33d), `Unofficial-Open-PS2-Loader` (uOPL), and `OPL-custom`. **All four share the identical structure** — same 60-frame hook, same raw-queue spinner, none of this fork's scheduling gates. That's why @zackcage6 reproduces the symptom on the main branch, and why our existing gates (idle ≥ 8 frames, queue-drain, art-pending, wall-clock throttle) already made Beta-3449 quiet on his rig while slower setups could still cross the visibility threshold. There was nothing to port — the visibility split is new.

## Fix

Requests gain a `quiet` flag:

- `ioPutRequestQuiet()` — same queue, same handlers, same drain semantics, excluded from the spinner count. `menuUpdateHook`'s steady-state rescans use it.
- `gVisibleCount` tracks non-quiet requests from enqueue until the worker has **finished** processing (the node is unlinked only after its handler returns), so the spinner still spans the full duration of real work. Updated under `gEndSemaId` at every link/unlink site: enqueue, worker free, `ioRemoveRequests`, shutdown drain.
- The spinner keys off `ioHasVisiblePendingRequests()`. **Every drain and throttle keeps the full check** — a quiet request still occupies the worker, still delays a launch, still holds off the next rescan.

## What adversarial review changed before this PR

The first cut had two defects a three-lens review caught:

1. **The `genChanged` hotplug bypass was quiet.** It fires precisely *because* a device changed and populates a page the user is waiting on — quieting it would have hidden a hotplugged USB stick's entire multi-second list scan. It stays visible.
2. **The Last-Played Auto-Start countdown shared the spinner's `pending` local**, so quieting rescans would have silently let the countdown run — and fire the launch — while a rescan occupied the worker. It now takes its own full-queue check, preserving the pre-existing freeze behaviour.

## Known residual — stated, not hidden

Work a quiet rescan enqueues *onward* is still visible: `bdmLoadBlockDeviceModules` retries (an enabled BDM-HDD toggle with no drive attached re-probes every cycle) and the favourites reload. On rigs where those persistently re-fire, the spinner can still flash. Each is a separate judgement call; none is made worse by this change.

## Verification

- `make clean && make opl.elf` green on `ps2dev:latest`; `clang-format` clean on touched files
- `ioPutRequestQuiet` / `ioHasVisiblePendingRequests` confirmed linked via `nm`
- Counter audited across all four link/unlink paths under the existing semaphore discipline
- **Not hardware-tested** — @PixeliGer's rig is the reproduction environment; @zackcage6's Beta-3449 observation ("spinner only on real work") is the expected post-fix behaviour everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Background auto-refresh activity no longer repeatedly displays the loading spinner.
  * User-visible loading indicators remain active for foreground operations and meaningful device changes.
  * Automatic startup waits for all pending background work to finish before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->