### PR TITLE
fix(pad): restore edgedata edge-tracking to prevent false re-presses on missed reads

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -539,13 +539,14 @@ static int readPad(struct pad_data_t *pad)
 
         // merge into the global vars
         paddata |= pad->paddata;
-        edgedata |= pad->paddata;
 
         if (newpdata != 0x0) // something
             rcode = 1;
     } else {
         // no successful read: baseline behavior (do not carry state)
     }
+
+    edgedata |= pad->paddata;
 
     return rcode;
 }

--- a/src/pad.c
+++ b/src/pad.c
@@ -152,6 +152,8 @@ void padGetDiag(pad_diag_t *out)
  * A tap pressed and released entirely inside the fade remains intentionally
  * ignored. Polling continues for rumble timing, pad state, and reconnects.
  */
+static u32 edgedata;
+static u32 oldedgedata;
 static int edgeBaselineFrozen = 0;
 
 void padFreezeEdgeBaseline(int freeze)
@@ -160,6 +162,7 @@ void padFreezeEdgeBaseline(int freeze)
 
     if (next && !edgeBaselineFrozen) {
         oldpaddata = paddata;
+        oldedgedata = edgedata;
     }
 
     edgeBaselineFrozen = next;
@@ -536,6 +539,7 @@ static int readPad(struct pad_data_t *pad)
 
         // merge into the global vars
         paddata |= pad->paddata;
+        edgedata |= pad->paddata;
 
         if (newpdata != 0x0) // something
             rcode = 1;
@@ -776,8 +780,10 @@ int readPads()
 
     if (!edgeBaselineFrozen) {
         oldpaddata = paddata;
+        oldedgedata = edgedata;
     }
     paddata = 0;
+    edgedata = 0;
 
     /*
      * Difference the raw 32-bit clock before converting to milliseconds, then
@@ -889,8 +895,7 @@ int getKeyOn(int id)
     // old v.s. new pad data
     int keyid = keyToPad[id];
 
-    // baseline edge: compare current vs previous sampled level only (wOPL-style)
-    return (paddata & keyid) && (!(oldpaddata & keyid));
+    return (edgedata & keyid) && (!(oldedgedata & keyid));
 }
 
 /** Detects key-off event. Returns true if the button was pressed the last frame but is not pressed this frame.
@@ -905,8 +910,7 @@ int getKeyOff(int id)
     // old v.s. new pad data
     int keyid = keyToPad[id];
 
-    // baseline edge-off: compare current vs previous sampled level only (wOPL-style)
-    return (!(paddata & keyid)) && (oldpaddata & keyid);
+    return (!(edgedata & keyid)) && (oldedgedata & keyid);
 }
 
 /** Returns true (nonzero) if the button is currently pressed


### PR DESCRIPTION
## Summary

Restores `edgedata` / `oldedgedata` edge tracking in `src/pad.c` to resolve issue #272 (menu scrolling skipping 2-3 items on dropped pad reads).

### Key Fix
- **Edge Tracking Restoration**: Restores `edgedata` and `oldedgedata` tracking in `readPad()`, `readPads()`, `getKeyOn()`, and `getKeyOff()`.
- **Prevents False Re-Presses**: When a pad read drops or misses a frame during storage I/O, `paddata` temporarily drops to 0. Inspecting `edgedata` ensures that when the pad read recovers on the next frame, it is recognized as a continued button hold rather than a brand-new button press (`getKeyOn`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button press and release detection.
  * Preserved button edge events during frozen screen transitions.
  * Ensured held-button state continues to report the current input accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->