### PR TITLE
fix(pad): count miss bursts as activity so the analog self-heal can't fire mid-navigation (#272)

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -1115,7 +1115,12 @@ int readPads()
     // Stamp input activity AFTER the merge: any button or stick held this poll re-arms the
     // self-heal idle gate. One-poll staleness inside readPad (it reads the previous stamp) is
     // irrelevant at a 1000 ms threshold.
-    if (paddata != 0)
+    // #272: an active miss burst (streak != 0) counts as activity too -- same "a miss is unknown,
+    // not released" principle the delaycnt pause uses. Without it, a burst outlasting the 48 ms
+    // carry drops the held bits out of paddata while the user is still tapping, the stamp goes
+    // stale, and after 1 s of this registered-input starvation the idle gate opens and readPad()
+    // runs initializePad() INLINE on the GUI thread -- a 250-600 ms blackout that eats every tap.
+    if (paddata != 0 || streak != 0)
         lastInputActivityMs = curtime;
 
     // Expire any rumble tap. Deliberately ms-based off time_since_last rather than a frame counter:

--- a/src/sound.c
+++ b/src/sound.c
@@ -305,8 +305,12 @@ void sfxPlay(int id)
             cursorChannelIndex = (cursorChannelIndex + 1) % CURSOR_SFX_CHANNEL_COUNT;
             channel = sfxGetCursorChannel(chosenSlot);
 
-            // Cut off any prior cursor tick tails so the next navigation sound feels immediate.
-            sfxSetCursorChannelsVolume(0);
+            // Cut off the tail on the one channel about to be reused so the next navigation sound
+            // feels immediate. #272: do NOT sweep all six rotation channels here -- every
+            // audsrv_adpcm_set_volume_and_pan is a blocking SIF RPC, so the sweep made each scroll
+            // step issue ~8 RPCs on the GUI thread. Zeroing only the reused channel (whose old
+            // sample is being cut anyway) plus the volume set and the play is 3.
+            audsrv_adpcm_set_volume_and_pan(channel, 0, 0);
             audsrv_adpcm_set_volume_and_pan(channel, gSFXVolume, 0);
             audsrv_ch_play_adpcm(channel, &sfx[id]);
         } else {


### PR DESCRIPTION
Fixes #272.

## Root cause

The settings-menu heaviness and dropped D-pad taps on real hardware are the #295 analog self-heal firing **while the user is mid-navigation**:

1. The #288 read-miss carry deliberately drops held bits out of the global `paddata` once a miss burst outlasts `PAD_READ_CARRY_MS` (48 ms) — a miss is unknown, not held.
2. But `lastInputActivityMs` (the #295 idle-gate stamp) was only updated when `paddata != 0`. So during any miss burst longer than 48 ms — user still holding or tapping — the activity stamp went stale even though input was happening.
3. After ≥1 s of this *registered-input* starvation (`PAD_SELF_HEAL_IDLE_MS`), the idle gate opened and `readPad()` called `initializePad()` **inline on the GUI thread**: 250–600 ms of blocking polled waits, a blackout that eats every tap in it.
4. `PAD_ANALOG_RETRY_DELAY` (≈1 s) re-arms the retry, so while the freepad error-recovery flap persists the blackout repeats about once a second — exactly the reporter's "hangs ~1 s every ~5 items" pattern.
5. PCSX2 never reproduces this because pad reads never miss there; with no miss bursts, `paddata` tracks held buttons faithfully and the stamp never starves.

## Fix

`src/pad.c` (`readPads()`): the activity stamp now also counts an active miss burst as activity:

```c
if (paddata != 0 || streak != 0)
    lastInputActivityMs = curtime;
```

`streak` (longest current consecutive-miss run across pads) is already computed just above for the HUD MB/MX counters. This is the same "a miss is unknown, not released" principle #300 applied to `delaycnt`, extended to the idle gate: while reads are missing we cannot know the user went idle, so the heal must not fire.

**Why it's safe:** the heal still runs on the first genuinely clean 1 s window — the first second with zero misses and zero input re-arms the gate exactly as before. Error-recovery flaps are episodic, so a clean window always arrives; and D-pad navigation works in digital mode the whole time regardless, so deferring the analog heal costs nothing the user can feel. No timing constants were touched.

## Secondary: cursor SFX RPC trim (`src/sound.c`)

`sfxPlay(SFX_CURSOR)` ran `sfxSetCursorChannelsVolume(0)`, sweeping all 6 rotation channels — 6 blocking audsrv SIF RPCs, plus the volume set and the play, i.e. ~8 blocking RPCs on the GUI thread **per scroll step**. Now only the one channel about to be reused is zeroed (its previous sample is being cut anyway; the rotation isolates the other channels' tails): 8 → 3 RPCs per step, no audible behavior change.

## Deliberately deferred

The optional game-list change (feeding `missHeld`/`rcode` into the list view's input path) was investigated and intentionally left out of this PR to keep the diff minimal and reviewable. It's a follow-up candidate if navigation still feels heavy after this lands.

## Verification

- Built in the `oplbuild` container: full `make -j8 opl.elf`, then forced rebuild of `obj/pad.o` + `obj/sound.o` and relink — zero new warnings.
- `clang-format12 --style=file --output-replacements-xml` on both files: 0 replacements.
- **Hardware verification needed.** Reporter: please re-test the settings menu on real hardware with `gEnableDebug` on and watch the HUD counters — SH (self-heal fires) should stay at 0 while scrolling, PT (worst poll period) should stop spiking into the 250–600 ms range, and MX (max miss streak) tells us how long the bursts underneath actually run. If MX stays high but the heaviness is gone, the deferral is doing its job; if SH still climbs mid-scroll, the flap is producing clean-but-wrong reads and we need the deferred follow-up.
