### PR TITLE
fix(nbd): skip the RPC network teardown on unload; the IOP reboot supersedes it (#307)

### DIFF
--- a/include/ethsupport.h
+++ b/include/ethsupport.h
@@ -17,6 +17,7 @@ typedef struct
 
 void ethInit(item_list_t *itemList); // Full initialization (Start ETH + SMB and apply configuration). GUI must be already initialized, used by GUI to start SMB mode.
 void ethDeinitModules(void);         // Module-only deinitialization, without the GUI's knowledge (for specific reasons, otherwise unused).
+void ethInvalidateModules(void);     // Bookkeeping-only deinit for paths that immediately reboot the IOP (NBD unload): the IOP reset wipes the stack, so no RPC teardown is needed (or safe, #307).
 int ethLoadInitModules(void);        // Initializes Ethernet and applies configuration.
 int ethGetModulesLoaded(void);       // 1 if the SMB NIC stack is loaded (UDPBD must not load on top).
 void ethDisplayErrorStatus(void);    // Displays the current error status (if any). GUI must be already initialized.

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -359,6 +359,21 @@ void ethDeinitModules(void)
     }
 }
 
+// Bookkeeping-only deinit for teardown paths that IMMEDIATELY reboot the IOP (unloadLwnbdSvr ->
+// reset -> sysReset -> SifIopReset). The IOP reboot wipes netman/smap/ps2ip/ps2ips/lwnbdsvr
+// outright, so ethDeinitModules' graceful RPC teardown is redundant there -- and it is also the
+// only part of that path that can deadlock: after a FAILED network bring-up (no cable, no link,
+// no DHCP -- issue #307) NetManDeinit/ps2ip_deinit can park the EE on a SIF reply the
+// half-configured stack never sends, freezing the console (pads dead, hard reset required).
+// Skip the RPC calls entirely and just clear the EE-side state. ethInitSemaID is an EE kernel
+// object -- it survives the IOP reboot and ethInitSema() reuses it, so it is deliberately kept.
+// ethReadNetConfig's sync is pointless here: NBD never reconfigures the interface.
+void ethInvalidateModules(void)
+{
+    ethModulesLoaded = 0;
+    gNetworkStartup = ERROR_ETH_NOT_STARTED;
+}
+
 int ethLoadInitModules(void)
 {
     int ret;

--- a/src/opl.c
+++ b/src/opl.c
@@ -2718,7 +2718,11 @@ static int loadLwnbdSvr(void)
 
 static void unloadLwnbdSvr(void)
 {
-    ethDeinitModules();
+    // Bookkeeping-only (#307): reset() below reboots the IOP (sysReset -> SifIopReset), which
+    // wipes the whole network stack regardless -- and the graceful RPC teardown in
+    // ethDeinitModules is exactly what wedges after a failed offline bring-up (no cable/link),
+    // freezing the console before the reset is ever reached.
+    ethInvalidateModules();
     unloadPads();
 
     reset();


### PR DESCRIPTION
Fixes #307 — NBD server unload freezes the console (pads dead, hard reset required) when the network was never up (`mass:` only, no Ethernet cable). Also reproducible in uOPL, per the reporter — this is shared-lineage code, no upstream fix exists ([upstream #1012](https://github.com/ps2homebrew/Open-PS2-Loader/issues/1012) is the related online variant).

## Root cause (static analysis)

Offline, `loadLwnbdSvr()` loads netman/smap/ps2ip, `ethInitApplyConfig()` fails the link wait (30 s), and the atad/lwnbdsvr modules never load — the stack is **half-configured**. When the flow then unloads, `ethDeinitModules()` runs its graceful RPC teardown (`NetManDeinit()` / `ps2ip_deinit()`) against that state, and the EE parks on a SIF reply the stack never sends: total freeze.

The kicker: `unloadLwnbdSvr()` calls `reset()` → `sysReset()` → `SifIopReset` **immediately after** — a full IOP reboot that wipes the entire network stack regardless. The graceful RPC deinit was redundant on this path the whole time, and it was the only component that could deadlock.

## Fix

`unloadLwnbdSvr()` now calls the new `ethInvalidateModules()` — EE bookkeeping only (`ethModulesLoaded`, `gNetworkStartup`), zero RPC calls; the IOP reboot does the real teardown.

- `ethInitSemaID` is an EE kernel object — survives the IOP reboot, reused by `ethInitSema()`, deliberately kept.
- `ethReadNetConfig()`'s sync is skipped here on purpose: NBD never reconfigures the interface.
- All other `ethDeinitModules()` callers (SMB etc.) keep the full graceful path — only the about-to-reboot-the-IOP path changes.

## Verification

- Docker build green; forced rebuild of `obj/opl.o` + `obj/ethsupport.o`, zero new warnings.
- clang-format 12.0.1 clean on all touched files.
- Code-level: offline flow traced — load fails link wait → STARTFAIL msgbox → unload now does bookkeeping + IOP reset; no RPC to the half-configured stack anywhere in the path. Online stop-server flow unchanged in end state (IOP reset kills the stack either way).

HW check wanted post-merge (reporter, SCPH-300001R): boot offline, enable NBD, get the start-fail message, confirm return to menu without freeze.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network module handling during immediate IOP restarts.
  * Prevented potential stalls when unloading the NBD server by recording Ethernet modules as inactive before reset.
  * Ensured network startup state is correctly reset after a restart-triggered teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->