### PR TITLE
fix: truthful pad sampling, List viewport cover warming, latest-wins backgrounds

### DIFF
--- a/include/themes.h
+++ b/include/themes.h
@@ -72,6 +72,10 @@ typedef struct
 
     const char *decorator;
     mutable_image_t *decoratorImage;
+    // Non-owning link to the family's COV game-image element, set at theme validation for
+    // Lists WITHOUT a decorator: lets drawItemsList warm the visible page's covers through
+    // the normal cache path instead of loading them one highlight at a time (#296).
+    struct theme_element *coverElem;
 } items_list_t;
 
 typedef struct theme_element

--- a/src/pad.c
+++ b/src/pad.c
@@ -441,11 +441,14 @@ static int readPad(struct pad_data_t *pad)
     }
 
     /*
-     * A failed read is not a sampled release. Keep the last valid sample until
-     * the next successful read or an explicit disconnect. This one rule feeds
-     * level, edge, repeat, and inactivity handling consistently.
+     * Aggregate button data only from successful reads (upstream semantics).
+     * Merging the retained sample after a FAILED ready-state read would carry
+     * "pressed" indefinitely when the missed poll was a release: the next real
+     * tap then has no observed release-to-press edge and is swallowed, and the
+     * stale hold eventually reaches repeat handling as a multi-item skip
+     * (#271/#272).
      */
-    if (padsRead > 0 || isPadReadyState(pad->state))
+    if (padsRead > 0)
         paddata |= pad->paddata;
 
     return pad->paddata != 0;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1054,6 +1054,27 @@ GSTEXTURE *cacheGetTexture(image_cache_t *cache, item_list_t *list, int *cacheId
         }
     }
 
+    /*
+     * Latest-selection-wins, ONE-SLOT "BG" cache only (#296): a background queued
+     * or loading for a selection the user has already left must not block the
+     * current selection for the whole load (~2s on a slow device). A stale QUEUED
+     * background is dropped so the slot scan below recycles it in this same frame;
+     * a stale LOADING one is aborted and the normal ERR_LOAD_ABORTED completion
+     * clears the slot, so the current selection enqueues on the next frame. READY
+     * backgrounds keep plain LRU eviction; every other suffix and cache size is
+     * untouched.
+     */
+    if (cache->count == 1 && cache->suffix != NULL && strcmp(cache->suffix, "BG") == 0) {
+        cache_entry_t *only = &cache->content[0];
+
+        if (only->value != NULL && strcmp(only->value, value) != 0) {
+            if (only->state == CACHE_ENTRY_QUEUED && only->qr != NULL)
+                cacheDropQueuedRequestLocked(only->qr);
+            else if (only->state == CACHE_ENTRY_LOADING && only->qr != NULL)
+                ((load_image_request_t *)only->qr)->abortRequested = 1;
+        }
+    }
+
     if (effectiveMode == MMCE_MODE &&
         (cacheIsNavigationActive() ||
          guiInactiveFrames < cacheGetMmceIdleFrames(cache))) {

--- a/src/themes.c
+++ b/src/themes.c
@@ -1499,14 +1499,16 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
                 getGameImageTexture(selImg->cache, menu->item->userdata, &item->item);
         }
 
-        // Bound viewport warming to the COV cache's own slot count (10 by default,
-        // selected row included): demanding more rows than slots would only thrash it.
-        int coverWarmRows = 0;
-        if (itemsList->decoratorImage == NULL && itemsList->coverElem != NULL) {
-            mutable_image_t *warmImg = (mutable_image_t *)itemsList->coverElem->extended;
-            if (warmImg != NULL && warmImg->cache != NULL)
-                coverWarmRows = warmImg->cache->count < itemsList->displayedItems ? warmImg->cache->count : itemsList->displayedItems;
-        }
+        // Budget viewport warming PER RESOLVED CACHE, minus one slot kept for the
+        // selected cover requested above, so row warming can never evict it. Two
+        // slots suffice: thmGetElemForItem routes a row to either the family COV
+        // cache or (Favourites APP rows) the apps COV cache, whose slot count may
+        // differ. Rows past a budget are simply not requested this frame.
+        struct
+        {
+            image_cache_t *cache;
+            int left;
+        } warmBudget[2] = {{NULL, 0}, {NULL, 0}};
 
         submenu_list_t *ps = menu->item->pagestart;
         int others = 0;
@@ -1545,13 +1547,26 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
                 textEndX = fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, dispText, color);
             } else {
                 // No decorator: warm this visible row's cover so scrolling never waits on a
-                // cold cache (#296). Bounded to the COV cache's slot count; folders carry no
-                // cover. The selected row's request above makes its lookup here a
-                // value-keyed cache hit.
-                if (others <= coverWarmRows && !ps->item.isFolder) {
+                // cold cache (#296). The selected row was already requested above; folders
+                // carry no cover. Warming stops when the resolved cache's frame budget is
+                // spent (selected's slot stays reserved).
+                if (ps != item && !ps->item.isFolder && itemsList->coverElem != NULL) {
                     mutable_image_t *rowImg = (mutable_image_t *)thmGetElemForItem(menu, ps, itemsList->coverElem)->extended;
-                    if (rowImg != NULL && rowImg->cache != NULL)
-                        getGameImageTexture(rowImg->cache, list, &ps->item);
+                    if (rowImg != NULL && rowImg->cache != NULL) {
+                        int b;
+                        for (b = 0; b < 2 && warmBudget[b].cache != NULL && warmBudget[b].cache != rowImg->cache; b++)
+                            ;
+                        if (b < 2) {
+                            if (warmBudget[b].cache == NULL) {
+                                warmBudget[b].cache = rowImg->cache;
+                                warmBudget[b].left = rowImg->cache->count - 1; // selected's reserved slot
+                            }
+                            if (warmBudget[b].left > 0) {
+                                warmBudget[b].left--;
+                                getGameImageTexture(rowImg->cache, list, &ps->item);
+                            }
+                        }
+                    }
                 }
                 textEndX = fntRenderString(elem->font, elem->posX, posY, elem->aligned, elem->width, elem->height, dispText, color);
             }
@@ -2017,11 +2032,16 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
     // Default (decorator-less) Lists never demanded covers beyond the selection, so viewport
     // artwork loaded one highlight at a time (#296). Give each such List a non-owning link to
     // its family's COV element; drawItemsList uses it to warm the visible page through the
-    // normal per-frame cache path. After the splits, so linked caches are final.
+    // normal per-frame cache path. After the splits, so linked caches are final. Info
+    // families too: a devices=-filtered ItemsList can live there (validateFilteredItemsLists).
     linkItemsListCoverElems(&theme->mainElems);
+    linkItemsListCoverElems(&theme->infoElems);
     linkItemsListCoverElems(&theme->appsMainElems);
+    linkItemsListCoverElems(&theme->appsInfoElems);
     linkItemsListCoverElems(&theme->favsMainElems);
+    linkItemsListCoverElems(&theme->favsInfoElems);
     linkItemsListCoverElems(&theme->vcdMainElems);
+    linkItemsListCoverElems(&theme->vcdInfoElems);
 }
 
 static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_elems_t *elems, const char *type, const char *name)

--- a/src/themes.c
+++ b/src/themes.c
@@ -1489,6 +1489,24 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
         // reuses the same value-keyed cache entry.
         if (itemsList->decoratorImage != NULL && !item->item.isFolder)
             getGameImageTexture(itemsList->decoratorImage->cache, menu->item->userdata, &item->item);
+        else if (itemsList->coverElem != NULL && !item->item.isFolder) {
+            // No decorator: the plain List only ever demanded the selected cover (via the
+            // separately drawn COV element), so artwork arrived one highlight at a time
+            // (#296). Warm the selected cover first through the family COV element;
+            // thmGetElemForItem keeps Favourites game/APP routing intact.
+            mutable_image_t *selImg = (mutable_image_t *)thmGetElemForItem(menu, item, itemsList->coverElem)->extended;
+            if (selImg != NULL && selImg->cache != NULL)
+                getGameImageTexture(selImg->cache, menu->item->userdata, &item->item);
+        }
+
+        // Bound viewport warming to the COV cache's own slot count (10 by default,
+        // selected row included): demanding more rows than slots would only thrash it.
+        int coverWarmRows = 0;
+        if (itemsList->decoratorImage == NULL && itemsList->coverElem != NULL) {
+            mutable_image_t *warmImg = (mutable_image_t *)itemsList->coverElem->extended;
+            if (warmImg != NULL && warmImg->cache != NULL)
+                coverWarmRows = warmImg->cache->count < itemsList->displayedItems ? warmImg->cache->count : itemsList->displayedItems;
+        }
 
         submenu_list_t *ps = menu->item->pagestart;
         int others = 0;
@@ -1525,8 +1543,18 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
                         rmDrawPixmap(&itemsList->decoratorImage->defaultTexture->source, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol, 0);
                 }
                 textEndX = fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, dispText, color);
-            } else
+            } else {
+                // No decorator: warm this visible row's cover so scrolling never waits on a
+                // cold cache (#296). Bounded to the COV cache's slot count; folders carry no
+                // cover. The selected row's request above makes its lookup here a
+                // value-keyed cache hit.
+                if (others <= coverWarmRows && !ps->item.isFolder) {
+                    mutable_image_t *rowImg = (mutable_image_t *)thmGetElemForItem(menu, ps, itemsList->coverElem)->extended;
+                    if (rowImg != NULL && rowImg->cache != NULL)
+                        getGameImageTexture(rowImg->cache, list, &ps->item);
+                }
                 textEndX = fntRenderString(elem->font, elem->posX, posY, elem->aligned, elem->width, elem->height, dispText, color);
+            }
 
             // Favourites: draw a small star just after the item text.
             if (ps->item.favourited) {
@@ -1563,6 +1591,7 @@ static void initItemsList(const char *themePath, config_set_t *themeConfig, them
         itemsList->decorator = decorator; // Will be used later (thmValidate)
 
     itemsList->decoratorImage = NULL;
+    itemsList->coverElem = NULL;
     elem->extended = itemsList;
     // elem->endElem = &endBasic; does the job
 
@@ -1907,6 +1936,26 @@ static void separateVcdCoverCache(theme_t *theme)
         cacheDestroyCache(replacement);
 }
 
+// Link every non-decorator ItemsList of a family to that family's existing COV element (the
+// selected-cover game-image / coverflow carousel). Runs AFTER the cache splits above, so the
+// linked element's cache pointer is already final; the link itself is to the element, which
+// survives the splits untouched. Families without a COV element simply get no warming.
+static void linkItemsListCoverElems(theme_elems_t *elems)
+{
+    theme_element_t *e;
+
+    for (e = elems->first; e != NULL; e = e->next) {
+        items_list_t *itemsList;
+
+        if (e->type != ELEM_TYPE_ITEMS_LIST || e->extended == NULL)
+            continue;
+
+        itemsList = (items_list_t *)e->extended;
+        if (itemsList->decoratorImage == NULL)
+            itemsList->coverElem = thmFindElemBySuffix(elems, "COV");
+    }
+}
+
 static void validateGUIElems(const char *themePath, config_set_t *themeConfig, theme_t *theme)
 {
     // 1. check we have a valid Background elements
@@ -1964,6 +2013,15 @@ static void validateGUIElems(const char *themePath, config_set_t *themeConfig, t
     // The L3 VCD view reuses the device's own game list (same item ids), so its selected/carousel covers
     // must not share a COV cache with the ISO list -- otherwise toggling thrashes the same cache slots.
     separateVcdCoverCache(theme);
+
+    // Default (decorator-less) Lists never demanded covers beyond the selection, so viewport
+    // artwork loaded one highlight at a time (#296). Give each such List a non-owning link to
+    // its family's COV element; drawItemsList uses it to warm the visible page through the
+    // normal per-frame cache path. After the splits, so linked caches are final.
+    linkItemsListCoverElems(&theme->mainElems);
+    linkItemsListCoverElems(&theme->appsMainElems);
+    linkItemsListCoverElems(&theme->favsMainElems);
+    linkItemsListCoverElems(&theme->vcdMainElems);
 }
 
 static int addGUIElem(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_elems_t *elems, const char *type, const char *name)


### PR DESCRIPTION
## Summary

Two focused commits closing the remaining Beta-3500 defects:

- **Commit 1 (`1b6522ed`) — pad sampling fix for #271 / #272.** `readPad()` merged the retained per-pad sample into the global `paddata` after a *failed* ready-state `padRead()`. When the missed poll was a release, "pressed" was carried indefinitely: the next physical tap had no observed release-to-press edge and was swallowed, and the stale hold later reached repeat handling as a multi-item skip. Now a pad's buttons contribute only after a successful `padRead()` (upstream sampling semantics). Disconnect/reconnect handling, transition freezing, `getKey()`/`getKeyOn()`, and repeat timing are unchanged; no timers, retries, alternate input streams, or Settings-specific handling were added. The #272 recording (input clicks audible while the plasma keeps animating) is this same lost-edge mechanism, so one root fix closes both issues.
- **Commit 2 (`0a92ff27`) — bounded visible-cover warming + stale-BG cancellation for #296.**
  1. *Warm the visible List viewport:* decorator-less Lists never demanded covers beyond the selection, so artwork arrived one highlight at a time. Adds a non-owning `coverElem` link to `items_list_t`, resolved at theme validation (after the cache splits) to the family's existing `COV` element via `thmFindElemBySuffix()`. `drawItemsList()` requests the selected cover first, then visible non-folder rows through `thmGetElemForItem()` + `getGameImageTexture()` (Favourites game/APP routing preserved), bounded by the visible row count and the existing cover cache's own slot count. Decorator Lists keep their existing path. No library preload, no cache growth.
  2. *Latest-selection-wins backgrounds:* the one-slot `BG` cache could be occupied by a queued/loading background for a selection the user already left, blocking the current background for ~2 s. A stale queued BG is now dropped and its slot recycled in the same frame; a stale loading one is aborted via the existing `abortRequested` flag and the normal `ERR_LOAD_ABORTED` cleanup frees the slot for the next frame. READY backgrounds keep plain LRU eviction; `COV`/`ICO`/`SCR`/`ART` and all other cache behavior are unchanged.

Fixes #271
Fixes #272
Fixes #296

No public API or configuration format changes. No full-library preload, cache growth, priority framework, scheduler, or generation system.

## Validation (local, pinned ps2dev container identical to CI)

- `git diff --check` — clean
- clang-format-12 (CI's version) on all four touched files — clean
- `make download_lng languages` — pass
- Clean `make release` — pass (`RIPTOPL-v1.2.0-Beta-3500-0a92ff2.ELF`)

## Hardware acceptance requested (@zackcage6, one build, one compact pass)

1. At least 50 isolated Up/Down taps in Settings, List, and Coverflow: every click must move exactly once — no swallowed taps, hangs, or multi-item jumps.
2. Hold and release both directions long enough to exercise repeat: smooth repeat, immediate stop on release, no phantom repeats.
3. 3-cover and 5-cover Coverflow with several full wraps: no hang, skip, or lost 3D effect.
4. Cold-start List and Coverflow with known artwork: current-viewport covers populate without highlighting every game individually.
5. Scroll rapidly across several games and stop: the final selection's background wins; an older background must never appear late.
6. Missing-art placeholders, folders, Favourites containing games/APPS, and VCD fallbacks remain correct.

Note: if discrete taps improve but sustained holds regress, do not compensate elsewhere — report it so the actual read-failure pattern can be isolated first.

## Test plan

- [ ] CI check matrix green
- [ ] Hardware acceptance pass above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cover-image loading for item lists, including selected and visible items.
  * Added smoother background-image loading by prioritizing the latest request.
  * Improved cover-image availability across themed item lists, while avoiding unnecessary loading for folders.

* **Bug Fixes**
  * Prevented failed controller reads from reusing outdated input data.
  * Improved image-cache handling by discarding stale background requests and stopping obsolete loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->