### PR TITLE
ci: add OFFICIALSDK build flavour (official OPL's toolchain)

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -167,6 +167,68 @@ jobs:
             LICENSE
             README.md
 
+  build-officialsdk:
+    runs-on: ubuntu-latest
+    # Third toolchain flavour: the EXACT container official OPL's rolling pre-release compiles
+    # in (ghcr.io/ps2homebrew/ps2homebrew:main). ps2dev/ps2dev and this image are separate SDK
+    # lineages, so this flavour isolates toolchain-vs-code questions on hardware reports.
+    # Best-effort (continue-on-error): a failure here must never block the two ps2dev flavours.
+    continue-on-error: true
+    container: ghcr.io/ps2homebrew/ps2homebrew:main
+    steps:
+      # Same rationale as the ps2dev jobs: git must exist BEFORE checkout or the version
+      # string collapses to "-dirty". The ps2homebrew image ships official OPL's build deps
+      # already; the guarded installs below only top up whatever this fork additionally
+      # needs (py3-yaml for the language overlay compiler, zip/gawk for packaging) and
+      # no-op on either package manager if everything is present.
+      - name: Install host dependencies (either package manager)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache bash make git zip unzip tar gzip xz python3 py3-pip py3-yaml gawk coreutils findutils grep sed diffutils || true
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq bash make git zip unzip python3 python3-yaml gawk || true
+          fi
+
+      - name: git checkout
+        uses: actions/checkout@v6
+
+      - run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --prune --unshallow || true
+
+      - name: Install menu-coherent mmceman (officialsdk)
+        # Official OPL has no MMCE, so this container's SDK may ship a desynced or absent
+        # mmceman prebuilt. Rebuild it from the pinned ps2-mmce source exactly as the
+        # ps2dev-latest flavour does, so all three flavours run the same MMCE menu driver.
+        run: sh ./.github/scripts/install_coherent_mmce.sh
+
+      - name: Compile -> make clean release
+        # LOCALVERSION brands the in-ELF version string ("-OFFICIALSDK") so hardware
+        # reports self-identify which toolchain's binary produced them.
+        run: make --trace clean && make --trace LOCALVERSION=OFFICIALSDK release
+
+      - name: Create detailed changelog
+        run: sh ./make_changelog.sh
+
+      - name: Upload release artifact ELF (officialsdk)
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: RIPTOPL-officialsdk
+          path: |
+            RIPTOPL-*.ELF
+
+      - name: Upload release artifact info (officialsdk)
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: INFO-officialsdk
+          path: |
+            DETAILED_CHANGELOG
+            CREDITS
+            LICENSE
+            README.md
+
   build-variants:
     strategy:
       fail-fast: false

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -321,8 +321,70 @@ jobs:
           path: rolling
           if-no-files-found: error
 
+  build-rolling-officialsdk:
+    runs-on: ubuntu-latest
+    # OFFICIALSDK (third flavour): the EXACT container official OPL's rolling pre-release
+    # compiles in (ghcr.io/ps2homebrew/ps2homebrew:main) -- a separate SDK lineage from
+    # ps2dev/ps2dev, so hardware reports can split toolchain effects from RiptOPL code.
+    # Best-effort by design (continue-on-error): main ELF only, no ds5/1080p/extras; a
+    # failure here must never block the two ps2dev flavours from publishing.
+    continue-on-error: true
+    container: ghcr.io/ps2homebrew/ps2homebrew:main
+    steps:
+      # The ps2homebrew image ships official OPL's build deps; the guarded installs only
+      # top up this fork's extras (py3-yaml for the language overlay compiler, zip/gawk
+      # for packaging) and no-op on either package manager if everything is present.
+      - name: Install host dependencies (either package manager)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache bash make git zip unzip tar gzip xz python3 py3-pip py3-yaml gawk coreutils findutils grep sed diffutils || true
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq bash make git zip unzip python3 python3-yaml gawk || true
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Mark workspace safe and fetch history
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --prune --unshallow || true
+
+      - name: Install menu-coherent mmceman (officialsdk)
+        # Official OPL has no MMCE, so this container's SDK may ship a desynced or absent
+        # mmceman prebuilt. Rebuild it from the pinned ps2-mmce source exactly as the
+        # ps2dev-latest flavour does, so all three flavours run the same MMCE menu driver.
+        run: sh ./.github/scripts/install_coherent_mmce.sh
+
+      - name: Build (make clean release)
+        # LOCALVERSION brands the in-ELF version string ("-OFFICIALSDK") so hardware
+        # reports self-identify which toolchain's binary produced them.
+        run: make --trace clean && make --trace LOCALVERSION=OFFICIALSDK release
+
+      - name: Stage rolling assets (officialsdk)
+        run: |
+          set -eu
+          mkdir -p rolling
+          MAIN_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+          if [ -z "${MAIN_ELF:-}" ] || [ ! -f "$MAIN_ELF" ]; then
+            echo "No RIPTOPL ELF produced by the officialsdk build" >&2
+            exit 1
+          fi
+          cp -f "$MAIN_ELF" rolling/RIPTOPL-OFFICIALSDK.ELF
+          # IRX provenance manifest for this container's SDK prebuilts.
+          sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST-OFFICIALSDK.txt 2>/dev/null || true
+          echo "Staged officialsdk rolling assets:"
+          ls -la rolling
+
+      - name: Upload officialsdk rolling assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: rolling-assets-officialsdk
+          path: rolling
+          if-no-files-found: error
+
   publish-rolling:
-    needs: [build-rolling-pinned, build-rolling-ps2dev-latest]
+    needs: [build-rolling-pinned, build-rolling-ps2dev-latest, build-rolling-officialsdk]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -360,6 +422,14 @@ jobs:
           name: rolling-assets-pinned
           path: rolling
 
+      - name: Download officialsdk rolling assets
+        # Optional: the official-SDK flavour is best-effort; publish what we have.
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: rolling-assets-officialsdk
+          path: rolling
+
 
       - name: Name assets with the build version
         run: |
@@ -377,6 +447,9 @@ jobs:
           fi
           if [ -f rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF ]; then
             mv -f rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF "rolling/RIPTOPL-${VER}-PS2DEVPINNEDSDK.ELF"
+          fi
+          if [ -f rolling/RIPTOPL-OFFICIALSDK.ELF ]; then
+            mv -f rolling/RIPTOPL-OFFICIALSDK.ELF "rolling/RIPTOPL-${VER}-OFFICIALSDK.ELF"
           fi
           # DualSense (DS5) named loaders, one per SDK flavour (best-effort -- any may be absent).
           for sdk in PS2DEVPINNEDSDK PS2DEVLATESTSDK; do
@@ -452,6 +525,13 @@ jobs:
           else
             echo "WARN: pinned fallback build missing this run; package ships without APP_RIPTOPL-PS2DEVPINNEDSDK" >&2
           fi
+          OFFICIAL_ELF="rolling/${VERSIONED_BASE}-OFFICIALSDK.ELF"
+          if [ -f "$OFFICIAL_ELF" ]; then
+            mkdir -p "$PKG/APP_RIPTOPL-OFFICIALSDK"
+            cp -f "$OFFICIAL_ELF" "$PKG/APP_RIPTOPL-OFFICIALSDK/RIPTOPL.ELF"
+          else
+            echo "WARN: officialsdk build missing this run; package ships without APP_RIPTOPL-OFFICIALSDK" >&2
+          fi
           cp -f POPS/{smbman.irx,ps2ip.irx,ps2smap.irx,ps2dev9.irx,SMSUTILS.irx,poweroff.irx,del.icn,list.icn,icon.sys} "$PKG/POPSTARTER/"
           cp -f popsmb/* "$PKG/POPSTARTER/"
           cp -f POPS/* "$PKG/POPS/"
@@ -506,6 +586,7 @@ jobs:
             cd "$PKG"
             zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-PS2DEVLATESTSDK POPSTARTER POPS PS2-Servers.url >/dev/null
             if [ -d APP_RIPTOPL-PS2DEVPINNEDSDK ]; then zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-PS2DEVPINNEDSDK >/dev/null; fi
+            if [ -d APP_RIPTOPL-OFFICIALSDK ]; then zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-OFFICIALSDK >/dev/null; fi
             # the extracted neutrino/ folder (drag-and-drop; replaces the old zip-in-zip neutrino_*.7z)
             if [ -d neutrino ]; then zip -r -X "../rolling/${ZIP}" neutrino >/dev/null; fi
           )
@@ -537,6 +618,8 @@ jobs:
           set -eu
           HAS_PS2DEVPINNEDSDK=no
           [ -f "rolling/${VERSIONED_BASE}-PS2DEVPINNEDSDK.ELF" ] && HAS_PS2DEVPINNEDSDK=yes
+          HAS_OFFICIALSDK=no
+          [ -f "rolling/${VERSIONED_BASE}-OFFICIALSDK.ELF" ] && HAS_OFFICIALSDK=yes
           {
             if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
               printf 'RiptOPL %s -- tagged release.\n\n' "$OPL_VERSION"
@@ -548,8 +631,8 @@ jobs:
             printf 'Built: %s UTC\n' "$(date -u '+%Y-%m-%d %H:%M')"
             printf 'Run: %s/%s/actions/runs/%s\n' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
             printf '\n## Get started -- which build should I download?\n'
-            printf 'Grab **RIPTOPL-*.zip** and extract it. It ships two loader folders that differ ONLY by the\n'
-            printf 'SDK toolchain each was built with -- the RiptOPL code in every one is identical. Pick a folder\n'
+            printf 'Grab **RIPTOPL-*.zip** and extract it. It ships up to three loader folders that differ ONLY by\n'
+            printf 'the SDK toolchain each was built with -- the RiptOPL code in every one is identical. Pick a folder\n'
             printf 'and copy its RIPTOPL.ELF to your launch method. Recommended in this order (by reliability):\n'
             printf '\n'
             printf '  1. **APP_RIPTOPL-PS2DEVLATESTSDK/** -- built on the ps2dev:latest toolchain (version ends\n'
@@ -560,6 +643,12 @@ jobs:
             printf '     The SAFE FALLBACK. Because #1 tracks a MOVING tag, it can occasionally regress on some\n'
             printf '     consoles (see issue #102) -- if it black-screens at startup or the cursor does not\n'
             printf '     respond, use this one and please say so in the report.\n'
+            if [ "$HAS_OFFICIALSDK" = yes ]; then
+              printf '  3. **APP_RIPTOPL-OFFICIALSDK/** -- built in the EXACT container official OPL'"'"'s rolling\n'
+              printf '     pre-release compiles in (ghcr.io/ps2homebrew/ps2homebrew:main; version ends\n'
+              printf '     "-OFFICIALSDK"). A separate SDK lineage from ps2dev -- useful for isolating\n'
+              printf '     toolchain effects when comparing against official OPL on the same console.\n'
+            fi
             printf '\n'
             printf 'When something misbehaves on hardware, please say WHICH flavour you ran (the in-app version\n'
             printf 'string suffix tells you). A PS2DEVLATESTSDK-only failure points at an SDK regression; a\n'
@@ -618,6 +707,9 @@ jobs:
               printf -- '- (pinned %s PS2DEVPINNEDSDK build FAILED this run)\n' "$SDK_VER"
             fi
             printf -- '- %s-PS2DEVLATESTSDK.ELF: bare loader, ps2dev:latest toolchain (RECOMMENDED -- current SDK; see "Get started")\n' "$VERSIONED_BASE"
+            if [ "$HAS_OFFICIALSDK" = yes ]; then
+              printf -- '- %s-OFFICIALSDK.ELF: bare loader, official OPL'"'"'s ps2homebrew:main container (toolchain A/B vs official)\n' "$VERSIONED_BASE"
+            fi
             for sdk in PS2DEVPINNEDSDK PS2DEVLATESTSDK; do
               if [ -f "rolling/${VERSIONED_BASE}-${sdk}-ds5.ELF" ]; then
                 printf -- '- %s-%s-ds5.ELF: %s toolchain WITH DualSense (DS5 USB) pad support (same reliability as the %s bare loader above)\n' "$VERSIONED_BASE" "$sdk" "$sdk" "$sdk"


### PR DESCRIPTION
Third build flavour using **ghcr.io/ps2homebrew/ps2homebrew:main** — the exact container official OPL's rolling pre-release compiles in. Confirmed different from our ps2dev/ps2dev images (separate SDK lineage).

- **compilation.yml**: new `build-officialsdk` job → artifacts `RIPTOPL-officialsdk` / `INFO-officialsdk`, version branded `-OFFICIALSDK`
- **rolling-release.yml**: new `build-rolling-officialsdk` job (main ELF only, no ds5/1080p extras) → `RIPTOPL-<ver>-OFFICIALSDK.ELF` asset + `APP_RIPTOPL-OFFICIALSDK/` package folder + release-notes entry + IRX manifest
- **Best-effort everywhere** (`continue-on-error`): if the official container can't build our tree, the two ps2dev flavours publish exactly as before
- Runs `install_coherent_mmce.sh` like the latest flavour (the official container has no reason to carry a coherent mmceman)

This PR's own CI run is the validation — check the `build-officialsdk` job result before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OfficialSDK builds to standard and rolling releases.
  * OfficialSDK loader artifacts are included in release packages and archives when available.
  * Release notes now document the optional OfficialSDK loader and its supported loader folders.

* **Bug Fixes**
  * OfficialSDK build failures no longer block other builds or releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->