### PR TITLE
docs(gh-pages): audit corrections for menu paths, start mode defaults, and toolchain info

### DIFF
--- a/data/search-index.json
+++ b/data/search-index.json
@@ -26,7 +26,7 @@
  {
   "title": "Walk-through: USB to first launch",
   "cat": "start",
-  "text": "Five-step walkthrough using USB: format the drive, place the ISO in DVD/, boot RiptOPL, enable USB in Device Settings, launch the game, and save settings_riptopl.cfg.",
+  "text": "Five-step walkthrough using USB: format the drive, place the ISO in DVD/, boot RiptOPL, enable USB under Game Sources, launch the game, and save settings_riptopl.cfg.",
   "url": "getting-started.html#walk-through"
  },
  {
@@ -62,7 +62,7 @@
  {
   "title": "First boot walkthrough",
   "cat": "start",
-  "text": "Launch the ELF, enable a device in Device Settings, save settings (which auto-creates the OPL folder tree), and launch your first game.",
+  "text": "Launch the ELF, enable a device under Game Sources, save settings (which auto-creates the OPL folder tree), and launch your first game.",
   "url": "install.html#first-boot"
  },
  {

--- a/getting-started.html
+++ b/getting-started.html
@@ -139,16 +139,16 @@ USB root
 
 <div class="step">
 <h3>2. Plug in and boot RiptOPL</h3>
-<p>Connect the USB drive to the PS2's USB port, then launch <code>RIPTOPL.ELF</code> from your homebrew launcher (FMCB, FHDB, or equivalent). RiptOPL boots directly into the <b>Coverflow</b> game list. The first boot also creates any missing OPL folders on the drive automatically.</p>
+<p>Connect the USB drive to the PS2's USB port, then launch <code>RIPTOPL.ELF</code> from your homebrew launcher (FMCB, FHDB, or equivalent). On a fresh install, RiptOPL boots to the main start menu (all storage backends ship off by default until enabled). The first boot also creates any missing OPL folders on the drive automatically.</p>
 </div>
 
 <div class="step">
-<h3>3. Enable USB in Device Settings</h3>
-<p>RiptOPL ships with USB enabled by default. If your game list is empty, confirm USB is on:</p>
+<h3>3. Enable USB in Game Sources</h3>
+<p>On a fresh install, enable your storage options under <b>Game Sources</b>:</p>
 <ol>
   <li>Press <b>Start</b> to open the main menu.</li>
-  <li>Navigate to <b>Device Settings</b>.</li>
-  <li>Ensure <b>USB Games</b> is set to <b>On</b>.</li>
+  <li>Navigate to <b>Game Sources</b>.</li>
+  <li>Set <b>USB Start Mode</b> to <b>Auto</b> (or <b>Manual</b>).</li>
   <li>Press <b>Cross</b> to confirm and return (on Japanese consoles, Circle confirms — the confirm button follows the console's regional convention).</li>
 </ol>
 <p>The game list refreshes and your title should now appear in the Coverflow carousel.</p>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 <h1>RiptOPL <span class="g">Documentation</span></h1>
 <p class="lead">An opinionated fork of <b>Open PS2 Loader</b> aiming to be the "definitive build" — a cover-art
 <b>Coverflow</b> menu by default, a <b>Favourites</b> tab, per-game <b>Neutrino</b> external-core launching, a
-consolidated <b>Device Settings</b> hub, PS1 support via POPSTARTER, and every storage backend the PS2 can reach.</p>
+reorganized <b>Game Sources</b> category settings layout, PS1 support via POPSTARTER, and every storage backend the PS2 can reach.</p>
 <div class="btn-row">
   <a class="btn" href="getting-started.html">🚀 New here? Launch your first game</a>
   <a class="btn ghost" href="#sections">Browse the full reference</a>
@@ -79,10 +79,8 @@ built-in core, with a <b>Device</b> picker and a structured <b>Launch Args</b> s
 <li><b>Network boot</b> — stream games from a PC over the LAN as their own list via <b>UDPBD</b> or <b>UDPFS</b> (Neutrino).</li>
 <li><b>PS1 games via POPSTARTER</b> — a per-device <b>L3</b> "VCD" view lists your PS1 <code>*.VCD</code> games, including
 from an <b>exFAT</b> drive (BDMAssault) and the internal HDD.</li>
-<li><b>Device Settings hub</b> — one page for per-device options, cache sizes, Block-Device (BDM) settings, all MMCE
-settings, network-boot controls, and the Favourites toggle.</li>
-<li><b>Ready-to-use defaults</b> — widescreen, cover art, notifications, sound + boot sound, USB and the PS2 logo are
-on out of the box; DualSense (PS5 controller, USB) is an optional build.</li>
+<li><b>Category settings layout</b> — organized category pages (Game Sources, Settings, Interface, Display, Game Launching, POPStarter, MMCE, Network, Controller, Audio, Security, Advanced, Tools, About) instead of one flat list.</li>
+<li><b>Ready-to-use defaults</b> — widescreen, cover art, notifications, sound + boot sound, and the PS2 logo are on out of the box; storage devices ship off by default until enabled under Game Sources.</li>
 </ul>
 
 <h2 id="sections">Full reference</h2>

--- a/releases.html
+++ b/releases.html
@@ -94,27 +94,24 @@ The headline item is a full installable package zip; all other assets are publis
 <thead><tr><th>Asset</th><th>What it is</th></tr></thead>
 <tbody>
 <tr>
-  <td><code>RIPTOPL-&lt;sdk&gt;-&lt;rel&gt;-&lt;sha&gt;.zip</code></td>
-  <td><b>The installable package.</b> Contains <code>APP_RIPTOPL/RIPTOPL.ELF</code> (built with
-  <code>ps2dev/ps2dev:latest</code>, the default), <code>APP_RIPTOPL-WOPLSDK/RIPTOPL.ELF</code>
-  (wOPL's digest-pinned container with stock MMCE drivers) and
-  <code>APP_RIPTOPL-OLDSDK/RIPTOPL.ELF</code> (the pinned/stable toolchain, as a fallback), the
-  <code>POPSTARTER/</code> and <code>POPS/</code> folders for PS1 support, an already-extracted
-  <code>neutrino/</code> folder (drag-and-drop — with <code>config/bsd-udpfsbd.toml</code> injected so
-  UDPFS works), and a host-side <code>PC-SMB-Server/</code> folder (a pure-Python SMBv1 server you run
-  on your PC for Windows 11). Extract it and use <code>APP_RIPTOPL/RIPTOPL.ELF</code>.</td>
+  <td><code>RIPTOPL-&lt;rel&gt;-&lt;sha&gt;.zip</code></td>
+  <td><b>The installable package.</b> Contains labeled SDK loader folders:
+  <code>APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF</code> (#1, built with the current <code>ps2dev/ps2dev:latest</code> SDK),
+  and <code>APP_RIPTOPL-PS2DEVPINNEDSDK/RIPTOPL.ELF</code> (#2, built on a digest-pinned ps2dev SDK as the safe fallback),
+  the <code>POPSTARTER/</code> and <code>POPS/</code> folders for PS1 support, the bundled <code>neutrino/</code> folder, and a <code>PS2-Servers.url</code> shortcut.
+  Extract it and use <code>APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF</code>.</td>
 </tr>
 <tr>
-  <td><code>RIPTOPL-&lt;version&gt;.ELF</code></td>
-  <td>Bare loader ELF, <code>ps2dev/ps2dev:latest</code> toolchain (primary).</td>
+  <td><code>RIPTOPL-&lt;version&gt;-PS2DEVLATESTSDK.ELF</code></td>
+  <td>Bare loader ELF, <code>ps2dev/ps2dev:latest</code> toolchain (#1 recommended).</td>
 </tr>
 <tr>
-  <td><code>RIPTOPL-&lt;version&gt;-woplsdk.ELF</code></td>
-  <td>Bare loader ELF, wOPL's digest-pinned <code>ghcr.io/ps2homebrew</code> container with stock MMCE drivers.</td>
+  <td><code>RIPTOPL-&lt;version&gt;-PS2DEVPINNEDSDK.ELF</code></td>
+  <td>Bare loader ELF, digest-pinned <code>ps2dev/ps2dev</code> toolchain (#2 safe fallback).</td>
 </tr>
 <tr>
-  <td><code>RIPTOPL-&lt;version&gt;-oldsdk.ELF</code></td>
-  <td>Bare loader ELF, <code>ps2max/dev</code> pinned toolchain (fallback).</td>
+  <td><code>RIPTOPL-&lt;version&gt;-&lt;SDK&gt;-ds5.ELF</code></td>
+  <td>DualSense (DS5 USB) pad support loader ELFs for each SDK toolchain flavour (<code>DUALSENSE=1</code>).</td>
 </tr>
 <tr>
   <td><code>RIPTOPL-&lt;version&gt;-src.zip</code></td>
@@ -130,12 +127,12 @@ The headline item is a full installable package zip; all other assets are publis
 </tr>
 <tr>
   <td><code>RIPTOPL-VARIANTS-*.zip</code></td>
-  <td>Alternate build configs: the full <code>EXTRA_FEATURES × PADEMU × DUALSENSE</code> matrix, in all three SDK flavours. For testing or diagnostics.</td>
+  <td>Alternate build configs and variants for testing or diagnostics.</td>
 </tr>
 <tr>
   <td><code>RIPTOPL-DEBUG-*.zip</code></td>
   <td>Debug builds (<code>iopcore</code>, <code>ingame</code>, <code>eesio</code>, <code>iopcore_ppctty</code>, <code>ingame_ppctty</code>,
-  <code>DTL_T10000</code> variants), all three SDK flavours. For diagnostics only.</td>
+  <code>DTL_T10000</code> variants). For diagnostics only.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Applies documentation audit fixes to the gh-pages docs site:
- Updates getting-started.html & index.html to describe fresh install start mode defaults and Game Sources menu path.
- Corrects releases.html & data/search-index.json to describe the 2 current toolchain builds (PS2DEVLATESTSDK & PS2DEVPINNEDSDK) following WOPLSDK retirement.