### PR TITLE
fix(art): heal transient art failures at idle, un-starve prefetch, unpin the busy orb (#296/#299)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2268,12 +2268,14 @@ static void guiDrawOverlays()
     // requests at all -- art loads on the texcache worker -- so without this the loader could
     // never trigger in the game listings, only on screens that read per-game config through the
     // queue (the info screen).
-    // #296 baseline restore: count ALL art (interactive + prefetch), not just interactive -- this
-    // mirrors official OPL, whose loader trigger is "IO queue non-empty" with ALL art on that
-    // queue. This does NOT resurrect the idle-flash #290 killed: prefetch bursts only exist
-    // post-settle (the walk runs once navigation stops), so the loader pulses while art is
-    // genuinely loading, and quiet background rescans stay excluded via ioHasVisiblePendingRequests.
-    int pending = ioHasVisiblePendingRequests() || cacheHasPendingArt();
+    // #296 Beta-3482 regression: counting ALL art (interactive + prefetch) pinned the loader on
+    // every browsing frame -- queued prefetch SURVIVES each scroll step (generation advance
+    // preserves it), so pending was effectively continuous while scrolling ("orb spins every
+    // time I scroll past games"). Count interactive art only: prefetch is speculative by
+    // definition, and the art the user is actually waiting on (the highlighted item's
+    // cover/BG/icons) is always an interactive request, so #299's loader-in-listings keeps
+    // working without the pinned orb.
+    int pending = ioHasVisiblePendingRequests() || cacheHasPendingInteractiveArt();
 
     // During the boot intro, when an animated boot logo is shown, suppress the
     // loading spinner -- the animated logo is the boot activity indicator there.

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -6,6 +6,7 @@
 #include "include/texcache.h"
 #include "include/textures.h"
 #include "include/gui.h"
+#include "include/ioman.h"
 #include "include/util.h"
 #include "include/renderman.h"
 #include "include/vcdsupport.h"
@@ -909,6 +910,17 @@ static load_image_request_t *cacheDequeueRequest(void)
             return NULL;
         }
 
+        /* #296: speculative reads also yield the bus to real IO. Official OPL serializes art
+         * BEHIND everything else on the single IO queue; here the art worker has its own
+         * channel, so a prefetch staged read can collide with queued io work (boot-time
+         * module/list/config loads) and lose with a contended-bus EIO -- which then
+         * poisons the entry's failure memo. Don't START a prefetch while the io queue has
+         * work pending; interactive dequeues stay aggressive. */
+        if (ioHasPendingRequests()) {
+            cacheUnlock();
+            return NULL;
+        }
+
         req = gArtPrefetchReqList;
         gArtPrefetchReqList = req->next;
         req->next = NULL;
@@ -1574,8 +1586,19 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
         *UID = -1;
     } else if (*cacheId == -3) {
         if (*UID == gCacheGeneration) {
-            cacheUnlock();
-            return NULL;
+            /* #296: the generation only advances on cursor move/screen switch, so a
+             * transient failure memo written in the boot window (art worker racing the
+             * io worker for the bus) NEVER heals while the console sits parked -- that
+             * game's art stays dead until the user scrolls, the exact "assets load only
+             * when highlighted" report. On fast devices, drop the memo once idle and
+             * re-probe: a contended-bus EIO heals within ~8 idle frames, while the memo
+             * still suppresses hammering DURING navigation (guiInactiveFrames is low)
+             * and MMCE keeps the generation-keyed behavior (failing opens are expensive
+             * on SIO2; the memo is load-bearing there). */
+            if (effectiveMode == MMCE_MODE || guiInactiveFrames < MENU_MIN_INACTIVE_FRAMES) {
+                cacheUnlock();
+                return NULL;
+            }
         }
 
         *cacheId = -1;

--- a/src/themes.c
+++ b/src/themes.c
@@ -817,16 +817,24 @@ static GSTEXTURE *getGameImageTexture(image_cache_t *cache, void *support, struc
     return NULL;
 }
 
-static int canPrefetchAdjacentGameImages(image_cache_t *cache, item_list_t *list, GSTEXTURE *selectedTexture)
+static int canPrefetchAdjacentGameImages(image_cache_t *cache, item_list_t *list)
 {
-    if (cache == NULL || list == NULL || selectedTexture == NULL || selectedTexture->Mem == NULL)
+    if (cache == NULL || list == NULL)
         return 0;
 
     if (list->mode == MMCE_MODE)
         return 0;
 
+    /* #296: gate on pending INTERACTIVE art for every mode -- not on the selected
+     * cover's success. Requiring selectedTexture->Mem != NULL disabled the whole walk
+     * whenever the parked game had no art (or its boot-window load failed), so nothing
+     * ever warmed. Selected-first is already guaranteed by interactive queue priority,
+     * which dequeues ahead of prefetch regardless of enqueue order. */
+    if (cacheHasPendingInteractiveArt())
+        return 0;
+
     if (list->mode == APP_MODE) {
-        if (guiInactiveFrames < APP_PREFETCH_IDLE_FRAMES || cacheHasPendingInteractiveArt())
+        if (guiInactiveFrames < APP_PREFETCH_IDLE_FRAMES)
             return 0;
     }
 
@@ -895,7 +903,7 @@ static void drawGameImage(struct menu_list *menu, struct submenu_list *item, con
         GSTEXTURE *texture = getGameImageTexture(gameImage->cache, menu->item->userdata, &item->item);
 
         if (gameImage->cache != NULL && gameImage->cache->suffix != NULL && strcmp(gameImage->cache->suffix, "COV") == 0 &&
-            canPrefetchAdjacentGameImages(gameImage->cache, list, texture)) {
+            canPrefetchAdjacentGameImages(gameImage->cache, list)) {
             int prefetchInactiveFrames = (list != NULL && list->mode == APP_MODE) ? APP_PREFETCH_IDLE_FRAMES : MENU_MIN_INACTIVE_FRAMES;
             prefetchAdjacentGameImages(gameImage->cache, menu->item->userdata, item, 1, prefetchInactiveFrames);
         }
@@ -1131,8 +1139,6 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     int drawFirst = cfIsAnimating ? 0 : COVERFLOW_PAD;
     int drawLast = cfIsAnimating ? coverTotal : coverTotal - COVERFLOW_PAD;
 
-    GSTEXTURE *centerTexture = NULL; // the selection's LOADED art, if any -- gates the neighbor prefetch below
-
     // #296 baseline restore: the left->right draw loop below doubles as the interactive ENQUEUE
     // order (getGameImageTexture queues a request on a cache miss), so on a cold settle the
     // SELECTED cover used to load 2nd/3rd, behind its left neighbours. Fire the selection's
@@ -1161,8 +1167,6 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
 
         GSTEXTURE *texture = getGameImageTexture(cimg->cache, sourceList, &covers[i]->item);
         int hasArt = (texture && texture->Mem);
-        if (i == centerIdx && hasArt)
-            centerTexture = texture;
         // #2 (Nadwislanski): a no-art Favourites entry (a favourited app / PS1 title / game with no
         // ART/<id>_COV.png) must NOT draw the embedded cover placeholder wrapped in the two-layer case
         // frame -- that reads as a hollow grey "empty tray" box. Skip the whole cover instead (draw
@@ -1239,9 +1243,9 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
       (prefetchAdjacentGameImages, drawGameImage): PREFETCH priority, so MMCE stays exempt (SIO2)
       -- including an MMCE-SOURCED FAVOURITE on the FAV tab, whose owner mode texcache resolves
       per value (cacheGetEffectiveMode -> favGetArtMode) before applying the exemption -- and APP
-      keeps its longer settle + pending-interactive check via canPrefetchAdjacentGameImages. The
-      walk also only runs once the selection's own art has landed, so the focused cover always
-      wins the queue. The walk wraps last<->first exactly like the covers[]
+      keeps its longer settle via canPrefetchAdjacentGameImages. The walk yields to pending
+      interactive art (canPrefetchAdjacentGameImages) and interactive requests dequeue ahead
+      of prefetch regardless of enqueue order, so the focused cover always wins the queue. The walk wraps last<->first exactly like the covers[]
       build; distance is bounded so the whole warmed window (visible + pads + lookahead) fits the
       cache's slot count with no LRU thrash: (count-1)/2 = 4 each side on the 10-slot COV cache,
       i.e. one cover beyond the pad slot in 5-up mode, two in 3-up. Per-item element redirect
@@ -1251,7 +1255,7 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     if (elem->extended != NULL) {
         mutable_image_t *baseImg = (mutable_image_t *)elem->extended;
         if (baseImg->cache != NULL && baseImg->cache->suffix != NULL && strcmp(baseImg->cache->suffix, "COV") == 0 &&
-            canPrefetchAdjacentGameImages(baseImg->cache, sourceList, centerTexture)) {
+            canPrefetchAdjacentGameImages(baseImg->cache, sourceList)) {
             int prefetchInactiveFrames = (sourceList != NULL && sourceList->mode == APP_MODE) ? APP_PREFETCH_IDLE_FRAMES : MENU_MIN_INACTIVE_FRAMES;
             int maxDistance = (baseImg->cache->count - 1) / 2;
             struct submenu_list *next = item;


### PR DESCRIPTION
## What Beta-3482 testing showed

PR #306 fixed the scroll-lag class of #296, but @zackcage6's videos show the core complaint standing: **on USB, assets load only when each game is highlighted — never at startup, never for idle neighbors** ("cannot be loaded from the start of Riptopl as other launchers do"). Plus a new regression: **the orb spins on every scroll step**.

## Root causes (static analysis + video evidence)

**1. Transient-failure memo poisoning.** A failed load is memoized `(cacheId -3, UID gCacheGeneration)`, and the generation only advances on cursor move/screen switch. Parked at boot or idle, *nothing* bumps it — so one contended-bus EIO in the boot window (the art worker reads `mass:` concurrently with the io worker's busiest period) kills that game's art until the user scrolls. That is precisely "loads only when highlighted."

**2. Prefetch structurally starved.** The idle walk required the *selected cover* to be loaded first — parked on a game with no/failed art, nothing ever warmed. And official OPL serializes art *behind* all other IO on one queue; our dedicated art worker has its own channel, so prefetch reads collide with boot-time io work and lose with the EIO that writes the poisoning memo.

**3. Orb pinned.** `3fa104c0` switched the loader trigger to `cacheHasPendingArt()`, which counts queued prefetch — but queued prefetch *survives every scroll step* (generation advance preserves it), so pending was continuous while browsing and the #299 fade latch pinned the orb at full alpha.

## Changes

- **`texcache.c` (`-3` memo early-out):** on fast devices, drop the transient memo once `guiInactiveFrames >= MENU_MIN_INACTIVE_FRAMES` and re-probe — failures heal within ~8 idle frames. Anti-hammer during navigation preserved (inactive count is low while scrolling); MMCE keeps the generation-keyed behavior (failing opens are expensive on SIO2); the `-2` genuine-absence memo is untouched.
- **`texcache.c` (`cacheDequeueRequest`):** never *start* a prefetch while `ioHasPendingRequests()` — official's implicit art-behind-IO ordering, removing the boot-window collision that produces the poisoning EIO. Interactive dequeues stay aggressive.
- **`themes.c` (`canPrefetchAdjacentGameImages`):** gate on `!cacheHasPendingInteractiveArt()` for all modes instead of the selected cover's success. Selected-first is already guaranteed by interactive queue priority. MMCE stays prefetch-exempt; APP keeps its longer idle settle.
- **`gui.c` (loader trigger):** back to `ioHasVisiblePendingRequests() || cacheHasPendingInteractiveArt()`. The art the user is actually waiting on (the highlighted item's cover/BG/icons) is always an interactive request, so #299's loader-in-listings keeps working — without the pinned orb.

## What the tester should see on USB

- Highlighted game's art appears at boot **without scrolling**.
- Neighbor covers warm while idle; a bus hiccup heals itself instead of killing a game's art until scroll.
- Orb shows only while the highlighted item's art is genuinely loading — not pinned during browsing.

Build: opl.elf relinked clean in the oplbuild container, zero new warnings. clang-format12: 0 replacements on all touched files.

Refs #296, refs #299