### PR TITLE
fix(gui): land in-flight screen transitions under message boxes and wait screens

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2763,6 +2763,23 @@ static void guiShow()
         screenHandler->renderScreen();
 }
 
+// A message box or modal wait raised mid-transition must land on the DESTINATION screen:
+// letting the fade keep running behind it renders the OLD screen for the first half -- reported
+// as "error messages always have the previous frame as their background". Snapping makes the same
+// assignments guiShow() makes when the fade completes naturally (transIndex == transition_frames).
+// One deliberate timing shift: the padFreezeEdgeBaseline input freeze, gated on
+// screenHandlerTarget != NULL, releases up to ~13 frames earlier than the fade would have. Benign
+// -- the box consumes its own edge-triggered dismiss (getKeyOn) and the transition-triggering
+// button is long released by the time a box is dismissed.
+static void guiSnapTransition(void)
+{
+    if (screenHandlerTarget) {
+        screenHandler = screenHandlerTarget;
+        screenHandlerTarget = NULL;
+        transIndex = 0;
+    }
+}
+
 void guiIntroLoop(void)
 {
     int greetingAlpha = 0x80;
@@ -2906,6 +2923,14 @@ int guiMsgBox(const char *text, int addAccept, struct UIItem *ui)
 {
     int terminate = 0;
 
+    // Background contract (the "error box shows the previous frame" report): a box raised while a
+    // screen transition is in flight must land on the DESTINATION screen -- letting the fade keep
+    // running renders the OLD screen behind the box for the first half. Snap it. (The dialog-flow
+    // background case, rendering the settings dialog rather than the main screen behind the box, is
+    // intentionally NOT handled here: the deferred error hook fires after the dialog's stack-local
+    // enum arrays have died, and rendering it then would deref freed stack -- the #154 landmine.)
+    guiSnapTransition();
+
     sfxPlay(SFX_MESSAGE);
 
     while (!terminate) {
@@ -3039,6 +3064,10 @@ void guiGameHandleDeferedIO(int *ptr, struct UIItem *ui, int type, void *data)
 
 void guiRenderTextScreen(const char *message)
 {
+    // Same transition contract as guiMsgBox: land any in-flight fade so the wait screen does not
+    // sit on the old screen mid-transition.
+    guiSnapTransition();
+
     guiStartFrame();
 
     guiShow();


### PR DESCRIPTION
Addresses zackcage6's repeated report: **error/notice message boxes show the previous frame as their background.**

## Cause

`guiMsgBox` and `guiRenderTextScreen` draw their background with `guiShow()`, which renders the current `screenHandler`. During a screen transition (the 26-frame cross-fade after `guiSwitchScreen`), `guiShow()` deliberately renders the **old, fading-out** screen for the first half. So a box raised right as a transition begins — exactly when errors tend to fire (pick a game → transition → launch fails) — sits on the previous screen for ~13 frames.

Verified the main screen otherwise repaints its own background every frame (`menuRenderMain` → theme background element), so `guiShow()` is not itself a stale-frame source outside a transition.

## Fix

`guiSnapTransition()` completes any in-flight transition to its destination before the box renders — the same state assignments `guiShow()` makes when a fade finishes naturally. One file, +29 lines. The input-freeze release timing shift it introduces is benign (documented inline; the box consumes its own edge-triggered dismiss).

## Deliberately out of scope

The other 'wrong background' shape — a box raised from a **settings flow** rendering the main screen instead of the dialog behind it — is **not** handled here. I prototyped it (record the active dialog, render it under the box) and adversarial review caught that it reintroduces the **#154 dangling-enum landmine**: the deferred error hook fires *after* the dialog's `guiShowXxx` setup returns and its **stack-local** enum arrays die, so rendering that dialog then dereferences freed stack (confirmed reachable via Network → Reconnect → sync eth re-init failure). A safe version requires making the affected dialog enum arrays `static` first — a separate change, only if the transition snap doesn't fully cover the report.

Separate from the #340 input work. HW test pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screen transitions behind message boxes and text wait screens.
  * Modal content now appears immediately on the destination screen without displaying transitional frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->