### PR TITLE
fix(themes): idle-prefetch coverflow neighbors so covers stop waiting for focus

### DIFF
--- a/docs/THEME_ENGINE.md
+++ b/docs/THEME_ENGINE.md
@@ -378,6 +378,13 @@ You can point `default=`/`overlay=` at any of OPL's embedded textures (no file n
 It behaves like a `GameImage` (uses the `COV` cover cache) but draws 3 or 5 covers with a
 slide animation.
 
+While the user is idle, the carousel also *prefetches* the covers just outside the visible
+window (up to 4 positions each side of the selection, wrapping around the list ends), so a
+scroll step reveals a cover that is usually already loaded instead of the placeholder
+(issue #296). The prefetch only starts once the selection's own cover has loaded, and it is
+skipped entirely on MMCE-backed items (including MMCE-sourced favourites) to keep the shared
+SIO2 bus quiet — those covers still load on selection, as before.
+
 ### Per-theme properties (in `conf_theme.cfg`)
 
 | Property | Notes |

--- a/include/favsupport.h
+++ b/include/favsupport.h
@@ -22,6 +22,13 @@ unsigned char favGetFlags(item_list_t *itemList);
 // theme engine to draw APP favourites with the apps element (proper art box + overlay).
 int favGetItemSourceMode(int id);
 
+// Source device mode of the favourite whose art-cache value (source startup / VCD name) matches,
+// or -1 if none does. Used by texcache's cacheGetEffectiveMode so every mode-keyed art gate
+// (MMCE prefetch exemption, MMCE/HDD nav defer, MMCE abort sweeps, load-priority drop) applies
+// to the device a FAV-tab read actually lands on. GUI thread only -- favArray is rebuilt
+// unlocked on the IO worker; see favGetArtMode's safety note in favsupport.c.
+int favGetArtMode(const char *value);
+
 // R3-toggle helpers (called from opl.c). add/remove rewrite favourites.bin and return 1 on a
 // successful write, 0 on failure (so the caller won't set a lying star). add returns 1 if the
 // item is already present. removeFavouriteByIdAndText matches mode (BDM-lenient) + id + text + isVcd.

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -689,6 +689,50 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
     return -1;
 }
 
+// Resolve an art-cache `value` (a source item's startup, or a VCD favourite's .VCD name /
+// strict PS1 id) to the favourite's SOURCE device mode, using the same matching favGetImage
+// uses to route the actual read. Lets texcache's cacheGetEffectiveMode key every mode-gated
+// protection (the MMCE prefetch exemption, the MMCE/HDD nav-time defer, the MMCE abort
+// sweeps, the MMCE/HDD load-priority drop) on the device the read really lands on, instead
+// of the FAV wrapper mode -- without this, an MMCE-sourced favourite's SIO2 art read was
+// invisible to all four. Returns -1 when no favourite matches (e.g. a theme attribute-image
+// value, which takes the passthrough path in favGetImage). Pure in-memory scan, no IO.
+//
+// Thread safety: callers are GUI-thread render paths (prio 31), but favArray is rebuilt
+// UNLOCKED by favUpdateItemList on the prio-30 IO worker (menuDeferredUpdate). Safe today
+// because the IO thread outranks the GUI thread (a rebuild in progress keeps us off-CPU),
+// favFreeArray NULLs favArray/favCount before the rebuild's first blocking point (favReadFile)
+// so a scan started around a rebuild hits the NULL guard, entries become visible only after
+// full population (favCount++ last), and the FAV submenu rows that drive these scans are torn
+// down (clearMenuGameList) before the rebuild starts. Do NOT raise the GUI thread's priority
+// to/above the IO worker's or add a yield inside favFreeArray without adding real
+// synchronization here.
+int favGetArtMode(const char *value)
+{
+    if (favArray == NULL || value == NULL)
+        return -1;
+    for (int i = 0; i < favCount; i++) {
+        item_list_t *o = favArray[i].owner;
+        if (o == NULL)
+            continue;
+        if (favArray[i].isVcd) {
+            if (strcmp(favArray[i].text, value) != 0) {
+                char fallbackKey[VCD_ID_MAX];
+                if (!vcdExtractGameId(favArray[i].text, fallbackKey, sizeof(fallbackKey)) ||
+                    strcmp(fallbackKey, value) != 0)
+                    continue;
+            }
+            return favArray[i].mode;
+        }
+        if (o->itemGetStartup == NULL || !favOwnerHasId(o, favArray[i].id))
+            continue;
+        char *s = o->itemGetStartup(o, favArray[i].id);
+        if (s != NULL && strcmp(s, value) == 0)
+            return favArray[i].mode;
+    }
+    return -1;
+}
+
 // Rename/Delete are blocked for favourites (also guarded at the menu level).
 static void favDeleteItem(item_list_t *itemList, int id) {}
 static void favRenameItem(item_list_t *itemList, int id, char *newName) {}

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1,6 +1,7 @@
 #include "include/opl.h"
 #include "include/diag.h"
 #include "include/appsupport.h"
+#include "include/favsupport.h"
 #include "include/pad.h"
 #include "include/texcache.h"
 #include "include/textures.h"
@@ -397,6 +398,23 @@ static int cacheGetEffectiveMode(const item_list_t *list, const char *value)
         return -1;
 
     mode = list->mode;
+    // A FAV-tab read proxies to the favourite's OWNER device (favGetImage), so resolve to the
+    // owner's mode FIRST or every mode-keyed gate below and at the call sites (MMCE prefetch
+    // exemption, MMCE/HDD nav-time defer, MMCE abort sweeps, MMCE/HDD load-priority drop) is
+    // blind to e.g. an MMCE-sourced favourite's SIO2 read -- the #116/#120 class of contention
+    // with the FAV wrapper stripping the mode. An APP-sourced favourite falls through to the
+    // existing APP branch (value is the app's startup, exactly what appGetArtMode keys on).
+    // Thread contract: this runs on the GUI thread only (all callers are render-path); the art
+    // WORKER's defer check reads the request's stamped effectiveMode instead
+    // (cacheShouldDeferInteractiveArtOnInputMode). favArray itself is rebuilt UNLOCKED on the
+    // prio-30 IO worker (menuDeferredUpdate) -- see favGetArtMode's safety note for why the
+    // GUI-thread scan is safe against that rebuild.
+    if (mode == FAV_MODE && value != NULL) {
+        int srcMode = favGetArtMode(value);
+
+        if (srcMode >= 0)
+            mode = srcMode;
+    }
     if (mode == APP_MODE && value != NULL) {
         int artMode = appGetArtMode(value);
 
@@ -415,10 +433,11 @@ static int cacheGetBaseDelay(const item_list_t *list)
     return MENU_MIN_INACTIVE_FRAMES;
 }
 
-static int cacheGetInteractiveDelay(const item_list_t *list, const char *value)
+// Delay helpers take the caller's already-resolved effective mode: cacheGetEffectiveMode's FAV
+// resolution scans favArray per call, so resolve ONCE per cacheGetTextureInternal invocation.
+static int cacheGetInteractiveDelay(const item_list_t *list, int mode)
 {
     int delay = cacheGetBaseDelay(list);
-    int mode = cacheGetEffectiveMode(list, value);
 
     if (list != NULL && list->mode == APP_MODE) {
         if (mode != MMCE_MODE)
@@ -437,10 +456,9 @@ static int cacheGetInteractiveDelay(const item_list_t *list, const char *value)
     return delay;
 }
 
-static int cacheGetPrefetchDelay(const item_list_t *list, const char *value)
+static int cacheGetPrefetchDelay(const item_list_t *list, int mode)
 {
     int delay = cacheGetBaseDelay(list);
-    int mode = cacheGetEffectiveMode(list, value);
 
     if (mode == APP_MODE && delay < CACHE_APP_PREFETCH_DELAY)
         delay = CACHE_APP_PREFETCH_DELAY;
@@ -506,20 +524,19 @@ static int cacheIsNavigationActive(void)
     return gNavInputActive;
 }
 
-static int cacheShouldDeferInteractiveArtOnInput(const item_list_t *list, const char *value)
+// Defer interactive cover reads while the user is actively scrolling on the SLOW filesystem
+// backends -- MMCE (SIO2) and APA-HDD (PFS over ATA). Both read art through the single fileXio
+// channel the menu also uses for badge/config IO, so starting a read mid-scroll stalls nav (the
+// "HDD is not very responsive... like the MMCE was" report). USB/exFAT BDM is fast and stays
+// unthrottled. Covers still land once navigation goes idle (the per-value settle below).
+static int cacheShouldDeferInteractiveArtOnInputMode(int effectiveMode)
 {
-    int effectiveMode = cacheGetEffectiveMode(list, value);
-
-    // Defer interactive cover reads while the user is actively scrolling on the SLOW filesystem
-    // backends -- MMCE (SIO2) and APA-HDD (PFS over ATA). Both read art through the single fileXio
-    // channel the menu also uses for badge/config IO, so starting a read mid-scroll stalls nav (the
-    // "HDD is not very responsive... like the MMCE was" report). USB/exFAT BDM is fast and stays
-    // unthrottled. Covers still land once navigation goes idle (the per-value settle below).
-    if (list != NULL && (effectiveMode == MMCE_MODE || effectiveMode == HDD_MODE))
+    if (effectiveMode == MMCE_MODE || effectiveMode == HDD_MODE)
         return cacheIsNavigationActive();
 
     return 0;
 }
+
 
 static int cacheGetLoadThreadPriority(const load_image_request_t *req)
 {
@@ -654,7 +671,7 @@ static void cacheInvalidateEntryLocked(cache_entry_t *entry, int freeTxt, int pr
                 // (#116 "held in reserve", #120 static-screen gate) cancelled the in-flight read on
                 // every held-nav carousel step, discarding partial SIO2 progress and forcing a full
                 // re-read after settle -- the residual "backs up like it's buffering". It bought
-                // nothing: during a hold, cacheShouldDeferInteractiveArtOnInput already blocks new
+                // nothing: during a hold, cacheShouldDeferInteractiveArtOnInputMode already blocks new
                 // MMCE/HDD enqueues (cacheGetTextureInternal) AND worker dequeues (cacheDequeueRequest),
                 // so at most this ONE read finishes into an otherwise idle bus.
                 if (!preserveLoaded)
@@ -828,7 +845,10 @@ static load_image_request_t *cacheDequeueRequest(void)
     cacheLock();
 
     if (gArtInteractiveReqList != NULL) {
-        if (cacheShouldDeferInteractiveArtOnInput(gArtInteractiveReqList->list, gArtInteractiveReqList->value)) {
+        // Mode variant, NOT the (list, value) resolver: this runs on the art worker thread, and
+        // the resolver's FAV lookup scans favArray unlocked. effectiveMode was stamped on the
+        // GUI thread at enqueue.
+        if (cacheShouldDeferInteractiveArtOnInputMode(gArtInteractiveReqList->effectiveMode)) {
             cacheUnlock();
             return NULL;
         }
@@ -842,7 +862,7 @@ static load_image_request_t *cacheDequeueRequest(void)
     } else if (gArtPrefetchReqList != NULL) {
         // Same nav-time defer the interactive head gets: a prewarm (or HDD cover) prefetch read
         // must never START mid-scroll on a slow shared bus.
-        if (cacheShouldDeferInteractiveArtOnInput(gArtPrefetchReqList->list, gArtPrefetchReqList->value)) {
+        if (cacheShouldDeferInteractiveArtOnInputMode(gArtPrefetchReqList->effectiveMode)) {
             cacheUnlock();
             return NULL;
         }
@@ -1591,18 +1611,18 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
          * global left by the previous draw, re-arm the window, and return "defer" -- so no MMCE
          * cover was ever enqueued and art never loaded on those themes. It was also redundant:
          * the interactive settle is already enforced below by guiInactiveFrames < delay (4-12
-         * MMCE frames) and, during an active scroll, by cacheShouldDeferInteractiveArtOnInput.
+         * MMCE frames) and, during an active scroll, by cacheShouldDeferInteractiveArtOnInputMode.
          * The 2-frame debounce window was strictly shorter than that settle, so its only
          * distinct effect was to block a cover that scrolled into view while the user was
          * already settled -- exactly when it should load. Removed; the two gates below are the
          * complete throttle. */
-        if (cacheShouldDeferInteractiveArtOnInput(list, value)) {
+        if (cacheShouldDeferInteractiveArtOnInputMode(effectiveMode)) {
             cacheUnlock();
             return NULL;
         }
 
         if (!skipSettle) {
-            int delay = cacheGetInteractiveDelay(list, value);
+            int delay = cacheGetInteractiveDelay(list, effectiveMode);
             /* In MMCE mode, give Cover art a 1-frame inactivity head start over
              * other art types (Background, Screenshot, etc.).  The default theme
              * draws Background (main0) before Cover (main5) every frame, so
@@ -1624,7 +1644,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
         // MMCE is prefetch-exempt (browse-time prefetch hurt nav on the SIO2 bus) EXCEPT for an
         // explicit info-art prewarm, whose caller only fires after a long settle with the art
         // pipeline idle.
-        if (list == NULL || (effectiveMode == MMCE_MODE && !prewarm) || guiInactiveFrames < cacheGetPrefetchDelay(list, value)) {
+        if (list == NULL || (effectiveMode == MMCE_MODE && !prewarm) || guiInactiveFrames < cacheGetPrefetchDelay(list, effectiveMode)) {
             cacheUnlock();
             return NULL;
         }
@@ -1639,7 +1659,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     if (req != NULL && req->entry != NULL) {
         if (priority == CACHE_REQ_PRIORITY_INTERACTIVE) {
             cachePromoteQueuedRequestLocked(req);
-            if (!cacheShouldDeferInteractiveArtOnInput(list, value))
+            if (!cacheShouldDeferInteractiveArtOnInputMode(effectiveMode))
                 wakeWorker = 1;
         }
 
@@ -1708,7 +1728,14 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     req->entry = oldestEntry;
     req->list = list;
     req->effectiveMode = effectiveMode;
-    req->vcdFallback = vcdViewActive(effectiveMode);
+    // Key the strict-PS1-id retry on the REQUESTING list's view, not the resolved backend mode:
+    // the FAV->owner resolution in cacheGetEffectiveMode would otherwise read the OWNER page's
+    // independent L3 view (default ISO under GAME_VIEW_BOTH) and silently disarm the retry for a
+    // VCD favourite the FAV tab is displaying right now -- the FAV tab only lists VCD favourites
+    // while ITS OWN view is VCD, so the requesting-list stamp is 1 exactly when it should be.
+    // Behavior-identical for device lists (list->mode == the pre-resolution mode) and for APP
+    // lists (vcdModeSupported(APP_MODE) == 0, and an app value never yields a strict-ID retry).
+    req->vcdFallback = (list != NULL) ? vcdViewActive(list->mode) : 0;
     req->priority = priority;
     req->generation = gCacheGeneration;
     req->failEpoch = gCacheFailEpoch; // pin the absence epoch to when the load STARTED, not when it finishes

--- a/src/themes.c
+++ b/src/themes.c
@@ -841,6 +841,12 @@ static void prefetchGameImageTexture(image_cache_t *cache, void *support, struct
     if (cache == NULL || item == NULL || guiInactiveFrames < minInactiveFrames)
         return;
 
+    // Folder rows have no cover art -- same guard getGameImageTexture applies on the
+    // interactive path, so a prefetch walk that crosses a folder row cannot thrash the
+    // cache with the folder's non-art startup key.
+    if (item->item.isFolder)
+        return;
+
     list = (item_list_t *)support;
     if (list == NULL)
         return;
@@ -1125,6 +1131,8 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     int drawFirst = cfIsAnimating ? 0 : COVERFLOW_PAD;
     int drawLast = cfIsAnimating ? coverTotal : coverTotal - COVERFLOW_PAD;
 
+    GSTEXTURE *centerTexture = NULL; // the selection's LOADED art, if any -- gates the neighbor prefetch below
+
     for (i = drawFirst; i < drawLast; i++) {
         if (!covers[i])
             continue;
@@ -1142,6 +1150,8 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
 
         GSTEXTURE *texture = getGameImageTexture(cimg->cache, sourceList, &covers[i]->item);
         int hasArt = (texture && texture->Mem);
+        if (i == centerIdx && hasArt)
+            centerTexture = texture;
         // #2 (Nadwislanski): a no-art Favourites entry (a favourited app / PS1 title / game with no
         // ART/<id>_COV.png) must NOT draw the embedded cover placeholder wrapped in the two-layer case
         // frame -- that reads as a hollow grey "empty tray" box. Skip the whole cover instead (draw
@@ -1204,6 +1214,63 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     }
 
     rmSetReflectionYOffset(0); // don't leak the offset to any other reflection draw
+
+    /*
+      Idle prefetch of the OFF-SCREEN neighbors (issue #296). Two gates keep every cover off the
+      carousel until the user pauses: interactive requests are settle-gated (guiInactiveFrames
+      resets to 0 while any button is held), and at rest the two padding covers are not drawn at
+      all (the #271 rest-state optimization above), so the incoming cover's FIRST request happens
+      mid-slide -- exactly when the settle gate blocks it. Every step therefore slides in the
+      placeholder, which then pops to real art only after the user settles -- the "art only loads
+      when I focus each game" report.
+
+      Warm those neighbors during the SAME idle windows the list-mode cover panel already uses
+      (prefetchAdjacentGameImages, drawGameImage): PREFETCH priority, so MMCE stays exempt (SIO2)
+      -- including an MMCE-SOURCED FAVOURITE on the FAV tab, whose owner mode texcache resolves
+      per value (cacheGetEffectiveMode -> favGetArtMode) before applying the exemption -- and APP
+      keeps its longer settle + pending-interactive check via canPrefetchAdjacentGameImages. The
+      walk also only runs once the selection's own art has landed, so the focused cover always
+      wins the queue. The walk wraps last<->first exactly like the covers[]
+      build; distance is bounded so the whole warmed window (visible + pads + lookahead) fits the
+      cache's slot count with no LRU thrash: (count-1)/2 = 4 each side on the 10-slot COV cache,
+      i.e. one cover beyond the pad slot in 5-up mode, two in 3-up. Per-item element redirect
+      (thmGetElemForItem) keeps a FAV-tab APP favourite prefetching into the apps cache, matching
+      its draw. Duplicate visits (small wrapped lists) dedupe inside the cache by value.
+    */
+    if (elem->extended != NULL) {
+        mutable_image_t *baseImg = (mutable_image_t *)elem->extended;
+        if (baseImg->cache != NULL && baseImg->cache->suffix != NULL && strcmp(baseImg->cache->suffix, "COV") == 0 &&
+            canPrefetchAdjacentGameImages(baseImg->cache, sourceList, centerTexture)) {
+            int prefetchInactiveFrames = (sourceList != NULL && sourceList->mode == APP_MODE) ? APP_PREFETCH_IDLE_FRAMES : MENU_MIN_INACTIVE_FRAMES;
+            int maxDistance = (baseImg->cache->count - 1) / 2;
+            struct submenu_list *next = item;
+            struct submenu_list *prev = item;
+
+            for (i = 1; i <= maxDistance; i++) {
+                if (next != NULL) {
+                    next = next->next ? next->next : menu->item->submenu;
+                    if (next == item)
+                        next = NULL; // wrapped full circle
+                }
+                if (prev != NULL) {
+                    prev = prev->prev ? prev->prev : menu->item->last;
+                    if (prev == item)
+                        prev = NULL; // wrapped full circle (or no tail yet)
+                }
+
+                if (next != NULL) {
+                    mutable_image_t *nimg = (mutable_image_t *)thmGetElemForItem(menu, next, elem)->extended;
+                    if (nimg != NULL)
+                        prefetchGameImageTexture(nimg->cache, sourceList, next, prefetchInactiveFrames);
+                }
+                if (prev != NULL && prev != next) {
+                    mutable_image_t *pimg = (mutable_image_t *)thmGetElemForItem(menu, prev, elem)->extended;
+                    if (pimg != NULL)
+                        prefetchGameImageTexture(pimg->cache, sourceList, prev, prefetchInactiveFrames);
+                }
+            }
+        }
+    }
 }
 
 static void initCoverflow(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_element_t *elem, const char *name)


### PR DESCRIPTION
Fixes #296 — in CoverFlow (and the same pipeline behind List mode's cover panel), artwork for the covers around the selection stayed on the generic OPL placeholder and only popped in after each game was individually focused and the pad went quiet.

## Root cause (verified against the code by a 17-agent adversarial review)

Three mechanisms stack:

1. **The settle gate blocks all art requests during any scroll.** Every interactive art request requires `guiInactiveFrames >= 8` (`texcache.c`), and `readPads()` reports *held* buttons as activity (`pad.c` — `rcode = 1` whenever `newpdata != 0`), so `guiInactiveFrames` is pinned at 0 for the entire duration of a held d-pad scroll. Nothing can enqueue mid-scroll, on any backend including fast exFAT USB.
2. **The incoming cover is never requested before it appears.** At rest the carousel deliberately skips drawing the two off-screen padding slots (the #271 rest-state optimization), and drawing is what requests art — so the cover that slides in next gets its *first* `cacheGetTexture` call mid-slide, exactly when gate 1 blocks it. Every step slides in the placeholder; the enqueue only happens ~133 ms after release, plus load time.
3. **No prefetch in the carousel.** List mode's big cover panel already idle-prefetches ±1; `drawCoverFlow` had none.

Why uOPL "doesn't have this": its gating is byte-identical (same 8-frame settle, same held-input semantics, same per-frame visible-3 requests, no prefetch) — but it steps instantly (no slide revealing a never-requested pad cover) and loads art on the **priority-30 IO worker**, which preempts everything and lands each cover in a burst right after the settle. Our art worker is deliberately deprioritized (0x40/90) so decodes never hitch the carousel — the cost was visible load lag at tap-scroll cadence. This fix keeps the smooth-nav priority design and instead makes the reveal warm.

## The fix

`drawCoverFlow` now **prefetches the off-screen neighbors during idle** — a wrap-aware walk out to `(cache slots − 1) / 2 = 4` positions each side of the selection, at PREFETCH priority, only once the selection's own cover has loaded (so the focused cover always wins the queue). The warmed window (visible + pads + lookahead = 9 of the 10 COV slots) provably cannot thrash the LRU — an adversarial reviewer's thrash scenario was refuted by simulation (zero in-window evictions across steady scroll, zigzag, bursts, and 4800 random steps). `prefetchGameImageTexture` also gains the `isFolder` guard the interactive path already had.

Net effect: at rest the ±4 neighborhood is warm, so a scroll step reveals an already-loaded cover; a long held scroll still fills within a beat of release (visible covers first, then the lookahead) — better than uOPL rather than merely matching it.

## Hardening surfaced by the review

The review confirmed a **pre-existing** hole the prefetch would have widened: FAV-tab art reads proxy to the favourite's owner device, but `cacheGetEffectiveMode` never unwrapped `FAV_MODE`, so an **MMCE-sourced favourite's** SIO2 reads bypassed the MMCE prefetch exemption, the MMCE/HDD nav-time defer, the MMCE abort sweeps (launch/theme/config quiesce!), and the load-priority drop. Now:

- `favGetArtMode(value)` (mirrors `favGetImage`'s matching) resolves a FAV value to the owner's mode inside `cacheGetEffectiveMode` — all four mode-keyed gates now see the device the read actually lands on, for the coverflow prefetch, the list-mode prefetch, and interactive requests alike.
- A second review round caught a regression in that very hardening: the resolution changed what `req->vcdFallback` stamps, disarming the strict-PS1-ID art retry for VCD favourites whenever the owner page sits in its default ISO view. Fixed by stamping from the **requesting list's** view (`vcdViewActive(list->mode)`) — behavior-identical for device and APP lists, restores the pre-change semantics for FAV.
- Thread contract kept clean: the art worker's dequeue defer now reads the request's enqueue-time `effectiveMode` (mode-only variant), so the unlocked `favArray` scan runs once per enqueue attempt, on the GUI thread only. The delay helpers take the resolved mode (no redundant re-scans under `cacheLock`).

## Validation

- Root cause + patch adversarially reviewed by two workflow rounds (17 + 13 agents); all confirmed findings addressed, final pass reports zero remaining defects.
- Builds clean in both local ps2dev container runs (`opl.elf` linked, `-Wall` silent on the three changed objects).
- HW validation pending as usual: the video's tap cadence (~1 Hz on exFAT USB) is the case the prefetch targets — covers should now be present when revealed; MMCE browsing should be unchanged (prefetch stays fully exempt, now including MMCE-sourced favourites).

Docs: `docs/THEME_ENGINE.md` §8 documents the new prefetch behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coverflow now preloads nearby cover images during idle time, including items beyond the visible window and wrapping at list ends.
  * Prefetching begins after the selected cover has loaded for smoother browsing.
* **Bug Fixes**
  * Improved artwork loading for favourites and slower storage devices during navigation.
  * Prevented unnecessary prefetching for folders and MMCE-backed items, reducing cache and bus activity.
* **Documentation**
  * Updated Coverflow documentation to describe idle-time cover prefetch behavior and exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->