### PR TITLE
feat(themes/gui): extend custom UI colors support to Coverflow mode (#326)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1192,7 +1192,7 @@ void guiShowArtworkConfig(void)
 void guiShowColorsConfig(void)
 {
     int themeID = thmGetGuiValue();
-    int editable = (themeID == 0);
+    int editable = (themeID == 0 || themeID == thmFindGuiID("<Coverflow>"));
 
     if (editable) {
         // Display the default theme's colours.

--- a/src/themes.c
+++ b/src/themes.c
@@ -1266,7 +1266,7 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
             configGetStr(config, attributeImage->cache->suffix, (const char **)&attributeImage->currentValue);
         }
         if (attributeImage->currentValue) {
-            if (thmGetGuiValue() == 0) {
+            if (thmGetGuiValue() == 0 || thmGetGuiValue() == nThemes + 1) {
                 GSTEXTURE *texture = thmGetTexture(thmAttributeTexId(attributeImage));
                 if (texture && texture->Mem)
                     rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
@@ -2859,7 +2859,7 @@ int thmSetGuiValue(int themeID, int reload)
 
             guiThemeID = themeID;
             return 1;
-        } else if (guiThemeID == 0)
+        } else if (guiThemeID == 0 || guiThemeID == nThemes + 1)
             thmSetColors(gTheme);
     }
     return 0;


### PR DESCRIPTION
## Summary

Fixes #326. Extends custom UI color customization support to Coverflow mode (`<Coverflow>`).

### Changes
- **Settings Dialog Enablement**: Allows modifying custom color parameters (background plasma, text color, UI text, highlight selection color) when Coverflow mode is active.
- **Theme Color Application**: Updates `thmSetGuiValue` and `drawAttributeImage` so user-defined colors dynamically apply to Coverflow mode.
