### PR TITLE
fix(nbd): graceful network teardown + DEV9 shutdown before the IOP reset (#307)

### DIFF
--- a/include/ethsupport.h
+++ b/include/ethsupport.h
@@ -17,7 +17,6 @@ typedef struct
 
 void ethInit(item_list_t *itemList); // Full initialization (Start ETH + SMB and apply configuration). GUI must be already initialized, used by GUI to start SMB mode.
 void ethDeinitModules(void);         // Module-only deinitialization, without the GUI's knowledge (for specific reasons, otherwise unused).
-void ethInvalidateModules(void);     // Bookkeeping-only deinit for paths that immediately reboot the IOP (NBD unload): the IOP reset wipes the stack, so no RPC teardown is needed (or safe, #307).
 int ethLoadInitModules(void);        // Initializes Ethernet and applies configuration.
 int ethGetModulesLoaded(void);       // 1 if the SMB NIC stack is loaded (UDPBD must not load on top).
 void ethDisplayErrorStatus(void);    // Displays the current error status (if any). GUI must be already initialized.

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -359,21 +359,6 @@ void ethDeinitModules(void)
     }
 }
 
-// Bookkeeping-only deinit for teardown paths that IMMEDIATELY reboot the IOP (unloadLwnbdSvr ->
-// reset -> sysReset -> SifIopReset). The IOP reboot wipes netman/smap/ps2ip/ps2ips/lwnbdsvr
-// outright, so ethDeinitModules' graceful RPC teardown is redundant there -- and it is also the
-// only part of that path that can deadlock: after a FAILED network bring-up (no cable, no link,
-// no DHCP -- issue #307) NetManDeinit/ps2ip_deinit can park the EE on a SIF reply the
-// half-configured stack never sends, freezing the console (pads dead, hard reset required).
-// Skip the RPC calls entirely and just clear the EE-side state. ethInitSemaID is an EE kernel
-// object -- it survives the IOP reboot and ethInitSema() reuses it, so it is deliberately kept.
-// ethReadNetConfig's sync is pointless here: NBD never reconfigures the interface.
-void ethInvalidateModules(void)
-{
-    ethModulesLoaded = 0;
-    gNetworkStartup = ERROR_ETH_NOT_STARTED;
-}
-
 int ethLoadInitModules(void)
 {
     int ret;

--- a/src/opl.c
+++ b/src/opl.c
@@ -2704,6 +2704,22 @@ static int loadLwnbdSvr(void)
         }
     }
 
+    if (ret != 0) {
+        /* The server is not starting, so nothing will ever consume the network stack a
+         * FAILED bring-up just left resident (netman/smap/ps2ip, DEV9 powered). Tear it
+         * down NOW, while the state is fresh and known (#307): unloadLwnbdSvr reboots the
+         * IOP via reset() -> sysReset(), whose unbounded SifIopReset/SifIopSync waits are
+         * the wedge when they run against a live, half-configured stack. Every other
+         * network teardown in the tree (ethCleanUp/ethShutdown) does deinit + DEV9
+         * shutdown and never reboots afterwards; this makes the NBD lifecycle match.
+         * The loaded-check mirrors ethShutdown: DEV9's refcount is shared with BDM/HDD,
+         * so only release it when the eth path actually holds it. */
+        int ethWasLoaded = ethGetModulesLoaded();
+        ethDeinitModules();
+        if (ethWasLoaded)
+            sysShutdownDev9();
+    }
+
     padInit(0);
 
     // init all pads
@@ -2718,11 +2734,19 @@ static int loadLwnbdSvr(void)
 
 static void unloadLwnbdSvr(void)
 {
-    // Bookkeeping-only (#307): reset() below reboots the IOP (sysReset -> SifIopReset), which
-    // wipes the whole network stack regardless -- and the graceful RPC teardown in
-    // ethDeinitModules is exactly what wedges after a failed offline bring-up (no cable/link),
-    // freezing the console before the reset is ever reached.
-    ethInvalidateModules();
+    /* Graceful teardown BEFORE the IOP reboot (#307): reset() -> sysReset() parks the EE in
+     * unbounded SifIopReset/SifIopSync waits, and those wedge when they run against a live,
+     * DEV9-powered, half-configured network stack (failed offline bring-up). The first #307
+     * attempt skipped the RPC teardown entirely and the console still froze, proving the
+     * reset -- not the teardown -- is the hazardous step. So do here what every other
+     * network teardown in the tree does (ethShutdown: deinit + DEV9 power-off, no reboot
+     * after) and let the reset below reboot a clean IOP. The loaded-check mirrors
+     * ethShutdown: DEV9's refcount is shared with BDM/HDD, so only release it when the eth
+     * path actually holds it (a failed bring-up already released it in loadLwnbdSvr). */
+    int ethWasLoaded = ethGetModulesLoaded();
+    ethDeinitModules();
+    if (ethWasLoaded)
+        sysShutdownDev9();
     unloadPads();
 
     reset();
@@ -2733,9 +2757,18 @@ static void unloadLwnbdSvr(void)
     // reinit the input pads
     padInit(0);
 
-    int ret = 0;
-    while (!ret)
+    /* Bounded retry (#307): an unbounded startPads loop turns a half-completed IOP reset
+     * into a hard freeze at exactly the reported "NBD Server unloading..." screen. ~5 s of
+     * retries covers a slow IOP; if pads still won't start, degrade (log + continue, the
+     * menu's own pad handling recovers on later polls) instead of wedging forever. */
+    int ret = 0, tries = 0;
+    while (!ret && tries++ < 100) {
         ret = startPads();
+        if (!ret)
+            delay(50);
+    }
+    if (!ret)
+        LOG("unloadLwnbdSvr: pads did not start after IOP reset (%d tries)\n", tries);
 
     // now start io again
     ioBlockOps(0);


### PR DESCRIPTION
## Why v2

PR #308 (shipped in Beta-3482) skipped `ethDeinitModules()`'s RPC teardown on the theory that it wedged against the half-configured stack after a failed offline bring-up. @zackcage6's Beta-3482 test **disproved that**: the console still freezes at the *"NBD Server unloading..."* screen with the teardown removed. The hazardous step is therefore downstream — `reset()` → `sysReset()`, whose unbounded `while (!SifIopReset("", 0))` and `while (!SifIopSync())` waits (src/system.c) run against a **live, DEV9-powered, half-configured smap/ps2ip stack**.

That combination exists nowhere else in the tree: every other network teardown (`ethCleanUp`/`ethShutdown` in src/ethsupport.c) does `ethDeinitModules()` + `sysShutdownDev9()` and never reboots the IOP afterwards. The NBD unload was the sole bare `sysReset()` on a live network stack.

Notably, **official OPL has the identical unfixed flow** — [ps2homebrew/Open-PS2-Loader#1012](https://github.com/ps2homebrew/Open-PS2-Loader/issues/1012) is the same frozen screenshot, still open. This fix is upstreamable.

## Changes

- **`loadLwnbdSvr` (failure branch):** tear the network stack down *immediately* after a failed bring-up (`ethDeinitModules()` + `sysShutdownDev9()`), while the state is fresh and known — nothing will ever consume it.
- **`unloadLwnbdSvr`:** same graceful sequence *before* `reset()`, so `SifIopReset` reboots a clean, DEV9-off IOP — the same state as the proven boot/exit paths. The loaded-check mirrors `ethShutdown`: DEV9's refcount is shared with BDM/HDD, so it's only released when the eth path actually holds it.
- **`ethInvalidateModules`** (added by #308) is now unused — removed.
- **Bounded pad restart:** the post-reset `while (!ret) ret = startPads();` was unbounded; a half-completed IOP reset there produces exactly the reported freeze with dead pads. Now ~5 s of retries, then log + continue (degrade, don't wedge). The working loop in `loadLwnbdSvr` is untouched.

## Residual honesty

Which of `sysReset`'s waits stalls can't be proven statically (EE-kernel ROM syscalls). If this still freezes on hardware, **where the freeze moves to is the diagnostic**: before the error msgbox ⇒ the RPC teardown really is hazardous on that unit; same screen ⇒ a deeper `SifIopReset` issue, and the fallback is [bignaux's upstream #904](https://github.com/ps2homebrew/Open-PS2-Loader/pull/904) architecture (persistent lwnbdsvr with RPC start/stop, its unbounded `SifBindRpc` fixed).

Build: opl.elf relinked clean in the oplbuild container, zero new warnings. clang-format12: 0 replacements on all touched files.

Fixes #307 (second attempt)