### PR TITLE
docs(pad): PAD_ANALOG_RETRY_DELAY unit note (CodeRabbit #319 follow-up)

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -99,6 +99,8 @@ struct pad_data_t
 // hidden inside a miss burst cannot manufacture repeats: inside the window at most one carried
 // poll sits in any repeat cycle. The EDGE view needs no such bound (see edgedata below).
 #define PAD_READ_CARRY_MS      48
+// Successful-read polls between analog self-heal attempts -- a POLL COUNT, decremented once per
+// good read, not milliseconds like its neighbours.
 #define PAD_ANALOG_RETRY_DELAY 60
 // Milliseconds without registered input before an inline initializePad() -- reconnect edge or
 // analog self-heal -- may run (#271/#272). That init is 250-600 ms of polled waits ON THE GUI


### PR DESCRIPTION
CodeRabbit review of #319, accepted item: PAD_ANALOG_RETRY_DELAY is decremented once per successful read, so document it as a poll count next to its millisecond neighbours. Comment-only change. The second finding (share SFX_CLOCKS_PER_MS) was denied on the PR with reasoning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that analog retry delays are measured by successful-read polls rather than milliseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->