### PR TITLE
fix(art): restore the official/uOPL art-loading baseline on fast devices (#296/#299)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2245,9 +2245,11 @@ static int endIntro = 0; // Break intro loop and start 'Last Played Auto Start' 
 // sub-second one (fast-USB save, manual refresh, device enable) faded back out before ever becoming
 // perceptible -- the loader was unreachable in practice. The retune: a fast fade-in (full 0x80 in
 // 0x80/BUSY_FADE_IN_STEP = 8 frames, ~133ms; clearly visible in ~4) plus a minimum on-screen latch,
-// so even a ~200ms op is seen for roughly latch + fade-out ~= 1.5s. The TRIGGER is unchanged --
-// ioHasVisiblePendingRequests() only, so quiet background rescans/prefetch still never show it
-// (#290) -- as are the boot suppression below and the slow fade-out.
+// so even a ~200ms op is seen for roughly latch + fade-out ~= 1.5s. The trigger's IO half is
+// unchanged -- ioHasVisiblePendingRequests(), so quiet background rescans never show it (#290) --
+// as are the boot suppression below and the slow fade-out. (The ART half widened to interactive +
+// prefetch in the #296 baseline restore; prefetch bursts only exist post-settle, so this still
+// never flashes at idle.)
 #define BUSY_FADE_IN_STEP    0x10 // alpha per frame while visible work is pending (or latched)
 #define BUSY_FADE_OUT_STEP   0x02 // alpha per frame once done: unchanged, ~64 frames (~1.1s) from full
 #define BUSY_MIN_HOLD_FRAMES 30   // latch: once triggered, stay up at least this many frames (~0.5s @60fps)
@@ -2262,14 +2264,16 @@ static void guiDrawOverlays()
     // presence scan takes a few hundred ms (MMCE SIO2 round-trips), keying the spinner off the raw
     // queue made it fade in "every few seconds" while the console sat idle. Real work -- list
     // loads, config saves, module loads, theme switches -- is still counted.
-    // #299 follow-up: also count pending INTERACTIVE art (the selected item's cover/BG/icon).
-    // Browsing enqueues no IO-queue requests at all -- art loads on the texcache worker -- so
-    // without this the loader could never trigger in the game listings, only on screens that
-    // read per-game config through the queue (the info screen). Interactive-only on purpose:
-    // neighbor prefetch (#296) and quiet background IO must never show the loader (#290), and
-    // during a held scroll the interactive defer gate hasn't enqueued anything yet, so the
-    // loader pulses only once the selection settles and its art is actually loading.
-    int pending = ioHasVisiblePendingRequests() || cacheHasPendingInteractiveArt();
+    // #299 follow-up: also count pending art (covers/BG/icons). Browsing enqueues no IO-queue
+    // requests at all -- art loads on the texcache worker -- so without this the loader could
+    // never trigger in the game listings, only on screens that read per-game config through the
+    // queue (the info screen).
+    // #296 baseline restore: count ALL art (interactive + prefetch), not just interactive -- this
+    // mirrors official OPL, whose loader trigger is "IO queue non-empty" with ALL art on that
+    // queue. This does NOT resurrect the idle-flash #290 killed: prefetch bursts only exist
+    // post-settle (the walk runs once navigation stops), so the loader pulses while art is
+    // genuinely loading, and quiet background rescans stay excluded via ioHasVisiblePendingRequests.
+    int pending = ioHasVisiblePendingRequests() || cacheHasPendingArt();
 
     // During the boot intro, when an animated boot logo is shown, suppress the
     // loading spinner -- the animated logo is the boot activity indicator there.

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1595,8 +1595,12 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
             entry->value != NULL && strcmp(entry->value, value) == 0) {
             switch (entry->state) {
                 case CACHE_ENTRY_QUEUED:
-                    if (priority == CACHE_REQ_PRIORITY_INTERACTIVE && entry->qr != NULL)
+                    if (priority == CACHE_REQ_PRIORITY_INTERACTIVE && entry->qr != NULL) {
                         cachePromoteQueuedRequestLocked((load_image_request_t *)entry->qr);
+                        /* Same yield as the by-value path below: the promoted cover must not
+                         * queue behind an unrelated in-flight prefetch read. */
+                        cacheYieldInFlightPrefetchLocked();
+                    }
                     cacheUnlock();
                     return NULL;
                 case CACHE_ENTRY_LOADING:

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -599,6 +599,24 @@ static void cacheEnqueueRequestLocked(load_image_request_t *req)
         req->cache->queuedPrefetchRequests++;
 }
 
+/* Speculative work always yields to real demand: when INTERACTIVE demand arrives while a
+ * prefetch read is in flight, flag that read for abort so the selected item's cover does not
+ * queue behind up to a whole cover read it never asked for. This is the #296 patterned ~1 s
+ * stall (Beta-3457, zackcage6): #297's settle-triggered prefetch bursts monopolized the single
+ * art worker exactly when the user was most likely to tap again, in-flight USB reads were not
+ * preemptible (the MMCE abort sweeps don't cover fast modes), and the burst re-armed each time
+ * the cursor exited the warmed +/-4 window -- i.e. every ~5 items. Both readers check
+ * texLoadAbortRequested() between chunks, so the yield lands within one read chunk (~32 KB).
+ * A same-value in-flight prefetch never reaches here (the loading-entry path returns first),
+ * and an aborted prefetch is safe by construction: ERR_LOAD_ABORTED clears the entry and the
+ * walk re-requests it at the next settle. Mode-agnostic on purpose: prefetch is by definition
+ * speculative on every backend. */
+static void cacheYieldInFlightPrefetchLocked(void)
+{
+    if (gArtCurrentReq != NULL && gArtCurrentReq->priority == CACHE_REQ_PRIORITY_PREFETCH)
+        gArtCurrentReq->abortRequested = 1;
+}
+
 static int cacheRemoveQueuedRequestLocked(load_image_request_t *target)
 {
     load_image_request_t *req = *cacheGetQueueHead(target->priority);
@@ -1687,6 +1705,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     if (req != NULL && req->entry != NULL) {
         if (priority == CACHE_REQ_PRIORITY_INTERACTIVE) {
             cachePromoteQueuedRequestLocked(req);
+            cacheYieldInFlightPrefetchLocked();
             if (!cacheShouldDeferInteractiveArtOnInputMode(effectiveMode))
                 wakeWorker = 1;
         }
@@ -1805,6 +1824,8 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
 
     cache->activeRequests++;
     cacheEnqueueRequestLocked(req);
+    if (req->priority == CACHE_REQ_PRIORITY_INTERACTIVE)
+        cacheYieldInFlightPrefetchLocked();
     cacheUnlock();
 
     cacheWakeWorker();

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -449,6 +449,19 @@ static int cacheGetInteractiveDelay(const item_list_t *list, int mode)
             return 0;
     }
 
+    // #296/#299 baseline restore: fast devices (USB/ETH, and any list-less caller) get NO
+    // interactive settle -- fire the art request on draw, mid-hold-scroll included. This is
+    // official OPL's behaviour: upstream texcache.c gates on guiInactiveFrames < list->delay
+    // with the delay DEFAULTING TO 0 (the *_frames_delay config keys are unset by default),
+    // and uOPL feels instant for the same reason. cacheGetBaseDelay's 8-frame floor
+    // (MENU_MIN_INACTIVE_FRAMES) was built for slow devices, so the slow-mode protections
+    // below stay untouched: MMCE keeps its floor/cap, APP its caps, and HDD keeps the floor
+    // (its spin-up reads contend with the GUI far worse than BDM USB). Fail-storm protection
+    // is unaffected (epoch fail memos) and duplicate requests still dedup via
+    // cacheFindQueuedRequestLocked.
+    if (mode != MMCE_MODE && mode != APP_MODE && mode != HDD_MODE)
+        return 0;
+
     if ((mode == APP_MODE || mode == MMCE_MODE) && delay < CACHE_SLOW_MODE_INTERACTIVE_DELAY)
         delay = CACHE_SLOW_MODE_INTERACTIVE_DELAY;
 

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -387,7 +387,13 @@ static int cacheGetPrefetchLimit(const image_cache_t *cache)
     if (cache == NULL || cache->count <= 1)
         return 0;
 
-    return cache->count - 1 < 4 ? cache->count - 1 : 4;
+    // #296 walk/cap consistency: drawCoverFlow's idle prefetch walks +/-(count-1)/2 covers --
+    // 8 requests on the 10-slot COV cache -- so a cap of 4 silently dropped the far half of
+    // every walk (the +/-3 and +/-4 covers never queued, then re-missed when the user stepped
+    // again). Size the cap to the walk: count-1 admits the whole warmed window (walk + the
+    // visible selection still fits the slots, so the LRU never has to evict a visible cover --
+    // the #297 anti-thrash invariant), and the 8 ceiling bounds the queue for larger caches.
+    return cache->count - 1 < 8 ? cache->count - 1 : 8;
 }
 
 static int cacheGetEffectiveMode(const item_list_t *list, const char *value)

--- a/src/textures.c
+++ b/src/textures.c
@@ -125,6 +125,11 @@ static int maxSize = 720 * 512 * 4;
 // crossing the watchdog. A one-shot getStat+single-read is rejected for the same reason.
 #define TEX_MMCE_STAGE_READ_SIZE 32768
 
+// Hard cap on the staged payload. Legitimate art is <= a few MB even at 1080p; anything bigger is
+// corrupt or misplaced content, and letting the doubling buffer chase it would eat the 32 MB EE
+// RAM before malloc can fail (CodeRabbit review of #306 -- vetted, accepted).
+#define TEX_STAGE_MAX_SIZE (8 * 1024 * 1024)
+
 typedef struct
 {
     int id;
@@ -431,13 +436,13 @@ static int texShouldUseMemoryReader(const char *filePath)
     return filePath != NULL && (!strncmp(filePath, "mmce0:", 6) || !strncmp(filePath, "mmce1:", 6) || !strncmp(filePath, "mass", 4));
 }
 
-static int texStageExternalFileIntoMemory(int fd, void **buffer, int shortReadIsEof)
+static int texStageExternalFileIntoMemory(int fd, void **buffer, u32 *stagedSize, int shortReadIsEof)
 {
     int bytesRead = 0;
     int capacity;
     unsigned char *fileBuffer;
 
-    if (buffer == NULL)
+    if (buffer == NULL || stagedSize == NULL)
         return ERR_FILE_IO;
 
     // Do NOT size the file with lseek(SEEK_END) first: the MMCE newlib device (mmceman) does not
@@ -461,7 +466,17 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer, int shortReadIs
         }
 
         if (capacity - bytesRead < TEX_MMCE_STAGE_READ_SIZE) {
-            unsigned char *grown = realloc(fileBuffer, capacity * 2);
+            unsigned char *grown;
+
+            if (capacity >= TEX_STAGE_MAX_SIZE) {
+                // Over the staged-payload cap: not art anyone ships, and NOT transient -- memo it
+                // absent like any other broken file or every generation re-reads 8 MB of garbage.
+                LOG("texStage: refusing oversized art file (> %d bytes staged)\n", TEX_STAGE_MAX_SIZE);
+                free(fileBuffer);
+                return ERR_BAD_FILE;
+            }
+
+            grown = realloc(fileBuffer, capacity * 2);
             if (grown == NULL) {
                 free(fileBuffer);
                 return ERR_FILE_IO;
@@ -499,6 +514,7 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer, int shortReadIs
     }
 
     *buffer = fileBuffer;
+    *stagedSize = (u32)bytesRead;
     return 0;
 }
 
@@ -702,7 +718,8 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
 
             // mmceman's short-read==EOF guarantee (see the staging function) is MMCE-only; BDM
             // mass must stage until a real result==0 EOF.
-            result = texStageExternalFileIntoMemory(fd, &pFileBuffer, !strncmp(filePath, "mmce", 4));
+            u32 stagedSize = 0;
+            result = texStageExternalFileIntoMemory(fd, &pFileBuffer, &stagedSize, !strncmp(filePath, "mmce", 4));
 
             close(fd);
             fd = -1;
@@ -710,9 +727,16 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
                 LOG("texLoadAll: failed to stage file %s\n", filePath);
                 return result;
             }
-            PngFileBufferPtr = pFileBuffer;
-            readData = &PngFileBufferPtr;
-            readFunction = &texReadMemFunction;
+            // Decode through the BOUNDED memory reader, not texReadMemFunction's raw memcpy: the
+            // staged buffer is user-supplied media and may be truncated/corrupt, and libpng keeps
+            // requesting bytes until it has a full stream -- an unbounded reader would walk past
+            // the staged allocation (CodeRabbit review of #306; pre-existing on the MMCE arm since
+            // the staging path landed, this PR only widened the exposure to USB). Over-read here
+            // png_errors -> the setjmp cleanup below frees the texture, same as the tar arm.
+            memReader.ptr = (const u8 *)pFileBuffer;
+            memReader.remaining = stagedSize;
+            readData = &memReader;
+            readFunction = &texReadMemBoundedFunction;
         } else {
             fd = open(filePath, O_RDONLY, 0);
             if (fd < 0) {

--- a/src/textures.c
+++ b/src/textures.c
@@ -3,7 +3,7 @@
 #include "include/textures.h"
 #include "include/util.h"
 #include "include/ioman.h"
-#include <errno.h> // errno/ENOENT in the mmce staging-arm open classifier (transitively via opl.h, but be explicit)
+#include <errno.h> // errno/ENOENT in the staging-arm open classifier (transitively via opl.h, but be explicit)
 #include <kernel.h>
 #include <png.h>
 
@@ -111,7 +111,8 @@ extern void *case_overlay_png;
 
 // Not related to screen size, just to limit at some point
 static int maxSize = 720 * 512 * 4;
-// Per-read() chunk for staging an MMCE cover into RAM. Each read() is one COMPLETE mmceman FS RPC
+// Per-read() chunk for staging an MMCE or BDM-mass cover into RAM. Each MMCE read() is one
+// COMPLETE mmceman FS RPC
 // over the shared SIO2 channel (command handshake + bulk DMA + trailer + a card-side seek/read-ahead
 // prime), and mmceman has NO read-size cap (its length field is a full 32 bits), so a big chunk is
 // served in ONE RPC. At 4 KB a ~100 KB cover cost ~25 RPCs; 32 KB serves it in ~4 -- an ~8x cut in
@@ -421,10 +422,16 @@ static void texReadFileFunction(png_structp pngPtr, png_bytep data, png_size_t l
 
 static int texShouldUseMemoryReader(const char *filePath)
 {
-    return filePath != NULL && (!strncmp(filePath, "mmce0:", 6) || !strncmp(filePath, "mmce1:", 6));
+    // #296 baseline restore: stage BDM USB/MX4SIO art ("massN:" and the bare "mass:") whole-file
+    // into RAM too, not just MMCE. uOPL/official read each cover in ONE transfer; our streaming
+    // reader pays one read() RPC per small chunk DURING decode (texReadFileFunction), so USB
+    // covers decode at chunk granularity. One staged read per cover is uOPL's single biggest USB
+    // win. HDD (pfs:) and ETH (smb:) keep the streaming reader: different perf profiles, no
+    // evidence staging helps there.
+    return filePath != NULL && (!strncmp(filePath, "mmce0:", 6) || !strncmp(filePath, "mmce1:", 6) || !strncmp(filePath, "mass", 4));
 }
 
-static int texStageExternalFileIntoMemory(int fd, void **buffer)
+static int texStageExternalFileIntoMemory(int fd, void **buffer, int shortReadIsEof)
 {
     int bytesRead = 0;
     int capacity;
@@ -435,10 +442,11 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
 
     // Do NOT size the file with lseek(SEEK_END) first: the MMCE newlib device (mmceman) does not
     // support SEEK_END, so it returned <= 0 and EVERY MMCE cover failed here with ERR_BAD_FILE (ISO
-    // and VCD alike) while USB -- which streams via read() only -- worked. Grow a heap buffer as we
-    // read the file sequentially (read()-only, the same access the working USB reader uses) and stop
-    // at EOF, so no up-front file length is needed. We keep the bulk-into-RAM staging (the reason this
-    // path exists: MMCE streaming reads during decode are unreliable) -- only the size probe changes.
+    // and VCD alike) while USB -- which streamed via read() only -- worked. Grow a heap buffer as we
+    // read the file sequentially (read()-only, the same access the old USB streaming reader uses)
+    // and stop at EOF, so no up-front file length is needed. We keep the bulk-into-RAM staging
+    // (the reason this path exists: MMCE streaming reads during decode are unreliable, and USB
+    // streaming pays one read() RPC per chunk -- #296) -- only the size probe changes.
     capacity = TEX_MMCE_STAGE_READ_SIZE * 2; // 64 KB; doubles on demand for larger covers
     fileBuffer = malloc(capacity);
     if (fileBuffer == NULL)
@@ -469,14 +477,19 @@ static int texStageExternalFileIntoMemory(int fd, void **buffer)
         }
         bytesRead += result;
 
-        // A SHORT read means EOF here -- break without the extra read()==0 RPC (and the buffer
-        // realloc it would trigger). This is safe ONLY because of how mmceman serves an FS read
-        // (verified against ps2-mmce/mmceman mmce_fs_read + mmce_sio2_rx_mixed @ db3e93f0): the card
-        // always transfers the FULL requested size on the wire and reports the valid byte count
-        // separately, and any mid-transfer stall returns -1 (handled above) -- never a partial
-        // positive count. So result<SIZE is only ever the card's file running out, i.e. EOF; there
-        // is no "short now, more later" case. Do NOT copy this short==EOF break to a non-mmce reader.
-        if (result < TEX_MMCE_STAGE_READ_SIZE)
+        if (result == 0)
+            break; // real EOF, every device
+
+        // For MMCE a SHORT read also means EOF -- break without the extra read()==0 RPC (and the
+        // buffer realloc it would trigger). This is safe ONLY because of how mmceman serves an FS
+        // read (verified against ps2-mmce/mmceman mmce_fs_read + mmce_sio2_rx_mixed @ db3e93f0):
+        // the card always transfers the FULL requested size on the wire and reports the valid byte
+        // count separately, and any mid-transfer stall returns -1 (handled above) -- never a
+        // partial positive count. So result<SIZE is only ever the card's file running out, i.e.
+        // EOF; there is no "short now, more later" case. Non-mmce readers (BDM mass, gated by the
+        // caller's shortReadIsEof) make no such guarantee, so they keep reading until the
+        // result==0 EOF above instead of breaking on a short count.
+        if (shortReadIsEof && result < TEX_MMCE_STAGE_READ_SIZE)
             break;
     }
 
@@ -671,21 +684,25 @@ static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId, const
             fd = open(filePath, O_RDONLY, 0);
             if (fd < 0) {
                 // Memoize as PERMANENTLY absent (ERR_BAD_FILE -> the fail-epoch memo) only on a real
-                // ENOENT. This is the MMCE staging arm, and mmceman used to return ONE bare -1 for six
-                // different open failures -- fd-pool exhausted, three packet timeouts, a garbled reply,
-                // AND the card's genuine not-found -- so a rapid-nav contention storm branded every
-                // browsed game's art "nonexistent" for the whole session (HW batch S3: art dies, never
-                // recovers). The paired mmceman patch makes the driver return -ENOENT only for the
-                // card's explicit not-found reply; every other failure lands in the EXISTING transient
-                // lane (ERR_FILE_IO, re-probed lazily once per generation) so art self-heals when the
-                // bus quiets. If the newlib glue ever maps errno unfaithfully, the degradation is a
-                // bounded once-per-generation re-probe -- never a hard failure. The generic loose-file
-                // branch below keeps its unconditional ERR_BAD_FILE (BDM/HDD semantics unchanged).
-                LOG("texLoadAll: mmce art open failed: %s (errno %d)\n", filePath, errno);
+                // ENOENT. This is the MMCE/USB staging arm, and mmceman used to return ONE bare -1
+                // for six different open failures -- fd-pool exhausted, three packet timeouts, a
+                // garbled reply, AND the card's genuine not-found -- so a rapid-nav contention storm
+                // branded every browsed game's art "nonexistent" for the whole session (HW batch S3:
+                // art dies, never recovers). The paired mmceman patch makes the driver return
+                // -ENOENT only for the card's explicit not-found reply; every other failure lands in
+                // the EXISTING transient lane (ERR_FILE_IO, re-probed lazily once per generation) so
+                // art self-heals when the bus quiets. The same self-heal applies to BDM USB (#296):
+                // a contended-bus open failure there must not brand the cover absent either. If the
+                // newlib glue ever maps errno unfaithfully, the degradation is a bounded
+                // once-per-generation re-probe -- never a hard failure. The generic loose-file
+                // branch below keeps its unconditional ERR_BAD_FILE (HDD/ETH semantics unchanged).
+                LOG("texLoadAll: staged art open failed: %s (errno %d)\n", filePath, errno);
                 return (errno == ENOENT) ? ERR_BAD_FILE : ERR_FILE_IO;
             }
 
-            result = texStageExternalFileIntoMemory(fd, &pFileBuffer);
+            // mmceman's short-read==EOF guarantee (see the staging function) is MMCE-only; BDM
+            // mass must stage until a real result==0 EOF.
+            result = texStageExternalFileIntoMemory(fd, &pFileBuffer, !strncmp(filePath, "mmce", 4));
 
             close(fd);
             fd = -1;

--- a/src/themes.c
+++ b/src/themes.c
@@ -1133,6 +1133,17 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
 
     GSTEXTURE *centerTexture = NULL; // the selection's LOADED art, if any -- gates the neighbor prefetch below
 
+    // #296 baseline restore: the left->right draw loop below doubles as the interactive ENQUEUE
+    // order (getGameImageTexture queues a request on a cache miss), so on a cold settle the
+    // SELECTED cover used to load 2nd/3rd, behind its left neighbours. Fire the selection's
+    // request FIRST; the loop's own call for the center then dedups against the queued request
+    // (cacheFindQueuedRequestLocked), so nothing else about draw or queue behaviour changes.
+    if (covers[centerIdx]) {
+        mutable_image_t *centerImg = (mutable_image_t *)thmGetElemForItem(menu, covers[centerIdx], elem)->extended;
+        if (centerImg)
+            getGameImageTexture(centerImg->cache, sourceList, &covers[centerIdx]->item);
+    }
+
     for (i = drawFirst; i < drawLast; i++) {
         if (!covers[i])
             continue;


### PR DESCRIPTION
Restores the official/uOPL art-loading baseline on fast devices. Closes the remaining #296 lag mechanism and the #299 loader-trigger gap.

## Diagnosis (three-way code comparison: upstream OPL @ 3e3f34e9, uOPL @ 9fe0ae6d, ours)

- **Official OPL**: one settle gate (`guiInactiveFrames < list->delay`) with delay **defaulting to 0**; busy icon = "IO queue non-empty" with **all** art on that queue; one whole-file `read()` per image.
- **uOPL**: same shape — no defer on fast media, instant selection step, whole-file reads. That recipe is its "feels instant."
- **Ours**: ~25 gates accreted for slow devices (MMCE/APP), several of which also throttle fast ones (USB/ETH). This PR removes exactly those, and only those.

## Commits (independently revertable)

1. **`5afda005` texcache** — fast devices (USB/ETH) skip the 8-frame interactive settle entirely (`cacheGetInteractiveDelay` returns 0 unless resolved mode is MMCE/APP/HDD). This is the big one: on USB the art request now fires on draw, mid-hold-scroll included — official's delay-0 behavior.
2. **`8253c423` themes** — coverflow enqueues the **selected** cover's art first instead of left→right (was loading 2nd/3rd on a cold settle).
3. **`31bd8cf9` texcache** — prefetch cap 4 → `min(count-1, 8)` so the ±4 coverflow walk (8 requests on the 10-slot COV cache) isn't half-dropped; the #297 anti-thrash invariant (never evict a visible cover) still holds.
4. **`28aa3210` textures** — BDM USB/MX4SIO art staged whole-file into RAM (the previously MMCE-only growable-buffer reader) instead of small-buffer streaming during decode — uOPL's single biggest USB win. mmceman's short-read==EOF assumption stays MMCE-only; mass reads to a real EOF. HDD/ETH keep the streaming reader.
5. **`3fa104c0` gui** — loader trigger counts prefetch art too (`cacheHasPendingArt()`), mirroring official's "queue non-empty = all art". Quiet background rescans stay excluded (#290 intact); prefetch bursts only exist post-settle, so no idle-flash.
6. **`2e104317` texcache** — in-flight prefetch reads **yield to interactive demand**. Static root cause of zackcage6's Beta-3457 patterned ~1 s stall (every ~5 items): the 3449→3457 window contains only three functional PRs — #294 (probes now need 60 idle frames; cannot fire mid-nav) and #295 (pad self-heal needs 1000 ms of no input; cannot fire mid-nav) are exonerated by construction. #297's settle-triggered prefetch bursts are the only in-window machinery that runs *during* navigation on USB. Each burst monopolized the single art worker right when the user was most likely to tap again, and in-flight USB reads were not preemptible (only MMCE had abort sweeps) — so every new cover queued behind up to one full cover read, repeating each time the cursor exited the warmed ±4 window. Now an interactive arrival flags the in-flight prefetch for abort; both readers checkpoint the abort flag between ~32 KB chunks, so the yield lands within one read.

**Deliberately NOT changed**: art worker priority (64 → 30 would restore uOPL burst scheduling, but it's the #271 anti-hitch choice and the highest-risk knob — deferred pending HW feedback on this PR).

## Verification

- Docker build green (`make download_lng download_lwNBD && make -j8 languages && make -j8 opl.elf`), forced rebuild of all four touched objects, zero new warnings.
- clang-format 12.0.1 (CI binary) clean on all touched files.
- Code-level: MMCE/APP/HDD paths traced unchanged (steps 1/4 gate them out explicitly).

## HW validation wanted (post-merge)

- **@zackcage6** (#296): continuous coverflow scroll on USB — covers should lead/track the cursor, not trail; steady 2-3 taps/sec; held-scroll then release should land center-first.
- **@PixeliGer** (#299): loader should now appear in the main listings during art load, like the info screen already does.

Refs #296, #299.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Center cover’s artwork is now queued first to appear sooner when browsing.
  * Enhanced staging-based texture loading with stricter bounds and better device-agnostic handling of partial reads.

* **Bug Fixes**
  * Loader visibility now reflects all pending artwork more accurately, reducing unnecessary idle-flash.
  * Improved interactive responsiveness via adjusted prefetch limits, reduced interactive settle delays for non-interactive modes, and fairer prefetch behavior during interactive demand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

