### PR TITLE
fix(pad): restore 3x initial press delay multiplier to stop runaway menu skipping (#340)

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -570,13 +570,9 @@ static int getKeyDelay(int id, int repeat)
 {
     int delay = paddelay[id - 1];
 
-    // Initial press delay before auto-repeat begins: add a modest initial offset (+100ms)
-    // rather than multiplying the millisecond delay by 3 (which bloated 300ms up to 900ms!).
-    if (!repeat) {
-        delay += 100;
-        if (delay > 350)
-            delay = 350;
-    }
+    // Initial press delay before auto-repeat begins (3x repeat delay).
+    if (!repeat)
+        delay *= 3;
 
     return delay;
 }


### PR DESCRIPTION
Fixes #340.

### Cause
In commit fafc14d0, the initial press delay calculation in \getKeyDelay()\ (\src/pad.c\) was changed from the classic 3x multiplier (\delay *= 3\) to an offset capped at 350ms (\delay += 100; if (delay > 350) delay = 350;\).

This capped the initial delay before auto-repeat on Medium/Slow settings down to only 350ms (0.35s). Short button presses frequently triggered auto-repeat prematurely, causing the selection cursor to race down lists, wrap around menu boundaries, and accidentally confirm wrong settings options.

### Fix
Restored the classic 3x initial press delay multiplier in \getKeyDelay()\. Initial holds now require a distinct threshold (e.g. 300ms on Fast, 900ms on Medium, 1500ms on Slow) before auto-repeat begins, giving crisp single-press navigation and preventing runaway skipping.