### PR TITLE
refactor(texcache): remove dead prewarm plumbing; ungate HDD art throttling to match official

### DIFF
--- a/include/opl.h
+++ b/include/opl.h
@@ -51,7 +51,6 @@
 // IO type IDs
 #define IO_CUSTOM_SIMPLEACTION    1 // handler for parameter-less actions
 #define IO_MENU_UPDATE_DEFFERED   2
-#define IO_CACHE_LOAD_ART         3 // io call to handle the loading of covers
 #define IO_COMPAT_UPDATE_DEFFERED 4
 
 // Codes have been planned to fit the design of the GUI functions within gui.c.

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -100,10 +100,6 @@ void cacheAdvanceGeneration(void);
 // Drop the genuine-absence art memos (see texcache.c). Call only on a deliberate settings/theme apply.
 void cacheInvalidateFailMemo(void);
 
-/** Advances the failure-retry generation without canceling queued art loads.
- */
-void cacheBumpGeneration(void);
-
 /** Invalidates stale interactive art loads while keeping queued prefetch work.
  */
 void cacheAdvanceGenerationPreservePrefetch(void);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1457,8 +1457,7 @@ void menuHandleInputMain()
 }
 
 // Info-element family for a list: mirrors menuRenderInfo's dispatch (VCD view first -- it also
-// covers the Favourites tab's L3 VCD view -- then FAV/APP, else the games family). Shared with the
-// info-art prewarm so render and prewarm can never pick different families.
+// covers the Favourites tab's L3 VCD view -- then FAV/APP, else the games family).
 //
 // A page-specific info family (VCD / Favourites / Apps) falls back to the theme's OWN games info family
 // when the LOADED theme does not define it -- NEVER to the built-in/baked theme (gTheme is always the

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -455,17 +455,16 @@ static int cacheGetInteractiveDelay(const item_list_t *list, int mode)
             return 0;
     }
 
-    // #296/#299 baseline restore: fast devices (USB/ETH, and any list-less caller) get NO
+    // #296/#299 baseline restore: fast devices (USB/ETH, HDD, and any list-less caller) get NO
     // interactive settle -- fire the art request on draw, mid-hold-scroll included. This is
     // official OPL's behaviour: upstream texcache.c gates on guiInactiveFrames < list->delay
     // with the delay DEFAULTING TO 0 (the *_frames_delay config keys are unset by default),
     // and uOPL feels instant for the same reason. cacheGetBaseDelay's 8-frame floor
     // (MENU_MIN_INACTIVE_FRAMES) was built for slow devices, so the slow-mode protections
-    // below stay untouched: MMCE keeps its floor/cap, APP its caps, and HDD keeps the floor
-    // (its spin-up reads contend with the GUI far worse than BDM USB). Fail-storm protection
+    // below stay untouched: MMCE keeps its floor/cap and APP its caps. Fail-storm protection
     // is unaffected (epoch fail memos) and duplicate requests still dedup via
     // cacheFindQueuedRequestLocked.
-    if (mode != MMCE_MODE && mode != APP_MODE && mode != HDD_MODE)
+    if (mode != MMCE_MODE && mode != APP_MODE)
         return 0;
 
     if ((mode == APP_MODE || mode == MMCE_MODE) && delay < CACHE_SLOW_MODE_INTERACTIVE_DELAY)
@@ -548,14 +547,14 @@ static int cacheIsNavigationActive(void)
     return gNavInputActive;
 }
 
-// Defer interactive cover reads while the user is actively scrolling on the SLOW filesystem
-// backends -- MMCE (SIO2) and APA-HDD (PFS over ATA). Both read art through the single fileXio
-// channel the menu also uses for badge/config IO, so starting a read mid-scroll stalls nav (the
-// "HDD is not very responsive... like the MMCE was" report). USB/exFAT BDM is fast and stays
-// unthrottled. Covers still land once navigation goes idle (the per-value settle below).
+// Defer interactive cover reads while the user is actively scrolling on the MMCE (SIO2)
+// backend: it reads art through the single fileXio channel the menu also uses for badge/config
+// IO, so starting a read mid-scroll stalls nav. USB/exFAT BDM and APA-HDD are fast and stay
+// unthrottled, matching official OPL. Covers still land once navigation goes idle (the
+// per-value settle below).
 static int cacheShouldDeferInteractiveArtOnInputMode(int effectiveMode)
 {
-    if (effectiveMode == MMCE_MODE || effectiveMode == HDD_MODE)
+    if (effectiveMode == MMCE_MODE)
         return cacheIsNavigationActive();
 
     return 0;
@@ -565,10 +564,10 @@ static int cacheShouldDeferInteractiveArtOnInputMode(int effectiveMode)
 static int cacheGetLoadThreadPriority(const load_image_request_t *req)
 {
     if (req != NULL && req->list != NULL) {
-        // MMCE and APA-HDD both read art through the single slow fileXio channel; deprioritize the
+        // MMCE reads art through the single slow fileXio channel; deprioritize the
         // art worker (higher number = lower EE priority) so an in-flight read yields that channel to
         // the priority-30 IO worker's nav-time badge/config reads instead of starving them.
-        if (req->effectiveMode == MMCE_MODE || req->effectiveMode == HDD_MODE)
+        if (req->effectiveMode == MMCE_MODE)
             return CACHE_MMCE_LOAD_THREAD_PRIORITY;
 
         if (req->list->mode == APP_MODE)

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -495,8 +495,8 @@ static int cacheHasPendingInteractiveArtLocked(void)
     return gArtInteractiveReqList != NULL || gArtInteractiveActiveCount > 0;
 }
 
-// Mode checks span BOTH queues: since the info-art prewarm, MMCE-backed requests can sit on the
-// PREFETCH queue too, and every quiesce path (launch, theme swap, config IO) must drain those as well.
+// Mode checks span BOTH queues: MMCE-backed requests can sit on either queue, and every
+// quiesce path (launch, theme swap, config IO) must drain those as well.
 static int cacheHasQueuedModeLocked(int mode)
 {
     load_image_request_t *req;
@@ -521,7 +521,7 @@ static int cacheHasActiveModeLocked(int mode)
 static int cacheIsAbortableMmceRequest(load_image_request_t *req)
 {
     // Any MMCE-backed read is abortable, whatever its queue: the abort flag is polled by the same
-    // 4KB staging loop regardless of priority, and a prewarm PREFETCH read holds the SIO2 bus just
+    // 4KB staging loop regardless of priority, and a PREFETCH read holds the SIO2 bus just
     // like an interactive one.
     return req != NULL && req->effectiveMode == MMCE_MODE;
 }
@@ -902,8 +902,8 @@ static load_image_request_t *cacheDequeueRequest(void)
         if (gArtInteractiveReqEnd == req)
             gArtInteractiveReqEnd = NULL;
     } else if (gArtPrefetchReqList != NULL) {
-        // Same nav-time defer the interactive head gets: a prewarm (or HDD cover) prefetch read
-        // must never START mid-scroll on a slow shared bus.
+        // Same nav-time defer the interactive head gets: a prefetch read on a slow shared
+        // bus must never START mid-scroll.
         if (cacheShouldDeferInteractiveArtOnInputMode(gArtPrefetchReqList->effectiveMode)) {
             cacheUnlock();
             return NULL;
@@ -1336,7 +1336,7 @@ int cacheAbortMmceImageLoadsTimed(int timeoutTicks)
         if (req->effectiveMode == MMCE_MODE)
             cacheDropQueuedRequestLocked(req);
     }
-    // Prewarm can queue MMCE art at PREFETCH priority too -- every quiesce caller (launch, theme
+    // MMCE art can sit at PREFETCH priority too -- every quiesce caller (launch, theme
     // swap, deferred config IO, deinit) needs those off the SIO2 bus just the same.
     for (load_image_request_t *req = gArtPrefetchReqList, *next; req != NULL; req = next) {
         next = req->next;
@@ -1398,13 +1398,6 @@ void cacheInvalidateFailMemo(void)
         gCacheFailEpoch = 1;
     else
         gCacheFailEpoch++;
-    cacheUnlock();
-}
-
-void cacheBumpGeneration(void)
-{
-    cacheLock();
-    cacheNextGenerationLocked();
     cacheUnlock();
 }
 
@@ -1486,8 +1479,8 @@ void cacheWakeInteractiveArtOnInputIdle(void)
     int wakeWorker = 0;
 
     cacheLock();
-    // Prefetch heads can be nav-parked too (prewarm / HDD covers defer at dequeue), so wake the
-    // worker for parked work on EITHER queue once input goes idle.
+    // Prefetch heads can be nav-parked too (prefetch reads defer at dequeue on the slow
+    // backends), so wake the worker for parked work on EITHER queue once input goes idle.
     if (gArtRunning && gArtThreadId >= 0 && gArtActiveCount == 0 &&
         (gArtInteractiveReqList != NULL || gArtPrefetchReqList != NULL))
         wakeWorker = 1;
@@ -1539,10 +1532,7 @@ GSTEXTURE *cacheGetTextureIfReady(image_cache_t *cache, int *cacheId, int *UID)
     return result;
 }
 
-// prewarm: an explicit info-art prewarm request -- lifts the MMCE prefetch exemption and the
-// per-cache prefetch cap for THIS call only (the caller bounds when it fires). skipSettle: skip the
-// interactive inactivity settle (Square-entry prewarm fires the reads immediately, under the fade).
-static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value, unsigned char priority, int prewarm, int skipSettle)
+static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value, unsigned char priority)
 {
     cache_entry_t *entry;
     cache_entry_t *oldestEntry = NULL;
@@ -1667,30 +1657,26 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
             return NULL;
         }
 
-        if (!skipSettle) {
-            int delay = cacheGetInteractiveDelay(list, effectiveMode);
-            /* In MMCE mode, give Cover art a 1-frame inactivity head start over
-             * other art types (Background, Screenshot, etc.).  The default theme
-             * draws Background (main0) before Cover (main5) every frame, so
-             * without this adjustment BG would always queue first and block COV
-             * with a potentially slow open() failure on cards that lack BG art.
-             * A single extra inactivity frame guarantees COV queues on frame N
-             * while BG/SCR are deferred to frame N+1, by which time COV is
-             * already in-flight and the MMCE one-at-a-time throttle keeps the
-             * others waiting naturally. */
-            if (effectiveMode == MMCE_MODE && cache->suffix != NULL &&
-                strcmp(cache->suffix, "COV") != 0)
-                delay++;
-            if (guiInactiveFrames < delay) {
-                cacheUnlock();
-                return NULL;
-            }
+        int delay = cacheGetInteractiveDelay(list, effectiveMode);
+        /* In MMCE mode, give Cover art a 1-frame inactivity head start over
+         * other art types (Background, Screenshot, etc.).  The default theme
+         * draws Background (main0) before Cover (main5) every frame, so
+         * without this adjustment BG would always queue first and block COV
+         * with a potentially slow open() failure on cards that lack BG art.
+         * A single extra inactivity frame guarantees COV queues on frame N
+         * while BG/SCR are deferred to frame N+1, by which time COV is
+         * already in-flight and the MMCE one-at-a-time throttle keeps the
+         * others waiting naturally. */
+        if (effectiveMode == MMCE_MODE && cache->suffix != NULL &&
+            strcmp(cache->suffix, "COV") != 0)
+            delay++;
+        if (guiInactiveFrames < delay) {
+            cacheUnlock();
+            return NULL;
         }
     } else {
-        // MMCE is prefetch-exempt (browse-time prefetch hurt nav on the SIO2 bus) EXCEPT for an
-        // explicit info-art prewarm, whose caller only fires after a long settle with the art
-        // pipeline idle.
-        if (list == NULL || (effectiveMode == MMCE_MODE && !prewarm) || guiInactiveFrames < cacheGetPrefetchDelay(list, effectiveMode)) {
+        // MMCE is prefetch-exempt (browse-time prefetch hurt nav on the SIO2 bus).
+        if (list == NULL || effectiveMode == MMCE_MODE || guiInactiveFrames < cacheGetPrefetchDelay(list, effectiveMode)) {
             cacheUnlock();
             return NULL;
         }
@@ -1739,7 +1725,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
     // worker; match that. The queue is still bounded by the 10-slot LRU cache (a full cache yields no
     // free victim, so no unbounded growth).
 
-    if (priority == CACHE_REQ_PRIORITY_PREFETCH && !prewarm && cache->queuedPrefetchRequests >= cacheGetPrefetchLimit(cache)) {
+    if (priority == CACHE_REQ_PRIORITY_PREFETCH && cache->queuedPrefetchRequests >= cacheGetPrefetchLimit(cache)) {
         cacheUnlock();
         return NULL;
     }
@@ -1839,10 +1825,10 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
 
 GSTEXTURE *cacheGetTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
 {
-    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_INTERACTIVE, 0, 0);
+    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_INTERACTIVE);
 }
 
 GSTEXTURE *cachePrefetchTexture(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value)
 {
-    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_PREFETCH, 0, 0);
+    return cacheGetTextureInternal(cache, list, cacheId, UID, value, CACHE_REQ_PRIORITY_PREFETCH);
 }

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -180,7 +180,7 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
     // #195 (Blade, HW): VCD lists arrived in readdir order -- i.e. FAT directory-entry order, which is
     // effectively random after any add/delete churn -- while every other list reads alphabetical. Sort
     // the BACKING array here at the scan, not the menu rows: every consumer then agrees (device pages,
-    // the FAV VCD view, art prewarm), ids stay in lockstep with parallel arrays (the HDD path keeps a
+    // the FAV VCD view), ids stay in lockstep with parallel arrays (the HDD path keeps a
     // per-id partition-label array), and it holds no matter which publish path builds the rows.
     // Gated on the same Automatic Sorting switch the game lists honour: Autosort off = raw dir order,
     // as for every other list. Launch/favourites are unaffected either way -- VCDs resolve BY NAME.


### PR DESCRIPTION
## What

Two independent cleanups in the art pipeline, per the "simple code is good code" directive:

### 1. Dead-code removal (zero behavior change)

- **`prewarm`/`skipSettle` plumbing in `cacheGetTextureInternal`** — the info-art prewarm feature was reverted in `cadd4a38` ("fix(texcache): remove the info-art prewarm -- it wedges the MMCE fileXio channel on VCD info"), but the parameter plumbing stayed. Proof it's dead: the only two callers are the public wrappers `cacheGetTexture` / `cachePrefetchTexture`, and both passed `0,0`. Removed the parameters, the doc comment, the `!skipSettle` guard around the interactive settle, the MMCE-prefetch-exempt prewarm exception, and the prewarm bypass of the per-cache prefetch cap. Stale prewarm comments updated in `texcache.c`, `menusys.c`, `vcdsupport.c`.
- **`IO_CACHE_LOAD_ART` define** (`include/opl.h`) — grep of the whole tree shows no references.
- **`cacheBumpGeneration`** (`src/texcache.c` + declaration in `include/texcache.h`) — no callers anywhere in the tree.

### 2. HDD back on the official/fast art path

Official OPL applies **no** HDD-specific art throttling; the fork's came from a single report (commit `4ba0d28b`, "HDD is not very responsive... like the MMCE was"). Removed `HDD_MODE` from the three slow-mode gates:

- `cacheShouldDeferInteractiveArtOnInputMode`: no nav-time defer for HDD (MMCE still defers)
- `cacheGetInteractiveDelay`: HDD now returns 0 like USB/ETH (was the `MENU_MIN_INACTIVE_FRAMES` floor)
- `cacheGetLoadThreadPriority`: HDD art worker runs at default priority `0x40` like USB/ETH (was deprioritized to 90); MMCE keeps 90, APP keeps 0x38

**`src/hddsupport.c` was deliberately NOT changed.** The `cacheAbortMmceImageLoadsTimed(0)` call in `hddDoLaunchVcd` was *not* part of the `4ba0d28b` throttle grouping — it predates it (added in `b2c63abe`, "fix(vcd): keep art mount live") and guards the POPSTARTER VCD launch path (it remounts `pfs0:` onto the POPSTARTER partition, then `deinit()`s and hands off). Quiescing in-flight art reads before a partition remount + teardown is load-bearing regardless of nav-time throttling, so it stays.

## Deliberately NOT touched

All MMCE machinery (staged 32 KB reader, short-read==EOF, abort sweeps, nav defer, COV head start, two-tier fail memos), FAV/APP mode resolution (`cacheGetEffectiveMode`), `vcdFallback`, prefetch, priming (PRIMED/DISPLAYABLE), `cloneImageCache`, hardened `cacheEnd`, art.tar. No constants retuned.

## Verification

- Full docker build (`make -j8 opl.elf`) succeeds; forced recompile of `texcache.o`/`menusys.o`/`vcdsupport.o` + relink of `opl.elf` with **zero new warnings** (only pre-existing `expr: syntax error` / clock-skew noise). `nm` confirms `cacheBumpGeneration` is gone from the binary.
- `clang-format12 --style=file --output-replacements-xml` reports **0 replacements** for all 5 touched files.
- LOC delta: **+43 / −64** across 5 files.

## Note

Hardware verification recommended for HDD nav during art load (the scenario the original `4ba0d28b` report was about), to confirm official-parity behavior doesn't regress that user's setup.
