### PR TITLE
docs: correct uOPL/wOPL feature attribution in credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,15 @@ and ideas from [rickgaiser's OPL](https://github.com/rickgaiser/Open-PS2-Loader)
 
 With special and sincere thanks to:
 
-- **Wolf3s** and **KrahJohlito** — the driving force behind **uOPL / wOPL**, where much of
-  this fork's modern functionality originated. The Neutrino external-core loader and the
-  Coverflow and Favourites interfaces are all reimplementations of features they designed and
-  pioneered together. We learned an enormous amount reading their code, and this fork is as
-  much a tribute to it as anything else. Thank you both.
+- **KrahJohlito** — the creator of **uOPL (Unofficial Open PS2 Loader)** and its continuation
+  **[wOPL](https://github.com/KrahJohlito/wOPL)**, where much of this fork's modern
+  functionality originated. The Neutrino external-core loader and the Coverflow and
+  Favourites interfaces are all reimplementations of features he designed and pioneered
+  there. We learned an enormous amount reading that code, and this fork is as much a
+  tribute to it as anything else. Thank you.
+- **Wolf3s** — for contributions across the wOPL effort and the wider OPL scene, and for
+  maintaining an independent **[uOPL](https://github.com/Wolf3s/uOPL)** fork that keeps
+  unique features and unmerged work alive. Thank you.
 - **bbsan2k** — for the **MMCE (Memory Card Mass Storage) protocol** that makes SD-via-memory-card
   loading through the PS2's memory-card slot possible. OPL's MMCE support builds directly on it.
 - **saildot4k** — for **BDMA-ATA** (exFAT internal-HDD block-device support), and the fixes,


### PR DESCRIPTION
Documentation correction, per KrahJohlito's note: the Neutrino external-core loader, Coverflow, and Favourites interfaces all originated in **KrahJohlito's uOPL (Unofficial Open PS2 Loader)** and its continuation **wOPL** — they were not co-developed. The credits now thank KrahJohlito directly for those features, and thank Wolf3s for his own independent uOPL fork and contributions across the wider OPL scene.

The companion correction to the docs site (credits.html + index.html) is already pushed to `gh-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated acknowledgements to separately recognize contributions to uOPL and wOPL.
  * Clarified maintenance credit for an independent uOPL fork.
  * Replaced previous combined attribution wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->