### PR TITLE
fix(config): redirect config home to Memory Card when booted from CD-ROM / ISO (#353)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ PNG_ASSETS = load0 load1 load2 load3 load4 load5 load6 load7 usb usb_bd ilk_bd \
 	Index_0 Index_1 Index_2 Index_3 Index_4 fav fav_mark R3 L3 PS1 PS2 case_overlay
 	# unused icons - up down l1 l2 r1 r2
 
-GFX_OBJS = $(PNG_ASSETS:%=%_png.o) poeveticanew.o
+GFX_OBJS = $(PNG_ASSETS:%=%_png.o) poeveticanew.o icon_sys.o icon_icn.o
 
 # NOTE: audio/bgm.ogg is intentionally NOT compiled into the ELF (saves ~324 KB).
 # It is kept in the repo only as a reference/default track. BGM is loaded at
@@ -850,6 +850,12 @@ $(EE_ASM_DIR)mcserv.c: $(PS2SDK)/iop/irx/mcserv.irx | $(EE_ASM_DIR)
 
 $(EE_ASM_DIR)poeveticanew.c: thirdparty/PoeVeticaNew.ttf | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ $(*F)_raw
+
+$(EE_ASM_DIR)icon_sys.c: gfx/icon.sys | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
+
+$(EE_ASM_DIR)icon_icn.c: gfx/opl.icn | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
 $(EE_ASM_DIR)icon_sys_A.c: misc/icon_A.sys | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ $(*F)

--- a/src/config.c
+++ b/src/config.c
@@ -297,10 +297,10 @@ void configInit(char *prefix)
     char path[256];
     int i;
 
-    if (prefix)
-        snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
-    else
+    if (!prefix)
         prefix = gBaseMCDir;
+
+    snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
 
     for (i = 0; i < CONFIG_INDEX_COUNT; i++) {
         snprintf(path, sizeof(path), "%s/%s", prefix, configFilenames[i]);
@@ -315,10 +315,10 @@ void configSetMove(char *prefix)
     char path[256];
     int i;
 
-    if (prefix)
-        snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
-    else
+    if (!prefix)
         prefix = gBaseMCDir;
+
+    snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
 
     for (i = 0; i < CONFIG_INDEX_COUNT; i++) {
         snprintf(path, sizeof(path), "%s/%s", prefix, configFilenames[i]);

--- a/src/opl.c
+++ b/src/opl.c
@@ -1546,6 +1546,16 @@ static void resolveBootDirToMass(void)
         return;
     }
 
+    // CD-ROM / ISO boot (PS3 PS2-Classic ISO or PS2 disc boot): cdrom0: is read-only hardware.
+    // Re-home the config to the Memory Card (mc?:OPL) so saves land on Memory Card Slot 1/2 (#353).
+    if (!strncmp(gBootDir, "cdrom", 5)) {
+        LOG("BOOT read-only cdrom boot dir %s -> redirecting config home to MC\n", gBootDir);
+        gBootDir[0] = '\0';
+        configEnd();
+        configInit(NULL);
+        return;
+    }
+
     // MMCE boot: the mmceman driver is likewise not loaded at boot time (sysReset loads none of the
     // device stacks), so mmceN: is unreadable exactly when settings must load. Load it (idempotent)
     // and give the card a moment to register its filesystem. mmceN: IS the readable namespace, so no

--- a/src/util.c
+++ b/src/util.c
@@ -21,6 +21,11 @@
 extern int probed_fd;
 extern u32 probed_lba;
 
+extern unsigned char icon_sys[];
+extern unsigned int size_icon_sys;
+extern unsigned char icon_icn[];
+extern unsigned int size_icon_icn;
+
 static int mcID = -1;
 
 void guiWarning(const char *text, int count);
@@ -94,13 +99,12 @@ static int checkMC()
     return mcID;
 }
 
-// Ensure mc?:OPL/ exists so config/notification writes land. Previously this also wrote a browser
-// save icon (opl.icn + icon.sys) for the folder, but the 3D icon (~21 KB) was embedded in the ELF
-// purely for that cosmetic PS2-browser icon; dropped to reclaim the space (test note #11). The folder
-// still gets created here (and the config write's O_CREAT would create it anyway).
+// Ensure mc?:OPL/ exists and contains browser save icon (opl.icn + icon.sys) so PS2/PS3
+// Memory Card Manager displays the save folder with a valid icon instead of 'Corrupted Data' (#353).
 void checkMCFolder(void)
 {
     char path[32];
+    int fd;
 
     if (checkMC() < 0) {
         return;
@@ -108,6 +112,30 @@ void checkMCFolder(void)
 
     snprintf(path, sizeof(path), "mc%d:OPL/", mcID & 1);
     mkdir(path, 0777);
+
+    snprintf(path, sizeof(path), "mc%d:OPL/opl.icn", mcID & 1);
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+        if (fd >= 0) {
+            write(fd, icon_icn, size_icon_icn);
+            close(fd);
+        }
+    } else {
+        close(fd);
+    }
+
+    snprintf(path, sizeof(path), "mc%d:OPL/icon.sys", mcID & 1);
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+        if (fd >= 0) {
+            write(fd, icon_sys, size_icon_sys);
+            close(fd);
+        }
+    } else {
+        close(fd);
+    }
 }
 
 static int checkFile(char *path, int mode)


### PR DESCRIPTION
Fixes #353.

When RiptOPL is booted from an ISO image or disc (e.g. on a backwards-compatible PS3 running a PS2-Classic ISO or a PS2 disc launch), gBootDir is set to cdrom0:. Because cdrom0: is read-only hardware, calls to saveConfig() fail with 'unable to save to cdrom0' because _saveConfig skips the Memory Card fallback when gBootDir is non-empty.

In resolveBootDirToMass() (src/opl.c):
Detect when gBootDir starts with cdrom. Re-home the config using configInit(NULL) (mc?:OPL), allowing all settings saves to target Memory Card Slot 1/2 (mc0:OPL / mc1:OPL) cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot configuration handling when starting from a CD-ROM or ISO.
  * Redirected configuration storage to a writable memory card instead of the read-only disc.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->