### PR TITLE
fix(apps): load theme attribute images on the Apps Info screen (#298)

### DIFF
--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -11,6 +11,7 @@
 #include "include/ethsupport.h"
 #include "include/hddsupport.h"
 #include "include/texcache.h"
+#include "include/textures.h"
 
 #include <elf-loader.h>
 
@@ -815,6 +816,17 @@ static config_set_t *appGetConfig(item_list_t *itemList, int id)
 static int appGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     app_info_t *app;
+
+    // Absolute (theme-folder) requests (#298): info-page attribute caches (Rating/Players/Vmode/Scan)
+    // are created with an absolute prefix and key their request on the attribute VALUE ("4", "ntsc",
+    // ...) -- never an app startup -- so the appLookupByStartup gate below must not run for them, or
+    // texcache would memoize a bogus miss and the placeholder renders forever. `folder` is the theme
+    // path; build it directly like hddGetImage does.
+    if (!isRelative) {
+        char path[256];
+        snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
+        return texDiscoverLoad(resultTex, path, -1);
+    }
 
     app = appLookupByStartup(value);
     if (app == NULL || app->artMode < 0)


### PR DESCRIPTION
## Why

On the Apps Info screen, the `Rating` / `Players` / `Vmode` / `Scan` theme assets never load — the placeholder (e.g. hollow stars) renders forever even though the files exist in the theme folder. The same assets load fine on the games info screen.

Root cause: info-page `AttributeImage` elements resolve through the art worker as **absolute theme-path** requests keyed on the attribute *value* — `<themePath>4_Rating.png`, `ntsc_Vmode.png`, etc. Every games-mode loader treats `isRelative == 0` as a pure path build, but `appGetImage` gated **all** requests on `appLookupByStartup(value)` — and an attribute value is never an app startup, so each request returned -1 at the gate, texcache memoized the miss, and the placeholder was permanent.

This is exactly the defect class #213 fixed for the Favourites page (`favGetImage` passthrough) — but on the Apps page the startup-keyed loader is the *only* image loader, so there was nothing to route around; the gate itself had to move.

## What

`src/appsupport.c` `appGetImage`: handle `isRelative == 0` **before** the startup gate — build `<folder><value>_<suffix>` directly and `texDiscoverLoad` it, byte-for-byte the pattern `hddGetImage`/`bdmGetImage` use. The startup-keyed ART cover path (`isRelative == 1`) is untouched. (+1 include: `textures.h` for `texDiscoverLoad`.)

Built clean in the ps2dev Docker container (forced `appsupport.o` rebuild, zero warnings), format-checked with CI's exact clang-format-12 binary.

## Note for testing

Apps whose `title.cfg` genuinely lacks the attribute key still (correctly) show the placeholder — this fix covers apps whose configs carry the values, which matches the reporter's screenshot (values present, assets missing).