### PR TITLE
rebuild-07: Neutrino external core + keep-IOP launch bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ifneq ($(GIT_TAG),latest)
 endif
 endif
 
-FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o lang.o lang_internal.o config.o hdd.o dialogs.o favsupport.o \
+FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o elfldr_noreset.o elfldr.o lang.o lang_internal.o config.o hdd.o dialogs.o favsupport.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o hddsupport.o zso.o lz4.o \
 		appsupport.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o
 
@@ -276,6 +276,8 @@ clean:	download_lwNBD
 	rm -fr $(MAPFILE) $(EE_BIN) $(EE_BIN_PACKED) $(EE_BIN_STRIPPED) $(EE_VPKD).* $(EE_OBJS_DIR) $(EE_ASM_DIR)
 	echo "-EE core"
 	$(MAKE) -C ee_core clean
+	echo "-ELF loader"
+	$(MAKE) -C elfldr clean
 	echo "-IOP core"
 	echo " -imgdrv"
 	$(MAKE) -C modules/iopcore/imgdrv clean
@@ -398,6 +400,13 @@ ee_core/ee_core.elf: ee_core
 
 $(EE_ASM_DIR)ee_core.c: ee_core/ee_core.elf | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ eecore_elf
+
+elfldr/elfldr.elf: elfldr
+	echo "-ELF loader (no-IOP-reset handoff)"
+	$(MAKE) -C $<
+
+$(EE_ASM_DIR)elfldr.c: elfldr/elfldr.elf | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ elfldr_elf
 
 $(EE_ASM_DIR)udnl.c: $(UDNL_OUT) | $(EE_ASM_DIR)
 	$(BIN2C) $(UDNL_OUT) $@ udnl_irx

--- a/elfldr/Makefile
+++ b/elfldr/Makefile
@@ -1,0 +1,27 @@
+# RiptOPL no-IOP-reset child loader (see loader.c). Built like NHDDL's loader:
+# a tiny ELF linked into BIOS-unused memory (0x84000) so it can overwrite user
+# memory with the target ELF while OPL's IOP state stays untouched.
+
+EE_LINKFILE := linkfile
+# NEWLIB_PORT_AWARE: this loader calls the raw fileXio client on purpose (no newlib fds exist
+# here); the SDK headers #error on direct fio/fileXio use unless the caller declares awareness.
+EE_CFLAGS = -D_EE -DNEWLIB_PORT_AWARE -Os -G0 -Wall
+EE_CFLAGS += -fdata-sections -ffunction-sections
+EE_LDFLAGS = -Wl,-zmax-page-size=128
+EE_LDFLAGS += -s -Wl,--gc-sections
+
+EE_BIN = elfldr.elf
+
+EE_OBJS = loader.o
+
+# fileXio EE client: the child loads the target ELF through the resident fileXio server
+# (iomanX-aware -- reaches mmceN:/pfs/smb paths the ROM LOADFILE's plain-ioman lookup cannot).
+EE_LIBS = -lfileXio
+
+all: $(EE_BIN)
+
+clean:
+	rm -f -r $(EE_OBJS) $(EE_BIN)
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal

--- a/elfldr/linkfile
+++ b/elfldr/linkfile
@@ -1,0 +1,69 @@
+ENTRY(__start);
+
+MEMORY {
+	bios	: ORIGIN = 0x00000000, LENGTH = 528K /* 0x00000000 - 0x00084000: BIOS memory */
+	bram	: ORIGIN = 0x00084000, LENGTH = 496K /* 0x00084000 - 0x00100000: BIOS unused memory */
+	gram	: ORIGIN = 0x00100000, LENGTH =  31M /* 0x00100000 - 0x02000000: GAME memory */
+}
+
+REGION_ALIAS("MAIN_REGION", bram);
+
+PHDRS {
+  text PT_LOAD;
+}
+
+SECTIONS {
+	.text : {
+		*(.text)
+	} >MAIN_REGION :text
+
+	.reginfo : { *(.reginfo) } >MAIN_REGION
+
+	.ctors ALIGN(16): {
+		KEEP(*crtbegin*.o(.ctors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
+		KEEP(*(SORT(.ctors.*)))
+		KEEP(*(.ctors))
+	} >MAIN_REGION
+
+	.dtors ALIGN(16): {
+		KEEP(*crtbegin*.o(.dtors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
+		KEEP(*(SORT(.dtors.*)))
+		KEEP(*(.dtors))
+	} >MAIN_REGION
+
+	.rodata ALIGN(128): {
+		*(.rodata)
+	} >MAIN_REGION
+
+	.data ALIGN(128): {
+		_fdata = . ;
+		*(.data)
+		SORT(CONSTRUCTORS)
+	} >MAIN_REGION
+
+	_gp = ALIGN(128) + 0x7ff0;
+	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
+	.lit8 ALIGN(128): { *(.lit8) } >MAIN_REGION
+
+	.sdata ALIGN(128): {
+		*(.sdata)
+	} >MAIN_REGION
+
+	.sbss ALIGN(128) : {
+		_fbss = . ;
+		*(.sbss)
+	} >MAIN_REGION
+
+	.bss ALIGN(128) : {
+		*(.bss)
+	} >MAIN_REGION
+
+	/* Symbols needed by crt0.s.  */
+	PROVIDE(_end = .);
+	PROVIDE(_heap_size = -1);
+
+	PROVIDE(_stack = .);
+	PROVIDE(_stack_size = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION) - _stack);
+}

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -1,0 +1,218 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Modified for RiptOPL: NO IOP reset (same approach as NHDDL's neutrino
+# handoff). This child loader runs from BIOS-unused memory (0x84000), loads
+# the target ELF through the STILL-LIVE IOP -- OPL's drivers and mounts stay
+# up -- and jumps into it. The target (Neutrino/POPSTARTER) reads its
+# config/modules and the game through those mounts, then performs its own
+# IOP reset.
+#
+# The target is read via SifLoadElf (rom0:LOADFILE) FIRST, with fileXio
+# (iomanX) as the rescue path. Both are needed:
+#   * LOADFILE cannot see iomanX-ONLY filesystems -- mmceman registers its
+#     mmceN: device with iomanX and never with ioman (binary import tables:
+#     mmceman imports iomanx, bdmfs_fatfs imports ioman) -- so an MMCE-hosted
+#     neutrino.elf probed fine from OPL (fileXio) but SifLoadElf() returned
+#     -ENOENT here. LOADFILE fails CLEANLY on those, and fileXio takes over.
+#   * The SDK's EE fileXio client is a moving target: the 2026-05 snapshot
+#     (the -WOPLSDK flavour's container) sits between the 2026-06-03 "SIF
+#     binding handling" and 2026-06-17 "cleaner (re-)initialization" fixes,
+#     and its client misloads from a fresh child program -- VCD/POPSTARTER
+#     launches on that flavour bounced to OSDSYS when fileXio was primary.
+#     Keeping the battle-tested LOADFILE first means ioman-visible devices
+#     (mass/mc, i.e. every POPSTARTER launch) never touch the fragile client.
+*/
+
+#include <kernel.h>
+#include <loadfile.h>
+#include <ps2sdkapi.h>
+#include <sifrpc.h>
+#include <fileXio_rpc.h>
+#include <fileio.h>
+#include <errno.h>
+#include <string.h>
+
+//--------------------------------------------------------------
+// Redefinition of init/deinit libc:
+//--------------------------------------------------------------
+// DON'T REMOVE is for reducing binary size.
+// These functions are defined as weak in /libc/src/init.c
+//--------------------------------------------------------------
+void _libcglue_init() {}
+void _libcglue_deinit() {}
+void _libcglue_args_parse(int argc, char **argv) {}
+
+DISABLE_PATCHED_FUNCTIONS();
+DISABLE_EXTRA_TIMERS_FUNCTIONS();
+PS2_DISABLE_AUTOSTART_PTHREAD();
+
+#define ELF_MAGIC   0x464c457f
+#define ELF_PT_LOAD 1
+
+typedef struct
+{
+    u8 ident[16];
+    u16 type;
+    u16 machine;
+    u32 version;
+    u32 entry;
+    u32 phoff;
+    u32 shoff;
+    u32 flags;
+    u16 ehsize;
+    u16 phentsize;
+    u16 phnum;
+    u16 shentsize;
+    u16 shnum;
+    u16 shstrndx;
+} elf_header_t;
+
+typedef struct
+{
+    u32 type;
+    u32 offset;
+    void *vaddr;
+    u32 paddr;
+    u32 filesz;
+    u32 memsz;
+    u32 flags;
+    u32 align;
+} elf_pheader_t;
+
+//--------------------------------------------------------------
+// Clear user memory
+// PS2Link (C) 2003 Tord Lindstrom (pukko@home.se)
+//         (C) 2003 adresd (adresd_ps2dev@yahoo.com)
+//--------------------------------------------------------------
+static void wipeUserMem(void)
+{
+    int i;
+    for (i = 0x100000; i < GetMemorySize(); i += 64) {
+        __asm__ __volatile__(
+            "\tsq $0, 0(%0) \n"
+            "\tsq $0, 16(%0) \n"
+            "\tsq $0, 32(%0) \n"
+            "\tsq $0, 48(%0) \n" ::"r"(i));
+    }
+}
+
+static int readAll(int fd, void *buf, int size)
+{
+    u8 *p = (u8 *)buf;
+    while (size > 0) {
+        int got = fileXioRead(fd, p, size);
+        if (got <= 0)
+            return -1;
+        p += got;
+        size -= got;
+    }
+    return 0;
+}
+
+// Manual ELF load through the resident fileXio server (iomanX-aware). The program segments load
+// into user memory (>= 0x100000, already wiped) well above this loader's bram home, so reading
+// straight to each vaddr is safe. Returns 0 and sets *entry on success. gp stays 0 at ExecPS2:
+// standard PS2 crt0s load $gp themselves (POPSLoader's embedded loader ships the same way).
+static int loadElfViaFileXio(const char *path, u32 *entry)
+{
+    elf_header_t eh;
+    elf_pheader_t ph;
+    int fd, i, loaded = 0;
+
+    if (fileXioInit() < 0)
+        return -1;
+    fd = fileXioOpen(path, FIO_O_RDONLY);
+    if (fd < 0)
+        return -1;
+
+    // phentsize must match our struct or the per-header stride below reads garbage.
+    if (readAll(fd, &eh, sizeof(eh)) != 0 || _lw((u32)&eh.ident) != ELF_MAGIC || eh.phnum == 0 ||
+        eh.phentsize != sizeof(elf_pheader_t)) {
+        fileXioClose(fd);
+        return -1;
+    }
+
+    for (i = 0; i < eh.phnum; i++) {
+        if (fileXioLseek(fd, eh.phoff + i * sizeof(elf_pheader_t), SEEK_SET) < 0 ||
+            readAll(fd, &ph, sizeof(ph)) != 0) {
+            fileXioClose(fd);
+            return -1;
+        }
+        if (ph.type != ELF_PT_LOAD || ph.memsz == 0)
+            continue;
+        // Defensive bounds: a truncated/half-copied ELF (a real hazard on flaky cards) must fail
+        // CLEANLY here -- into the SifLoadElf fallback / -ENOENT -- not scribble over the kernel
+        // or this loader (below 0x100000) or wrap past the end of RAM. The memsz-vs-RAM test runs
+        // FIRST so the subtraction in the last clause cannot underflow.
+        if (ph.filesz > ph.memsz || (u32)ph.vaddr < 0x100000 ||
+            ph.memsz > (u32)GetMemorySize() || (u32)ph.vaddr > (u32)GetMemorySize() - ph.memsz) {
+            fileXioClose(fd);
+            return -1;
+        }
+        if (ph.filesz > 0) {
+            if (fileXioLseek(fd, ph.offset, SEEK_SET) < 0 || readAll(fd, ph.vaddr, ph.filesz) != 0) {
+                fileXioClose(fd);
+                return -1;
+            }
+        }
+        if (ph.memsz > ph.filesz)
+            memset((u8 *)ph.vaddr + ph.filesz, 0, ph.memsz - ph.filesz);
+        loaded++;
+    }
+    fileXioClose(fd);
+
+    if (!loaded)
+        return -1;
+    *entry = eh.entry;
+    return 0;
+}
+
+// argv[0] = path of the ELF to LOAD; argv[1..] = the target's FULL argv, forwarded verbatim
+// (argv[1] becomes the target's argv[0]). The caller CONTROLS the target's argv[0]: Neutrino
+// gets its own path (NHDDL convention), POPSTARTER gets the "XX./SB." selector it string-parses
+// to pick its backend -- the stock SDK loader clobbers argv[0] with the load path, which is
+// exactly what sent POPSTARTER down its HDD "__common" route on every non-HDD VCD launch.
+// The ExecPS2 syscall marshals the strings, so wiping user memory is safe.
+int main(int argc, char *argv[])
+{
+    static t_ExecData elfdata;
+    u32 entry;
+    int ret;
+
+    if (argc < 2)
+        return -EINVAL;
+
+    SifInitRpc(0);
+    wipeUserMem();
+
+    // Writeback data cache before loading ELF.
+    FlushCache(0);
+
+    // Primary: the classic LOADFILE path (see header -- every ioman-visible device stays on it).
+    elfdata.epc = 0;
+    SifLoadFileInit();
+    ret = SifLoadElf(argv[0], &elfdata);
+    SifLoadFileExit();
+    if (ret == 0 && elfdata.epc != 0) {
+        FlushCache(0);
+        FlushCache(2);
+        return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, &argv[1]);
+    }
+
+    // Rescue: fileXio (iomanX) for the devices LOADFILE cannot see (mmceN:, pfs, ...).
+    if (loadElfViaFileXio(argv[0], &entry) == 0) {
+        FlushCache(0);
+        FlushCache(2);
+        return ExecPS2((void *)entry, NULL, argc - 1, &argv[1]);
+    }
+
+    SifExitRpc();
+    return -ENOENT;
+}

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -16,6 +16,7 @@ typedef struct
 } bdm_vmc_infos_t;
 
 #define MAX_BDM_DEVICES 5
+#define BDM_DEVICE_ROOT_MAX 32
 
 #define BDM_TYPE_UNKNOWN -1
 #define BDM_TYPE_USB     0
@@ -52,5 +53,8 @@ void bdmEnumerateDevices();
 
 void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData);
 int bdmHDDIsPresent(u32 timeoutMs);
+
+// First mounted device of a BDM_TYPE_*: writes its massN:/ root; 1 = found.
+int bdmGetDeviceRootByType(int bdmType, char *root, int rootLen);
 
 #endif

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -15,7 +15,7 @@ typedef struct
     vmc_spec_t specs; /* Card specifications */
 } bdm_vmc_infos_t;
 
-#define MAX_BDM_DEVICES 5
+#define MAX_BDM_DEVICES     5
 #define BDM_DEVICE_ROOT_MAX 32
 
 #define BDM_TYPE_UNKNOWN -1

--- a/include/gui.h
+++ b/include/gui.h
@@ -144,6 +144,8 @@ void guiShowColorsConfig(void);
 int guiDrawBGSettings(void);
 int guiDeviceTypeToIoMode(int deviceType);
 int guiIoModeToDeviceType(int ioMode);
+void guiShowNeutrinoDefaults(void);
+void guiShowNeutrinoArgsConfig(char *argsBuf, int bufSize);
 void guiShowAudioConfig();
 void guiShowControllerConfig();
 void guiShowNetConfig();

--- a/include/opl.h
+++ b/include/opl.h
@@ -79,6 +79,8 @@ void menuDeferredUpdate(void *data);
 void moduleUpdateMenu(int mode, int themeChanged, int langChanged);
 void handleLwnbdSrv();
 void deinit(int exception, int modeSelected);
+// Neutrino keep-IOP handoff: deinit that spares a SECOND mode's mounts (the neutrino.elf device).
+void deinitEx(int exception, int modeSelected, int modeSelected2);
 
 // Shutdown minimal services initiated for auto loading.
 void miniDeinit(config_set_t *configSet);
@@ -125,6 +127,22 @@ extern int hddCacheSize;
 extern int smbCacheSize;
 
 extern int gEnableUSB;
+// Neutrino Device picker: a driver-accurate device TYPE that holds <root>:/neutrino/neutrino.elf.
+enum { NEUTRINO_DEV_AUTO = 0, // game device, then mc0/mc1 (legacy behaviour)
+       NEUTRINO_DEV_MC,       // mc0: / mc1:
+       NEUTRINO_DEV_USB,      // BDM "usb"        -> the mounted massN:
+       NEUTRINO_DEV_MX4SIO,   // BDM "mx4sio"/sdc -> the mounted massN:
+       NEUTRINO_DEV_MMCE,     // mmce0: / mmce1: (checklist item 1)
+       NEUTRINO_DEV_EXFAT_HDD, // BDM "ata" internal exFAT HDD -> the mounted massN:
+       NEUTRINO_DEV_APA_HDD,  // APA HDD: the mounted OPL data partition (pfs0:)
+       NEUTRINO_DEV_GAME };   // the active game's OWN device ONLY; appended last to keep saved ints stable
+extern int gNeutrinoDevice;
+extern int gDefaultCoreLoader;
+extern int gNeutrinoVideoDefault;
+extern int gNeutrinoGsmCompDefault;
+extern int gNeutrinoElfArg;
+extern char gNeutrinoArgs[256];
+extern char gNeutrinoPath[256];
 extern int gEnableBGArt;
 extern unsigned char gDefaultPlasBlendColor[3];
 extern int gEnableILK;

--- a/include/opl.h
+++ b/include/opl.h
@@ -128,14 +128,14 @@ extern int smbCacheSize;
 
 extern int gEnableUSB;
 // Neutrino Device picker: a driver-accurate device TYPE that holds <root>:/neutrino/neutrino.elf.
-enum { NEUTRINO_DEV_AUTO = 0, // game device, then mc0/mc1 (legacy behaviour)
-       NEUTRINO_DEV_MC,       // mc0: / mc1:
-       NEUTRINO_DEV_USB,      // BDM "usb"        -> the mounted massN:
-       NEUTRINO_DEV_MX4SIO,   // BDM "mx4sio"/sdc -> the mounted massN:
-       NEUTRINO_DEV_MMCE,     // mmce0: / mmce1: (checklist item 1)
+enum { NEUTRINO_DEV_AUTO = 0,  // game device, then mc0/mc1 (legacy behaviour)
+       NEUTRINO_DEV_MC,        // mc0: / mc1:
+       NEUTRINO_DEV_USB,       // BDM "usb"        -> the mounted massN:
+       NEUTRINO_DEV_MX4SIO,    // BDM "mx4sio"/sdc -> the mounted massN:
+       NEUTRINO_DEV_MMCE,      // mmce0: / mmce1: (checklist item 1)
        NEUTRINO_DEV_EXFAT_HDD, // BDM "ata" internal exFAT HDD -> the mounted massN:
-       NEUTRINO_DEV_APA_HDD,  // APA HDD: the mounted OPL data partition (pfs0:)
-       NEUTRINO_DEV_GAME };   // the active game's OWN device ONLY; appended last to keep saved ints stable
+       NEUTRINO_DEV_APA_HDD,   // APA HDD: the mounted OPL data partition (pfs0:)
+       NEUTRINO_DEV_GAME };    // the active game's OWN device ONLY; appended last to keep saved ints stable
 extern int gNeutrinoDevice;
 extern int gDefaultCoreLoader;
 extern int gNeutrinoVideoDefault;

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -1,6 +1,8 @@
 #ifndef __SUPPORT_BASE_H
 #define __SUPPORT_BASE_H
 
+#include "include/system.h" // neutrino_vmc_args_t
+
 #define UL_GAME_NAME_MAX       32
 #define ISO_GAME_NAME_MAX      160
 #define ISO_GAME_EXTENSION_MAX 4
@@ -56,5 +58,35 @@ int sbProbeISO9660(const char *path, base_game_info_t *game, u32 layer1_offset);
 int sbProbeISO9660_64(const char *path, base_game_info_t *game, u32 layer1_offset);
 
 int sbLoadCheats(const char *path, const char *file);
+
+
+int sbFileExists(const char *path);
+
+// First existing Neutrino core ELF, or NULL. In AUTO mode (gNeutrinoDevice==0): custom gNeutrinoPath
+// -> the active game's device (activePrefix) -> mc0/mc1 install spots. An explicit Device picker
+// ignores activePrefix. Pass NULL when no game device applies.
+const char *sbResolveNeutrinoPath(const char *activePrefix);
+
+// Structured view of the USER-settable Neutrino launch flags (the catch-all "Launch Args" box).
+typedef struct
+{
+    int qb;          // -qb (quick-boot)
+    int dbc;         // -dbc (debug colors)
+    int logo;        // -logo (PS2 logo)
+    char cwd[64];    // -cwd=
+    char cfg[64];    // -cfg=
+    char elf[64];    // -elf=
+    char ata0[64];   // -ata0=
+    char ata0id[64]; // -ata0id=
+    char ata1[64];   // -ata1=
+    char extra[64];  // unrecognised/free tokens, space-joined; "--b ..." preserved at the tail
+} neutrino_args_t;
+// Parse an args string into the struct; assemble it back in a Neutrino-accepted order (--b last).
+void neutrinoArgsParse(const char *in, neutrino_args_t *na);
+void neutrinoArgsAssemble(const neutrino_args_t *na, char *out, int outSize);
+
+// Fully-formed Neutrino -mcN VMC args for both slots, resolved from the per-game config
+// BEFORE deinit frees it. vmcPrefix = the device prefix VMC/ lives under.
+void sbBuildVmcNeutrinoArgs(config_set_t *configSet, const char *vmcPrefix, neutrino_vmc_args_t *vmcArgs);
 
 #endif

--- a/include/system.h
+++ b/include/system.h
@@ -14,6 +14,35 @@ void sysShutdownDev9(void);
 void sysReset(int modload_mask);
 void sysExecExit(void);
 int sysLaunchDisc(void); // boot the physical PS2 disc in the drive; <0 (stays in OPL) on failure
+
+#define NEUTRINO_PATH     "mc0:NEUTRINO/neutrino.elf"
+#define NEUTRINO_ALT_PATH "mc1:NEUTRINO/neutrino.elf"
+
+#define NEUTRINO_VMC_SLOTS 2
+
+// Fully-formed Neutrino "-mcN=<prefix>VMC/<name>.bin" args, one per VMC slot, resolved by the
+// device support layer BEFORE deinit frees the per-game config. Carried into sysLaunchNeutrino
+// and emitted as DISCRETE argv[] entries -- never whitespace-tokenized -- so a VMC whose name
+// contains a space survives intact.
+typedef struct neutrino_vmc_args
+{
+    // "-mcN=<prefix>VMC/<name>.bin"; "" => slot unconfigured / skipped.
+    char arg[NEUTRINO_VMC_SLOTS][160];
+} neutrino_vmc_args_t;
+
+// neutrinoBsdfs: per-game -bsdfs override, 0=Auto (per-device default), 1=exfat, 2=hdl, 3=bd.
+void sysLaunchNeutrino(const char *driver, const char *path, const char *startup, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, int neutrinoGsmComp, int neutrinoBsdfs, const neutrino_vmc_args_t *vmcArgs);
+
+// Pre-deinit launch pre-flight: validates the driver token while every mount is up and the GUI
+// can still toast. Call BEFORE deinit in every Neutrino leg. Returns 0 = proceed; <0 = abort
+// the launch (a toast has already been shown).
+int sysNeutrinoPreflight(const char *driver, const char *neutrinoPath);
+
+// ELF handoff that KEEPS the IOP (drivers + mounts) alive -- NHDDL parity: the vendored elfldr/
+// child loader SifLoadElf()s the target through OPL's live mounts and never SifIopReset()s (the
+// target resets the IOP itself). argv is the target's FULL argv, argv[0] INCLUDED and
+// caller-controlled. Returns only on failure (bad path/ELF). Implemented in elfldr_noreset.c.
+int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, char *argv[]);
 void sysPowerOff(void);
 #ifdef __DECI2_DEBUG
 int sysInitDECI2(void);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -932,3 +932,17 @@ gui_strings:
   string: Controller
 - label: MENU_AUDIO
   string: Audio
+- label: NEUTRINO_DEV_UNSUPPORTED
+  string: Neutrino cannot launch from this device -- launch aborted.
+- label: NEUTRINO_TOML_SYNC_FAILED
+  string: Neutrino network config (bsd toml) missing or unwritable -- launch aborted, check the neutrino folder.
+- label: NEUTRINO_VMC_MISSING
+  string: Per-game VMC file not found -- launching without it (game uses its real card).
+- label: GAMES_DEVICE
+  string: Game's Device
+- label: NEUTRINO_BAD_FORMAT
+  string: Neutrino does not support this file format, launching with <OPL> core
+- label: NEUTRINO_NOT_FOUND
+  string: Neutrino ELF not found, launching with <OPL> core
+- label: NEUTRINO_TOO_FRAGMENTED
+  string: Too fragmented for Neutrino (%d fragments, limit %d incl. VMCs) -- trying the OPL core instead.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -106,6 +106,70 @@ static void bdmLoadBlockDeviceModules(void)
     SignalSema(bdmLoadModuleLock);
 }
 
+// BDM device identity helpers (Neutrino device-TYPE picker; trimmed to the identity
+// surface only -- the fork's wider slot-search/equip machinery arrives with items 14/16).
+static int bdmDetermineDeviceType(const char *driverName)
+{
+    if (!strcmp(driverName, "usb"))
+        return BDM_TYPE_USB;
+    if (!strcmp(driverName, "sd") && strlen(driverName) == 2)
+        return BDM_TYPE_ILINK;
+    if (!strcmp(driverName, "sdc") && strlen(driverName) == 3)
+        return BDM_TYPE_SDC;
+    if (!strcmp(driverName, "ata") && strlen(driverName) == 3)
+        return BDM_TYPE_ATA;
+    return -1;
+}
+
+static int bdmReadDeviceIdentity(const char *path, char *driverName, int driverNameLength, int *deviceIndex)
+{
+    int dir, result;
+
+    if (driverNameLength > 0)
+        memset(driverName, 0, driverNameLength);
+    *deviceIndex = -1;
+
+    dir = fileXioDopen(path);
+    if (dir < 0)
+        return dir;
+
+    result = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, driverName, driverNameLength - 1);
+    if (result >= 0)
+        result = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, deviceIndex, sizeof(*deviceIndex));
+
+    fileXioDclose(dir);
+    return result;
+}
+
+// Find the first mounted BDM device whose driver matches bdmType (BDM_TYPE_*) and write its
+// massN: FILESYSTEM root WITH a trailing slash (e.g. "mass0:/") to root. Returns 1 if such a
+// device is mounted, 0 otherwise. The root is ALWAYS the legacy mass<slot>: mount, never a
+// typed root -- consumers (Neutrino picker, future POPSTARTER equip) must stay on massN:.
+int bdmGetDeviceRootByType(int bdmType, char *root, int rootLen)
+{
+    if (root == NULL || rootLen <= 0)
+        return 0;
+
+    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+        char path[16], driver[32];
+        int devIndex = -1;
+
+        snprintf(path, sizeof(path), "mass%d:/", i);
+        // Identify the device by its DRIVER NAME only; GET_DEVICE_NUMBER can fail on a
+        // perfectly usable device and the device pages already tolerate that.
+        bdmReadDeviceIdentity(path, driver, sizeof(driver), &devIndex);
+        if (driver[0] == '\0')
+            continue;
+        if (bdmDetermineDeviceType(driver) != bdmType)
+            continue;
+
+        snprintf(root, rootLen, "mass%d:/", i);
+        return 1;
+    }
+    return 0;
+}
+
+
 void bdmLoadModules(void)
 {
     LOG("BDMSUPPORT LoadModules\n");
@@ -315,6 +379,123 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
     pDeviceData->bdmULSizePrev = -2;
     pDeviceData->ForceRefresh = 1;
 }
+// Neutrino frag budget: neutrino only discovers a blown fragment budget after its own IOP
+// reset (debug printf + exit = black screen). Count it now. i_bdm's GET_FRAGLIST with a NULL
+// buffer returns the fragment COUNT for the open file.
+#define NEUTRINO_BDM_MAX_FRAGS 64
+
+static int bdmNeutrinoFragBudgetOk(const char *isoPath, const neutrino_vmc_args_t *vmcArgs)
+{
+    const char *paths[1 + NEUTRINO_VMC_SLOTS];
+    int nPaths = 0, total = 0, i;
+
+    paths[nPaths++] = isoPath;
+    for (i = 0; i < NEUTRINO_VMC_SLOTS; i++) {
+        const char *eq = vmcArgs->arg[i][0] ? strchr(vmcArgs->arg[i], '=') : NULL;
+        if (eq != NULL && eq[1] != '\0')
+            paths[nPaths++] = eq + 1; // "-mcN=<path>"; the builder already verified the file exists
+    }
+
+    for (i = 0; i < nPaths; i++) {
+        int fd = open(paths[i], O_RDONLY);
+        if (fd < 0) { // advisory check only: never veto the launch on a probe failure
+            LOG("[NEUTRINO] frag pre-count: open(%s) failed, file skipped\n", paths[i]);
+            continue;
+        }
+        int frags = fileXioIoctl2(ps2sdk_get_iop_fd(fd), USBMASS_IOCTL_GET_FRAGLIST, NULL, 0, NULL, 0);
+        close(fd);
+        if (frags < 0) {
+            LOG("[NEUTRINO] frag pre-count: ioctl(%s) = %d, file skipped\n", paths[i], frags);
+            continue;
+        }
+        total += frags;
+    }
+
+    if (total > NEUTRINO_BDM_MAX_FRAGS) {
+        guiWarning(_l(_STR_NEUTRINO_TOO_FRAGMENTED), 6);
+        return 0;
+    }
+    return 1;
+}
+
+// Neutrino core launch leg: everything the native path below prepares (VMC/mcemu patching,
+// cdvdman patch, fraglists, layer-1 probing, cheats, ATA DMA setup) exists for the EMBEDDED
+// cdvdman core; Neutrino re-derives all of it from -bsd/-dvd after its own IOP reset.
+// Returns 1 = handled (handed off, or aborted with the user informed -- caller returns);
+// 0 = proceed with the native launch.
+// NOTE(rebuild): the UDP forced-core branch returns with items 5/6 (no udp driver can be
+// mounted yet); the MMCE cross-device GameID send returns with item 3.
+static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, bdm_device_data_t *pDeviceData, config_set_t *configSet)
+{
+    int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
+    configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+    if (!coreLoader)
+        return 0;
+
+    if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
+        // Neutrino cannot run UL or ZSO images.
+        guiWarning(_l(_STR_NEUTRINO_BAD_FORMAT), 6);
+        return 0;
+    }
+
+    const char *neutrinoPath = sbResolveNeutrinoPath(pDeviceData->bdmPrefix); // AUTO probes this device for a co-located install
+    if (neutrinoPath == NULL) {
+        guiWarning(_l(_STR_NEUTRINO_NOT_FOUND), 6);
+        return 0;
+    }
+
+    // Everything Neutrino actually needs from the config/device, copied to THIS stack frame
+    // (deinit below frees configSet's owner + pDeviceData). Absent per-game keys = follow the
+    // global defaults.
+    int compatmask = 0, neutrinoVideo = gNeutrinoVideoDefault, neutrinoGsmComp = gNeutrinoGsmCompDefault, neutrinoBsdfs = 0;
+    char neutrinoExtraArgs[256] = "";
+    neutrino_vmc_args_t neutrinoVmc = {0};
+    char partname[256], bdmCurrentDriver[32];
+    configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatmask);
+    configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_GSMCOMP, &neutrinoGsmComp);
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_BSDFS, &neutrinoBsdfs);
+    sbBuildVmcNeutrinoArgs(configSet, pDeviceData->bdmPrefix, &neutrinoVmc);
+    sbCreatePath(game, partname, pDeviceData->bdmPrefix, "/", 0); // -dvd target
+    snprintf(bdmCurrentDriver, sizeof(bdmCurrentDriver), "%s", pDeviceData->bdmDriver);
+
+    if (!bdmNeutrinoFragBudgetOk(partname, &neutrinoVmc))
+        return 0; // stay native: the embedded core handles fragmentation via fraglists
+
+    if (gRememberLastPlayed) {
+        configSetStr(configGetByType(CONFIG_LAST), "last_played", game->startup);
+        saveConfig(CONFIG_LAST, 0);
+    }
+
+    // Preflight (driver token validation) -- abort stays in a live menu.
+    if (sysNeutrinoPreflight(bdmCurrentDriver, neutrinoPath) < 0)
+        return 0;
+
+    // game->startup lives inside bdmGames / gAutoLaunchBDMGame, both freed below. Copy it
+    // before the teardown so sysLaunchNeutrino's -elf build reads valid stack memory.
+    char bdmStartup[GAME_STARTUP_MAX + 1];
+    snprintf(bdmStartup, sizeof(bdmStartup), "%s", game->startup);
+
+    if (gAutoLaunchBDMGame == NULL) {
+        // Keep-IOP handoff: keep BOTH the game device and the neutrino.elf device mounted
+        // (Neutrino reads its -cwd config/modules and the ISO through our mounts pre-reset).
+        int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+        deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp frees bdmGames/game
+    } else {
+        miniDeinit(configSet);
+        free(gAutoLaunchBDMGame);
+        gAutoLaunchBDMGame = NULL;
+        free(gAutoLaunchDeviceData);
+        gAutoLaunchDeviceData = NULL;
+    }
+
+    // gPS2Logo passes the user's preference straight through: Neutrino performs its own logo
+    // read/validation for -logo.
+    sysLaunchNeutrino(bdmCurrentDriver, partname, bdmStartup, compatmask, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, neutrinoBsdfs, &neutrinoVmc);
+    return 1;
+}
+
 
 void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 {
@@ -338,6 +519,11 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         pDeviceData = gAutoLaunchDeviceData;
         game = gAutoLaunchBDMGame;
     }
+
+    // Neutrino core gets its own lean path FIRST -- everything below is native-core prep it
+    // neither needs nor should be able to die on (see bdmTryNeutrinoLaunch).
+    if (bdmTryNeutrinoLaunch(itemList, game, pDeviceData, configSet))
+        return;
 
     char vmc_name[32], vmc_path[256], have_error = 0;
     int vmc_id, size_mcemu_irx = 0;

--- a/src/elfldr_noreset.c
+++ b/src/elfldr_noreset.c
@@ -1,0 +1,144 @@
+/*
+  No-IOP-reset ELF handoff (NHDDL parity) for the Neutrino launch path.
+
+  ps2sdk's LoadELFFromFileWithPartition SifLoadElf()s the target through the live IOP but then
+  SifIopReset()s and reloads ONLY rom0:SIO2MAN/MCMAN/MCSERV before jumping in
+  (ee/elf-loader/src/loader/src/loader.c). Neutrino must read its config/modules (-cwd) and open
+  the game ISO through the LAUNCHER's mounts before doing its own IOP reset, so that handoff
+  black-screens every setup whose neutrino/ folder or game lives on a BDM device.
+
+  ps2sdk gained a NoReset entry point in 8890d8b5 (2026-06-30), but neither build container ships
+  it yet (ps2dev:latest probed 2026-07-04 carries a 2026-06-21 SDK; the PS2MAXSDK pin is 2025-07-25),
+  so we vendor the child loader instead (elfldr/loader.c, the NHDDL approach): copy it into
+  BIOS-unused memory at 0x84000, ExecPS2 into it with argv[0] = target path, and it SifLoadElf()s
+  the target through OPL's still-live mounts -- no IOP reset. Works identically on both SDKs.
+*/
+
+#include <kernel.h>
+#include "include/ioman.h" // LOG (kernel argv-budget refusal trace)
+#include <sifrpc.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+extern unsigned char elfldr_elf[];
+extern unsigned int size_elfldr_elf;
+
+#define ELFLDR_ELF_MAGIC 0x464c457f
+#define ELFLDR_PT_LOAD   1
+
+typedef struct
+{
+    u8 ident[16];
+    u16 type;
+    u16 machine;
+    u32 version;
+    u32 entry;
+    u32 phoff;
+    u32 shoff;
+    u32 flags;
+    u16 ehsize;
+    u16 phentsize;
+    u16 phnum;
+    u16 shentsize;
+    u16 shnum;
+    u16 shstrndx;
+} elfldr_header_t;
+
+typedef struct
+{
+    u32 type;
+    u32 offset;
+    void *vaddr;
+    u32 paddr;
+    u32 filesz;
+    u32 memsz;
+    u32 flags;
+    u32 align;
+} elfldr_pheader_t;
+
+// Wipe the BIOS-unused region the child loader is linked into (0x84000 - 0x100000,
+// below OPL itself -- see elfldr/linkfile).
+static void wipeBramMem(void)
+{
+    int i;
+    for (i = 0x00084000; i < 0x100000; i += 64) {
+        __asm__ __volatile__(
+            "\tsq $0, 0(%0) \n"
+            "\tsq $0, 16(%0) \n"
+            "\tsq $0, 32(%0) \n"
+            "\tsq $0, 48(%0) \n" ::"r"(i));
+    }
+}
+
+int sysLoadELFKeepIOP(const char *filename, const char *partition, int argc, char *argv[])
+{
+    elfldr_header_t *eh;
+    elfldr_pheader_t *eph;
+    void *pdata;
+    int i, fd;
+
+    (void)partition; // callers pass "" -- no APA-partition context needed on this path
+
+    // argv here is the target's FULL argv -- argv[0] INCLUDED and caller-controlled (Neutrino:
+    // its own path; POPSTARTER: the XX./SB. selector it string-parses). At least argv[0] must
+    // be supplied: the child forwards &argv[1] verbatim, never synthesizing a replacement.
+    if (argc < 1 || argv == NULL || argv[0] == NULL)
+        return -1;
+
+    // Probe the target through our still-live mounts so a bad path fails fast in OPL
+    // instead of inside the child loader (which can only fall through to OSDSYS).
+    if (filename == NULL || (fd = open(filename, O_RDONLY)) < 0)
+        return -1;
+    close(fd);
+
+    // Kernel args-area budget, the last line of defense for EVERY keep-IOP handoff (Neutrino and
+    // POPSTARTER): SetArg copies at most 15 strings into ONE 256-byte pool (NULs included) and
+    // ExecPS2 forwards the UNCLAMPED count -- exceeding either limit corrupts rather than
+    // truncates. Callers are expected to fit (sysLaunchNeutrino budgets itself); refuse loudly
+    // here rather than hand the kernel a mangled argv.
+    {
+        int pool = (int)strlen(filename) + 1;
+        int j;
+        for (j = 0; j < argc; j++) {
+            if (argv[j] == NULL)
+                return -1; // a NULL mid-argv would crash SetArg's copy inside ExecPS2 -- refuse here
+            pool += (int)strlen(argv[j]) + 1;
+        }
+        if (argc + 1 > 15 || pool > 256) {
+            LOG("[ELFLDR] argv over the kernel budget (args=%d/15, pool=%d/256) -- refusing handoff\n", argc + 1, pool);
+            return -1;
+        }
+    }
+
+    // Child contract: argv[0] = load path (SifLoadElf'd), argv[1..] = the target's full argv;
+    // the ExecPS2 syscall marshals the strings across the jump.
+    char *new_argv[argc + 1];
+    new_argv[0] = (char *)filename;
+    for (i = 0; i < argc; i++)
+        new_argv[i + 1] = argv[i];
+
+    wipeBramMem();
+
+    eh = (elfldr_header_t *)elfldr_elf;
+    if (_lw((u32)&eh->ident) != ELFLDR_ELF_MAGIC)
+        return -1;
+
+    eph = (elfldr_pheader_t *)(elfldr_elf + eh->phoff);
+    for (i = 0; i < eh->phnum; i++) {
+        if (eph[i].type != ELFLDR_PT_LOAD)
+            continue;
+
+        pdata = (void *)(elfldr_elf + eph[i].offset);
+        memcpy(eph[i].vaddr, pdata, eph[i].filesz);
+
+        if (eph[i].memsz > eph[i].filesz)
+            memset((void *)((u8 *)(eph[i].vaddr) + eph[i].filesz), 0, eph[i].memsz - eph[i].filesz);
+    }
+
+    sceSifExitRpc();
+    FlushCache(0);
+    FlushCache(2);
+
+    return ExecPS2((void *)eh->entry, NULL, argc + 1, new_argv);
+}

--- a/src/gui.c
+++ b/src/gui.c
@@ -866,6 +866,130 @@ void guiShowParentalLockConfig(void)
         menuSetParentalLockCheckState(1);
     }
 }
+// Neutrino Defaults live-updater: the ":c" comp half is only ever emitted alongside a video mode
+// (-gsm=v:c grammar) -- grey it while the global Neutrino Video default is Off (same rule as the
+// per-game rows).
+static int guiNeutrinoDefaultsUpdater(int modified)
+{
+    int neutrinoVideoDef;
+
+    if (modified) {
+        diaGetInt(diaNeutrinoDefaults, CFG_NEUTRINO_VIDEO, &neutrinoVideoDef);
+        diaSetEnabled(diaNeutrinoDefaults, CFG_NEUTRINO_GSMCOMP, neutrinoVideoDef != 0);
+    }
+    return 0;
+}
+
+// Game Launching -> Neutrino Defaults: the global Neutrino device/video/gsm-comp defaults + the
+// structured Advanced Arguments editor.
+void guiShowNeutrinoDefaults(void)
+{
+    // Neutrino lives at <root>:/neutrino/neutrino.elf on ANY device -- offer the common roots.
+    // MUST stay in sync with the roots[] table in sbResolveNeutrinoPath() (supportbase.c).
+    const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", _l(_STR_GAMES_DEVICE), NULL}; // device TYPE holding /neutrino/neutrino.elf (NEUTRINO_DEV_*); "Game's Device" (NEUTRINO_DEV_GAME) appended last to match the enum tail
+    diaSetEnum(diaNeutrinoDefaults, CFG_NEUTRINO_DEVICE, neutrinoDevStrs);
+    diaSetInt(diaNeutrinoDefaults, CFG_NEUTRINO_DEVICE, gNeutrinoDevice);
+    // Global default Neutrino Video (-gsm) + comp half: same indices as the per-game picker
+    // (system.c gsmVideoTokens). static: literals only, and diaSetEnum stores the raw pointer.
+    static const char *neutrinoVideoDefStrs[] = {"Off", "240p", "480p", "1080i x1", "1080i x2", "1080i x3", NULL};
+    static const char *neutrinoGsmCompDefStrs[] = {"Off", "Type 1 (GSM/OPL)", "Type 2", "Type 3", NULL};
+    diaSetEnum(diaNeutrinoDefaults, CFG_NEUTRINO_VIDEO, neutrinoVideoDefStrs);
+    diaSetInt(diaNeutrinoDefaults, CFG_NEUTRINO_VIDEO, gNeutrinoVideoDefault);
+    diaSetEnum(diaNeutrinoDefaults, CFG_NEUTRINO_GSMCOMP, neutrinoGsmCompDefStrs);
+    diaSetInt(diaNeutrinoDefaults, CFG_NEUTRINO_GSMCOMP, gNeutrinoGsmCompDefault);
+    diaSetEnabled(diaNeutrinoDefaults, CFG_NEUTRINO_GSMCOMP, gNeutrinoVideoDefault != 0);
+
+    int ret;
+reshow_neutrino:
+    ret = diaExecuteDialog(diaNeutrinoDefaults, -1, 1, &guiNeutrinoDefaultsUpdater);
+    if (ret == CFG_NEUTRINO_ARGS) {
+        // the "Advanced Arguments" button -> open the structured args sub-screen, then re-enter
+        guiShowNeutrinoArgsConfig(gNeutrinoArgs, sizeof(gNeutrinoArgs));
+        goto reshow_neutrino;
+    }
+    if (ret) {
+        diaGetInt(diaNeutrinoDefaults, CFG_NEUTRINO_DEVICE, &gNeutrinoDevice);
+        diaGetInt(diaNeutrinoDefaults, CFG_NEUTRINO_VIDEO, &gNeutrinoVideoDefault);
+        diaGetInt(diaNeutrinoDefaults, CFG_NEUTRINO_GSMCOMP, &gNeutrinoGsmCompDefault);
+
+        applyConfig(-1, -1, 0);
+    }
+}
+
+// Neutrino Launch Args sub-screen: edit the user-settable Neutrino flags as structured fields and
+// reassemble them in a Neutrino-accepted order (--b last). Used for both the global args (here) and
+// the per-game args. argsBuf in/out is the stored "Launch Args" string.
+void guiShowNeutrinoArgsConfig(char *argsBuf, int bufSize)
+{
+    neutrino_args_t na;
+    neutrinoArgsParse(argsBuf, &na);
+
+    diaSetInt(diaNeutrinoArgs, NARGS_QB, na.qb ? 1 : 0);
+    diaSetInt(diaNeutrinoArgs, NARGS_DBC, na.dbc ? 1 : 0);
+    diaSetInt(diaNeutrinoArgs, NARGS_LOGO, na.logo ? 1 : 0);
+    diaSetString(diaNeutrinoArgs, NARGS_CWD, na.cwd);
+    diaSetString(diaNeutrinoArgs, NARGS_CFG, na.cfg);
+    diaSetString(diaNeutrinoArgs, NARGS_ELF, na.elf);
+    diaSetString(diaNeutrinoArgs, NARGS_ATA0, na.ata0);
+    diaSetString(diaNeutrinoArgs, NARGS_ATA0ID, na.ata0id);
+    diaSetString(diaNeutrinoArgs, NARGS_ATA1, na.ata1);
+    diaSetString(diaNeutrinoArgs, NARGS_EXTRA, na.extra);
+
+    // Baseline = the fields AS POPULATED (the UI caps each string at 31 chars). Comparing the
+    // post-dialog fields against this tells us which fields the user actually edited, so untouched
+    // fields can keep their FULL parsed value instead of the truncated UI copy.
+    neutrino_args_t pop;
+    diaGetInt(diaNeutrinoArgs, NARGS_QB, &pop.qb);
+    diaGetInt(diaNeutrinoArgs, NARGS_DBC, &pop.dbc);
+    diaGetInt(diaNeutrinoArgs, NARGS_LOGO, &pop.logo);
+    diaGetString(diaNeutrinoArgs, NARGS_CWD, pop.cwd, sizeof(pop.cwd));
+    diaGetString(diaNeutrinoArgs, NARGS_CFG, pop.cfg, sizeof(pop.cfg));
+    diaGetString(diaNeutrinoArgs, NARGS_ELF, pop.elf, sizeof(pop.elf));
+    diaGetString(diaNeutrinoArgs, NARGS_ATA0, pop.ata0, sizeof(pop.ata0));
+    diaGetString(diaNeutrinoArgs, NARGS_ATA0ID, pop.ata0id, sizeof(pop.ata0id));
+    diaGetString(diaNeutrinoArgs, NARGS_ATA1, pop.ata1, sizeof(pop.ata1));
+    diaGetString(diaNeutrinoArgs, NARGS_EXTRA, pop.extra, sizeof(pop.extra));
+
+    if (diaExecuteDialog(diaNeutrinoArgs, -1, 1, NULL)) {
+        neutrino_args_t out;
+        char after[256];
+        diaGetInt(diaNeutrinoArgs, NARGS_QB, &out.qb);
+        diaGetInt(diaNeutrinoArgs, NARGS_DBC, &out.dbc);
+        diaGetInt(diaNeutrinoArgs, NARGS_LOGO, &out.logo);
+        diaGetString(diaNeutrinoArgs, NARGS_CWD, out.cwd, sizeof(out.cwd));
+        diaGetString(diaNeutrinoArgs, NARGS_CFG, out.cfg, sizeof(out.cfg));
+        diaGetString(diaNeutrinoArgs, NARGS_ELF, out.elf, sizeof(out.elf));
+        diaGetString(diaNeutrinoArgs, NARGS_ATA0, out.ata0, sizeof(out.ata0));
+        diaGetString(diaNeutrinoArgs, NARGS_ATA0ID, out.ata0id, sizeof(out.ata0id));
+        diaGetString(diaNeutrinoArgs, NARGS_ATA1, out.ata1, sizeof(out.ata1));
+        diaGetString(diaNeutrinoArgs, NARGS_EXTRA, out.extra, sizeof(out.extra));
+        // Per-field merge: adopt only the fields the user actually changed; untouched fields keep
+        // their FULL parsed value (na) so editing one field never truncates the others to 31 chars.
+        if (out.qb != pop.qb)
+            na.qb = out.qb;
+        if (out.dbc != pop.dbc)
+            na.dbc = out.dbc;
+        if (out.logo != pop.logo)
+            na.logo = out.logo;
+        if (strcmp(out.cwd, pop.cwd) != 0)
+            snprintf(na.cwd, sizeof(na.cwd), "%s", out.cwd);
+        if (strcmp(out.cfg, pop.cfg) != 0)
+            snprintf(na.cfg, sizeof(na.cfg), "%s", out.cfg);
+        if (strcmp(out.elf, pop.elf) != 0)
+            snprintf(na.elf, sizeof(na.elf), "%s", out.elf);
+        if (strcmp(out.ata0, pop.ata0) != 0)
+            snprintf(na.ata0, sizeof(na.ata0), "%s", out.ata0);
+        if (strcmp(out.ata0id, pop.ata0id) != 0)
+            snprintf(na.ata0id, sizeof(na.ata0id), "%s", out.ata0id);
+        if (strcmp(out.ata1, pop.ata1) != 0)
+            snprintf(na.ata1, sizeof(na.ata1), "%s", out.ata1);
+        if (strcmp(out.extra, pop.extra) != 0)
+            snprintf(na.extra, sizeof(na.extra), "%s", out.extra);
+        neutrinoArgsAssemble(&na, after, sizeof(after));
+        snprintf(argsBuf, bufSize, "%s", after);
+    }
+}
+
 
 void guiShowLaunchConfig(void)
 {
@@ -874,21 +998,22 @@ void guiShowLaunchConfig(void)
     // stored value (0=<OPL>, 1=Neutrino) and the first two per-game COMPAT_LOADER options.
     const char *defaultCoreStrs[] = {"<OPL>", "Neutrino", NULL};
     diaSetEnum(diaLaunchConfig, CFG_DEFAULT_CORE, defaultCoreStrs);
-    // NOTE(rebuild): the Neutrino core (checklist items 21/23) returns in step 07 -- until then
-    // the Default Core row is locked to <OPL> and the Neutrino Defaults sub-page is hidden.
-    diaSetInt(diaLaunchConfig, CFG_DEFAULT_CORE, 0);
-    diaSetEnabled(diaLaunchConfig, CFG_DEFAULT_CORE, 0);
-    diaSetVisible(diaLaunchConfig, LAUNCH_NEUTRINO_DEFAULTS_BUTTON, 0);
+    diaSetInt(diaLaunchConfig, CFG_DEFAULT_CORE, gDefaultCoreLoader);
     diaSetInt(diaLaunchConfig, CFG_PS2LOGO, gPS2Logo);
 
     int ret;
 reshow_launch:
     ret = diaExecuteDialog(diaLaunchConfig, -1, 1, NULL);
+    if (ret == LAUNCH_NEUTRINO_DEFAULTS_BUTTON) {
+        guiShowNeutrinoDefaults();
+        goto reshow_launch;
+    }
     if (ret == LAUNCH_OSD_DEFAULTS_BUTTON) {
         guiGameShowOSDLanguageConfig(1);
         goto reshow_launch;
     }
     if (ret) {
+        diaGetInt(diaLaunchConfig, CFG_DEFAULT_CORE, &gDefaultCoreLoader);
         diaGetInt(diaLaunchConfig, CFG_PS2LOGO, &gPS2Logo);
 
         applyConfig(-1, -1, 0);

--- a/src/opl.c
+++ b/src/opl.c
@@ -149,6 +149,13 @@ int bdmCacheSize;
 int hddCacheSize;
 int smbCacheSize;
 int gEnableUSB;
+char gNeutrinoArgs[256];           // extra command-line flags appended to every Neutrino launch
+char gNeutrinoPath[256];           // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
+int gNeutrinoDevice;               // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy gNeutrinoPath
+int gDefaultCoreLoader;            // global default Loader Core (0=<OPL>, 1=Neutrino); per-game $CoreLoader overrides, absent key = follow this
+int gNeutrinoVideoDefault;         // global default Neutrino -gsm video mode (0=Off..5=1080i x3); per-game $NeutrinoVideo overrides
+int gNeutrinoGsmCompDefault;       // global default -gsm ":c" field-flip half (0=off, 1-3=type)
+int gNeutrinoElfArg;               // default-on (settings key only, no UI): auto-emit -elf=cdrom0: on Neutrino launches
 int gEnableILK;
 int gEnableBGArt;
 unsigned char gDefaultPlasBlendColor[3]; // plasma gradient low end; black = historical look
@@ -1033,6 +1040,27 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_APP_MODE, &gAPPStartMode);
             configGetInt(configOPL, CONFIG_OPL_ENABLE_USB, &gEnableUSB);
             configGetInt(configOPL, CONFIG_OPL_FAV_MODE, &gFAVStartMode);
+            configGetStrCopy(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs, sizeof(gNeutrinoArgs));
+            configGetStrCopy(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath, sizeof(gNeutrinoPath));
+            configGetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, &gNeutrinoElfArg);
+            configGetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, &gDefaultCoreLoader);
+            configGetInt(configOPL, CONFIG_OPL_NEUTRINO_VIDEO, &gNeutrinoVideoDefault);
+            if (gNeutrinoVideoDefault < 0 || gNeutrinoVideoDefault > 5)
+                gNeutrinoVideoDefault = 0; // sanitize (indexes system.c gsmVideoTokens at the launch legs)
+            configGetInt(configOPL, CONFIG_OPL_NEUTRINO_GSMCOMP, &gNeutrinoGsmCompDefault);
+            if (gNeutrinoGsmCompDefault < 0 || gNeutrinoGsmCompDefault > 3)
+                gNeutrinoGsmCompDefault = 0;
+            // Neutrino Device: prefer the new device-TYPE key; if absent (config predates the
+            // picker change), migrate the legacy device-INDEX value.
+            if (!configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, &gNeutrinoDevice)) {
+                int legacyDev = 0;
+                if (configGetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVICE, &legacyDev)) {
+                    if (legacyDev == 1 || legacyDev == 2)
+                        gNeutrinoDevice = NEUTRINO_DEV_MC;
+                    else
+                        gNeutrinoDevice = NEUTRINO_DEV_AUTO;
+                }
+            }
             configGetInt(configOPL, CONFIG_OPL_ENABLE_BGART, &gEnableBGArt);
             configGetColor(configOPL, CONFIG_OPL_PLAS_BLEND_COLOR, gDefaultPlasBlendColor);
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, &gCoverflowCount);
@@ -1224,6 +1252,13 @@ static void _saveConfig()
         configSetInt(configOPL, CONFIG_OPL_SMB_CACHE, smbCacheSize);
         configSetInt(configOPL, CONFIG_OPL_ENABLE_USB, gEnableUSB);
         configSetInt(configOPL, CONFIG_OPL_FAV_MODE, gFAVStartMode);
+        configSetStr(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs);
+        configSetStr(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath);
+        configSetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, gDefaultCoreLoader);
+        configSetInt(configOPL, CONFIG_OPL_NEUTRINO_VIDEO, gNeutrinoVideoDefault);
+        configSetInt(configOPL, CONFIG_OPL_NEUTRINO_GSMCOMP, gNeutrinoGsmCompDefault);
+        configSetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, gNeutrinoDevice);
+        configSetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, gNeutrinoElfArg);
         configSetInt(configOPL, CONFIG_OPL_ENABLE_BGART, gEnableBGArt);
         configSetColor(configOPL, CONFIG_OPL_PLAS_BLEND_COLOR, gDefaultPlasBlendColor);
         configSetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, gCoverflowCount);
@@ -1753,6 +1788,38 @@ static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected)
     clearMenuGameList(mod);
 }
 
+// deinitEx: deinit for the Neutrino keep-IOP handoff -- spares TWO modes' mounts (the game
+// device AND the device holding neutrino.elf), since Neutrino reads its -cwd config/modules
+// and the ISO through OPL's live mounts before performing its own IOP reset.
+void deinitEx(int exception, int modeSelected, int modeSelected2)
+{
+    // block all io ops, wait for the ones still running to finish
+    ioBlockOps(1);
+    guiExecDeferredOps();
+
+#ifdef PADEMU
+    ds34usb_reset();
+    ds34bt_reset();
+#endif
+    unloadPads();
+
+    for (int i = 0; i < MODE_COUNT; i++) {
+        if (list_support[i].support != NULL) {
+            int spared = (modeSelected2 >= 0 && list_support[i].support->mode == modeSelected2);
+            moduleCleanup(&list_support[i], exception, spared ? modeSelected2 : modeSelected);
+        }
+    }
+
+    audioEnd();
+    ioEnd();
+    guiEnd();
+    menuEnd();
+    lngEnd();
+    thmEnd();
+    rmEnd();
+    configEnd();
+}
+
 void deinit(int exception, int modeSelected)
 {
     // block all io ops, wait for the ones still running to finish
@@ -1876,6 +1943,13 @@ static void setDefaults(void)
 
     gEnableUSB = 0; // USB block device is opt-in, like the other BDM transports
     gFAVStartMode = START_MODE_DISABLED;
+    gNeutrinoArgs[0] = '\0';
+    gNeutrinoPath[0] = '\0';
+    gNeutrinoDevice = NEUTRINO_DEV_AUTO;
+    gDefaultCoreLoader = 0;    // <OPL> (native) -- preserves behaviour until the user opts into Neutrino globally
+    gNeutrinoVideoDefault = 0; // no global -gsm until the user opts in
+    gNeutrinoGsmCompDefault = 0;
+    gNeutrinoElfArg = 1; // auto-emit the game ELF for Neutrino compatibility lookup by default
     gEnableBGArt = 1; // inert while gEnableArt stays at the official OFF default
     gDefaultPlasBlendColor[0] = 0x00;
     gDefaultPlasBlendColor[1] = 0x00;

--- a/src/opl.c
+++ b/src/opl.c
@@ -149,13 +149,13 @@ int bdmCacheSize;
 int hddCacheSize;
 int smbCacheSize;
 int gEnableUSB;
-char gNeutrinoArgs[256];           // extra command-line flags appended to every Neutrino launch
-char gNeutrinoPath[256];           // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
-int gNeutrinoDevice;               // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy gNeutrinoPath
-int gDefaultCoreLoader;            // global default Loader Core (0=<OPL>, 1=Neutrino); per-game $CoreLoader overrides, absent key = follow this
-int gNeutrinoVideoDefault;         // global default Neutrino -gsm video mode (0=Off..5=1080i x3); per-game $NeutrinoVideo overrides
-int gNeutrinoGsmCompDefault;       // global default -gsm ":c" field-flip half (0=off, 1-3=type)
-int gNeutrinoElfArg;               // default-on (settings key only, no UI): auto-emit -elf=cdrom0: on Neutrino launches
+char gNeutrinoArgs[256];     // extra command-line flags appended to every Neutrino launch
+char gNeutrinoPath[256];     // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
+int gNeutrinoDevice;         // Neutrino ELF device (NEUTRINO_DEV_*); Auto scans mc0/mc1 + honors a legacy gNeutrinoPath
+int gDefaultCoreLoader;      // global default Loader Core (0=<OPL>, 1=Neutrino); per-game $CoreLoader overrides, absent key = follow this
+int gNeutrinoVideoDefault;   // global default Neutrino -gsm video mode (0=Off..5=1080i x3); per-game $NeutrinoVideo overrides
+int gNeutrinoGsmCompDefault; // global default -gsm ":c" field-flip half (0=off, 1-3=type)
+int gNeutrinoElfArg;         // default-on (settings key only, no UI): auto-emit -elf=cdrom0: on Neutrino launches
 int gEnableILK;
 int gEnableBGArt;
 unsigned char gDefaultPlasBlendColor[3]; // plasma gradient low end; black = historical look
@@ -1950,7 +1950,7 @@ static void setDefaults(void)
     gNeutrinoVideoDefault = 0; // no global -gsm until the user opts in
     gNeutrinoGsmCompDefault = 0;
     gNeutrinoElfArg = 1; // auto-emit the game ELF for Neutrino compatibility lookup by default
-    gEnableBGArt = 1; // inert while gEnableArt stays at the official OFF default
+    gEnableBGArt = 1;    // inert while gEnableArt stays at the official OFF default
     gDefaultPlasBlendColor[0] = 0x00;
     gDefaultPlasBlendColor[1] = 0x00;
     gDefaultPlasBlendColor[2] = 0x00;

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -848,3 +848,365 @@ int sbLoadCheats(const char *path, const char *file)
 
     return cheatMode;
 }
+
+// Δ1 (NHDDL-parity): a resolved neutrino.elf is only USABLE if its install is complete. Neutrino
+// chdir()s to the elf's dir (our -cwd) then opens config/system.toml; if absent it falls back to a
+// FLAT "system.toml" (SAS layout); if NEITHER loads it returns -1 = black screen post-teardown
+// (neutrino ee/loader/src/main.c:486-505). Mirror that EXACT detection so we never reject a valid
+// install: accept the elf only when config/system.toml OR flat system.toml sits beside it. A stale
+// folder (elf only, no config) is skipped so probing continues to a good install instead of
+// shadowing it. Uses its own buffer so the caller's returned path is untouched.
+static int sbNeutrinoInstallComplete(const char *elfPath)
+{
+    if (elfPath == NULL)
+        return 0;
+    const char *slash = strrchr(elfPath, '/');
+    char probe[320]; // longest caller path (~160) + "/config/system.toml" with headroom -- a TRUNCATED
+                     // probe would miss a real toml and reject a VALID install (PR #81 review)
+    int dirLen;
+
+    if (slash == NULL) // no directory component -- can't derive cwd; don't reject (custom path edge)
+        return 1;
+    dirLen = (int)(slash - elfPath);
+
+    snprintf(probe, sizeof(probe), "%.*s/config/system.toml", dirLen, elfPath);
+    if (sbFileExists(probe))
+        return 1;
+    snprintf(probe, sizeof(probe), "%.*s/system.toml", dirLen, elfPath);
+    return sbFileExists(probe);
+}
+
+// Δ5 (NHDDL-parity visibility): a stale/old neutrino folder winning silently was undiagnosable.
+// LOG the resolved pick + its version.txt (if present, like NHDDL's splash) at the single return
+// point. Returns the path unchanged so call sites read `return sbNeutrinoResolved(path)`.
+static const char *sbNeutrinoResolved(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+    const char *slash = strrchr(path, '/');
+    if (slash != NULL) {
+        char vpath[320], ver[128]; // same headroom rationale as sbNeutrinoInstallComplete's probe
+        int fd;
+        snprintf(vpath, sizeof(vpath), "%.*s/version.txt", (int)(slash - path), path);
+        fd = open(vpath, O_RDONLY, 0666);
+        if (fd >= 0) {
+            int n = read(fd, ver, sizeof(ver) - 1);
+            close(fd);
+            if (n > 0) {
+                char *nl;
+                ver[n] = '\0';
+                nl = strpbrk(ver, "\r\n");
+                if (nl != NULL)
+                    *nl = '\0';
+                LOG("[NEUTRINO] using %s (%s)\n", path, ver);
+                return path;
+            }
+        }
+    }
+    LOG("[NEUTRINO] using %s\n", path);
+    return path;
+}
+
+// Probe the ACTIVE game device for a co-located neutrino.elf: (A) the games-folder prefix, then
+// (B) the bare device root. Returns the resolved path of the first COMPLETE install (Δ1), or NULL.
+// Shared by the AUTO tier (one candidate among several) and the "Game's Device" pick (the ONLY
+// candidate -- a NULL here is surfaced to the user, no MC fallback). activePrefix NULL/"" -> NULL
+// (e.g. HDD passes NULL: raw APA is not POSIX-open()-reachable).
+static const char *sbNeutrinoProbeGameDevice(const char *activePrefix)
+{
+    if (activePrefix == NULL || activePrefix[0] == '\0')
+        return NULL;
+
+    char devRoot[64]; // bare device-root token, e.g. "mass0:" (everything up to & incl. ':')
+    const char *colon = strchr(activePrefix, ':');
+    size_t rootLen = (colon != NULL) ? (size_t)(colon - activePrefix + 1) : 0;
+    if (rootLen > 0 && rootLen < sizeof(devRoot)) {
+        memcpy(devRoot, activePrefix, rootLen);
+        devRoot[rootLen] = '\0';
+    } else {
+        devRoot[0] = '\0';
+    }
+    const char *bases[2] = {activePrefix, devRoot}; // (A) the games-folder prefix, (B) the device root
+    static const char *forms[] = {
+        "%sNEUTRINO/neutrino.elf",
+        "%sneutrino/neutrino.elf",
+        "%sNEUTRINO/NEUTRINO.ELF",
+        "%sneutrino/NEUTRINO.ELF",
+    };
+    static char probe[160];
+    for (int b = 0; b < 2; b++) {
+        if (bases[b] == NULL || bases[b][0] == '\0')
+            continue;
+        for (int i = 0; i < (int)(sizeof(forms) / sizeof(forms[0])); i++) {
+            snprintf(probe, sizeof(probe), forms[i], bases[b]);
+            // Δ1: a stale elf-only folder on the game device must NOT count as a valid install.
+            if (sbFileExists(probe) && sbNeutrinoInstallComplete(probe))
+                return sbNeutrinoResolved(probe);
+        }
+    }
+    return NULL;
+}
+
+// ---- Neutrino launch-args parse / assemble (the "Launch Args" picker) ----------------
+// naAppend joins a token onto out with a single separating space; naAppendKV joins "<key><val>".
+static void naAppend(char *out, int outSize, const char *tok)
+{
+    int len = (int)strlen(out);
+    if (len >= outSize - 1) // already full (or malformed) -- nothing more fits
+        return;
+    if (len > 0)
+        out[len++] = ' ';
+    snprintf(out + len, outSize - len, "%s", tok);
+}
+
+static void naAppendKV(char *out, int outSize, const char *key, const char *val)
+{
+    char tmp[96];
+    snprintf(tmp, sizeof(tmp), "%s%s", key, val);
+    naAppend(out, outSize, tmp);
+}
+
+int sbFileExists(const char *path)
+{
+    if (path == NULL)
+        return 0;
+    int fd = open(path, O_RDONLY, 0666);
+    if (fd < 0)
+        return 0;
+    close(fd);
+    return 1;
+}
+
+// Resolve the Neutrino core ELF: probe the install locations users actually use (folder-case
+// and leading-slash variants on mc0/mc1) and return the first COMPLETE install (Δ1), or NULL.
+// Centralised so the bdm + mmce launch paths stay in sync.
+const char *sbResolveNeutrinoPath(const char *activePrefix)
+{
+    // Neutrino Device (General Settings): a driver-accurate device TYPE (NEUTRINO_DEV_*) that holds
+    // <root>:/neutrino/neutrino.elf. Resolve the type to its live device-name token(s) -- USB/MX4SIO/
+    // exFAT-HDD via the mounted BDM device, MC/MMCE by slot, APA-HDD via the mounted OPL data partition
+    // (pfs0:) -- then probe each first. The token has NO trailing ':' so the forms[] below add it.
+    // GAME'S DEVICE: resolve ONLY on the active game's own device (co-located neutrino.elf); no
+    // legacy-custom-path / MC fallback. A miss returns NULL so the launch path toasts "not found"
+    // and aborts in a live menu (every caller handles NULL that way) rather than silently using an
+    // MC core the user did not pick.
+    if (gNeutrinoDevice == NEUTRINO_DEV_GAME)
+        return sbNeutrinoProbeGameDevice(activePrefix);
+
+    char cand[2][BDM_DEVICE_ROOT_MAX];
+    int nCand = 0;
+    switch (gNeutrinoDevice) {
+        case NEUTRINO_DEV_MC:
+            snprintf(cand[nCand++], BDM_DEVICE_ROOT_MAX, "mc0");
+            snprintf(cand[nCand++], BDM_DEVICE_ROOT_MAX, "mc1");
+            break;
+        case NEUTRINO_DEV_MMCE:
+            snprintf(cand[nCand++], BDM_DEVICE_ROOT_MAX, "mmce0");
+            snprintf(cand[nCand++], BDM_DEVICE_ROOT_MAX, "mmce1");
+            break;
+        case NEUTRINO_DEV_USB:
+        case NEUTRINO_DEV_MX4SIO:
+        case NEUTRINO_DEV_EXFAT_HDD: {
+            int bt = BDM_TYPE_ATA; // NEUTRINO_DEV_EXFAT_HDD
+            if (gNeutrinoDevice == NEUTRINO_DEV_USB)
+                bt = BDM_TYPE_USB;
+            else if (gNeutrinoDevice == NEUTRINO_DEV_MX4SIO)
+                bt = BDM_TYPE_SDC;
+            char bdmRoot[BDM_DEVICE_ROOT_MAX];
+            if (bdmGetDeviceRootByType(bt, bdmRoot, sizeof(bdmRoot))) {
+                char *colon = strchr(bdmRoot, ':'); // "massN:/" -> bare "massN" token
+                if (colon != NULL)
+                    *colon = '\0';
+                snprintf(cand[nCand++], BDM_DEVICE_ROOT_MAX, "%s", bdmRoot);
+            }
+            break;
+        }
+        case NEUTRINO_DEV_APA_HDD:
+            snprintf(cand[nCand++], BDM_DEVICE_ROOT_MAX, "pfs0"); // the already-mounted OPL data partition
+            break;
+        default: // AUTO -- no explicit device root
+            break;
+    }
+    if (nCand > 0) {
+        static const char *forms[] = {
+            "%s:NEUTRINO/neutrino.elf",
+            "%s:/neutrino/neutrino.elf",
+            "%s:/NEUTRINO/neutrino.elf",
+            "%s:/neutrino/NEUTRINO.ELF",
+            "%s:/NEUTRINO/NEUTRINO.ELF",
+            "%s:NEUTRINO/NEUTRINO.ELF",
+        };
+        static char built[64];
+        for (int c = 0; c < nCand; c++) {
+            for (int i = 0; i < (int)(sizeof(forms) / sizeof(forms[0])); i++) {
+                snprintf(built, sizeof(built), forms[i], cand[c]);
+                if (sbFileExists(built) && sbNeutrinoInstallComplete(built))
+                    return sbNeutrinoResolved(built);
+            }
+        }
+        // The picked device TYPE had no neutrino.elf -- do NOT dead-end here. Fall through to the AUTO
+        // discovery below (legacy custom path -> active game device co-located -> mc0/mc1) so a picker
+        // miss degrades to NHDDL-style cross-device discovery instead of returning NULL (which makes
+        // bdmLaunchGame drop to a native launch that can die to OSDSYS -- issue #51). The chosen device
+        // was tried FIRST above, so an explicit pick is still honoured when it holds the ELF.
+    }
+
+    // Auto: a legacy custom path (settings_riptopl.cfg "neutrino_path") wins when it exists;
+    // otherwise fall back to the mc0:/mc1: auto-detect candidates below. A custom path that names
+    // the elf directly (no dir) is honoured as-is (sbNeutrinoInstallComplete returns 1 for it).
+    if (gNeutrinoPath[0] != '\0' && sbFileExists(gNeutrinoPath) && sbNeutrinoInstallComplete(gNeutrinoPath))
+        return sbNeutrinoResolved(gNeutrinoPath);
+
+    // PR #300: in AUTO, probe the ACTIVE game device for a co-located neutrino.elf BEFORE the mc0/mc1
+    // fallbacks, so a neutrino.elf dropped next to the games (USB/MMCE) just works with zero config.
+    // Δ1 (inside the helper): a stale elf-only folder on the game device must NOT shadow a complete
+    // mc0/mc1 install below (the "worked once then never" failure). Same probe as NEUTRINO_DEV_GAME,
+    // but here a miss falls through to the mc0/mc1 candidates instead of returning NULL.
+    {
+        const char *gameHit = sbNeutrinoProbeGameDevice(activePrefix);
+        if (gameHit != NULL)
+            return gameHit;
+    }
+
+    static const char *candidates[] = {
+        NEUTRINO_PATH,     // mc0:NEUTRINO/neutrino.elf
+        NEUTRINO_ALT_PATH, // mc1:NEUTRINO/neutrino.elf
+        "mc0:/neutrino/neutrino.elf",
+        "mc1:/neutrino/neutrino.elf",
+        "mc0:/neutrino/NEUTRINO.ELF",
+        "mc1:/neutrino/NEUTRINO.ELF",
+        "mc0:NEUTRINO/NEUTRINO.ELF",
+        "mc1:/NEUTRINO/NEUTRINO.ELF",
+    };
+    for (int i = 0; i < (int)(sizeof(candidates) / sizeof(candidates[0])); i++) {
+        if (sbFileExists(candidates[i]) && sbNeutrinoInstallComplete(candidates[i]))
+            return sbNeutrinoResolved(candidates[i]);
+    }
+    LOG("[NEUTRINO] no complete install found (elf without config/system.toml is skipped)\n");
+    return NULL;
+}
+
+void neutrinoArgsParse(const char *in, neutrino_args_t *na)
+{
+    memset(na, 0, sizeof(*na));
+    if (in == NULL)
+        return;
+
+    char buf[256];
+    snprintf(buf, sizeof(buf), "%s", in);
+
+    int breakSeen = 0;
+    char *tok = strtok(buf, " \t");
+    while (tok != NULL) {
+        if (breakSeen || strcmp(tok, "--b") == 0) {
+            breakSeen = 1; // --b and everything after it is for the ELF: keep verbatim, in order
+            naAppend(na->extra, sizeof(na->extra), tok);
+        } else if (strcmp(tok, "-qb") == 0) {
+            na->qb = 1;
+        } else if (strcmp(tok, "-dbc") == 0) {
+            na->dbc = 1;
+        } else if (strcmp(tok, "-logo") == 0) {
+            na->logo = 1;
+        } else if (strncmp(tok, "-cwd=", 5) == 0) {
+            snprintf(na->cwd, sizeof(na->cwd), "%s", tok + 5);
+        } else if (strncmp(tok, "-cfg=", 5) == 0) {
+            snprintf(na->cfg, sizeof(na->cfg), "%s", tok + 5);
+        } else if (strncmp(tok, "-elf=", 5) == 0) {
+            snprintf(na->elf, sizeof(na->elf), "%s", tok + 5);
+        } else if (strncmp(tok, "-ata0id=", 8) == 0) {
+            snprintf(na->ata0id, sizeof(na->ata0id), "%s", tok + 8);
+        } else if (strncmp(tok, "-ata0=", 6) == 0) {
+            snprintf(na->ata0, sizeof(na->ata0), "%s", tok + 6);
+        } else if (strncmp(tok, "-ata1=", 6) == 0) {
+            snprintf(na->ata1, sizeof(na->ata1), "%s", tok + 6);
+        } else {
+            naAppend(na->extra, sizeof(na->extra), tok); // unknown/future flag -> preserved
+        }
+        tok = strtok(NULL, " \t");
+    }
+}
+
+void neutrinoArgsAssemble(const neutrino_args_t *na, char *out, int outSize)
+{
+    if (out == NULL || outSize <= 0)
+        return;
+    out[0] = '\0';
+    if (na->qb)
+        naAppend(out, outSize, "-qb");
+    if (na->dbc)
+        naAppend(out, outSize, "-dbc");
+    if (na->logo)
+        naAppend(out, outSize, "-logo");
+    if (na->cwd[0])
+        naAppendKV(out, outSize, "-cwd=", na->cwd);
+    if (na->cfg[0])
+        naAppendKV(out, outSize, "-cfg=", na->cfg);
+    if (na->elf[0])
+        naAppendKV(out, outSize, "-elf=", na->elf);
+    if (na->ata0[0])
+        naAppendKV(out, outSize, "-ata0=", na->ata0);
+    if (na->ata0id[0])
+        naAppendKV(out, outSize, "-ata0id=", na->ata0id);
+    if (na->ata1[0])
+        naAppendKV(out, outSize, "-ata1=", na->ata1);
+    if (na->extra[0]) // extra (may hold "--b ...") goes LAST so the break + ELF args stay at the tail
+        naAppend(out, outSize, na->extra);
+}
+
+// Resolve the per-game VMC slots ($VMC_0/$VMC_1) into discrete Neutrino "-mcN=<prefix>VMC/<name>.bin"
+// arg strings (issue #47: pass an OPL-configured VMC to Neutrino on launch). vmcPrefix is the device
+// path prefix ending in its separator (e.g. "mass0:/" or "mmce0:/"); the VMC file lives at
+// <vmcPrefix>VMC/<name>.bin -- the same location OPL's own mcemu uses, and the same path scheme as
+// the already-working -dvd arg. Each configured slot becomes its OWN argv entry in sysLaunchNeutrino,
+// so a VMC name containing a space is delivered to Neutrino intact instead of being shredded by the
+// whitespace args tokenizer (the root cause of #47). Unconfigured slots are left empty. Call BEFORE
+// deinit() frees the config/device data; vmcArgs is caller-owned storage that must outlive the launch.
+void sbBuildVmcNeutrinoArgs(config_set_t *configSet, const char *vmcPrefix, neutrino_vmc_args_t *vmcArgs)
+{
+    int slot;
+    char vmcName[32];
+
+    if (vmcArgs == NULL)
+        return;
+    for (slot = 0; slot < NEUTRINO_VMC_SLOTS; slot++)
+        vmcArgs->arg[slot][0] = '\0';
+
+    if (configSet == NULL || vmcPrefix == NULL)
+        return;
+
+    for (slot = 0; slot < NEUTRINO_VMC_SLOTS; slot++) {
+        vmcName[0] = '\0';
+        configGetVMC(configSet, vmcName, sizeof(vmcName), slot);
+        if (vmcName[0] != '\0') {
+            // Per-slot disable (parity-audit #14): the user toggled this slot off without deleting
+            // its card name. Skipping the -mc emission is the whole mechanism -- the empty arg also
+            // drops the slot from vmcSlotMask, so the MMCE gameID card-switch re-arms for it and the
+            // game sees the real card in that slot.
+            int slotDisabled = 0;
+            configGetVMCDisable(configSet, slot, &slotDisabled);
+            if (slotDisabled) {
+                LOG("[NEUTRINO] VMC slot %d (%s) disabled per-game -- launching without it\n", slot, vmcName);
+                continue;
+            }
+            // Δ2 (NHDDL-parity): Neutrino ABORTS the whole boot when a -mcN VMC file can't be opened
+            // post-reset (no "boot without VMC" fallback -- neutrino fhi_config.c) = black screen. Verify
+            // the .bin exists NOW (mounts are still up; this runs pre-deinit) and skip the arg with a
+            // toast instead of handing Neutrino an unopenable path. The game then boots with its real
+            // card rather than dying. NHDDL never hits this class -- it emits no -mc args at all.
+            char binPath[160]; // matches neutrino_vmc_args_t arg sizing: bdmPrefix(96)+"VMC/"+name(31)+".bin"
+            int b = snprintf(binPath, sizeof(binPath), "%sVMC/%s.bin", vmcPrefix, vmcName);
+            if (b >= (int)sizeof(binPath) || !sbFileExists(binPath)) {
+                LOG("[NEUTRINO] VMC slot %d (%s) not found/oversize -- launching without it\n", slot, vmcName);
+                guiWarning(_l(_STR_NEUTRINO_VMC_MISSING), 6);
+                vmcArgs->arg[slot][0] = '\0';
+                continue;
+            }
+            int n = snprintf(vmcArgs->arg[slot], sizeof(vmcArgs->arg[slot]), "-mc%d=%s", slot, binPath);
+            if (n >= (int)sizeof(vmcArgs->arg[slot])) { // "-mc0=" + path overflowed the arg buffer
+                LOG("[NEUTRINO] VMC slot %d arg truncated (%d bytes) -- launching without it\n", slot, n);
+                guiWarning(_l(_STR_NEUTRINO_VMC_MISSING), 6);
+                vmcArgs->arg[slot][0] = '\0';
+            }
+        }
+    }
+}

--- a/src/system.c
+++ b/src/system.c
@@ -11,6 +11,7 @@
 #include <delaythread.h> // DelayThread for the bounded disc re-detect polls in sysLaunchDisc
 #include "include/opl.h"
 #include "include/gui.h"
+#include "include/lang.h" // _l(_STR_...) -- Neutrino preflight abort toasts
 #include "include/ethsupport.h"
 #include "include/hddsupport.h"
 #include "include/util.h"
@@ -937,6 +938,465 @@ void sysPrintEECoreConfig(struct EECoreConfig_t *config)
     LOG("Compat Mask = 0x%02x\n", config->_CompatMask);
 }
 #endif
+
+// --- Neutrino external-core launch (per-game $CoreLoader) --------------------
+// Maps an OPL block-device driver token to Neutrino's -bsd backend name. Uses
+// exact strcmp per token (NOT a strncmp prefix test): a prefix test matches
+// "sdc" against "sd" first and mis-maps MX4SIO to ilink. Mirrors our hardened
+// bdmDriverIs* matchers. Returns "unsupported" for anything
+// Neutrino cannot back (e.g. eth/smb), which the caller treats as a hard stop.
+static const char *getDeviceName(const char *driver)
+{
+    if (driver == NULL)
+        return "unsupported";
+    if (!strcmp(driver, "usb"))
+        return "usb";
+    if (!strcmp(driver, "ilink") || !strcmp(driver, "sd"))
+        return "ilink";
+    if (!strcmp(driver, "mx4sio") || !strcmp(driver, "sdc"))
+        return "mx4sio";
+    if (!strcmp(driver, "ata"))
+        return "ata";
+    if (!strcmp(driver, "apa"))
+        return "apa";
+    if (!strcmp(driver, "mmce"))
+        return "mmce";
+    // NOTE(rebuild): the "udp"/"udpfs" network transport tokens return with checklist
+    // items 5/6/7 -- no network block device can be mounted until then, so falling
+    // through to "unsupported" (which aborts the launch with a toast) is exact.
+    return "unsupported";
+}
+
+// Re-encodes the OPL compatmask into Neutrino's -gc concatenated-digit format.
+// Forwards OPL bits 1,2,3,5 plus Mode 7 (COMPAT_MODE_7) -- a Neutrino-only flag with
+// no OPL ee-core effect (greyed under the OPL core) that emits -gc=7 "fix game buffer
+// overrun". result[] is sized off COMPAT_MODE_COUNT
+// and every append is bounds-guarded so widening the set later cannot overflow.
+// NOTE: Neutrino's -gc numbering is Neutrino's own, not OPL's bitmask semantics;
+// the OPL<->Neutrino correspondence must be hardware-verified before widening.
+static int convertCompatmaskToModes(int compatmask)
+{
+    char result[COMPAT_MODE_COUNT + 2];
+    int pos = 0;
+
+    if ((compatmask & COMPAT_MODE_1) && pos < (int)sizeof(result) - 1)
+        result[pos++] = '1';
+    if ((compatmask & COMPAT_MODE_2) && pos < (int)sizeof(result) - 1)
+        result[pos++] = '2';
+    if ((compatmask & COMPAT_MODE_3) && pos < (int)sizeof(result) - 1)
+        result[pos++] = '3';
+    if ((compatmask & COMPAT_MODE_5) && pos < (int)sizeof(result) - 1)
+        result[pos++] = '5';
+    if ((compatmask & COMPAT_MODE_7) && pos < (int)sizeof(result) - 1)
+        result[pos++] = '7'; // Neutrino "IOP: fix game buffer overrun"; greyed under the OPL core
+
+    result[pos] = '\0';
+    return atoi(result);
+}
+
+// Split a whitespace-separated argument string into individual argv entries appended
+// after the auto-built ones. `buf` receives a bounded mutable copy of `src`, and the
+// tokens point into it, so `buf` must stay live until the argv is consumed. Returns
+// the updated argc; never exceeds argvMax.
+static int appendArgTokens(char **argv, int argc, int argvMax, char *buf, int bufSize, const char *src)
+{
+    if (src == NULL || src[0] == '\0')
+        return argc;
+
+    snprintf(buf, bufSize, "%s", src);
+
+    char *tok = strtok(buf, " \t");
+    while (tok != NULL && argc < argvMax) {
+        // A leading '$' marks a user-disabled flag (NHDDL convention): keep it in the
+        // args field for easy re-enabling, but don't forward it to Neutrino. Neutrino
+        // flags are all '-'-prefixed, so '$' never collides with a real argument.
+        if (tok[0] != '$')
+            argv[argc++] = tok;
+        tok = strtok(NULL, " \t");
+    }
+    return argc;
+}
+
+// Does `s` look like a retail boot-file name (AAAA_NNN.NN, e.g. SLUS_123.45)? Gates the opt-in
+// -elf=cdrom0: emission below to startups neutrino can actually resolve a GameID from.
+static int sysStartupShapeOk(const char *s)
+{
+    int i;
+    if (s == NULL || strlen(s) != 11 || s[4] != '_' || s[8] != '.')
+        return 0;
+    for (i = 0; i < 4; i++)
+        if (!((s[i] >= 'A' && s[i] <= 'Z') || (s[i] >= '0' && s[i] <= '9')))
+            return 0;
+    for (i = 5; i <= 10; i++) {
+        if (i == 8)
+            continue;
+        if (s[i] < '0' || s[i] > '9')
+            return 0;
+    }
+    return 1;
+}
+
+// True if `args` contains `flag` as an ACTIVE token -- i.e. NOT $-disabled (the leading-$ convention
+// that appendArgTokens strips at dispatch). Lets an auto-emitted flag stay suppressed only by a flag
+// the user is actually forwarding, not by one they turned off with `$`.
+// Does `args` contain an ACTIVE (non-$-disabled) occurrence of `flag` as its OWN token? `flag` is
+// either an exact switch ("-dbc") or a key prefix ending in '=' ("-gsm="). A raw strstr is not
+// enough: "-dbc" also occurs inside path-valued tokens like -elf=my-dbc-game.elf (PR #96 review),
+// which must NOT count -- so a hit needs a token boundary on BOTH sides (start-of-string or
+// whitespace before; end-of-string or whitespace after, unless the flag itself is a key prefix
+// whose value legitimately continues). This also fixes the same latent false positive for -gsm=.
+static int neutrinoArgHasActiveFlag(const char *args, const char *flag)
+{
+    if (args == NULL)
+        return 0;
+    size_t flen = strlen(flag);
+    int keyPrefix = (flen > 0 && flag[flen - 1] == '=');
+    const char *p = args;
+    while ((p = strstr(p, flag)) != NULL) {
+        int disabled = (p > args && *(p - 1) == '$');
+        const char *tokStart = disabled ? p - 1 : p;
+        int startOk = (tokStart == args) || (tokStart[-1] == ' ') || (tokStart[-1] == '\t');
+        char after = p[flen];
+        int endOk = keyPrefix || after == '\0' || after == ' ' || after == '\t';
+        if (startOk && endOk && !disabled)
+            return 1; // a whole-token, non-$-disabled occurrence -> the user is forwarding this flag
+        p += flen;
+    }
+    return 0;
+}
+
+// Hand the game off to an external Neutrino ELF instead of OPL's embedded core.
+// Hardened vs the wOPL original: NULL-guarded; an "unsupported" device aborts
+// (never launches -bsd=unsupported); DISTINCT argv buffers (wOPL reused ONE
+// buffer for both -bsd=ata and -bsdfs=hdl, clobbering -bsd=ata on HDD); argv[32]
+// with per-append bounds guards (wOPL's argv[6] was exactly full). User-supplied
+// flags (global gNeutrinoArgs + the per-game extraArgs) are tokenized and appended last.
+// Rewrite the "ip=A.B.C.D" token inside <neutrino dir>/config/bsd-<device>.toml to the PS2's configured
+// static IP. Neutrino's ministack takes its IP from that toml -- hardcoded 192.168.1.10 in the stock and
+// bundled files -- NOT from anything OPL used while browsing, so any mismatch means the UDPFS server's
+// discovery reply never routes back and the game black-screens after a perfectly healthy list. Δ6: now
+// runs PRE-deinit via sysNeutrinoPreflight (every mount is up, the GUI is alive), so a hard failure can
+// abort to the menu with a toast instead of dying invisibly post-teardown. Anchored to the stock `"ip=`
+// quoting so a comment mentioning ip= can never be clobbered.
+// Returns 0 = OK to launch (synced / already-in-sync / benign leave-alone), <0 = abort the launch:
+// the toml is MISSING (neutrino cannot load its bsd config at all) or was mangled-then-restored (the
+// old ip survives, so the boot would black-screen on any other subnet).
+static int sysSyncNeutrinoUdpfsToml(const char *neutrinoPath, const char *deviceName)
+{
+    static char toml[4096]; // Δ6: raised from 2048 -- an annotated toml no longer gets skipped
+    static char updated[4096 + 20];
+    char tomlPath[288];
+    char newIp[20];
+    int fd, len;
+
+    const char *slash = strrchr(neutrinoPath, '/');
+    if (slash == NULL)
+        return 0; // custom flat path -- no dir to anchor on; old hand-edit contract
+    snprintf(tomlPath, sizeof(tomlPath), "%.*sconfig/bsd-%s.toml", (int)(slash - neutrinoPath) + 1, neutrinoPath, deviceName);
+
+    fd = open(tomlPath, O_RDONLY);
+    if (fd < 0) {
+        LOG("[NEUTRINO] no %s -- neutrino cannot boot this transport without it\n", tomlPath);
+        return -1; // missing bsd toml = guaranteed post-teardown failure -> abort while GUI is alive
+    }
+    len = read(fd, toml, sizeof(toml) - 1);
+    close(fd);
+    if (len <= 0)
+        return -1; // unreadable/empty bsd toml -> same guaranteed failure
+    if (len >= (int)sizeof(toml) - 1) {
+        LOG("[NEUTRINO] %s larger than %d -- ip= left as-is\n", tomlPath, (int)sizeof(toml));
+        return 0; // exotic hand-built toml: proceed on the old hand-edit contract
+    }
+    toml[len] = '\0';
+
+    char *tok = strstr(toml, "\"ip=");
+    if (tok == NULL) {
+        LOG("[NEUTRINO] %s has no \"ip= token -- left as-is\n", tomlPath);
+        return 0; // hand-restructured toml: the user owns the ip; proceed
+    }
+    char *valStart = tok + 4;
+    char *valEnd = valStart;
+    while (*valEnd == '.' || (*valEnd >= '0' && *valEnd <= '9'))
+        valEnd++;
+
+    snprintf(newIp, sizeof(newIp), "%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
+    if ((int)strlen(newIp) == (int)(valEnd - valStart) && !strncmp(valStart, newIp, strlen(newIp)))
+        return 0; // already in sync -- don't touch the file
+
+    snprintf(updated, sizeof(updated), "%.*s%s%s", (int)(valStart - toml), toml, newIp, valEnd);
+
+    fd = open(tomlPath, O_WRONLY | O_TRUNC);
+    if (fd < 0) {
+        LOG("[NEUTRINO] cannot rewrite %s (%d) -- ip= left as-is\n", tomlPath, fd);
+        return 0; // write-protected media: proceed on the old hand-edit contract
+    }
+    int expected = (int)strlen(updated);
+    int written = write(fd, updated, expected);
+    close(fd);
+    if (written != expected) {
+        // O_TRUNC already emptied the file; a short write would leave a mangled toml behind. Best
+        // recovery without atomic-rename support across every PS2 filesystem: put the ORIGINAL
+        // content back so the user is no worse off than before the sync (old hand-edit contract).
+        LOG("[NEUTRINO] short write to %s (%d/%d) -- restoring original toml\n", tomlPath, written, expected);
+        fd = open(tomlPath, O_WRONLY | O_TRUNC);
+        if (fd >= 0) {
+            write(fd, toml, len);
+            close(fd);
+        }
+        return -1; // the OLD ip survives -> the boot would black-screen; abort while GUI is alive
+    }
+    LOG("[NEUTRINO] synced %s ip= -> %s\n", tomlPath, newIp);
+    return 0;
+}
+
+// Δ6 (NHDDL parity): everything that can FAIL a Neutrino launch and is checkable pre-teardown runs
+// HERE, called by every device leg BEFORE deinitEx -- the GUI is alive for a toast and nothing has
+// been torn down, so a failure is "stay in the menu", not a post-teardown black screen. Returns
+// 0 = proceed; <0 = abort (a toast was shown).
+int sysNeutrinoPreflight(const char *driver, const char *neutrinoPath)
+{
+    if (driver == NULL || neutrinoPath == NULL)
+        return -1;
+
+    const char *deviceName = getDeviceName(driver);
+    if (!strcmp(deviceName, "unsupported")) {
+        LOG("[NEUTRINO] preflight: unsupported device '%s'\n", driver);
+        guiWarning(_l(_STR_NEUTRINO_DEV_UNSUPPORTED), 6);
+        return -1;
+    }
+
+    // Network transports: sync the bsd toml ip= NOW, while the toml's device is mounted and a
+    // failure can still be reported (see sysSyncNeutrinoUdpfsToml for the abort conditions).
+    if (!strcmp(deviceName, "udpfs") || !strcmp(deviceName, "udpfsbd") || !strcmp(deviceName, "udpbd")) {
+        if (sysSyncNeutrinoUdpfsToml(neutrinoPath, deviceName) < 0) {
+            guiWarning(_l(_STR_NEUTRINO_TOML_SYNC_FAILED), 6);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+void sysLaunchNeutrino(const char *driver, const char *path, const char *startup, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, int neutrinoGsmComp, int neutrinoBsdfs, const neutrino_vmc_args_t *vmcArgs)
+{
+    if (neutrinoPath == NULL || driver == NULL || path == NULL) {
+        LOG("[NEUTRINO] null arg, abort\n");
+        return;
+    }
+
+    const char *deviceName = getDeviceName(driver);
+    if (!strcmp(deviceName, "unsupported")) {
+        LOG("[NEUTRINO] unsupported device '%s', abort\n", driver);
+        return;
+    }
+
+    // HW-confirmed (issue #56, AndrewBento, PSXMemCard Gen2): Neutrino's -logo on the mmce backend
+    // black-screens GAME-DEPENDENTLY ("depends a bit on luck which game") -- and the identical
+    // failure reproduces on NHDDL, so it is a Neutrino/mmce interaction, not this launcher. Every
+    // affected game boots with the logo off, so the GLOBAL PS2-Logo toggle is suppressed for
+    // mmce-hosted games until that is fixed upstream. Deliberate escape hatch: a user-supplied
+    // "-logo" in the global/per-game Neutrino args still passes through the tokenizer untouched.
+    if (EnablePS2Logo && !strcmp(driver, "mmce")) {
+        LOG("[NEUTRINO] -logo suppressed on mmce (issue #56: game-dependent black screens, repro'd on NHDDL)\n");
+        EnablePS2Logo = 0;
+    }
+
+    char bsd[16];
+    char bsdfs[16];
+    char filePath[288];        // "-dvd=hdl:" (9) + up to a 255-char path + NUL — avoid truncation (B2)
+    char cwdArg[288];          // "-cwd=" + the neutrino.elf install dir (auto; Neutrino finds its config/modules there)
+    char compatModes[32] = ""; // stays empty when no compat modes are forwarded (B1)
+    char globalArgsBuf[256];   // mutable copy of gNeutrinoArgs for tokenizing (tokens point in)
+    char extraArgsBuf[256];    // mutable copy of the per-game extraArgs for tokenizing
+    char *argv[16];            // target argv[0] + auto args + tokenized user flags (kernel-budgeted)
+    int argc = 0;
+    // 14, NOT sizeof(argv): the kernel args area holds at most 15 strings per ExecPS2 hop (ps2sdk
+    // exit.c SetArg, SETARG_MAX_ARGS 15 -- and ExecPS2 forwards the UNCLAMPED count, so overflowing
+    // makes the kernel read string bytes as argv pointers). Hop 1 prepends the elfldr child's load
+    // path, spending one slot, so the target argv must stay <= 14 entries.
+    const int argvMax = 14;
+
+    // Target argv[0] = neutrino.elf's own path (NHDDL convention). sysLoadELFKeepIOP forwards
+    // argv verbatim -- argv[0] included -- so this must be supplied explicitly here (POPSTARTER
+    // launches use the same loader with a selector as argv[0] instead).
+    if (argc < argvMax)
+        argv[argc++] = (char *)neutrinoPath;
+
+    if (!strcmp(deviceName, "apa")) {
+        snprintf(bsd, sizeof(bsd), "-bsd=ata");
+        if (argc < argvMax)
+            argv[argc++] = bsd;
+        snprintf(bsdfs, sizeof(bsdfs), "-bsdfs=hdl");
+        if (argc < argvMax)
+            argv[argc++] = bsdfs;
+        snprintf(filePath, sizeof(filePath), "-dvd=hdl:%s", path);
+        if (argc < argvMax)
+            argv[argc++] = filePath;
+    } else {
+        snprintf(bsd, sizeof(bsd), "-bsd=%s", deviceName);
+        if (argc < argvMax)
+            argv[argc++] = bsd;
+        // Per-game -bsdfs override (parity-audit #11), Auto(0) = today's bytes exactly (no -bsdfs,
+        // bare -dvd). Valid driver values are ONLY exfat/hdl/bd; the -dvd prefix changes in lockstep
+        // (verified vs rickgaiser/neutrino main.c usage: "-bsdfs=hdl -dvd=hdl:..." and
+        // "-bsdfs=bd -dvd=bdfs:..."; exfat is the default fs and takes the bare path unchanged --
+        // any ':'-bearing -dvd value is file-mode, opened through the selected fs). NEVER emitted
+        // for mmce/udpfs: they are fileid backends with no filesystem layer (Neutrino forces
+        // sBSDFS="no" there regardless -- this guard just keeps the argv clean). A user-typed
+        // -bsdfs= wins (skip the structured emit); a user-typed -dvd= also wins on its own because
+        // user tokens are appended after these and Neutrino's arg parse is last-wins.
+        static const char *const bsdfsTokens[] = {"", "exfat", "hdl", "bd"};
+        static const char *const bsdfsDvdPrefix[] = {"", "", "hdl:", "bdfs:"};
+        int fsOverride = 0;
+        if (neutrinoBsdfs >= 1 && neutrinoBsdfs <= 3 &&
+            strcmp(deviceName, "mmce") != 0 && strcmp(deviceName, "udpfs") != 0 &&
+            !neutrinoArgHasActiveFlag(gNeutrinoArgs, "-bsdfs=") && !neutrinoArgHasActiveFlag(extraArgs, "-bsdfs="))
+            fsOverride = neutrinoBsdfs;
+        if (fsOverride) {
+            snprintf(bsdfs, sizeof(bsdfs), "-bsdfs=%s", bsdfsTokens[fsOverride]);
+            if (argc < argvMax)
+                argv[argc++] = bsdfs;
+        }
+        snprintf(filePath, sizeof(filePath), "-dvd=%s%s", bsdfsDvdPrefix[fsOverride], path);
+        if (argc < argvMax)
+            argv[argc++] = filePath;
+    }
+
+    // Everything up to and including -dvd is the boot-critical core: the pool-fit drop loop below
+    // must never shed these. A fixed floor of 3 silently stopped covering -dvd once the optional
+    // -bsdfs slots in front of it (argv[3]) -- record the real core count instead.
+    const int coreArgc = argc;
+
+    // Only forward -gc when at least one compat mode is set: Neutrino treats
+    // -gc=0 as an explicit mode (IOP fast reads), NOT a no-op, so passing it for
+    // a game with no OPL modes selected would force unwanted behavior (B1).
+    int gcModes = convertCompatmaskToModes(compatmask);
+    if (gcModes > 0) {
+        snprintf(compatModes, sizeof(compatModes), "-gc=%d", gcModes);
+        if (argc < argvMax)
+            argv[argc++] = compatModes;
+    }
+
+    // Global toggles auto-emit -dbc/-logo; the per-game/global args screens now carry them as
+    // structured bools too (forwarded via the tokenizer below), so suppress the auto-emit when the
+    // user's args already hold an active (non-$-disabled) copy -- one flag, emitted once.
+    if (gEnableDebug && argc < argvMax &&
+        !neutrinoArgHasActiveFlag(gNeutrinoArgs, "-dbc") && !neutrinoArgHasActiveFlag(extraArgs, "-dbc"))
+        argv[argc++] = "-dbc";
+
+    if (EnablePS2Logo && argc < argvMax &&
+        !neutrinoArgHasActiveFlag(gNeutrinoArgs, "-logo") && !neutrinoArgHasActiveFlag(extraArgs, "-logo"))
+        argv[argc++] = "-logo";
+
+    // Per-game Neutrino video mode (-gsm): 1=fp1 (240p), 2=fp2 (480p), 3=1080ix1 (1080i); 0/out-of-range
+    // = no -gsm. Neutrino is LAST-wins on -gsm and ABORTS the boot on a malformed value, so emit exactly
+    // ONE: skip the structured token when the user already typed a -gsm into the global or per-game args,
+    // letting that explicit value win (precedence confirmed vs rickgaiser/neutrino ee/loader/src/main.c).
+    int userHasGsm = neutrinoArgHasActiveFlag(gNeutrinoArgs, "-gsm=") ||
+                     neutrinoArgHasActiveFlag(extraArgs, "-gsm=");
+    if (neutrinoVideo >= 1 && neutrinoVideo <= 5 && !userHasGsm && argc < argvMax) {
+        // -gsm=v:c grammar (neutrino main.c parse_gsm_flags): v in {fp1, fp2, 1080ix1, 1080ix2,
+        // 1080ix3}, optional :c in {1,2,3} = field-flipping compatibility type. NEVER emit a bare
+        // ":c" -- an unrecognized -gsm value aborts the whole neutrino boot -- so the comp half is
+        // ignored unless a video mode is set (the GUI hint says as much).
+        static const char *const gsmVideoTokens[] = {"", "fp1", "fp2", "1080ix1", "1080ix2", "1080ix3"};
+        static char gsmArg[24]; // outlives argv[] until the ExecPS2 handoff below
+        if (neutrinoGsmComp >= 1 && neutrinoGsmComp <= 3)
+            snprintf(gsmArg, sizeof(gsmArg), "-gsm=%s:%d", gsmVideoTokens[neutrinoVideo], neutrinoGsmComp);
+        else
+            snprintf(gsmArg, sizeof(gsmArg), "-gsm=%s", gsmVideoTokens[neutrinoVideo]);
+        argv[argc++] = gsmArg;
+    }
+
+    // Parity Delta-10, enabled by default via settings_riptopl.cfg "neutrino_elf_arg"=1
+    // (deliberately no UI row): hand neutrino the boot ELF path directly so its per-GameID
+    // config/<GameID>.toml compat lookup can resolve pre-reset. Shape-guarded to AAAA_NNN.NN
+    // startups and skipped when the user already forwards an -elf= (structured field or free
+    // text) -- neutrino must see exactly one.
+    static char elfArg[40]; // outlives argv[] until the ExecPS2 handoff
+    if (gNeutrinoElfArg && sysStartupShapeOk(startup) && argc < argvMax &&
+        !neutrinoArgHasActiveFlag(gNeutrinoArgs, "-elf=") && !neutrinoArgHasActiveFlag(extraArgs, "-elf=")) {
+        snprintf(elfArg, sizeof(elfArg), "-elf=cdrom0:\\%s;1", startup);
+        argv[argc++] = elfArg;
+        LOG("[NEUTRINO] neutrino_elf_arg=1: emitting %s\n", elfArg);
+    }
+
+    // VMC slots (#47): emit each configured "-mcN=...bin" as its OWN argv entry. These come from
+    // sbBuildVmcNeutrinoArgs (caller storage, alive across the launch) and must NOT pass through the
+    // whitespace tokenizer below -- a VMC name with a space would otherwise be split into two args
+    // and Neutrino would receive a truncated, unopenable card path (silent no-mount).
+    if (vmcArgs != NULL) {
+        int slot;
+        for (slot = 0; slot < NEUTRINO_VMC_SLOTS; slot++) {
+            if (vmcArgs->arg[slot][0] != '\0' && argc < argvMax)
+                argv[argc++] = (char *)vmcArgs->arg[slot];
+        }
+    }
+
+    // Auto -cwd: point Neutrino at the directory holding neutrino.elf so it loads its config / extra
+    // modules relative to its install location, UNLESS the user already supplied one (precedence like
+    // -gsm above). Without it Neutrino launches with no working dir, so a setup that keeps config next
+    // to the ELF would not be found. mc:NEUTRINO/neutrino.elf paths also contain a '/', so this works
+    // for memory-card installs too.
+    int userHasCwd = neutrinoArgHasActiveFlag(gNeutrinoArgs, "-cwd=") ||
+                     neutrinoArgHasActiveFlag(extraArgs, "-cwd=");
+    if (!userHasCwd) {
+        const char *slash = strrchr(neutrinoPath, '/');
+        if (slash != NULL) {
+            int dirLen = (int)(slash - neutrinoPath) + 1; // keep the trailing '/'
+            snprintf(cwdArg, sizeof(cwdArg), "-cwd=%.*s", dirLen, neutrinoPath);
+            if (argc < argvMax)
+                argv[argc++] = cwdArg;
+        }
+    }
+
+    // Δ6: the bsd toml ip= sync (network transports) now runs PRE-deinit inside sysNeutrinoPreflight
+    // -- called by every device leg before deinitEx -- so a failure aborts to a live menu with a
+    // toast instead of dying invisibly here, post-teardown. Nothing to do at this point.
+
+    // Append user-supplied Neutrino flags: global defaults first, then the per-game
+    // string (so a game can extend the global set). Both are tokenized on whitespace.
+    argc = appendArgTokens(argv, argc, argvMax, globalArgsBuf, sizeof(globalArgsBuf), gNeutrinoArgs);
+    argc = appendArgTokens(argv, argc, argvMax, extraArgsBuf, sizeof(extraArgsBuf), extraArgs);
+
+    // ExecPS2 argv BYTE budget (verified vs ps2sdk exit.c SetArg + the crt0 args struct): each hop
+    // carries its strings in ONE 256-byte pool, every NUL included. Hop 1 packs the child's load
+    // path PLUS this argv -- neutrinoPath is counted TWICE (loadpath and target argv[0]). SetArg's
+    // copy is UNbounded, so exceeding the pool corrupts rather than truncates. Fit by dropping tail
+    // args (user extras sit last; each drop LOGged); the boot-critical core (argv[0]/-bsd/
+    // [-bsdfs]/-dvd, counted as coreArgc above) must survive or nothing can boot anyway -- past
+    // that, refuse and let the LOG name the overage.
+    {
+        int pool = (int)strlen(neutrinoPath) + 1; // hop-1 child argv[0] = the load path
+        int i;
+        for (i = 0; i < argc; i++)
+            pool += (int)strlen(argv[i]) + 1;
+        while (pool > 256 && argc > coreArgc) {
+            argc--;
+            pool -= (int)strlen(argv[argc]) + 1;
+            LOG("[NEUTRINO] argv pool over 256 bytes -- dropping tail arg: %s\n", argv[argc]);
+        }
+        if (pool > 256) {
+            LOG("[NEUTRINO] argv pool %d bytes even at the core-args floor (256 max) -- refusing handoff\n", pool);
+            return;
+        }
+    }
+
+    // Log the FULL argv (not just bsd/dvd/compat) so the VMC -mc args are verifiable on hardware (#47).
+    LOG("[NEUTRINO] elf=%s argc=%d\n", neutrinoPath, argc);
+    {
+        int i;
+        for (i = 0; i < argc; i++)
+            LOG("[NEUTRINO]   argv[%d]=%s\n", i, argv[i]);
+    }
+
+    // Hand off WITHOUT the elf-loader IOP reset (NHDDL parity, vendored elfldr/): Neutrino reads
+    // its config/modules (-cwd) and opens the game ISO through OUR still-mounted devices, and only
+    // then does its own IOP reset -- the old resetting handoff left it a bare SIO2MAN/MCMAN/MCSERV
+    // IOP, so any USB/BDM-hosted neutrino.elf setup black-screened to OSDSYS. The callers keep both
+    // the game device and the neutrino.elf device mounted (deinitEx).
+    if (sysLoadELFKeepIOP(neutrinoPath, "", argc, argv) < 0)
+        LOG("[NEUTRINO] keep-IOP handoff failed for %s\n", neutrinoPath);
+}
 
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags)
 {


### PR DESCRIPTION
**Rebuild step 07** (items 21 + 23, global-core scope): the Neutrino launch system — vendored elfldr child loader (NHDDL-parity, no IOP reset), full `sysLaunchNeutrino`, device-type picker with legacy migration, Defaults + Args GUI pages, `deinitEx` two-mount teardown, and the BDM launch leg with fragment pre-count and live-menu aborts. Per-game selector and HDD/ETH legs follow with their steps (breadcrumbed in-code).

Local full clean build passes (MAKE_EXIT=0). No hardware gate — merge on CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)