### PR TITLE
fix(pad/art): restore miss-tolerant input, gated re-init, coverflow lookahead + Debug-Colors instrumentation (#271, #272, #296)

### DIFF
--- a/include/gui.h
+++ b/include/gui.h
@@ -197,6 +197,11 @@ void guiSetBootStatusSticky(const char *label);
 
 void guiWarning(const char *text, int count);
 
+/** Debug-Colors instrumentation line (#271/#272/#296). Renders the pad/SFX diagnostic counters
+ *  at the bottom of the frame; NO-OP unless Settings -> Debug Colors is on, so the normal path
+ *  pays nothing. Safe to call from any EE-main-thread render loop (guiDrawOverlays, dialogs). */
+void guiDrawDebugLine(void);
+
 int guiConfirmVideoMode(void);
 
 int guiGameShowRemoveSettings(config_set_t *configSet, config_set_t *configGame);

--- a/include/pad.h
+++ b/include/pad.h
@@ -28,6 +28,25 @@ int readPads();
 void padFreezeEdgeBaseline(int freeze);
 void unloadPads();
 
+// Debug-Colors instrumentation snapshot (#271/#272). Counters are cumulative and maintained on
+// the EE main thread regardless of the setting; they are only RENDERED when Settings -> Debug
+// Colors is on (gui.c / dia.c). Field semantics live with the writers in pad.c.
+typedef struct
+{
+    unsigned int readMisses;   // total failed ready-state pad reads
+    unsigned int missBurst;    // current consecutive-miss run, max across pads (polls)
+    unsigned int missBurstMax; // session peak of the above
+    unsigned int pollMaxMs;    // worst readPads() period this session
+    unsigned int stateFlaps;   // DISCONN -> ready reconnect edges seen
+    unsigned int reinitRuns;   // initializePad runs (reconnect edge + analog self-heal)
+    unsigned int reinitDefers; // reconnect-edge inits deferred by the idle gate
+    unsigned int reinitLastMs; // wall time of the last initializePad
+    unsigned int reinitMaxMs;  // worst initializePad this session
+    int analogCapable;         // last verdict (-1 unknown / 0 digital-only / 1 DualShock-capable)
+} pad_diag_t;
+
+void padGetDiag(pad_diag_t *out);
+
 // Menu rumble (#172), gated by gEnableRumble. Tap/Bump arm a pulse on every capable pad and never
 // block -- safe to call from the GUI thread; they no-op when disabled or the pad can't rumble.
 // Rumble is INERT until this is called (once, from main(), when the boot is over and guiMainLoop is

--- a/include/sound.h
+++ b/include/sound.h
@@ -21,6 +21,8 @@ void audioSetVolume(void);
 int sfxInit(int bootSnd);
 int sfxGetSoundDuration(int id);
 void sfxPlay(int id);
+// Debug-Colors instrumentation (#271/#272): wall time of the last / worst audsrv play RPC.
+void sfxGetPlayDiag(unsigned int *lastMs, unsigned int *maxMs);
 
 void bgmStart(void);
 void bgmStop(void);

--- a/include/themes.h
+++ b/include/themes.h
@@ -173,6 +173,7 @@ extern theme_t *gTheme;
 
 extern int gCoverflowCount, gCoverflowCenterScale, gCoverflowAnimSpeed, gCoverflowDimCovers;
 void thmTriggerCoverflowAnim(int dir);
+int thmCoverflowIsAnimating(void);
 
 void thmInit(void);
 void thmReinit(const char *path);

--- a/src/dia.c
+++ b/src/dia.c
@@ -1097,6 +1097,10 @@ int diaExecuteDialog(struct UIItem *ui, int uiId, short inMenu, int (*updater)(i
     while (1) {
         rmStartFrame();
         diaRenderUI(ui, inMenu, cur, haveFocus);
+        // Settings dialogs render directly, never reaching guiDrawOverlays -- so the Debug-
+        // Colors instrumentation line (#271/#272) must be drawn here too, in exactly the
+        // dialogs where the settings-scroll reports live. No-op unless Debug Colors is on.
+        guiDrawDebugLine();
         rmEndFrame();
 
         readPads();

--- a/src/gui.c
+++ b/src/gui.c
@@ -2239,6 +2239,30 @@ void guiDrawSubMenuHints(void)
 static int endIntro = 0; // Break intro loop and start 'Last Played Auto Start' countdown
 #define BUSY_FADE_STEP 0x10
 
+// #271/#272/#296 on-screen instrumentation. Draws ONE line with the pad and SFX counters that
+// the fixes in this file's input path are instrumented by -- miss bursts, reconnect flaps,
+// inline initializePad blackouts (count + last/worst ms, deferred count), worst poll period,
+// and per-press audsrv RPC cost. Rendered ONLY when the user turns Settings -> Debug Colors on,
+// so the normal path pays nothing but the integer bumps in pad.c/sound.c. A hardware tester can
+// then film the line while reproducing a hitch instead of us guessing at the mechanism.
+void guiDrawDebugLine(void)
+{
+    if (!gEnableDebug)
+        return;
+
+    pad_diag_t pd;
+    unsigned int sfxLastMs, sfxMaxMs;
+    char dbg[160];
+
+    padGetDiag(&pd);
+    sfxGetPlayDiag(&sfxLastMs, &sfxMaxMs);
+    snprintf(dbg, sizeof(dbg), "PAD miss:%u brst:%u/%u flap:%u init:%u(%u/%ums) def:%u poll:%ums AC:%d SFX:%u/%ums",
+             pd.readMisses, pd.missBurst, pd.missBurstMax, pd.stateFlaps,
+             pd.reinitRuns, pd.reinitLastMs, pd.reinitMaxMs, pd.reinitDefers,
+             pd.pollMaxMs, pd.analogCapable, sfxLastMs, sfxMaxMs);
+    fntRenderString(gTheme->fonts[0], 0, screenHeight - 24, ALIGN_NONE, 0, 0, dbg, GS_SETREG_RGBA(255, 255, 0, 128));
+}
+
 static void guiDrawOverlays()
 {
     static int busyAlpha = 0x00; // Fully transparant
@@ -2325,6 +2349,12 @@ static void guiDrawOverlays()
     // BLURT output
     // if (gEnableDebug)
     //     fntRenderString(gTheme->fonts[0], 0, screenHeight - 24, ALIGN_NONE, 0, 0, blurttext, GS_SETREG_RGBA(255, 255, 0, 128));
+
+    // Debug-Colors instrumentation (#271/#272/#296). Steps aside during coverflow slides:
+    // binding the font atlas every frame can evict cover textures from the near-saturated VRAM
+    // arena mid-animation (the historic #120 HUD note).
+    if (!thmCoverflowIsAnimating())
+        guiDrawDebugLine();
 }
 
 static void guiReadPads()

--- a/src/pad.c
+++ b/src/pad.c
@@ -75,6 +75,14 @@ struct pad_data_t
 
     char actAlign[6];
     int actuators;
+    int analogCapable; // -1 unknown/not ready, 0 digital-only (fully published table), 1 DualShock-capable
+    int analogRetryDelay;
+
+    // Read-miss state for the two-view sampling below (#271/#272). A failed ready-state read is
+    // "unknown", not "released": missStreak counts the current burst (diag), readMissMs bounds
+    // the level-view carry.
+    u32 readMissMs;
+    unsigned int missStreak;
 
     unsigned char rumbleOn;    // 1 = an "on" was sent that still owes its matching "off"
     unsigned char rumbleLevel; // big-engine level for the pulse in flight (0 = none armed)
@@ -86,6 +94,20 @@ struct pad_data_t
 // GUI thread.
 #define PAD_WAIT_POLLS     25
 #define PAD_WAIT_POLL_US   1000
+// How long a still-connected pad's held buttons may be carried across failed reads, in MILLISECONDS.
+// Bounded UNDER the fastest list key-repeat OPL uses (gScrollSpeed "fast" = 100 ms) so a release
+// hidden inside a miss burst cannot manufacture repeats: inside the window at most one carried
+// poll sits in any repeat cycle. The EDGE view needs no such bound (see edgedata below).
+#define PAD_READ_CARRY_MS      48
+#define PAD_ANALOG_RETRY_DELAY 60
+// Milliseconds without registered input before an inline initializePad() -- reconnect edge or
+// analog self-heal -- may run (#271/#272). That init is 250-600 ms of polled waits ON THE GUI
+// THREAD, and its triggers (reconnect flaps, freepad dropping to digital) are driven by the read
+// errors that cluster under SIO2 load -- so ungated it fired precisely while the user was
+// navigating and ate the taps in flight. A digital-mode pad still reads every d-pad press, so
+// deferring costs nothing the user can feel; the heal fires within a second of the last
+// REGISTERED press. Known residual: a hardware-stuck button starves the heal for the session.
+#define PAD_SELF_HEAL_IDLE_MS  1000
 // A padSetMainMode round-trip can NEVER finish under freepad's own minimum latency: the IOP main
 // thread dispatches the task on the next vblank, SetMainModeThread needs three vblank-gated SIO2
 // transfers, and the request only flips COMPLETE after the next good ReadData -- >= 5 vblanks,
@@ -98,6 +120,11 @@ struct pad_data_t
 #define PAD_INIT_UNSUPPORTED 0
 #define PAD_INIT_OK          1
 
+/// current time in miliseconds (last update time)
+static u32 curtime = 0;
+// Last readPads() poll (curtime ms) on which ANY button/stick input was down -- or a miss burst
+// was active, since a miss is "unknown", not idle. Drives the PAD_SELF_HEAL_IDLE_MS gate.
+static u32 lastInputActivityMs = 0;
 static u32 time_since_last = 0;
 // Raw-tick bookkeeping for the wrap-correct delta in readPads(). lastticks is the previous poll's
 // cpu_ticks(); tickrem carries the sub-millisecond remainder so dividing a delta stays drift-free.
@@ -111,6 +138,37 @@ static struct pad_data_t pad_data[MAX_PADS];
 // gathered pad data
 static u32 paddata;
 static u32 oldpaddata;
+
+/*
+  SECOND, SEPARATELY-CARRIED VIEW OF THE SAME BUTTONS, used ONLY by getKeyOn()/getKeyOff() (#271).
+
+  paddata above is the LEVEL view: "is the button down right now". Its read-miss carry is bounded
+  to PAD_READ_CARRY_MS because it feeds getKeyPressed() and therefore delaycnt, where carrying too
+  long would manufacture auto-repeats the user never asked for.
+
+  edgedata is the EDGE view: "was the button newly pressed". It carries a missed poll's bits
+  WITHOUT a time bound, because the two detectors fail in opposite directions and cannot share one
+  budget: over-carrying the LEVEL view INVENTS movement (phantom repeats), while over-carrying the
+  EDGE view can only ever SUPPRESS a second edge -- an edge needs a 0 -> 1 transition and carrying
+  a 1 forward never produces one. It self-corrects the instant a successful read shows the button
+  clear. Sharing one view (or dropping the carried bit on a miss) is exactly what made one ~150 ms
+  tap move the list 2-3 times: the bit vanished mid-tap, the recovery read saw 0 -> 1 again, and
+  getKeyOn re-fired.
+*/
+static u32 edgedata;
+static u32 oldedgedata;
+
+// Debug-Colors instrumentation (#271/#272). All writers run on the EE main thread inside
+// readPads/readPad/initializePad, and the HUD (gui.c/dia.c) reads on the same thread, so no
+// locking is needed. Counters are cumulative and always maintained (integer bumps only); they
+// are SHOWN only when Settings -> Debug Colors is on.
+static pad_diag_t padDiag;
+
+void padGetDiag(pad_diag_t *out)
+{
+    if (out)
+        *out = padDiag;
+}
 
 /*
  * Screen transitions keep polling pads but do not dispatch input. Freeze the
@@ -127,8 +185,10 @@ void padFreezeEdgeBaseline(int freeze)
 {
     int next = freeze ? 1 : 0;
 
-    if (next && !edgeBaselineFrozen)
+    if (next && !edgeBaselineFrozen) {
         oldpaddata = paddata;
+        oldedgedata = edgedata;
+    }
 
     edgeBaselineFrozen = next;
 }
@@ -197,7 +257,7 @@ static int waitPadRequestComplete(struct pad_data_t *pad)
     return 0;
 }
 
-static int initializePad(struct pad_data_t *pad)
+static int initializePadInner(struct pad_data_t *pad)
 {
     int tmp;
     int modes;
@@ -266,8 +326,14 @@ static int initializePad(struct pad_data_t *pad)
             return PAD_INIT_RETRY;
         }
         LOG("PAD This is no Dual Shock controller\n");
+        // Only a FULLY-published table lacking DualShock may latch digital-only -- latching off a
+        // half-built one permanently disarms the self-heal until the next physical replug.
+        pad->analogCapable = 0;
+        padDiag.analogCapable = 0;
         return PAD_INIT_UNSUPPORTED;
     }
+    pad->analogCapable = 1;
+    padDiag.analogCapable = 1;
 
     // If ExId != 0x0 => This controller has actuator engines
     // This check should always pass if the Dual Shock test above passed
@@ -322,6 +388,22 @@ static int initializePad(struct pad_data_t *pad)
 
     waitPadReady(pad);
     return PAD_INIT_OK;
+}
+
+// Timed wrapper. initializePad is the single biggest GUI-thread blackout in the pad path
+// (250-600 ms of bounded polled waits), and its triggers cluster under exactly the SIO2 load
+// that causes read misses -- so every run and its cost go to the Debug-Colors HUD (#271/#272).
+static int initializePad(struct pad_data_t *pad)
+{
+    u32 start = cpu_ticks();
+    int rc = initializePadInner(pad);
+    unsigned int costMs = (unsigned int)((cpu_ticks() - start) / CLOCKS_PER_MILISEC);
+
+    padDiag.reinitRuns++;
+    padDiag.reinitLastMs = costMs;
+    if (costMs > padDiag.reinitMaxMs)
+        padDiag.reinitMaxMs = costMs;
+    return rc;
 }
 
 static void updatePadState(struct pad_data_t *pad, int state)
@@ -380,6 +462,7 @@ static u32 readLeftJoy(struct pad_data_t *pad, u32 pdata)
 
 static int readPad(struct pad_data_t *pad)
 {
+    int rcode = 0;
     int oldState;
     int newState;
     int ret;
@@ -391,18 +474,62 @@ static int readPad(struct pad_data_t *pad)
     updatePadState(pad, newState);
 
     if (oldState == PAD_STATE_DISCONN && isPadReadyState(pad->state)) {
+        // Pad just connected.
         LOG("PAD pad %d,%d connected\n", pad->port, pad->slot);
-        initializePad(pad);
+        pad->analogCapable = -1;
+        pad->analogRetryDelay = 0;
+        pad->readMissMs = 0;
+        pad->missStreak = 0;
+        padDiag.stateFlaps++;
+        // Idle-gated (#271): this init is the same 250-600 ms inline blackout as the self-heal
+        // below, and a reconnect edge can be DRIVEN by the very read errors that cluster under
+        // load (sustained misses drop freepad to DISCONN, the recovery reconnects). Defer while
+        // input is active: a digital-mode pad still reads every d-pad press, and the self-heal
+        // branch below picks the init up on the first poll after a second of quiet.
+        if ((u32)(curtime - lastInputActivityMs) >= PAD_SELF_HEAL_IDLE_MS)
+            initializePad(pad);
+        else
+            padDiag.reinitDefers++;
     } else if (oldState != PAD_STATE_DISCONN && pad->state == PAD_STATE_DISCONN) {
+        // The pad may transit from any state to disconnected. A real unplug is not a transient
+        // miss: drop the held sample at once so a re-plug starts from a clean slate.
         LOG("PAD pad %d,%d disconnected\n", pad->port, pad->slot);
+        pad->analogCapable = -1;
+        pad->analogRetryDelay = 0;
+        pad->readMissMs = 0;
+        pad->missStreak = 0;
         pad->paddata = 0;
     }
 
     if (isPadReadyState(pad->state)) {
-        ret = padRead(pad->port, pad->slot, &pad->buttons);
+        ret = padRead(pad->port, pad->slot, &pad->buttons); // port, slot, buttons
+
         if (ret != 0) {
             newpdata = 0xffff ^ pad->buttons.btns;
             padsRead++;
+
+            if ((pad->buttons.mode >> 4) == 0x07) {
+                pad->analogCapable = 1;
+                padDiag.analogCapable = 1;
+                pad->analogRetryDelay = 0;
+            } else if (pad->analogCapable != 0) {
+                // freepad can temporarily return a pad to digital mode while recovering from a
+                // read error. Retry forever with a backoff; a real digital-only controller is
+                // disabled once its fully-published mode table proves DualShock mode absent.
+                if (pad->analogRetryDelay > 0) {
+                    pad->analogRetryDelay--;
+                } else if (newpdata != 0 || (u32)(curtime - lastInputActivityMs) < PAD_SELF_HEAL_IDLE_MS) {
+                    // User is actively providing input: DEFER the heal (see PAD_SELF_HEAL_IDLE_MS)
+                    // -- initializePad here would block this thread 250-600 ms and eat the taps in
+                    // flight. newpdata (THIS poll's sample) closes the one-poll staleness hole
+                    // where the first press after a quiet spell lands while the activity stamp is
+                    // still one poll old. Leaving the retry budget at 0 makes the heal fire on
+                    // the first poll after a second of quiet.
+                } else {
+                    initializePad(pad);
+                    pad->analogRetryDelay = PAD_ANALOG_RETRY_DELAY;
+                }
+            }
         }
     }
 
@@ -436,22 +563,47 @@ static int readPad(struct pad_data_t *pad)
 #endif
 
     if (padsRead > 0) {
+        pad->readMissMs = 0;
+        pad->missStreak = 0;
         newpdata = readLeftJoy(pad, newpdata);
         pad->paddata = newpdata;
+
+        paddata |= pad->paddata;
+        edgedata |= pad->paddata;
+
+        if (newpdata != 0x0) // something
+            rcode = 1;
+    } else if (isPadReadyState(pad->state)) {
+        // FAILED ready-state read: "unknown", not "released" (#271/#272). padRead() returns 0
+        // whenever freepad has nothing fresh, which on real hardware happens regularly: the pads
+        // share the SIO2 bus with the memory-card slots and MMCE, so cover-art and config traffic
+        // makes reads intermittently come back empty. That is why this only shows on console,
+        // never in an emulator, and why it gets worse the more art loads the list triggers.
+        pad->missStreak++;
+        padDiag.readMisses++;
+
+        // EDGE view, carried UNBOUNDED: a missed poll must not make getKeyOn() see the button go
+        // away, or the recovery read fires a second key-on from ONE physical tap ("scrolling
+        // skips 2-3 games"). Carrying a 1 can never invent an edge -- only suppress one -- and
+        // self-corrects on the next good read.
+        edgedata |= pad->paddata;
+
+        if (pad->paddata != 0 && pad->readMissMs < PAD_READ_CARRY_MS) {
+            // LEVEL view, carried BOUNDED: keeps getKeyPressed() true so the repeat timers keep
+            // running instead of re-arming the full initial delay on every miss ("sluggish and
+            // heavy, have to press the D-pad several times"). Bounded so a release hidden inside
+            // a burst cannot manufacture repeats; past the window the countdown PAUSES (see
+            // readPads' missHeld) rather than inventing movement.
+            pad->readMissMs += time_since_last;
+            paddata |= pad->paddata;
+            // Counts as activity for the same reason a real read does: guiReadPads() treats a 0
+            // return as "user idle" and releases background art/config IO -- scheduling card
+            // traffic into precisely the SIO2 stall this branch exists to ride out.
+            rcode = 1;
+        }
     }
 
-    /*
-     * Aggregate button data only from successful reads (upstream semantics).
-     * Merging the retained sample after a FAILED ready-state read would carry
-     * "pressed" indefinitely when the missed poll was a release: the next real
-     * tap then has no observed release-to-press edge and is swallowed, and the
-     * stale hold eventually reaches repeat handling as a multi-item skip
-     * (#271/#272).
-     */
-    if (padsRead > 0)
-        paddata |= pad->paddata;
-
-    return pad->paddata != 0;
+    return rcode;
 }
 
 /** Returns delay (in miliseconds) specified for the given key.
@@ -682,9 +834,12 @@ int readPads()
     int i;
     int result = 0;
 
-    if (!edgeBaselineFrozen)
+    if (!edgeBaselineFrozen) {
         oldpaddata = paddata;
+        oldedgedata = edgedata;
+    }
     paddata = 0;
+    edgedata = 0;
 
     /*
      * Difference the raw 32-bit clock before converting to milliseconds, then
@@ -701,9 +856,30 @@ int readPads()
     lastticks = nowticks;
     time_since_last = dticks / CLOCKS_PER_MILISEC;
     tickrem = dticks % CLOCKS_PER_MILISEC;
+    curtime += time_since_last;
+    // Debug-Colors diag (HUD poll): worst poll period this session -- the spike that accompanies
+    // an SIO2 stall (~16/17 ms at a steady 60 Hz).
+    if (time_since_last > padDiag.pollMaxMs)
+        padDiag.pollMaxMs = time_since_last;
 
     for (i = 0; i < pad_count; ++i)
         result |= readPad(&pad_data[i]);
+
+    // Stamp input activity AFTER the merge: any held button/stick -- OR an active miss burst,
+    // since a miss is "unknown", not idle -- re-arms the PAD_SELF_HEAL_IDLE_MS gate. Without the
+    // burst term, a burst outlasting the carry window drops the held bits out of paddata while
+    // the user is still tapping, the stamp goes stale, and after a second of this registered-
+    // input starvation the idle gate opens and readPad() runs initializePad() INLINE on the GUI
+    // thread -- a 250-600 ms blackout that eats every tap (#271).
+    unsigned int streak = 0;
+    for (i = 0; i < pad_count; ++i)
+        if (pad_data[i].missStreak > streak)
+            streak = pad_data[i].missStreak;
+    padDiag.missBurst = streak;
+    if (streak > padDiag.missBurstMax)
+        padDiag.missBurstMax = streak;
+    if (paddata != 0 || streak != 0)
+        lastInputActivityMs = curtime;
 
     // Rumble duration is millisecond-based because some paths poll twice in one frame.
     for (i = 0; i < pad_count; ++i) {
@@ -730,11 +906,28 @@ int readPads()
             pad->rumbleOn = 0;
     }
 
+    // Buttons a still-connected pad holds but this poll cannot SEE: pad->paddata is the last
+    // SAMPLED hold; readMissMs > 0 says every read since has come back empty. Inside the carry
+    // window the level carry keeps getKeyPressed() true, so this mask only matters once the
+    // window lapses and the held bits fall out of the global level view mid-burst.
+    u32 missHeld = 0;
+    for (i = 0; i < pad_count; ++i) {
+        struct pad_data_t *pad = &pad_data[i];
+        if (isPadReadyState(pad->state) && pad->readMissMs > 0)
+            missHeld |= pad->paddata;
+    }
+
     for (i = 0; i < 16; ++i) {
         if (getKeyPressed(i + 1))
             delaycnt[i] -= (int)time_since_last;
-        else
+        else if (!(missHeld & keyToPad[i + 1]))
             delaycnt[i] = getKeyDelay(i + 1, 0);
+        // else: the button reads up ONLY because the pad is mid-read-miss -- PAUSE the countdown
+        // instead of re-arming the full 3x initial delay. A miss is "unknown", not "released";
+        // resetting here is what turned a ~67 ms SIO2 burst into a ~1 s dead cursor, with every
+        // remaining poll of the burst re-arming 900 ms (#272). The reset still fires where it
+        // must: a SAMPLED release clears readMissMs on the recovery read, and a disconnect fails
+        // isPadReadyState -- both take the else-if above.
     }
 
     return result;
@@ -785,7 +978,9 @@ int getKeyOn(int id)
     // old v.s. new pad data
     int keyid = keyToPad[id];
 
-    return (paddata & keyid) && (!(oldpaddata & keyid));
+    // EDGE view, not the level view: a transient read miss must not read as release-then-press,
+    // or the recovery read manufactures a second key-on from ONE tap (#271 "skips 2-3 games").
+    return (edgedata & keyid) && (!(oldedgedata & keyid));
 }
 
 /** Detects key-off event. Returns true if the button was pressed the last frame but is not pressed this frame.
@@ -800,7 +995,8 @@ int getKeyOff(int id)
     // old v.s. new pad data
     int keyid = keyToPad[id];
 
-    return (!(paddata & keyid)) && (oldpaddata & keyid);
+    // Edge view, for the same reason as getKeyOn: a miss is "unknown", not "released".
+    return (!(edgedata & keyid)) && (oldedgedata & keyid);
 }
 
 /** Returns true (nonzero) if the button is currently pressed

--- a/src/pad.c
+++ b/src/pad.c
@@ -92,8 +92,8 @@ struct pad_data_t
 
 // Pad commands are asynchronous. Keep every wait bounded so a transient SIO2/pad error cannot hang the
 // GUI thread.
-#define PAD_WAIT_POLLS     25
-#define PAD_WAIT_POLL_US   1000
+#define PAD_WAIT_POLLS         25
+#define PAD_WAIT_POLL_US       1000
 // How long a still-connected pad's held buttons may be carried across failed reads, in MILLISECONDS.
 // Bounded UNDER the fastest list key-repeat OPL uses (gScrollSpeed "fast" = 100 ms) so a release
 // hidden inside a miss burst cannot manufacture repeats: inside the window at most one carried
@@ -114,7 +114,7 @@ struct pad_data_t
 // ~83-100 ms. The generic 25 ms budget above therefore ALWAYS timed out on this leg, so analog
 // arming worked only when the IOP happened to finish in the background and the pressure/rumble
 // setup below it was unreachable. Give request-completion waits a budget above the happy path.
-#define PAD_REQ_WAIT_POLLS 150
+#define PAD_REQ_WAIT_POLLS     150
 
 #define PAD_INIT_RETRY       -1
 #define PAD_INIT_UNSUPPORTED 0

--- a/src/sound.c
+++ b/src/sound.c
@@ -5,6 +5,7 @@
  */
 
 #include <audsrv.h>
+#include <timer.h>
 #include <vorbis/vorbisfile.h>
 
 #include "include/sound.h"
@@ -257,6 +258,22 @@ int sfxGetSoundDuration(int id)
     return sfx_files[id].duration_ms;
 }
 
+// Debug-Colors instrumentation (#271/#272): per-press audsrv RPC wall time. audsrv_ch_play_adpcm
+// is a SYNCHRONOUS SIF RPC on the GUI thread (one per nav press); under IOP contention it stalls
+// the menu mid-navigation. Always measured (two tick reads), rendered only when Settings ->
+// Debug Colors is on (gui.c / dia.c).
+#define SFX_CLOCKS_PER_MS 147456 // EE cpu_ticks() rate, same constant as pad.c's CLOCKS_PER_MILISEC
+static unsigned int sfxLastPlayMs = 0;
+static unsigned int sfxMaxPlayMs = 0;
+
+void sfxGetPlayDiag(unsigned int *lastMs, unsigned int *maxMs)
+{
+    if (lastMs)
+        *lastMs = sfxLastPlayMs;
+    if (maxMs)
+        *maxMs = sfxMaxPlayMs;
+}
+
 void sfxPlay(int id)
 {
     int channel;
@@ -299,6 +316,7 @@ void sfxPlay(int id)
     }
 
     if (gEnableSFX) {
+        u32 sfxStartTicks = cpu_ticks();
         if (id == SFX_CURSOR) {
             int chosenSlot = cursorChannelIndex;
 
@@ -311,6 +329,11 @@ void sfxPlay(int id)
         } else {
             audsrv_ch_play_adpcm(id, &sfx[id]);
         }
+
+        unsigned int costMs = (unsigned int)((cpu_ticks() - sfxStartTicks) / SFX_CLOCKS_PER_MS);
+        sfxLastPlayMs = costMs;
+        if (costMs > sfxMaxPlayMs)
+            sfxMaxPlayMs = costMs;
     }
 }
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -1098,8 +1098,7 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         int side;
         for (side = 0; side < 2; side++) {
             struct submenu_list *walk = walkSide[side];
-            struct submenu_list *next = side ? (walk->prev ? walk->prev : menu->item->last)
-                                             : (walk->next ? walk->next : menu->item->submenu);
+            struct submenu_list *next = side ? (walk->prev ? walk->prev : menu->item->last) : (walk->next ? walk->next : menu->item->submenu);
             if (!next || next == walk || next == item)
                 continue;
             walkSide[side] = next;

--- a/src/themes.c
+++ b/src/themes.c
@@ -936,6 +936,14 @@ void thmTriggerCoverflowAnim(int dir)
     cfAnimStartTime = clock();
 }
 
+// Poll-side read of the slide state. The Debug-Colors HUD (gui.c) steps aside while a slide is
+// in flight: binding the font atlas every frame can evict cover textures from the VRAM arena
+// mid-animation (the historic #120 HUD note).
+int thmCoverflowIsAnimating(void)
+{
+    return cfIsAnimating;
+}
+
 static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
 {
     if (!item)
@@ -1064,6 +1072,60 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         mutable_image_t *centerImg = (mutable_image_t *)thmGetElemForItem(menu, covers[centerIdx], elem)->extended;
         if (centerImg)
             getGameImageTexture(centerImg->cache, sourceList, &covers[centerIdx]->item);
+    }
+
+    /*
+      Lookahead warming (#296). The draw loop below only ever requests the covers on screen
+      (plus the slide padding), so scrolling faster than a decode leaves every incoming cover
+      cold -- "CF covers load only on focus". Walk the ring outward from the selection,
+      wrap-aware like the window builder above, and request neighbours beyond the window while
+      the cache budget lasts. Depth is (cache->count - 1)/2 per side, so one frame touches at
+      most cache->count distinct keys (selected + both walks) and warming can never evict the
+      selected cover; the per-cache request budget mirrors drawItemsList (a Favourites tab can
+      resolve covers into TWO caches via thmGetElemForItem). Folders carry no cover. Themes
+      tune the depth with the existing main0_count knob -- more cache slots, deeper warming.
+    */
+    mutable_image_t *elemImg = (mutable_image_t *)elem->extended;
+    int warmRadius = (elemImg != NULL && elemImg->cache != NULL) ? (elemImg->cache->count - 1) / 2 : 0;
+    struct
+    {
+        image_cache_t *cache;
+        int left;
+    } cfWarm[2] = {{NULL, 0}, {NULL, 0}};
+    struct submenu_list *walkSide[2] = {item, item}; // [0] = forward, [1] = backward
+    int step;
+    for (step = 0; step < warmRadius; step++) {
+        int side;
+        for (side = 0; side < 2; side++) {
+            struct submenu_list *walk = walkSide[side];
+            struct submenu_list *next = side ? (walk->prev ? walk->prev : menu->item->last)
+                                             : (walk->next ? walk->next : menu->item->submenu);
+            if (!next || next == walk || next == item)
+                continue;
+            walkSide[side] = next;
+            if (next->item.isFolder)
+                continue;
+
+            mutable_image_t *wimg = (mutable_image_t *)thmGetElemForItem(menu, next, elem)->extended;
+            if (wimg == NULL || wimg->cache == NULL || wimg->cache->count < 2)
+                continue;
+            if (step >= (wimg->cache->count - 1) / 2)
+                continue; // deeper than THIS resolved cache can hold
+
+            int b;
+            for (b = 0; b < 2 && cfWarm[b].cache != NULL && cfWarm[b].cache != wimg->cache; b++)
+                ;
+            if (b == 2)
+                continue;
+            if (cfWarm[b].cache == NULL) {
+                cfWarm[b].cache = wimg->cache;
+                cfWarm[b].left = wimg->cache->count - 1; // selected's slot stays reserved
+            }
+            if (cfWarm[b].left > 0) {
+                cfWarm[b].left--;
+                getGameImageTexture(wimg->cache, sourceList, &next->item);
+            }
+        }
     }
 
     for (i = drawFirst; i < drawLast; i++) {


### PR DESCRIPTION
## What broke and why

Beta-3493's `47b5d6d7` ("refactor: simplify runtime loading pipelines") deleted three pieces of load-bearing input/art machinery, and `1b6522ed` leaned further into the same model. zackcage6's reports (#271, #272, #296 — SCPH-30001R fat, exFAT USB; PCSX2 never reproduces any of it) trace to those deletions:

1. **Phantom edges (#271 "skips 2-3 games", #272 "sluggish/heavy").** `readPad()` aggregated button data only from *successful* reads. On hardware the pads share the SIO2 bus with the memory-card slots and MMCE, so `padRead()` intermittently returns 0 under art/config traffic. On a missed poll the held bits vanished from the global level for one frame; the next good read then looked like a fresh 0→1 transition, so `getKeyOn()` fired a **second edge from one physical tap** — and `getKeyPressed()` reading false re-armed the full 3× initial delay on every miss, killing held-repeat.
2. **Inline re-init blackouts (#271 "hangs ~0.5-1 s every ~5th press").** The reconnect edge ran `initializePad()` — 250-600 ms of bounded polled waits — **inline on the GUI thread**, and the flaps that trigger it cluster under exactly the SIO2 load that also causes read misses. It fired mid-navigation and ate the taps in flight. Pre-refactor code idle-gated this behind 1 s of input inactivity; the refactor removed the gate.
3. **Coverflow art only loads on focus (#296).** The CF draw loop only ever requested the covers on screen (plus slide padding), so scrolling faster than a decode left every incoming cover cold. (List covers were already fixed in Beta-3504; this is the CF half, plus the same walk depth is what BGs would need — backgrounds are deliberately *not* warmed: 1-slot BG cache, ~1 MB EE RAM each.)

## The fixes (restorations in spirit, not reverts)

- **`fix(pad)`** — two-view sampling returns: the **edge view** (`getKeyOn`/`getKeyOff`) carries missed reads *unbounded* (carrying a 1 can never invent a 0→1, only suppress a second edge, and self-corrects on the next good read); the **level view** (`getKeyPressed`/repeat timers) carries *bounded to 48 ms*, under the fastest repeat interval (100 ms), so a release hidden inside a burst cannot manufacture repeats; past the window the countdown **pauses** instead of re-arming. The reconnect-edge init and the analog self-heal are re-gated behind 1 s of registered input inactivity (an active miss burst counts as activity — "unknown", not idle). Digital-only latching again requires a fully-published mode table.
- **`fix(art)`** — wrap-aware lookahead walk in `drawCoverFlow()`: ±((cache->count−1)/2) neighbours from the selection with a per-cache request budget that reserves the selected cover's slot, mirroring `drawItemsList`. `thmGetElemForItem` keeps the Favourites APP redirect; folders skipped; depth follows the existing `main0_count` theme knob.
- **`feat(debug)`** — the instrumentation, shown **only when Settings → Debug Colors is on**: one bottom-screen line `PAD miss:.. brst:../.. flap:.. init:..(last/max ms) def:.. poll:..ms AC:.. SFX:../..ms`. Counters are always maintained (integer bumps on the EE main thread, zero cost with the setting off); the line renders from `guiDrawOverlays` and from the dialog loop (Settings dialogs never reach the overlays — exactly where #272 lives), and steps aside during CF slides so font-atlas binds can't evict covers mid-animation.

## For testers

1. Normal use first: Debug Colors **off** — navigation, CF, Settings should feel like Beta-3449 again.
2. Then turn **Settings → Debug Colors on** and reproduce a hitch while filming the bottom line:
   - `brst:`/`miss:` climbing during a hitch = SIO2 read misses (expected under load; the carry should make them invisible).
   - `init:` climbing with high `(max ms)` *while you are navigating* = the idle gate isn't holding — report the numbers.
   - `def:` = re-inits correctly deferred while you were active.
   - `SFX:` max above ~20 ms = audsrv RPC stalls contributing to press latency.

Built with `ps2dev/ps2dev:latest` (`make release`), clean compile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional on-screen diagnostics display for controller and audio performance.
  * Added public diagnostic information for controller status and sound playback timing.
* **Bug Fixes**
  * Improved controller handling when reads fail, preventing transient input loss from being treated as button releases.
  * Added safer controller recovery and improved analog-controller detection.
* **Performance**
  * Improved coverflow responsiveness by preparing nearby artwork in advance.
  * Avoided unnecessary diagnostic rendering during coverflow animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->