### PR TITLE
fix(core): apply audited Jules performance, safety, and cleanup enhancements (#334)

### DIFF
--- a/modules/network/smbinit/smbauth.c
+++ b/modules/network/smbinit/smbauth.c
@@ -55,7 +55,10 @@ static unsigned char *NTLM_Password_Hash(const char *password, unsigned char *ci
     memset(passwd_buf, 0, sizeof(passwd_buf));
 
     /* turn the password to unicode */
-    for (i = 0, j = 0; i < strlen(password); i++, j += 2)
+    size_t pass_len = strlen(password);
+    if (pass_len > 255)
+        pass_len = 255;
+    for (i = 0, j = 0; i < pass_len; i++, j += 2)
         passwd_buf[j] = password[i];
 
     /* get the message digest */

--- a/pc/smbserver/smbserver_opl.py
+++ b/pc/smbserver/smbserver_opl.py
@@ -104,13 +104,15 @@ def send_msg(sock, smb_msg):
 
 
 def _recv_exact(sock, n):
-    buf = b""
-    while len(buf) < n:
-        chunk = sock.recv(n - len(buf))
-        if not chunk:
+    buf = bytearray(n)
+    view = memoryview(buf)
+    pos = 0
+    while pos < n:
+        read_bytes = sock.recv_into(view[pos:], n - pos)
+        if not read_bytes:
             return None
-        buf += chunk
-    return buf
+        pos += read_bytes
+    return bytes(buf)
 
 
 def recv_msg(sock):

--- a/pc/ziso.py
+++ b/pc/ziso.py
@@ -136,6 +136,7 @@ def decompress_zso(fname_in, fname_out):
         print("ziso file format error")
         return -1
 
+    total_block = total_bytes // block_size
     index_data = fin.read(4 * (total_block + 1))
     index_buf = list(unpack(f'<{total_block + 1}I', index_data))
 

--- a/pc/ziso.py
+++ b/pc/ziso.py
@@ -136,11 +136,8 @@ def decompress_zso(fname_in, fname_out):
         print("ziso file format error")
         return -1
 
-    total_block = total_bytes // block_size
-    index_buf = []
-
-    for _ in range(total_block + 1):
-        index_buf.append(unpack('I', fin.read(4))[0])
+    index_data = fin.read(4 * (total_block + 1))
+    index_buf = list(unpack(f'<{total_block + 1}I', index_data))
 
     show_zso_info(fname_in, fname_out, total_bytes,
                   block_size, total_block, ver, align)

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -622,7 +622,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     if (vcdViewActive(itemList->mode))
         return 0;
 
-    sprintf(path, "%sCD", pDeviceData->bdmPrefix);
+    snprintf(path, sizeof(path), "%sCD", pDeviceData->bdmPrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
     if (pDeviceData->bdmModifiedCDPrev != st.st_mtime) {
@@ -630,7 +630,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
         result = 1;
     }
 
-    sprintf(path, "%sDVD", pDeviceData->bdmPrefix);
+    snprintf(path, sizeof(path), "%sDVD", pDeviceData->bdmPrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
     if (pDeviceData->bdmModifiedDVDPrev != st.st_mtime) {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -63,10 +63,10 @@ static void hddInitModules(void)
 
     // update Themes
     char path[256];
-    sprintf(path, "%sTHM", gHDDPrefix);
+    snprintf(path, sizeof(path), "%sTHM", gHDDPrefix);
     thmAddElements(path, "/", 1);
 
-    sprintf(path, "%sLNG", gHDDPrefix);
+    snprintf(path, sizeof(path), "%sLNG", gHDDPrefix);
     lngAddLanguages(path, "/", hddGameList.mode);
 
     sbCreateFolders(gHDDPrefix, 0);

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -1045,9 +1045,6 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // where the per-game folder genuinely matters: AndrewBento's logo-off report). The cross-device
     // paths (bdm/hdd/eth) send it too, with the same wait.
 
-    // mcReset();
-    // mcInit(MC_TYPE_XMC);
-
     if (gAutoLaunchBDMGame == NULL) {
         deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
     }

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -311,8 +311,12 @@ static int scanForISO(char *path, char type, struct game_list_t **glist, struct 
     int cacheLoaded = loadISOGameListCache(path, &cache) == 0;
 
     if ((dir = opendir(path)) != NULL) {
-        size_t base_path_len = strlen(path);
-        snprintf(fullpath, sizeof(fullpath), "%s", path);
+        int pathLen = snprintf(fullpath, sizeof(fullpath), "%s", path);
+        if (pathLen < 0 || pathLen >= (int)sizeof(fullpath) - 1) {
+            closedir(dir);
+            return 0;
+        }
+        size_t base_path_len = (size_t)pathLen;
         fullpath[base_path_len] = '/';
 
         while ((dirent = readdir(dir)) != NULL) {

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -312,7 +312,7 @@ static int scanForISO(char *path, char type, struct game_list_t **glist, struct 
 
     if ((dir = opendir(path)) != NULL) {
         size_t base_path_len = strlen(path);
-        strcpy(fullpath, path);
+        snprintf(fullpath, sizeof(fullpath), "%s", path);
         fullpath[base_path_len] = '/';
 
         while ((dirent = readdir(dir)) != NULL) {


### PR DESCRIPTION
Closes #334.

### Summary
Applies verified, high-value fixes from the audited Jules suggestion report (#334):

1. **Buffer Overflow Guards & Path Safety:**
   * Replaced unbounded \sprintf\ and \strcpy\ with \snprintf\ in \hddsupport.c\, \dmsupport.c\, and \supportbase.c\.

2. **Performance Optimizations:**
   * Cached \strlen(password)\ prior to NTLM Unicode conversion loop in \smbauth.c\.
   * Replaced \uf += chunk\ in \pc/smbserver/smbserver_opl.py\ with \ytearray\ / \memoryview\ buffer assembly.
   * Replaced single 4-byte \ead(4)\ loop in \pc/ziso.py\ with bulk index block read and \struct.unpack\.

3. **Code Cleanup:**
   * Removed obsolete commented-out legacy \mcReset\ / \mcInit\ lines in \mmcesupport.c\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved password handling with a maximum processing length.
  - Strengthened path construction to help prevent buffer overflows when accessing CD, DVD, theme, language, and ISO files.
  - Improved network data reception efficiency while preserving end-of-file behavior.
  - Updated compressed ISO index handling for more efficient loading.
- **Cleanup**
  - Removed obsolete memory-card initialization code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->