### PR TITLE
fix(pad): pause the repeat countdown during read misses instead of re-arming it (#272)

### DIFF
--- a/src/dia.c
+++ b/src/dia.c
@@ -14,6 +14,7 @@
 #include "include/themes.h"
 #include "include/util.h"
 #include "include/sound.h"
+#include "include/diag.h" // gDiag pad-miss line, drawn in diaRenderUI (dialogs never reach guiDrawOverlays)
 
 // UI spacing of the dialogues (pixels between consecutive items)
 #define UI_SPACING_H      10
@@ -799,6 +800,18 @@ void diaRenderUI(struct UIItem *ui, short inMenu, struct UIItem *cur, int haveFo
     uiX = guiDrawIconAndText(gSelectButton == KEY_CIRCLE ? uiIcons[0] : uiIcons[1], uiHints[0], gTheme->fonts[0], uiX, uiY, gTheme->textColor);
     uiX += 12;
     uiX = guiDrawIconAndText(gSelectButton == KEY_CIRCLE ? uiIcons[1] : uiIcons[0], uiHints[1], gTheme->fonts[0], uiX, uiY, gTheme->textColor);
+
+    // #272 pad-miss diagnostic line (see include/diag.h). diaExecuteDialog renders directly
+    // (rmStartFrame/diaRenderUI/rmEndFrame) and never reaches guiDrawOverlays, so without this the
+    // gDiag HUD is invisible in exactly the settings dialogs the freeze repro lives in. Same gate
+    // (gEnableDebug), font and colour convention as the gui.c lines; reads plain volatile counters,
+    // no IO -- the overlay must not add traffic to the bus under observation.
+    if (gEnableDebug) {
+        char diag[64];
+        snprintf(diag, sizeof(diag), "MISS PT:%u MB:%u MX:%u CD:%u",
+                 gDiag.padPollMaxMs, gDiag.padMissStreak, gDiag.padMissStreakMax, gDiag.padCarryDrops);
+        fntRenderString(gTheme->fonts[0], 0, screenHeight - 24, ALIGN_NONE, 0, 0, diag, GS_SETREG_RGBA(255, 255, 0, 128));
+    }
 }
 
 /// sets the ui item value to the default again

--- a/src/include/diag.h
+++ b/src/include/diag.h
@@ -92,6 +92,22 @@ typedef struct
     volatile unsigned int padRumbleDropped;
     volatile unsigned int padRumbleArmed;
     volatile unsigned int padRealignOk;
+    // MISS sub-line (#272 settings-scroll freeze instrument, 2026-07-30; all writers on the EE main
+    // thread inside readPads/readPad). This line is drawn by dia.c, because diaExecuteDialog renders
+    // directly and never reaches guiDrawOverlays -- so the other lines are invisible in exactly the
+    // dialogs where the #272 freeze repro lives. Read with Debug ON while holding a direction
+    // through a hitch:
+    //   PT  - max time_since_last (ms) seen by any readPads poll this session: the poll-period
+    //         spike that accompanies an SIO2 stall (~16/17 at a steady 60 Hz).
+    //   MB  - current consecutive-read-miss burst length in polls, max across pads.
+    //   MX  - longest such burst this session. MX >= 4 at 60 Hz means a burst outlasted the 48 ms
+    //         carry window -- the trigger the pause-on-miss fix in readPads() now covers.
+    //   CD  - carry-drops: times a held button's hold fell out of the level view because readMissMs
+    //         exceeded PAD_READ_CARRY_MS. On the pre-fix build, each CD was one ~900 ms re-arm.
+    volatile unsigned int padPollMaxMs;
+    volatile unsigned int padMissStreak;
+    volatile unsigned int padMissStreakMax;
+    volatile unsigned int padCarryDrops;
 } opl_diag_t;
 
 extern opl_diag_t gDiag;

--- a/src/pad.c
+++ b/src/pad.c
@@ -90,6 +90,8 @@ struct pad_data_t
     int rumbleMsLeft;          // ms remaining; ticked down in readPads() (see the ms-vs-frames note there)
     int realignDelay;          // backoff for the actuator-alignment self-heal (padRumbleRealign)
     u32 readMissMs;            // ms accumulated since the last successful read (see readPad's hold-carry)
+    unsigned int missStreak;   // consecutive missed reads while ready, in polls (gDiag HUD MB/MX)
+    unsigned char carryLapsed; // 1 once the carry window lapses mid-hold, until the next good read (HUD CD)
 };
 
 /*
@@ -535,6 +537,8 @@ static int readPad(struct pad_data_t *pad)
         pad->analogCapable = -1;
         pad->analogRetryDelay = 0;
         pad->readMissMs = 0;
+        pad->missStreak = 0;
+        pad->carryLapsed = 0;
         // Same idle gate as the analog self-heal below, for the same reason: this initializePad is
         // the SAME 250-600 ms inline blackout, and a reconnect edge can be driven by the very read
         // errors that cluster under load (sustained misses drop freepad to DISCONN, the recovery
@@ -553,6 +557,8 @@ static int readPad(struct pad_data_t *pad)
         // window: a real disconnect is not a transient miss, and the state gate below already stops
         // contributing -- this just makes a re-plug start from a clean slate.
         pad->readMissMs = 0;
+        pad->missStreak = 0;
+        pad->carryLapsed = 0;
         pad->paddata = 0;
         pad->oldpaddata = 0;
     }
@@ -622,6 +628,8 @@ static int readPad(struct pad_data_t *pad)
 #endif
     if (padsRead > 0) {
         pad->readMissMs = 0;
+        pad->missStreak = 0;
+        pad->carryLapsed = 0;
 
         newpdata = readLeftJoy(pad, newpdata);
 
@@ -649,6 +657,7 @@ static int readPad(struct pad_data_t *pad)
           whole release gap falls inside a stall), the following press is suppressed -- an extra move
           becomes a dropped one. That is the better failure of the two, but it is real.
         */
+        pad->missStreak++; // #272 diag (HUD MB/MX): this poll is one more consecutive miss
         edgedata |= pad->paddata;
     }
 
@@ -698,6 +707,14 @@ static int readPad(struct pad_data_t *pad)
         pad->readMissMs += time_since_last;
         paddata |= pad->paddata;
         rcode = 1;
+    } else if (padsRead == 0 && (pad->state == PAD_STATE_STABLE || pad->state == PAD_STATE_FINDCTP1) &&
+               pad->paddata != 0 && !pad->carryLapsed) {
+        // #272 diag (HUD CD): the carry window just lapsed MID-HOLD -- from this poll until the
+        // next good read the level view shows the button up although the finger never moved.
+        // Counted once per miss burst (carryLapsed latches until the recovery read), because this
+        // is exactly the poll where readPads()' delaycnt re-arm used to fire.
+        pad->carryLapsed = 1;
+        gDiag.padCarryDrops++;
     }
 
     return rcode;
@@ -1074,12 +1091,26 @@ int readPads()
     time_since_last = dticks / CLOCKS_PER_MILISEC;
     tickrem = dticks % CLOCKS_PER_MILISEC;
     curtime += time_since_last;
+    // #272 diag (HUD PT): worst poll period this session -- the spike that accompanies an SIO2 stall
+    if (time_since_last > gDiag.padPollMaxMs)
+        gDiag.padPollMaxMs = time_since_last;
 
     int rslt = 0;
 
     for (i = 0; i < pad_count; ++i) {
         rslt |= readPad(&pad_data[i]);
     }
+
+    // #272 diag (HUD MB/MX): longest consecutive-miss run any pad is currently riding, and the
+    // session peak. MX reaching 4+ at a 60 Hz poll rate means a burst outlasted the 48 ms carry
+    // window -- the trigger the pause-on-miss below now covers.
+    unsigned int streak = 0;
+    for (i = 0; i < pad_count; ++i)
+        if (pad_data[i].missStreak > streak)
+            streak = pad_data[i].missStreak;
+    gDiag.padMissStreak = streak;
+    if (streak > gDiag.padMissStreakMax)
+        gDiag.padMissStreakMax = streak;
 
     // Stamp input activity AFTER the merge: any button or stick held this poll re-arms the
     // self-heal idle gate. One-poll staleness inside readPad (it reads the previous stamp) is
@@ -1125,11 +1156,34 @@ int readPads()
             pad->rumbleOn = 0; // else retry next frame: the IOP briefly drops it outside TASK_UPDATE_PAD
     }
 
+    // #272: buttons a still-connected pad holds but this poll cannot SEE. pad->paddata is the last
+    // SAMPLED hold; readMissMs > 0 says every read since has come back empty. Inside the carry
+    // window the #288 carry keeps getKeyPressed() true, so this mask only matters once the window
+    // lapses and the held bits fall out of the global level view mid-burst.
+    u32 missHeld = 0;
+    for (i = 0; i < pad_count; ++i) {
+        struct pad_data_t *pad = &pad_data[i];
+        if (isPadReadyState(pad->state) && pad->readMissMs > 0)
+            missHeld |= pad->paddata;
+    }
+
     for (i = 0; i < 16; ++i) {
         if (getKeyPressed(i + 1))
             delaycnt[i] -= time_since_last;
-        else
+        else if (!(missHeld & keyToPad[i + 1]))
             delaycnt[i] = getKeyDelay(i + 1, 0);
+        // else: the button reads up ONLY because the pad is mid-read-miss -- PAUSE the countdown
+        // instead of re-arming the full 3x initial delay. A miss is "unknown", not "released";
+        // resetting here is what turned a ~67 ms SIO2 burst into a ~1 s dead cursor, with every
+        // remaining poll of the burst re-arming 900 ms. The reset still fires where it must: a
+        // SAMPLED release clears readMissMs on the recovery read, and a disconnect fails
+        // isPadReadyState -- both take the else-if above.
+        //
+        // Pause composes with the carry window rather than replacing it, so the window stays sized
+        // for the game list's 100 ms repeat: inside the window the countdown keeps running (the
+        // hold is almost certainly real, so the repeat clock should not get free extra time); past
+        // it the clock freezes mid-burst and resumes on recovery. Either way the re-arm now fires
+        // only on a release the hardware actually reported.
     }
 
     return rslt;


### PR DESCRIPTION
## Why

zackcage6's settings-scroll hang persists on Beta-3457, which is current master HEAD — so every previously merged #272 fix was already in the tested build. A line-by-line re-read of the input path found the amplifier: `readPads()` rebuilds the auto-repeat countdown from the *level* view each poll, and on any poll where the button doesn't look held it **assigns** the 3× initial delay (`getKeyDelay(i+1, 0)`, `delay *= 3` for non-repeat) instead of pausing. At default scroll speed the dialog repeat is 300 ms, so the re-arm is **900 ms**.

The #288 hold-carry latches off after 48 ms (`readMissMs < PAD_READ_CARRY_MS` tested before the increment). At ~16.7 ms vblank-locked polls, misses 1–3 carry and the 4th consecutive miss drops the hold — then every remaining poll of that burst re-arms 900 ms. **~67 ms of dead SIO2 becomes a ~1.0 s frozen cursor**, matching "hangs on that option for like a second". Bursts recurring faster than 900 ms mean the repeat leg never fires at all — "pauses until u lift ur finger" (releasing manufactures a fresh `getKeyOn` edge, the one path that ignores `delaycnt`).

Honest caveat: this is the **amplifier, not the trigger**. It explains the ~1 s magnitude from our own constants; it does not explain the every-~5-items cadence, which may not be truly periodic. The instrumentation below exists so one hardware run can confirm or kill the theory.

## What

- **`src/pad.c`** — the re-arm loop now builds a per-poll `missHeld` mask (OR of `pad->paddata` over pads that are `isPadReadyState() && readMissMs > 0`) and only re-arms `delaycnt` when the key's bit is not in that mask. Mid-read-miss = **pause**, not reset. A *sampled* release still resets (recovery read clears `readMissMs`); a disconnect still resets (fails `isPadReadyState`). The pause composes with the 48 ms carry window — inside the window the countdown keeps running, past it the clock freezes and resumes on recovery — so the window stays sized for the game list's 100 ms fast repeat. The unbounded edge carry at `pad.c:652` (the deliberate #271 skip fix) is untouched.
- **`src/include/diag.h`** — four counters: `padPollMaxMs` (max poll period), `padMissStreak` / `padMissStreakMax` (current / session-peak consecutive-miss burst), `padCarryDrops` (times a held button fell out of the level view past the carry window — each one was a 900 ms re-arm on the old code).
- **`src/dia.c`** — a `gEnableDebug`-gated `MISS PT/MB/MX/CD` line in `diaRenderUI`. `diaExecuteDialog` renders directly and never reaches `guiDrawOverlays`, so the existing HUD was invisible on exactly the screen under investigation. Same font/colour/anchor convention as the gui.c lines; reads plain volatile counters, no IO added.

## What the hardware test settles

With Settings → debug info ON, hold a direction through a hitch:
- **MX ≥ 4 and CD climbing, hangs shrunk to ~one step** → amplifier confirmed and fixed.
- **PT spiking well past ~67 ms, or hangs persisting with CD = 0** → something genuinely blocks the loop; the amplifier theory is dead or incomplete.

Built clean in the ps2dev Docker container (`make -j8 opl.elf`, no new warnings, clang-format-12 clean). Hardware-only bug (PCSX2 is smooth), so HW validation is the real gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded controller diagnostics showing missed reads, polling delays, missed-read streaks, and carry-window drops when debugging is enabled.
  * Diagnostics are now visible while settings dialogs are open.

* **Bug Fixes**
  * Improved handling of intermittent controller read failures during held inputs.
  * Prevented key-repeat timing from resetting unnecessarily during brief input-read interruptions.
  * Improved detection of expired input carry windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->