### PR TITLE
fix(gui): fix NBD server modal background rendering (#307)

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2803,9 +2803,9 @@ void handleLwnbdSrv()
     guiRenderTextScreen(_l(_STR_STARTINGNBD));
     if (loadLwnbdSvr(&teardownStarted) == 0) {
         snprintf(temp, sizeof(temp), "%s", _l(_STR_RUNNINGNBD));
-        guiMsgBox(temp, 0, diaToolsConfig);
+        guiMsgBox(temp, 0, NULL);
     } else
-        guiMsgBox(_l(_STR_STARTFAILNBD), 0, diaToolsConfig);
+        guiMsgBox(_l(_STR_STARTFAILNBD), 0, NULL);
 
     // Only a path that actually dismantled the menu needs the reset-and-restore cycle.
     if (teardownStarted) {


### PR DESCRIPTION
Fixes #307.

### Summary
Pass \NULL\ instead of \diaToolsConfig\ to \guiMsgBox\ in \handleLwnbdSrv()\. Passing \diaToolsConfig\ caused \diaRenderUI(diaToolsConfig, ...)\ to render the Settings / Tools menu UI items on top of the background behind the modal message box overlay. Passing \NULL\ restores the clean dimmed backdrop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected startup messages for the NBD server so they display without unnecessary configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->