### PR TITLE
Restore loading icon piping to official OPL baseline

### DIFF
--- a/include/gui.h
+++ b/include/gui.h
@@ -194,12 +194,6 @@ void guiRenderTextScreen(const char *message);
  */
 void guiShowGameID(const char *startup);
 
-/** Renders a single frame of the game menu with the loading animation at full alpha (#299).
- *  Pumped by hand around the blocking launch-prep steps in itemExecSelect(), where the main
- *  loop's busy animation never runs.
- */
-void guiRenderBusyFrame(void);
-
 /** Renders a single boot-splash (greeting) frame, used as the boot loading screen
  *  so the menu is not drawn before it is ready.
  */

--- a/include/ioman.h
+++ b/include/ioman.h
@@ -28,10 +28,6 @@ int ioRegisterHandler(int type, io_request_handler_t handler);
 /** schedules a new request into the pending request list
  * @note The data are not freed! */
 int ioPutRequest(int type, void *data);
-// Same queue and drain semantics as ioPutRequest, but excluded from the busy-spinner count (#290).
-// BACKGROUND MAINTENANCE only -- work the user did not ask for, whose usual outcome is "nothing
-// changed" (menuUpdateHook's periodic device rescans). User-initiated work must stay visible.
-int ioPutRequestQuiet(int type, void *data);
 
 /** removes all requests of a given type from the queue
  * @param type the type of the requests to remove
@@ -43,10 +39,6 @@ int ioGetPendingRequestCount(void);
 
 /** returns nonzero if there are any pending io requests */
 int ioHasPendingRequests(void);
-// Pending requests excluding quiet background maintenance -- what the loading spinner keys off.
-// Queue drains/throttles must keep using ioHasPendingRequests (a quiet request still occupies the
-// worker and still delays a launch).
-int ioHasVisiblePendingRequests(void);
 
 /** returns nonzero if the io thread is running */
 int ioIsRunning(void);

--- a/src/gui.c
+++ b/src/gui.c
@@ -2178,30 +2178,13 @@ void guiExecDeferredOps(void)
 
 static void guiDrawBusy(int alpha)
 {
-    // loadingIconCount is now a true contiguous-frame count (themes.c) and CAN be 0 -- a disk theme
-    // shipping no load*.png with use_default=0 -- so gate the modulo on it (no div-by-zero, no
-    // garbage texture id).
-    if (gTheme->loadingIcon && gTheme->loadingIconCount > 0) {
+    if (gTheme->loadingIcon) {
         GSTEXTURE *texture = thmGetTexture(LOAD0_ICON + (guiFrameId >> 1) % gTheme->loadingIconCount);
         if (texture && texture->Mem) {
             u64 mycolor = GS_SETREG_RGBA(0x80, 0x80, 0x80, alpha);
             rmDrawPixmap(texture, gTheme->loadingIcon->posX, gTheme->loadingIcon->posY, gTheme->loadingIcon->aligned, gTheme->loadingIcon->width, gTheme->loadingIcon->height, gTheme->loadingIcon->scaled, mycolor, 0);
         }
     }
-}
-
-// One hand-pumped loader frame for the synchronous launch path (#299). itemExecSelect() blocks the
-// GUI thread from confirm to the ELF handoff, so guiDrawOverlays()' busy animation never runs there
-// and the user stares at a frozen menu for the whole launch prep. Callers pump this around/between
-// the blocking steps: it leaves menu + loader (at full alpha -- no fade wait, the fade is a
-// guiDrawOverlays concern) scanned out while the next step blocks, and each pump ticks guiFrameId so
-// the animation frame advances. Pure rendering -- no IO-queue traffic, safe any time the GUI is up.
-void guiRenderBusyFrame(void)
-{
-    guiStartFrame();
-    guiShow();
-    guiDrawBusy(0x80);
-    guiEndFrame();
 }
 
 // Boot-splash status line setter (#297). Pass NULL to clear. Main-thread only (writes gBootStatus, which
@@ -2588,14 +2571,7 @@ void guiDrawSubMenuHints(void)
 }
 
 static int endIntro = 0; // Break intro loop and start 'Last Played Auto Start' countdown
-#define BUSY_FADE_STEP 0x10
 
-// #271/#272/#296 on-screen instrumentation. Draws ONE line with the pad and SFX counters that
-// the fixes in this file's input path are instrumented by -- miss bursts, reconnect flaps,
-// inline initializePad blackouts (count + last/worst ms, deferred count), worst poll period,
-// and per-press audsrv RPC cost. Rendered ONLY when the user turns Settings -> Debug Colors on,
-// so the normal path pays nothing but the integer bumps in pad.c/sound.c. A hardware tester can
-// then film the line while reproducing a hitch instead of us guessing at the mechanism.
 void guiDrawDebugLine(void)
 {
     if (!gEnableDebug)
@@ -2616,29 +2592,22 @@ void guiDrawDebugLine(void)
 
 static void guiDrawOverlays()
 {
+    // are there any pending operations?
+    int pending = ioHasPendingRequests();
     static int busyAlpha = 0x00; // Fully transparant
 
-    // Only explicit foreground IO owns the global loader. Art is rendered with
-    // placeholders while its worker runs, and quiet metadata/rescan work stays quiet.
-    int pending = ioHasVisiblePendingRequests();
-
-    // During the boot intro, when an animated boot logo is shown, suppress the
-    // loading spinner -- the animated logo is the boot activity indicator there.
-    // The spinner is used normally everywhere else (and on boot for themes/builds
-    // without animated logo frames, so a slow boot still shows activity).
-    int showBusy = endIntro || (gTheme->logoFrameCount < 1);
-    if (showBusy) {
-        if (!pending) {
-            if (busyAlpha > 0x00)
-                busyAlpha -= BUSY_FADE_STEP;
-        } else {
-            if (busyAlpha < 0x80)
-                busyAlpha += BUSY_FADE_STEP;
-        }
-
+    if (!pending) {
+        // Fade out
         if (busyAlpha > 0x00)
-            guiDrawBusy(busyAlpha);
+            busyAlpha -= 0x02;
+    } else {
+        // Fade in
+        if (busyAlpha < 0x80)
+            busyAlpha += 0x02;
     }
+
+    if (busyAlpha > 0x00)
+        guiDrawBusy(busyAlpha);
 
 #ifdef __DEBUG
     char text[20];

--- a/src/ioman.c
+++ b/src/ioman.c
@@ -24,9 +24,6 @@ struct io_request_t
 {
     int type;
     void *data;
-    // Nonzero = background maintenance (periodic device rescans): excluded from the busy-spinner
-    // count below, still counted by everything that DRAINS the queue. See ioPutRequestQuiet.
-    int quiet;
     struct io_request_t *next;
 };
 
@@ -42,28 +39,6 @@ static struct io_request_t *gReqEnd;
 
 // Total number of queued requests currently stored in the list.
 static int gReqCount;
-
-/*
-  Number of NON-QUIET requests between enqueue and processing-complete -- what the GUI busy spinner
-  keys off (#290).
-
-  The spinner used to key off the raw queue (ioHasPendingRequests), which also counts the periodic
-  background device rescans menuUpdateHook enqueues every MENU_GENERAL_UPDATE_DELAY frames. On a
-  device where one presence scan takes a few hundred ms (MMCE's SIO2 round-trips, a busy USB stick),
-  each rescan held the queue non-empty long enough for the fade-in to become visible -- the loading
-  spinner "reappearing every few seconds" while the console sat idle, doing maintenance the user
-  never asked for and cannot see the result of. Upstream OPL and wOPL share this (same hook, same
-  raw-queue spinner, none of our scheduling gates), which is why the reporter reproduces it on the
-  main branch.
-
-  A request is visible from ioPutRequest until the worker has FINISHED processing it (the node is
-  unlinked only after its handler returns), so the spinner still spans the whole duration of real
-  work, exactly as before. Only who gets counted changed.
-
-  Updated under gEndSemaId in every path that links or unlinks a node; read without the sema by the
-  render loop, same single-word-read discipline as ioHasPendingRequests' pointer peek.
-*/
-static int gVisibleCount;
 
 static struct io_handler_t gRequestHandlers[MAX_IO_HANDLERS];
 
@@ -175,8 +150,6 @@ static void ioWorkerThread(void *arg)
 
             // can't be sure if the request was
             gReqList = req->next;
-            if (!req->quiet && gVisibleCount > 0)
-                gVisibleCount--; // processing done only now, so visibility spans the handler run
             free(req);
             if (gReqCount > 0)
                 gReqCount--;
@@ -193,8 +166,6 @@ static void ioWorkerThread(void *arg)
     while (gReqList) {
         struct io_request_t *req = gReqList;
         gReqList = gReqList->next;
-        if (!req->quiet && gVisibleCount > 0)
-            gVisibleCount--;
         free(req);
         if (gReqCount > 0)
             gReqCount--;
@@ -225,7 +196,6 @@ void ioInit(void)
     gReqList = NULL;
     gReqEnd = NULL;
     gReqCount = 0;
-    gVisibleCount = 0;
 
     gIOThreadId = 0;
 
@@ -252,7 +222,7 @@ void ioInit(void)
     StartThread(gIOThreadId, NULL);
 }
 
-static int ioPutRequestInternal(int type, void *data, int quiet)
+int ioPutRequest(int type, void *data)
 {
     if (isIOBlocked)
         return IO_ERR_IO_BLOCKED;
@@ -267,8 +237,6 @@ static int ioPutRequestInternal(int type, void *data, int quiet)
     // If it exists, it won't be touched, if it does not exist, it is not being processed
     struct io_request_t *req = (struct io_request_t *)malloc(sizeof(struct io_request_t));
     if (!req) {
-        // Out of memory: do NOT corrupt the queue. The old code assigned the NULL straight into
-        // gReqList/gReqEnd and then dereferenced it (req->next = NULL). Release the lock and fail.
         SignalSema(gEndSemaId);
         return IO_ERR_TOO_MANY_REQUESTS;
     }
@@ -276,7 +244,6 @@ static int ioPutRequestInternal(int type, void *data, int quiet)
     req->next = NULL;
     req->type = type;
     req->data = data;
-    req->quiet = quiet;
 
     if (!gReqEnd)
         gReqList = req;
@@ -284,28 +251,12 @@ static int ioPutRequestInternal(int type, void *data, int quiet)
         gReqEnd->next = req;
     gReqEnd = req;
     gReqCount++;
-    if (!quiet)
-        gVisibleCount++;
 
     SignalSema(gEndSemaId);
 
     // Worker thread cannot wake itself up (WakeupThread will return an error), but it will find the new request before sleeping.
     WakeupThread(gIOThreadId);
     return IO_OK;
-}
-
-int ioPutRequest(int type, void *data)
-{
-    return ioPutRequestInternal(type, data, 0);
-}
-
-// Same queue, same handlers, same drain semantics -- but excluded from the busy-spinner count
-// (ioHasVisiblePendingRequests). For BACKGROUND MAINTENANCE only: work the user did not ask for and
-// whose usual outcome is "nothing changed", like menuUpdateHook's periodic device rescans. Anything
-// user-initiated (device enable, manual refresh, config save, module loads) must stay visible.
-int ioPutRequestQuiet(int type, void *data)
-{
-    return ioPutRequestInternal(type, data, 1);
 }
 
 int ioRemoveRequests(int type)
@@ -332,8 +283,6 @@ int ioRemoveRequests(int type)
                 gReqEnd = last;
 
             count++;
-            if (!req->quiet && gVisibleCount > 0)
-                gVisibleCount--;
             free(req);
             if (gReqCount > 0)
                 gReqCount--;
@@ -388,15 +337,6 @@ int ioGetPendingRequestCount(void)
 int ioHasPendingRequests(void)
 {
     return gReqList != NULL ? 1 : 0;
-}
-
-// Pending requests EXCLUDING quiet background maintenance -- what the loading spinner shows (#290).
-// Everything that drains or throttles the queue must keep using ioHasPendingRequests: a quiet
-// request still occupies the worker, still delays a launch, and must still hold off the next
-// background rescan.
-int ioHasVisiblePendingRequests(void)
-{
-    return gVisibleCount > 0 ? 1 : 0;
 }
 
 #ifdef __EESIO_DEBUG

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -319,7 +319,7 @@ static void _menuRequestConfig()
 
     int queueResult = IO_OK;
     if (shouldQueueLoad) {
-        queueResult = visibleLoad ? ioPutRequest(IO_CUSTOM_SIMPLEACTION, &_menuLoadConfig) : ioPutRequestQuiet(IO_CUSTOM_SIMPLEACTION, &_menuLoadConfig);
+        queueResult = ioPutRequest(IO_CUSTOM_SIMPLEACTION, &_menuLoadConfig);
     }
 
     if (queueResult != IO_OK) {
@@ -399,7 +399,7 @@ config_set_t *menuLoadConfigDirect(void)
 // Queued when the info screen opens: resolve #Size for the current item without blocking the UI.
 void menuRequestInfoSize(void)
 {
-    ioPutRequestQuiet(IO_CUSTOM_SIMPLEACTION, &_menuResolveInfoSize);
+    ioPutRequest(IO_CUSTOM_SIMPLEACTION, &_menuResolveInfoSize);
 }
 
 // we don't want a pop up when transitioning to or refreshing Game Menu gui.

--- a/src/opl.c
+++ b/src/opl.c
@@ -1132,13 +1132,8 @@ static void menuUpdateHook()
     int longIdle = (guiInactiveFrames >= MENU_BG_RESCAN_MIN_INACTIVE_FRAMES);
 
     // schedule updates of all the list handlers
-    // Quiet on purpose (#290): these are periodic background rescans the user never asked for, and
-    // their usual outcome is "nothing changed". Enqueued visibly, each slow presence scan faded the
-    // loading spinner in while the console sat idle -- the "spinner reappears every few seconds"
-    // report. A rescan that DOES find a change still rebuilds the list (the list itself changing is
-    // the signal; there was never a toast for it), it just does so without the spinner. Known
-    // residual: work a quiet rescan enqueues ONWARD (bdm module-load retries, favourites reload) is
-    // still visible and can flash the spinner on rigs where those persistently re-fire.
+    // Periodic background rescans. Both steady-state rescans enqueue standard requests and are
+    // rendered with the unified busy overlay.
     if (gAutoRefresh && longIdle) {
         for (i = 0; i < MODE_COUNT; i++) {
             if ((list_support[i].support && list_support[i].support->enabled) && ((list_support[i].support->updateDelay > 0) && (frameCounter % list_support[i].support->updateDelay == 0)))
@@ -1168,11 +1163,10 @@ static void menuUpdateHook()
             if ((list_support[i].support && list_support[i].support->enabled) && (list_support[i].support->updateDelay == 0)) {
                 int mode = list_support[i].support->mode;
                 // elapsed form is single-wrap-safe; zero-initialized timestamp allows one immediate rescan.
-                // genChanged (hotplug / Device-Settings apply) deliberately requires NEITHER longIdle
-                // nor quiet: it fires precisely BECAUSE a device changed, the scan populates a page the
-                // user is waiting on (visible, #290), and a plugged device should be noticed in the
-                // next tap gap rather than after a second of stillness (#271). Only the recurring
-                // steady-state probe is quiet AND waits for real idleness.
+                // genChanged (hotplug / Device-Settings apply) deliberately requires NEITHER longIdle:
+                // it fires precisely BECAUSE a device changed, the scan populates a page the
+                // user is waiting on, and a plugged device should be noticed in the
+                // next tap gap rather than after a second of stillness (#271).
                 if (genChanged || (longIdle && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
                     // Stamp the throttle only on an accepted request, so a rejected one retries on
                     // the next tick instead of being silently skipped for a full interval.

--- a/src/opl.c
+++ b/src/opl.c
@@ -347,22 +347,10 @@ static void itemExecSelect(struct menu_item *curMenu)
                 // Costs ~90ms at most, on a path that already takes seconds. No-op when rumble is off.
                 padRumbleFlush();
 
-                // #299 launch-prep loader: everything from here to the handoff blocks the GUI
-                // thread, so guiDrawOverlays' busy animation never runs and the user stares at a
-                // frozen menu for the whole load. Pump loader frames by hand around the blocking
-                // steps -- this one leaves menu+loader scanned out while the config read blocks,
-                // and guiShowGameID's frame hold (when enabled) cycles the animation for real.
-                guiRenderBusyFrame();
                 config_set_t *configSet = menuLoadConfigDirect();
                 // Flash the GameID barcode (Pixel FX/RetroGEM HDMI auto-profile) before handoff; this
                 // single menu chokepoint covers both the Neutrino and OPL-native cores. No-op when off.
                 guiShowGameID(support->itemGetStartup(support, curMenu->current->item.id));
-                // Final pre-handoff frame (#299): the last thing drawn before itemLaunch's blocking
-                // prep, so menu+loader -- not a stale menu or the GameID barcode -- is what stays
-                // scanned out until deinit()/ExecPS2. On a launch FAILURE itemLaunch returns and the
-                // next guiMainLoop frame replaces this, so the loader can never wedge on-screen.
-                // Both pumps run BEFORE itemLaunch, i.e. before deinit starts tearing the theme down.
-                guiRenderBusyFrame();
                 support->itemLaunch(support, curMenu->current->item.id, configSet);
             }
         } else {
@@ -1154,7 +1142,7 @@ static void menuUpdateHook()
     if (gAutoRefresh && longIdle) {
         for (i = 0; i < MODE_COUNT; i++) {
             if ((list_support[i].support && list_support[i].support->enabled) && ((list_support[i].support->updateDelay > 0) && (frameCounter % list_support[i].support->updateDelay == 0)))
-                ioPutRequestQuiet(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+                ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
         }
     }
 
@@ -1188,11 +1176,7 @@ static void menuUpdateHook()
                 if (genChanged || (longIdle && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
                     // Stamp the throttle only on an accepted request, so a rejected one retries on
                     // the next tick instead of being silently skipped for a full interval.
-                    int accepted;
-                    if (genChanged)
-                        accepted = (ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);
-                    else
-                        accepted = (ioPutRequestQuiet(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);
+                    int accepted = (ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);
                     if (accepted)
                         lastBgRescan[mode] = now;
                     else if (genChanged)

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -442,7 +442,7 @@ static load_image_request_t *cacheDequeueRequest(void)
          * The regular IO worker owns foreground list/config/module work. Art
          * remains queued until that work is clear, then drains in FIFO order.
          */
-        if (ioHasPendingRequests() || cacheShouldDeferRequest(gArtReqList)) {
+        if (cacheShouldDeferRequest(gArtReqList)) {
             cacheUnlock();
             return NULL;
         }
@@ -956,7 +956,6 @@ void cachePumpPendingArt(void)
         gArtThreadId >= 0 &&
         gArtActiveCount == 0 &&
         gArtReqList != NULL &&
-        !ioHasPendingRequests() &&
         !cacheShouldDeferRequest(gArtReqList))
         wakeWorker = 1;
     cacheUnlock();

--- a/src/themes.c
+++ b/src/themes.c
@@ -2632,24 +2632,20 @@ static int thmLoad(const char *themePath)
             break;
     }
 
-    // Busy-icon animation frames, each frame probed INDEPENDENTLY: the theme's own load<N>.png
-    // first (disk themes), the baked frame only when use_default=1 opts into it. thmLoadResource's
-    // return is the DISK load's result only (it discards the embedded fallback's result), so a
-    // frame counts as loaded only when its texture slot actually got data. loadingIconCount is the
-    // number of CONTIGUOUS frames from load0 -- a gap (e.g. load2.png missing on a use_default=0
-    // theme) ends the count instead of letting guiDrawBusy's `LOAD0_ICON + frame % count` wander
-    // into texture IDs that hold no frame. The old loop latched themePath_temp=NULL off the FIRST
-    // failed custom probe (so one missing/unreadable load0.png silently replaced the theme's whole
-    // animation with the baked set -- or, with use_default=0, dropped frames that did exist), which
-    // is why custom frames appeared "randomly" (#213).
-    newT->loadingIconCount = 0;
+    // First start with busy icon
+    const char *themePath_temp = themePath;
+    int customBusy = 0;
     for (i = LOAD0_ICON; i <= LOAD7_ICON; i++) {
-        thmLoadResource(&newT->textures[i], i, themePath, GS_PSM_CT32, newT->useDefault);
-        if (newT->textures[i].Mem != NULL)
-            newT->loadingIconCount++;
-        else
-            break;
+        if (thmLoadResource(&newT->textures[i], i, themePath_temp, GS_PSM_CT32, newT->useDefault) >= 0)
+            customBusy = 1;
+        else {
+            if (customBusy)
+                break;
+            else
+                themePath_temp = NULL;
+        }
     }
+    newT->loadingIconCount = i;
 
     // Customizable icons
     for (i = BDM_ICON; i <= START_ICON; i++)


### PR DESCRIPTION
Restores loading icon (load0.png ... load7.png) triggering, queue status tracking, alpha fading, and theme resource probing back to official Open-PS2-Loader baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loading indicators now appear for all pending background activity, including maintenance tasks.
  * Improved fallback behavior for custom loading animations when frame files are unavailable.

* **Bug Fixes**
  * Loading indicators now display reliably during startup and configuration loading.
  * Background menu updates and rescans now provide standard activity notifications.
  * Removed outdated manual loading-frame behavior and related public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->