### PR TITLE
fix(gui): step the debug HUD aside during coverflow slides

### DIFF
--- a/include/themes.h
+++ b/include/themes.h
@@ -179,6 +179,7 @@ extern theme_t *gTheme;
 
 extern int gCoverflowCount, gCoverflowCenterScale, gCoverflowAnimSpeed, gCoverflowDimCovers;
 void thmTriggerCoverflowAnim(int dir);
+int thmCoverflowIsAnimating(void);
 
 void thmInit(void);
 void thmReinit(const char *path);

--- a/src/gui.c
+++ b/src/gui.c
@@ -2370,7 +2370,12 @@ static void guiDrawOverlays()
     // debug info), no special build. Rendered here on the EE main thread every frame, independent of the
     // (possibly wedged) art worker, reading plain volatile counters -> zero MMCE-bus traffic. TK > 0 is
     // the smoking gun (art watchdog corrupted the shared RPC channel).
-    if (gEnableDebug) {
+    // Gate on coverflow slides: each line below binds the font atlas through gsKit's TexManager
+    // every frame (fntRenderString -> rmDrawQuad -> gsKit_TexManager_bind), and on a near-saturated
+    // 4 MB VRAM arena those binds evict cover textures mid-slide, causing a rolling evict/re-upload
+    // ping-pong and a visible pop/jump of covers during the wall-clock animation. The HUD the fork
+    // ships stays live at rest and during list-mode navigation; it only steps aside during slides.
+    if (gEnableDebug && !thmCoverflowIsAnimating()) {
         char diag[128];
         snprintf(diag, sizeof(diag), "#120 AO:%u MH:%u MM:%u TK:%u Vp:%u Ip:%u SE:%d",
                  gDiag.artOpens, gDiag.memoHit, gDiag.memoMiss, gDiag.artTerminate,

--- a/src/themes.c
+++ b/src/themes.c
@@ -1009,6 +1009,13 @@ void thmTriggerCoverflowAnim(int dir)
     cfAnimStartTime = clock();
 }
 
+// Exposes the slide state so per-frame diagnostic overlays (gui.c guiDrawOverlays) can step
+// aside mid-slide; see the gate there for the VRAM/TexManager rationale.
+int thmCoverflowIsAnimating(void)
+{
+    return cfIsAnimating;
+}
+
 static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
 {
     if (!item)


### PR DESCRIPTION
## What this is

A mitigation for the coverflow carousel glitch that tester **zackcage6** reported in connection with the **Debug Colors** (debug info) toggle.

**Full candor up front:** the original report could not be located on GitHub (most likely it was on Discord), and the glitch was **never reproduced in-house**. This PR does not claim to be a confirmed fix — it removes the most plausible mechanism identified by a source-level investigation, with the evidence cited below.

## Mechanism (leading hypothesis)

1. Settings → Debug Colors sets `gEnableDebug` (`src/opl.c:223`, declared `include/opl.h:299`). With it on, `guiDrawOverlays` (`src/gui.c:2373`) renders three diagnostic text lines **every frame**.
2. Each line goes `fntRenderString` → per-glyph `rmDrawQuad` → `gsKit_TexManager_bind` of the font atlas (`src/fntsys.c:511`, `src/renderman.c:371-387`).
3. The coverflow renderer `drawCoverFlow` (`src/themes.c:1012`) runs a wall-clock cubic ease-out slide and binds ~10 cover textures per frame plus reflection strips (`src/renderman.c:407-440`). VRAM is 4 MB (`src/renderman.c:15`) and the gsKit TexManager arena is near-saturated during slides.
4. So while a slide is in flight, the overlay's per-frame font-atlas binds can evict cover textures from the arena → rolling evict/re-upload ping-pong → visible pop/jump of covers during the animation, plus frame-budget theft. This matches the report: the glitch appears exactly when the toggle is flipped on.

## Change

- New accessor `thmCoverflowIsAnimating()` in `src/themes.c` (returns the file-static `cfIsAnimating` slide flag), declared in `include/themes.h`.
- `guiDrawOverlays` in `src/gui.c` now skips the three `gEnableDebug` diagnostic lines while a coverflow slide is animating. The diagnostic HUD this fork ships is **fully live at rest and during list-mode navigation** — it only steps aside for the duration of a carousel slide.
- The `dia.c` dialog MISS line is intentionally untouched (settings dialogs never show the carousel).

Net diff: 3 files, +14/-1.

## Alternative unverified hypothesis

A second plausible root cause was noted but **not** addressed here: any settings **Save** runs `applyConfig` → `cacheInvalidateFailMemo` + `initAllSupport(0)`, i.e. a full device re-init. The tester may have associated the glitch with the toggle simply because that was the setting he flipped before saving. If hardware testing shows this PR does not resolve the glitch, that save-path re-init is the next place to look.

## Testing

- Built clean in the `oplbuild` docker container: full `make opl.elf` plus an incremental `obj/gui.o`/`obj/themes.o` rebuild and relink — **zero new warnings**.
- clang-format12 (`--style=file`) reports **zero** required replacements on all three touched files.

## Request

@zackcage6 — could you confirm on hardware whether the carousel still glitches with Debug Colors enabled on this build? The change is zero-risk either way: the debug HUD is unaffected at rest, so merging is safe even if the root cause turns out to be the settings-save path instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debug diagnostic information is now hidden while Coverflow transitions are animating, preventing visual overlap or distraction.
  * Diagnostics remain visible when debug mode is enabled and no Coverflow transition is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->