### PR TITLE
fix(menu): keep background device probes out of active navigation (#271)

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1160,7 +1160,13 @@ static void menuUpdateHook()
         unsigned int gen = bdmGetGeneration();
         int genChanged = (gen != lastSeenBdmGeneration);
         clock_t now = clock();
-        lastSeenBdmGeneration = gen;
+        // Consume the generation bump only if every hotplug-driven enqueue is ACCEPTED (CodeRabbit,
+        // #294): ioPutRequest can fail (queue blocked during teardown, allocation failure), and
+        // committing lastSeenBdmGeneration up front would silently eat the one immediate-rescan
+        // event a hotplug gets -- the new device's tab then waits for the next steady-state probe,
+        // which after this change also needs a second of real idleness. Leaving the generation
+        // unconsumed makes the next 1 s tick retry the whole event instead.
+        int genConsumed = 1;
         for (i = 0; i < MODE_COUNT; i++) {
             if ((list_support[i].support && list_support[i].support->enabled) && (list_support[i].support->updateDelay == 0)) {
                 int mode = list_support[i].support->mode;
@@ -1171,14 +1177,22 @@ static void menuUpdateHook()
                 // next tap gap rather than after a second of stillness (#271). Only the recurring
                 // steady-state probe is quiet AND waits for real idleness.
                 if (genChanged || (longIdle && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
+                    // Stamp the throttle only on an accepted request, so a rejected one retries on
+                    // the next tick instead of being silently skipped for a full interval.
+                    int accepted;
                     if (genChanged)
-                        ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+                        accepted = (ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);
                     else
-                        ioPutRequestQuiet(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
-                    lastBgRescan[mode] = now;
+                        accepted = (ioPutRequestQuiet(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);
+                    if (accepted)
+                        lastBgRescan[mode] = now;
+                    else if (genChanged)
+                        genConsumed = 0;
                 }
             }
         }
+        if (genConsumed)
+            lastSeenBdmGeneration = gen;
     }
 }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1084,12 +1084,32 @@ void menuDeferredUpdate(void *data)
     }
 }
 
-#define MENU_GENERAL_UPDATE_DELAY         60
+#define MENU_GENERAL_UPDATE_DELAY          60
 // Minimum wall-clock gap between background rescans of the SAME updateDelay==0 device (Fix B). At
 // ~2 s this drops the steady SIO2/mass enumeration rate (and, for MMCE, the slot-probe drip) well
 // below the old every-60-frames cadence, cutting MX4SIO<->mmceman bus contention, while a real
 // device change still refreshes immediately (BdmGeneration bypass below). clock() = microseconds.
-#define MENU_BG_RESCAN_MIN_INTERVAL_TICKS (2 * CLOCKS_PER_SEC)
+#define MENU_BG_RESCAN_MIN_INTERVAL_TICKS  (2 * CLOCKS_PER_SEC)
+/*
+  Idle time required before STEADY-STATE background probes may run at all, in frames (~1 s NTSC).
+
+  The short gate (MENU_MIN_INACTIVE_FRAMES = 8, ~133 ms) is tuned for "the user paused between
+  inputs" -- right for waking cover-art loads, and WRONG for device probes. Frame analysis of
+  zackcage6's Beta-3449 capture (#271) showed why: tapping through the list at a steady ~4.3
+  taps/s leaves ~130 ms release gaps, which sit exactly AT the short gate, so the throttled
+  probes leaked into active navigation -- slides went missing at t=1.07/3.27/4.80/7.77 s,
+  spacings of 2.2/1.5/3.0 s, the quasi-periodic signature of the 1 s hook tick x 2 s per-device
+  throttle (multiple enabled devices desync, so events can land closer than 2 s). An MMCE/SIO2
+  presence probe contends with freepad on the same bus; the tap landing inside the resulting
+  read-miss burst is eaten. At 4.3 taps/s a ~2 s clock lands every ~9 games of a 7-game cycle,
+  drifting slowly -- his "it does hang on certain games casually, in a pattern".
+
+  60 frames of REAL idleness is far above any tap gap, so probes never fire mid-navigation, and a
+  parked console still probes within a second of the user stopping. Hotplug stays immediate-ish:
+  the BdmGeneration bypass below keeps the SHORT gate, so a plugged device is picked up in the
+  next tap gap rather than after a full second.
+*/
+#define MENU_BG_RESCAN_MIN_INACTIVE_FRAMES 60
 
 static void menuUpdateHook()
 {
@@ -1109,6 +1129,11 @@ static void menuUpdateHook()
     if (cacheHasPendingArt())
         return;
 
+    // Steady-state probes additionally require REAL idleness (see the define): a tap gap passes the
+    // short gate above, and a probe fired into it contends with the pads on SIO2 and eats the next
+    // tap (#271). Event-driven work (the genChanged hotplug bypass below) keeps the short gate.
+    int longIdle = (guiInactiveFrames >= MENU_BG_RESCAN_MIN_INACTIVE_FRAMES);
+
     // schedule updates of all the list handlers
     // Quiet on purpose (#290): these are periodic background rescans the user never asked for, and
     // their usual outcome is "nothing changed". Enqueued visibly, each slow presence scan faded the
@@ -1117,7 +1142,7 @@ static void menuUpdateHook()
     // the signal; there was never a toast for it), it just does so without the spinner. Known
     // residual: work a quiet rescan enqueues ONWARD (bdm module-load retries, favourites reload) is
     // still visible and can flash the spinner on rigs where those persistently re-fire.
-    if (gAutoRefresh) {
+    if (gAutoRefresh && longIdle) {
         for (i = 0; i < MODE_COUNT; i++) {
             if ((list_support[i].support && list_support[i].support->enabled) && ((list_support[i].support->updateDelay > 0) && (frameCounter % list_support[i].support->updateDelay == 0)))
                 ioPutRequestQuiet(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
@@ -1139,13 +1164,13 @@ static void menuUpdateHook()
         for (i = 0; i < MODE_COUNT; i++) {
             if ((list_support[i].support && list_support[i].support->enabled) && (list_support[i].support->updateDelay == 0)) {
                 int mode = list_support[i].support->mode;
-                // elapsed form is single-wrap-safe; zero-initialized timestamp allows one immediate rescan
-                if (genChanged || (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS) {
-                    // Quiet ONLY for the steady-state throttled rescan (#290). The genChanged branch
-                    // fires precisely BECAUSE a device changed (hotplug / Device-Settings apply) --
-                    // that scan populates a page the user is waiting on and can take seconds, so it
-                    // stays visible. The quiet rationale ("usual outcome is nothing changed") is
-                    // false by construction on that branch.
+                // elapsed form is single-wrap-safe; zero-initialized timestamp allows one immediate rescan.
+                // genChanged (hotplug / Device-Settings apply) deliberately requires NEITHER longIdle
+                // nor quiet: it fires precisely BECAUSE a device changed, the scan populates a page the
+                // user is waiting on (visible, #290), and a plugged device should be noticed in the
+                // next tap gap rather than after a second of stillness (#271). Only the recurring
+                // steady-state probe is quiet AND waits for real idleness.
+                if (genChanged || (longIdle && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
                     if (genChanged)
                         ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
                     else
@@ -2954,7 +2979,7 @@ static void setDefaults(void)
     gMMCEStartMode = START_MODE_DISABLED;
     gFAVStartMode = START_MODE_DISABLED;
 
-    gMMCESlot = 2; //Default to first Auto slot
+    gMMCESlot = 2; // Default to first Auto slot
     gMMCEIGRSlot = 3;
     /*
       Both GameID features now ship OFF (maintainer directive, 2026-07-28), matching the


### PR DESCRIPTION
Addresses the **hang half** of #271, from measured evidence rather than theory.

## What the video shows

I frame-differenced zackcage6's Beta-3449 capture (30 fps, 8.4 s, [his comment](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/271#issuecomment-5116835514)):

- His tapping is a **steady ~4.3 taps/s** (median slide interval 0.23 s) — confirming "my scroll pattern is continuous"
- **Four slides go missing**, at `t=1.07`, `3.27`, `4.80`, `7.77` s — spacings of **2.2 / 1.5 / 3.0 s**
- **No jumps** anywhere in the clip — consistent with #289's edge-dedup fix holding

Four events in 8.4 s **rules out** per-tap work (art wake / per-item config would show ~30 events) and game-specific content. It matches exactly one signature: the steady-state background probes — a 1 s hook tick × 2 s per-device wall-clock throttle, with multiple enabled devices desynced (so events can land closer than 2 s). And the *"hangs on certain games, in a pattern"* impression falls out arithmetically: a ~2 s clock at 4.3 taps/s lands every ~9 games of a 7-game cycle, drifting slowly across the same titles.

## Mechanism

`menuUpdateHook` holds probes behind `MENU_MIN_INACTIVE_FRAMES` = 8 frames (~133 ms) — tuned for "the user paused", which is right for waking cover-art loads and **wrong for device probes**: a ~4 taps/s rhythm leaves ~130 ms release gaps that sit exactly *at* the gate, so probes leak into active navigation. An MMCE presence probe is SIO2 round-trips, and SIO2 is the bus the controllers live on. The tap that lands inside the resulting read-miss burst is eaten.

## Fix

Steady-state probes (both loops) now additionally require `MENU_BG_RESCAN_MIN_INACTIVE_FRAMES` = 60 frames (~1 s) of real idleness — far above any tap gap, so probes never fire mid-navigation; a parked console still probes within a second of stopping.

**The `genChanged` hotplug bypass deliberately keeps the short gate**: a plugged device gets noticed in the next tap gap, and its one-off scan is user-caused. Only the *recurring* probe waits.

## How the sibling fixes fit

| PR | What it does |
|---|---|
| #288 / #289 (merged, HW-confirmed) | make the input layer *survive* read-miss bursts |
| **this** | removes the main *generator* of those bursts during navigation |
| #293 (open) | stops the *spinner* showing the probes |

Independent — either of the open two lands without the other. Note for merge sequencing: this and #293 touch adjacent lines in `menuUpdateHook`; whichever merges second I'll rebase.

## Not covered, stated

The settings-dialog *"highlighting takes a bit of time"* follow-up on #272 is a different animal: dialogs run their own input loop where this hook doesn't even execute. That's repeat-delay tuning, not probe contention — separate change if wanted.

## Verification

- Video measurement script + numbers above; `make clean && make opl.elf` green; `clang-format` clean
- **Prediction this build tests:** zack's same continuous-cycle test should show *zero* missing slides; hangs while actively tapping should be gone entirely. If they persist at the same ~2 s spacing, this diagnosis is wrong and the remaining suspect is the `SH` self-heal blackout (checkable on the debug HUD with no new build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced background refresh/rescan activity while users are actively navigating.
  * Deferred non-urgent menu/list updates until the interface has been idle for a sustained period.
  * Added stricter “real idleness” gating to limit steady-state recurring rescans.
  * Ensured device-generation changes are not lost if an update enqueue attempt fails, improving reliability of subsequent refreshes.
  * Continued to detect device-change events promptly when immediate updates are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->