### PR TITLE
fix(texcache): key the APP art gates off the resolved mode too (#297 follow-up)

### DIFF
--- a/src/texcache.c
+++ b/src/texcache.c
@@ -439,7 +439,12 @@ static int cacheGetInteractiveDelay(const item_list_t *list, int mode)
 {
     int delay = cacheGetBaseDelay(list);
 
-    if (list != NULL && list->mode == APP_MODE) {
+    // #297 follow-up: key the APP cases off the RESOLVED mode too. list->mode covers the apps
+    // list itself (its resolved mode is the art DEVICE mode, and a non-MMCE device must still
+    // skip the settle via the early return below); mode == APP_MODE adds the app-sourced FAV
+    // favourite whose art has no device configured (cacheGetEffectiveMode leaves APP_MODE when
+    // appGetArtMode < 0), which must behave exactly like the same app on the apps page.
+    if (list != NULL && (list->mode == APP_MODE || mode == APP_MODE)) {
         if (mode != MMCE_MODE)
             return 0;
     }
@@ -447,7 +452,7 @@ static int cacheGetInteractiveDelay(const item_list_t *list, int mode)
     if ((mode == APP_MODE || mode == MMCE_MODE) && delay < CACHE_SLOW_MODE_INTERACTIVE_DELAY)
         delay = CACHE_SLOW_MODE_INTERACTIVE_DELAY;
 
-    if (list != NULL && list->mode == APP_MODE && delay > CACHE_APP_INTERACTIVE_MAX_DELAY)
+    if (list != NULL && (list->mode == APP_MODE || mode == APP_MODE) && delay > CACHE_APP_INTERACTIVE_MAX_DELAY)
         delay = CACHE_APP_INTERACTIVE_MAX_DELAY;
 
     if (mode == MMCE_MODE && delay > CACHE_MMCE_INTERACTIVE_MAX_DELAY)
@@ -1649,7 +1654,11 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
             return NULL;
         }
 
-        if (list->mode == APP_MODE && cacheHasPendingInteractiveArtLocked()) {
+        // #297 follow-up: key the APP case off the RESOLVED mode too -- effectiveMode == APP_MODE
+        // is the app-sourced FAV favourite with no art device (cacheGetEffectiveMode leaves
+        // APP_MODE when appGetArtMode < 0); it must yield to pending interactive art exactly like
+        // the same app on the apps page. list is guaranteed non-NULL by the guard above.
+        if ((list->mode == APP_MODE || effectiveMode == APP_MODE) && cacheHasPendingInteractiveArtLocked()) {
             cacheUnlock();
             return NULL;
         }


### PR DESCRIPTION
## Why

Valid 🟡Minor from PR #297's CodeRabbit review (vetted against the code before applying — triage comment on #297). `cacheGetEffectiveMode` resolves the effective art-backend mode (FAV → owner device; APP → the app's art device, staying `APP_MODE` when `appGetArtMode < 0`), but two gates still keyed off the unresolved `list->mode == APP_MODE`, so **app-sourced favourites on the FAV tab** fell through the apps-page special cases:

1. **`cacheGetInteractiveDelay`** — an art-less app favourite got the SLOW settle *uncapped*, where the same app on the apps page gets zero delay (early-return for non-MMCE app art) and the `CACHE_APP_INTERACTIVE_MAX_DELAY` cap.
2. **Prefetch suppression** in `cacheGetTextureInternal` — an art-less app favourite's prefetch didn't yield to pending interactive art the way the apps page's does.

## What

Both gates now fire on `list->mode == APP_MODE || mode/effectiveMode == APP_MODE`. `list->mode` keeps covering the apps list itself (whose resolved mode is the art *device* mode — an apps-list item with USB-backed art must still skip the settle); the resolved `APP_MODE` adds exactly one new case: the FAV-tab app favourite with no art device, which now behaves identically to the same app on the apps page. Every other mode combination traced and confirmed behavior-identical (apps × {USB, MMCE, none}; FAV × {game, app+device art, app+MMCE art}).

## Verification

ps2dev Docker build green (forced `texcache.o` rebuild, zero texcache warnings), clang-format checked with CI's exact binary (0 replacements).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive artwork loading behavior when APP mode is resolved dynamically.
  * Ensured APP-mode items consistently honor interactive delay limits.
  * Updated texture loading to defer requests appropriately while interactive artwork is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->