### PR TITLE
fix(gui): trigger the loader on pending interactive art too (#299 follow-up)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2262,7 +2262,14 @@ static void guiDrawOverlays()
     // presence scan takes a few hundred ms (MMCE SIO2 round-trips), keying the spinner off the raw
     // queue made it fade in "every few seconds" while the console sat idle. Real work -- list
     // loads, config saves, module loads, theme switches -- is still counted.
-    int pending = ioHasVisiblePendingRequests();
+    // #299 follow-up: also count pending INTERACTIVE art (the selected item's cover/BG/icon).
+    // Browsing enqueues no IO-queue requests at all -- art loads on the texcache worker -- so
+    // without this the loader could never trigger in the game listings, only on screens that
+    // read per-game config through the queue (the info screen). Interactive-only on purpose:
+    // neighbor prefetch (#296) and quiet background IO must never show the loader (#290), and
+    // during a held scroll the interactive defer gate hasn't enqueued anything yet, so the
+    // loader pulses only once the selection settles and its art is actually loading.
+    int pending = ioHasVisiblePendingRequests() || cacheHasPendingInteractiveArt();
 
     // During the boot intro, when an animated boot logo is shown, suppress the
     // loading spinner -- the animated logo is the boot activity indicator there.


### PR DESCRIPTION
## Why

PixeliGer's evidence on Beta-3465 (which contains #302): the loader now appears on the **info screens** — "sometimes just by changing the game even if there are no assets to load" — but **never in the game listings**, any section/device, default interface included.

The asymmetry is structural, and both halves are by design:

- **Info screens trigger it** because the default theme's `info*` sections declare Attribute elements → `needsItemConfig` → every selection change enqueues a *visible* per-game config read (`_menuRequestConfig` → `ioPutRequest(IO_CUSTOM_SIMPLEACTION, _menuLoadConfig)`, menusys.c:348). The config read, not art, is what arms the loader — hence "even when there are no assets to load".
- **Listings can't trigger it**: browsing enqueues no IO-queue requests at all (covers/BGs/icons load on the texcache worker, in every OPL version including upstream), and the default theme's `main*` sections declare zero Attribute elements, so no config reads fire there either. Nothing visible ever pends.

## What

One line: `pending = ioHasVisiblePendingRequests() || cacheHasPendingInteractiveArt()` in `guiDrawOverlays`.

- **Interactive-only**: neighbor prefetch (#296) and quiet background IO still never show the loader — #290 stays dead.
- **Doesn't fight scrolling**: during a held scroll the interactive defer gate hasn't enqueued anything yet; the loader pulses only once the selection settles and its art is genuinely still loading. With #302's latch it then holds ~0.5s minimum.

## Verification

ps2dev Docker build green (forced `gui.o` rebuild, zero gui.c warnings), format-checked with CI's exact clang-format 12.0.1 binary (0 replacements).