### PR TITLE
fix(gui): retain Tools under NBD status modal

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2803,9 +2803,9 @@ void handleLwnbdSrv()
     guiRenderTextScreen(_l(_STR_STARTINGNBD));
     if (loadLwnbdSvr(&teardownStarted) == 0) {
         snprintf(temp, sizeof(temp), "%s", _l(_STR_RUNNINGNBD));
-        guiMsgBox(temp, 0, NULL);
+        guiMsgBox(temp, 0, diaToolsConfig);
     } else
-        guiMsgBox(_l(_STR_STARTFAILNBD), 0, NULL);
+        guiMsgBox(_l(_STR_STARTFAILNBD), 0, diaToolsConfig);
 
     // Only a path that actually dismantled the menu needs the reset-and-restore cycle.
     if (teardownStarted) {


### PR DESCRIPTION
## What

- Render both NBD startup result dialogs over `diaToolsConfig`, the dialog that launched the operation.
- Preserve the existing dim layer and message-box behavior for both the running and failure paths.

## Why

The Settings reorganization moved NBD startup into the Tools dialog, but both result calls still passed a null underlay. In `guiMsgBox`, a null underlay calls `guiShow()`, which redraws the top-level Settings screen before the normal dim layer is applied. That is why the popup itself appears but the wrong, overly prominent Settings screen is visible behind it.

Passing `diaToolsConfig` uses the existing non-null dialog-render path, so the Tools screen remains beneath the normal overlay. The global dim color is not the cause and is intentionally unchanged.

## Safety and impact

- Two argument changes only: success and failure use the same correct parent surface.
- No NBD startup, teardown, reset, networking, audio, pad, timing, or return-value behavior changes.
- `diaToolsConfig` is an existing static-duration dialog already declared in `dialogs.h`; it matches `guiMsgBox`'s existing UI pointer API.

## Validation

- Full `make clean release` build in the pinned PS2DEV image used by CI (`sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995`)
- `git diff --check origin/master`
- Source trace of both `guiMsgBox` rendering branches and both NBD outcomes

## Related

- Addresses the remaining visual regression reported in #307.
- Companion Edge observability PR: https://github.com/NathanNeurotic/PS2-Servers/pull/161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NBD server status dialogs to display correctly for both successful startup and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->