### PR TITLE
[DO NOT MERGE - TEST ONLY] test(mmce): no-mmceman diagnostic build - the conviction test (#340)

### DIFF
--- a/include/pad.h
+++ b/include/pad.h
@@ -33,8 +33,8 @@ void unloadPads();
 // Colors is on (gui.c / dia.c). Field semantics live with the writers in pad.c.
 typedef struct
 {
-    unsigned int readMisses;   // total failed ready-state pad reads
-    unsigned int missBurst;    // current consecutive-miss run, max across pads (polls)
+    unsigned int readMisses;   // polls where at least one ready-state pad produced no fresh sample
+    unsigned int missBurst;    // current consecutive run of such polls (0 when all ready pads read)
     unsigned int missBurstMax; // session peak of the above
     unsigned int pollMaxMs;    // worst readPads() period this session
     unsigned int stateFlaps;   // DISCONN -> ready reconnect edges seen

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -370,15 +370,27 @@ void mmceSetPrefix(void)
 
 void mmceLoadModules(void)
 {
-    // mmceman is a singleton -- loading the IRX buffer twice creates a 2nd instance. Guard so this is
-    // idempotent: mmceInit calls it, and the BDMA equip now also calls it (to wake an MMCE source when
-    // MMCE games are off / Manual-not-started). Set the flag first so a partial load can't double-load.
+    // TEST-ONLY BUILD (#340 diagnosis, DO NOT MERGE): never load mmceman into the menu IOP,
+    // regardless of config. mmceman's hook permanently replaces sio2man's sio2_transfer export
+    // and relinks freepad's import table; every MMCE command takes sio2man's exclusive lock and
+    // swaps the global SIO2 interrupt handler, and with no MMCE hardware each probe burns its
+    // full 200 ms timeout while freepad's vblank pad reads block (~12-13 missed polls -- the
+    // exact burst signature measured on HW). Official OPL / sOPL / uOPL ship no mmceman and are
+    // smooth on the same console; this build tests whether removing ONLY this module makes
+    // RiptOPL match them, on the tester's UNCHANGED config (his July-era settings_riptopl.cfg
+    // almost certainly still carries mmce_gameid=1 from the default-ON era). MMCE features are
+    // expectedly dead in this build -- USB-only test rig.
+    LOG("MMCESUPPORT LoadModules SUPPRESSED (#340 diagnostic build)\n");
+    mmceModLoaded = 1; // keep callers' idempotence expectations; nothing is actually loaded
+
+    /* -- original body --
     if (mmceModLoaded)
         return;
     mmceModLoaded = 1;
     LOG("MMCESUPPORT LoadModules\n");
     LOG("[MMCEMAN]:\n");
     sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
+    */
 }
 
 // Δ4 (NHDDL parity): arm the GameID transport OUTSIDE the launch path. NHDDL loads mmceman once at

--- a/src/pad.c
+++ b/src/pad.c
@@ -137,6 +137,13 @@ static u32 oldpaddata;
 // are SHOWN only when Settings -> Debug Colors is on.
 static pad_diag_t padDiag;
 
+// Per-poll read outcome, reset by readPads() and filled in by each readPad(): how many pads were
+// in a ready state, and how many produced a fresh sample. A poll where a ready pad produced no
+// fresh sample is a read MISS (per-pad accounting: another pad reading fine does not hide it).
+// Misses cluster under SIO2 load on real hardware; an emulator's pad never produces one.
+static int pollPadsReady;
+static int pollPadsRead;
+
 void padGetDiag(pad_diag_t *out)
 {
     if (out)
@@ -483,6 +490,7 @@ static int readPad(struct pad_data_t *pad)
     }
 
     if (isPadReadyState(pad->state)) {
+        pollPadsReady++;
         ret = padRead(pad->port, pad->slot, &pad->buttons); // port, slot, buttons
 
         if (ret != 0) {
@@ -544,6 +552,7 @@ static int readPad(struct pad_data_t *pad)
 #endif
 
     if (padsRead > 0) {
+        pollPadsRead++;
         newpdata = readLeftJoy(pad, newpdata);
         pad->paddata = newpdata;
 
@@ -817,8 +826,23 @@ int readPads()
     if (time_since_last > padDiag.pollMaxMs)
         padDiag.pollMaxMs = time_since_last;
 
+    pollPadsReady = 0;
+    pollPadsRead = 0;
     for (i = 0; i < pad_count; ++i)
         result |= readPad(&pad_data[i]);
+
+    // Debug-Colors diag: a read MISS is a poll where a ready pad produced no fresh sample --
+    // counted per-pad, so another pad (or a PADEMU ds34) reading fine does not hide it. These
+    // counters feed the HUD "PAD miss:" line; they had no writers between the PR #328 revert
+    // and this change, so the HUD showed miss:0 regardless of what the hardware did.
+    if (pollPadsRead < pollPadsReady) {
+        padDiag.readMisses++;
+        padDiag.missBurst++;
+        if (padDiag.missBurst > padDiag.missBurstMax)
+            padDiag.missBurstMax = padDiag.missBurst;
+    } else {
+        padDiag.missBurst = 0;
+    }
 
     // Stamp input activity AFTER the merge: any held button/stick re-arms the PAD_SELF_HEAL_IDLE_MS gate.
     if (paddata != 0)


### PR DESCRIPTION
**TEST BUILD E — the conviction test for the round-3 finding. Diagnostic only, never mergeable.**

## Why this build exists

Zack's clarified reports: official **rolling** (rebuilt Aug 2 from the *same June-7 source* — and ps2sdk's entire pad stack has **zero commits since 2026-07-15**, before all our pins, so 'the SDK fixed it' is refuted), sOPL (`mystyq/Stable-Open-PS2-Loader`, official fork, no MMCE code), and uOPL are **all smooth on his console**. Official rolling was never broken — he first tested it yesterday.

The one thing RiptOPL alone runs at menu time: **`mmceman.irx`**, whose hook replaces sio2man's `sio2_transfer` export, relinks freepad's import table, takes sio2man's exclusive lock per command and swaps the global SIO2 interrupt handler — burning **200 ms no-hardware timeouts while freepad's vblank pad reads block (~12-13 missed polls = the exact burst signature on his HUD)**. It loads because his July-era config almost certainly still carries `mmce_gameid=1` from the default-ON era (default until 2026-07-28; saved configs override the new default). Precedents: RiptOPL #254 (same module, total pad death), ps2sdk PR #898's own admission.

## The test (no settings changes needed!)

Boot this zip on the **unchanged** config. Scroll hard, list + settings, Debug Colors ON.

| Result | Meaning |
|---|---|
| Smooth like official/sOPL, `miss:` ~0 | **mmceman convicted.** Ship-fix = stale-config migration / load gate (maintainer's call re: the #254 arming contract) + keep the protective pad work |
| Still hangs, `miss:` climbing | mmceman acquitted; remaining fork deltas are the audio defaults — flip SFX off in-session as the next A/B (official's run was silent: different config file) |

MMCE features are expectedly dead in this build (USB-only rig — fine).

This branch = master + the Debug-HUD miss counters + one suppressed function. Nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)