### PR TITLE
fix(mmce): debounce Auto-slot presence, split absent vs contended VCD scan (#154)

### DIFF
--- a/.github/patches/mmceman-fs-dopen-enoent.patch
+++ b/.github/patches/mmceman-fs-dopen-enoent.patch
@@ -1,0 +1,20 @@
+diff --git a/mmceman/src/mmce_fs.c b/mmceman/src/mmce_fs.c
+--- a/mmceman/src/mmce_fs.c
++++ b/mmceman/src/mmce_fs.c
+@@ -644,9 +644,15 @@ int mmce_fs_dopen(iomanX_iop_file_t *file, const char *name)
+     if (rdbuf[0x1] != 0xff) {
+         *(int*)file->privdata = rdbuf[0x1];
+     } else {
++        // -ENOENT, not a bare -1: this is the ONLY dopen-failure path where the CARD ITSELF
++        // answered "no such directory" -- the timeout/garbled-reply paths above stay -1 (EE sees
++        // a non-ENOENT errno) so callers can tell genuine absence from a transient bus failure.
++        // Downstream, OPL's VCD scan (vcdScanOpenDir) treats ENOENT as "no POPS folder -> empty,
++        // no retry"; without it every contended dopen was indistinguishable from an absent dir
++        // and burned the bounded rescan budget. Same doctrine as the mmce_fs_open ENOENT fix.
+         DPRINTF("%s ERROR: Got invalid fd: %i\n", __func__, rdbuf[0x1]);
+         file->privdata = NULL;
+-        return -1;
++        return -ENOENT;
+     }
+ 
+     return 0;

--- a/.github/scripts/install_coherent_mmce.sh
+++ b/.github/scripts/install_coherent_mmce.sh
@@ -79,6 +79,20 @@ fi
 echo "== Applying mmceman open-ENOENT fix (distinct errno for genuine not-found) =="
 git -C "$WORK/mmceman" apply --verbose "$FS_ENOENT_PATCH"
 
+# Same split for DIRECTORY open (RiptOPL #154 audit residual): mmce_fs_dopen also returned one bare
+# -1 for every failure, so an absent POPS folder was indistinguishable from a contended bus and
+# burned OPL's bounded VCD rescan budget (MMCE_VCD_SCAN_RETRY_MAX) on every refresh. This patch
+# makes ONLY the card's explicit invalid-fd reply return -ENOENT; vcdScanOpenDir then treats ENOENT
+# as "no POPS folder -> empty, no retry" while contention keeps the -1 preserve-last-good path.
+# Applies on top of the two patches above (disjoint hunks); fail LOUD if it stops applying.
+FS_DOPEN_ENOENT_PATCH="$SCRIPT_DIR/../patches/mmceman-fs-dopen-enoent.patch"
+if [ ! -f "$FS_DOPEN_ENOENT_PATCH" ]; then
+    echo "ERROR: expected mmceman dopen-ENOENT patch not found at $FS_DOPEN_ENOENT_PATCH" >&2
+    exit 1
+fi
+echo "== Applying mmceman dopen-ENOENT fix (distinct errno for genuinely-absent dir) =="
+git -C "$WORK/mmceman" apply --verbose "$FS_DOPEN_ENOENT_PATCH"
+
 # Older-SDK make quirk: the per-module obj dir isn't auto-created by every Makefile.iopglobal
 # vintage -- pre-create it so the first compile step doesn't fail on a missing directory.
 mkdir -p "$WORK/mmceman/mmceman/obj"

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -26,10 +26,12 @@
 static char mmcePrefix[40]; // Contains the full path to the folder where all the games are.
 static char mmceArtPrimary[40];
 static int mmceULSizePrev = -2;
-// VCD-scan self-heal (HW batch S6): vcdFillGameList cannot tell an ABSENT POPS folder from a
-// CONTENDED one (-1 both), so ONE failed scan on a busy bus used to latch an empty VCD page under
-// NOUPDATE with no rescan for the session. Bounded retry, same shape as the ISO first-scan sentinel:
-// ~15 passes at the ~2s cadence, re-armed by a fresh L3 toggle, self-quiescing on success/expiry.
+// VCD-scan self-heal (HW batch S6): a failed vcdFillGameList on a CONTENDED bus (-1) used to latch
+// an empty VCD page under NOUPDATE with no rescan for the session. Bounded retry, same shape as the
+// ISO first-scan sentinel: ~15 passes at the ~2s cadence, re-armed by a fresh L3 toggle, self-
+// quiescing on success/expiry. (The other half of the old "-1 for both" ambiguity is now split at
+// the source: vcdScanOpenDir returns 0 for a genuinely-ABSENT POPS folder -- #154 residual -- so
+// only contention ever arms this budget.)
 static unsigned char mmceVcdScanFailed = 0;
 static unsigned char mmceVcdScanRetries = 0;
 #define MMCE_VCD_SCAN_RETRY_MAX 15
@@ -56,6 +58,18 @@ static int mmceResolvedDevice = -1;
 static char mmceFoldersCreatedFor[40] = {0};
 #define MMCE_FOLDER_RETRY_MAX 5 // bounded CFG-create retries per card before declaring it obstructed
 static unsigned char mmceFolderRetries = 0;
+// Auto-slot presence debounce (#154 audit residual): the cache-hit probe in mmceSetPrefix used to
+// invalidate the slot on ONE failed presence devctl -- and mmceUpdateGameList then frees BOTH game
+// lists -- so a transiently contended SIO2 bus (list scan + art read + MX4SIO traffic all sharing
+// it) read as "card pulled" and both lists vanished until the next ~2s refresh re-detected.
+// Require MMCE_PRESENCE_PROBE_MAX CONSECUTIVE failures before invalidating, re-probing INLINE with
+// a short gap (the same 200 ms DelayThread cadence the GameID settle loops use): worst case ~1.0 s
+// on a genuine pull (3x the devctl's own 200 ms timeout + 2 gaps), still inside the ~2s refresh
+// cadence, so a pull is still detected on THIS pass -- just two probes later -- while a bus-quiet
+// window between probes absorbs the transient. No persistent counter: any successful probe breaks
+// the loop and declares the card present.
+#define MMCE_PRESENCE_PROBE_MAX 3
+#define MMCE_PRESENCE_RETRY_US  (200 * 1000)
 
 // Card-switch wait: poll the MMCE busy bit every 500 ms for up to ~7.5 s, matching mmceman's own
 // switch handshake. On a CROSS-DEVICE launch (a USB/HDD/SMB game whose per-game card lives on the
@@ -326,13 +340,23 @@ void mmceSetPrefix(void)
         sprintf(mmcePrefix, "mmce1:/%s", gMMCEPrefix);
     else if (gMMCESlot == 2) {
         // Auto: reuse the previously-detected slot instead of probing BOTH slots every refresh.
-        // On a cache hit, ONE presence devctl on the resolved slot confirms the card is still there
-        // (mmcePrefix from the prior detect is still correct); a miss means the card was pulled, so
-        // invalidate and fall through to a full re-detect. Net: 1 SIO2 probe/cycle instead of 2, and
-        // card removal is now noticed (mmceDetectSlot alone leaves a stale prefix on a lost card).
+        // On a cache hit, a presence devctl on the resolved slot confirms the card is still there
+        // (mmcePrefix from the prior detect is still correct); only MMCE_PRESENCE_PROBE_MAX
+        // CONSECUTIVE misses mean the card was pulled (#154 debounce, below), so invalidate and fall
+        // through to a full re-detect. Net: 1 SIO2 probe/cycle instead of 2 on the happy path, and
+        // card removal is still noticed (mmceDetectSlot alone leaves a stale prefix on a lost card).
         if (mmceResolvedDevice > 0) {
             const char *root = (mmceResolvedDevice == 2) ? "mmce0:/" : "mmce1:/";
-            if (fileXioDevctl(root, 0x1, NULL, 0, NULL, 0) == -1) {
+            // Debounced presence check (#154): invalidate only after MMCE_PRESENCE_PROBE_MAX
+            // consecutive failed devctls -- see the define block above. One success = present.
+            int probe;
+            for (probe = 0; probe < MMCE_PRESENCE_PROBE_MAX; probe++) {
+                if (fileXioDevctl(root, 0x1, NULL, 0, NULL, 0) != -1)
+                    break;
+                if (probe + 1 < MMCE_PRESENCE_PROBE_MAX)
+                    DelayThread(MMCE_PRESENCE_RETRY_US); // let a contended bus quiet, then re-probe
+            }
+            if (probe >= MMCE_PRESENCE_PROBE_MAX) {
                 mmceResolvedDevice = -1;
                 mmcePrefix[0] = '\0';
             } else {

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>    // errno/ENOENT in the vcdScanOpenDir absent-vs-contended split (#154)
 #include <sys/stat.h> // mkdir (POSIX, used like util.c / OSDHistory.c)
 
 #include "include/opl.h"         // pulls <dirent.h> (opendir/readdir/DIR) + strcasecmp, like supportbase.c
@@ -107,13 +108,32 @@ static int vcdEntryCmp(const void *a, const void *b)
 // IO only (newlib-port rule). Shared by vcdScanDir (POPS subfolder) and vcdScanDirRoot (path as-is).
 static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
 {
+    errno = 0; // clear BEFORE opendir so the NULL branch reads THIS call's errno, not a stale one
     DIR *dir = opendir(dirPath);
-    if (dir == NULL)
-        return -1; // could NOT read the dir (absent OR device momentarily unreadable / bus contended).
-                   // Signal a scan FAILURE -- distinct from a readable-but-empty dir (opens fine, count
-                   // 0) -- so the caller PRESERVES its last-good list instead of blanking it on a
-                   // transient wedge. Mirrors scanForISO (the ISO path) -- the #120 fix: the VCD & ISO
-                   // views share one backing store, and returning 0 here zeroed BOTH on a contended bus.
+    if (dir == NULL) {
+        // Absent-vs-contended split (#154 audit residual): returning -1 for BOTH made a card with
+        // NO POPS folder burn mmcesupport's bounded rescan budget (MMCE_VCD_SCAN_RETRY_MAX) on
+        // every refresh. errno IS faithful here: newlib's opendir is a plain open() that returns
+        // NULL without touching errno (verified in the toolchain's libc disassembly), so the glue's
+        // __transform_errno result survives -- the same propagation textures.c's mmce art classifier
+        // and supportbase.c's sbRename already rely on. ENOENT = the folder is GENUINELY absent ->
+        // return 0 ("readable, no VCDs here"): the caller treats it as an empty scan and arms NO
+        // retry. Every other errno keeps the -1 failure semantics below.
+        if (errno == ENOENT)
+            return 0;
+        // could NOT read the dir (device momentarily unreadable / bus contended). Signal a scan
+        // FAILURE -- distinct from a readable-but-empty dir (opens fine, count 0) -- so the caller
+        // PRESERVES its last-good list instead of blanking it on a transient wedge. Mirrors
+        // scanForISO (the ISO path) -- the #120 fix: the VCD & ISO views share one backing store,
+        // and returning 0 here zeroed BOTH on a contended bus.
+        // MMCE caveat: mmceman's dopen collapses EVERY failure -- including the card's explicit
+        // not-found reply -- into a bare -1 (EE sees EPERM, not ENOENT), so on mmceN: an absent
+        // POPS still lands on this -1 path unless the paired mmceman-fs-dopen-enoent.patch is in
+        // the build (install_coherent_mmce.sh applies it, same doctrine as the fs-open ENOENT
+        // patch behind textures.c's classifier). Without it, MMCE behavior is exactly the old one:
+        // bounded retries, then quiesce -- never worse.
+        return -1;
+    }
 
     vcd_entry_t *list = (vcd_entry_t *)calloc(VCD_MAX_ITEMS, sizeof(vcd_entry_t));
     if (list == NULL) {


### PR DESCRIPTION
## Why

Two small robustness residuals found while auditing #154 against current master (the reported cascade itself is already fixed by post-3093 commits — see the status comment on the issue):

**1. One failed presence probe emptied both game lists.** In Auto slot mode, `mmceSetPrefix` invalidated the slot on a *single* failed presence devctl — and `mmceUpdateGameList` then frees both game lists. A transiently contended SIO2 bus (list scan + art read + MX4SIO traffic sharing it) read as "card pulled", and both lists vanished until the next ~2 s refresh.

**2. No-POPS cards burned the VCD rescan budget.** `vcdScanOpenDir` returned -1 for *both* an absent `POPS/` folder and a contended one, so a card with no POPS folder churned through the bounded retry budget (`MMCE_VCD_SCAN_RETRY_MAX 15`) on every refresh.

## What

- **Presence debounce** (`src/mmcesupport.c`): invalidate only after 3 *consecutive* failed probes, re-probed inline 200 ms apart. Worst case on a genuine pull is ~1.0 s (3× the devctl's own 200 ms timeout + 2 gaps) — still detected on the same pass, while a bus-quiet window absorbs transients. No persistent counter; any success declares the card present.
- **ENOENT split** (`src/vcdsupport.c`): `errno = 0` before `opendir`; `ENOENT` (genuinely absent) → return 0 (empty scan, no retry armed); every other errno keeps the -1 preserve-last-good semantics. errno propagation verified faithful (newlib's `opendir` returns NULL without touching errno, so the glue's `__transform_errno` survives).
- **Paired driver patch** (`.github/patches/mmceman-fs-dopen-enoent.patch`, NEW — force-added past the `*.patch` gitignore like its two siblings): the errno split alone would have been a **no-op on MMCE itself** — `mmce_fs_dopen` collapses every failure, including the card's explicit not-found reply, into a bare -1. The patch makes only the card's explicit invalid-fd reply return `-ENOENT` (timeout/garbled stay -1), same doctrine as the existing fs-open ENOENT patch, wired into `install_coherent_mmce.sh` fail-loud. Without the patch, MMCE degrades to exactly the old behavior — never worse; non-MMCE devices get the split regardless.

## Verification

- ps2dev Docker build green (forced rebuild of both touched objects, zero new warnings), clang-format 12 clean on both C files.
- All three mmceman patches apply cleanly in CI order on a fresh clone of ps2-mmce/mmceman @ db3e93f0; the patched driver compiles (only pre-existing upstream warnings); `install_coherent_mmce.sh` ran end-to-end twice (idempotent).

## Note for HW testing

Genuine-pull detection is now ~1 s instead of instant — inside one refresh cycle, invisible in practice. The flicker this kills (lists briefly vanishing under bus contention) is what to watch for on a Gen2 card.