### PR TITLE
fix(mx4sio): embed and load freesio2 for BDM_M4S_MODE game launch (#317)

### DIFF
--- a/ee_core/include/modules.h
+++ b/ee_core/include/modules.h
@@ -14,6 +14,7 @@ enum OPL_MODULE_ID {
     OPL_MODULE_ID_ILINKBD,
 
     // mx4sio mode modules
+    OPL_MODULE_ID_SIO2MAN,
     OPL_MODULE_ID_MX4SIOBD,
 
     // SMB mode modules

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -141,6 +141,7 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
             LoadOPLModule(OPL_MODULE_ID_ILINKBD, 0, 0, NULL);
             break;
         case BDM_M4S_MODE:
+            LoadOPLModule(OPL_MODULE_ID_SIO2MAN, 0, 0, NULL);
             LoadOPLModule(OPL_MODULE_ID_MX4SIOBD, 0, 0, NULL);
             break;
         case BDM_HDD_MODE:

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -141,8 +141,8 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
             LoadOPLModule(OPL_MODULE_ID_ILINKBD, 0, 0, NULL);
             break;
         case BDM_M4S_MODE:
-            LoadOPLModule(OPL_MODULE_ID_SIO2MAN, 0, 0, NULL);
-            LoadOPLModule(OPL_MODULE_ID_MX4SIOBD, 0, 0, NULL);
+            if (LoadOPLModule(OPL_MODULE_ID_SIO2MAN, 0, 0, NULL) >= 0)
+                LoadOPLModule(OPL_MODULE_ID_MX4SIOBD, 0, 0, NULL);
             break;
         case BDM_HDD_MODE:
             break;

--- a/src/system.c
+++ b/src/system.c
@@ -723,6 +723,8 @@ static unsigned int sendIrxKernelRAM(const char *startup, const char *mode_str, 
         irxptr_tab[modcount++].ptr = (void *)&IEEE1394_bd_irx;
     }
     if (modules & CORE_IRX_MX4SIO) {
+        irxptr_tab[modcount].info = size_sio2man_irx | SET_OPL_MOD_ID(OPL_MODULE_ID_SIO2MAN);
+        irxptr_tab[modcount++].ptr = (void *)&sio2man_irx;
         irxptr_tab[modcount].info = size_mx4sio_bd_irx | SET_OPL_MOD_ID(OPL_MODULE_ID_MX4SIOBD);
         irxptr_tab[modcount++].ptr = (void *)&mx4sio_bd_irx;
     }


### PR DESCRIPTION
### Summary

Fixes #317 (MX4SIO game launch green screen freeze on DECKARD PS2 consoles, SCPH-75000+).

### Root Cause & Approach
- DECKARD PS2 consoles load \om1:SIO2MAN\ (v2.x) from ROM on IOP reset during game launch.
- Rather than attempting to hook ROM \sio2man\ with custom legacy wrappers (which still wedged SD card transfers on console), this change embeds OPL's own \sio2man\ (\reesio2\ v2.7) into Kernel RAM and loads it prior to \mx4sio_bd\ for \BDM_M4S_MODE\ game launch.
- This provides \mx4sio_bd\ with the exact \sio2man\ version (v2.7) it expects and uses menu-side, bypassing ROM \sio2man\ compatibility issues.

### Changes Made
- \src/system.c\: Added \sio2man_irx\ (\reesio2\ v2.7) to \irxptr_tab\ in \sendIrxKernelRAM()\ when \modules & CORE_IRX_MX4SIO\ is set.
- \e_core/include/modules.h\: Added \OPL_MODULE_ID_SIO2MAN\ to \num OPL_MODULE_ID\.
- \e_core/src/iopmgr.c\: Updated \ResetIopSpecial()\ under \case BDM_M4S_MODE:\ to load \OPL_MODULE_ID_SIO2MAN\ before \OPL_MODULE_ID_MX4SIOBD\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MX4SIO initialization by loading the required SIO2MAN support module first.
  * Enhanced compatibility and reliability for BDM M4S and MX4SIO block-device operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->