### PR TITLE
rebuild-10: enablers (folder browsing + launch-id stubs + safe art globals)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 
 FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o elfldr_noreset.o elfldr.o lang.o lang_internal.o config.o hdd.o dialogs.o favsupport.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o hddsupport.o zso.o lz4.o \
-		appsupport.o vcdsupport.o retrogem.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o
+		appsupport.o vcdsupport.o retrogem.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o
 
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
 		bdm.o bdmfs_fatfs.o usbmass_bd.o iLinkman.o IEEE1394_bd.o mx4sio_bd.o \

--- a/include/folderbrowse.h
+++ b/include/folderbrowse.h
@@ -1,0 +1,46 @@
+#ifndef __FOLDERBROWSE_H
+#define __FOLDERBROWSE_H
+
+// Lazy per-device folder navigation for the game list (opt-in: gEnableFolderNav).
+//
+// A subdirectory found under <prefix>CD/ or <prefix>DVD/ is listed as a GAME_FORMAT_FOLDER row.
+// Selecting it (the select button) DESCENDS -- the list rescans one level deeper; the cancel
+// button ASCENDS back up. Each folder view is the same flat game list repopulated in place, so
+// covers / favourites / coverflow / per-game settings all keep working unchanged.
+//
+// Only the loose-file tree scanners participate (BDM/USB/MX4SIO/iLink/exFAT-HDD-BDM, MMCE and
+// UDPFS-Files) -- every device that reaches sbReadList/scanForISO with a "/" separator. APA-HDD
+// (HDL partitions), the UDPFS block device and the VCD/POPS view are structurally excluded: they
+// never scan a CD/DVD directory tree. SMB/ETH is deferred (it uses a "\\" separator).
+//
+// The state model deliberately mirrors the proven VCD-view machinery (vcdsupport.c): a per-mode
+// subpath + a dirty flag consumed in each device's NeedsUpdate to force the deferred rescan.
+
+#define FOLDER_SUB_MAX   128 // joined subpath cap; fits <prefix>CD/<sub> inside the 256-byte path buffers
+#define FOLDER_DEPTH_MAX 8   // max nesting levels below the CD/DVD root
+
+// True only for the loose-file tree device modes that can browse folders.
+int folderModeSupported(int mode);
+
+// The current subpath BELOW the CD/DVD root, "/"-joined (e.g. "RPGs/SNES"); "" at the device root.
+// Never returns NULL. Returns "" when folder-nav is off or the mode is not folder-capable.
+const char *folderGetSub(int mode);
+
+// Nesting depth (0 == at the device root).
+int folderDepth(int mode);
+
+// Push a folder level (descend). Returns 1 on success, 0 if refused (disabled, at depth cap, or the
+// joined path would overflow). Marks the mode dirty so its next NeedsUpdate forces a rescan.
+int folderDescend(int mode, const char *name);
+
+// Pop a folder level (ascend). Returns 1 if it actually ascended, 0 if already at the root.
+int folderAscend(int mode);
+
+// Force the mode back to the device root (marks dirty only if it was not already at root).
+void folderReset(int mode);
+
+// One-shot: returns 1 once after a descend/ascend/reset, so NeedsUpdate can force the rescan even
+// when the device's own change-detection would otherwise short-circuit (mirrors vcdConsumeDirty).
+int folderConsumeDirty(int mode);
+
+#endif

--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -8,4 +8,24 @@ static inline void mmceLoadModules(void)
 {
 }
 
+// GameID transport stubs, matching the real implementation's feature-off paths exactly:
+// mmceSendGameID returns 0 when the feature is off (real code: !gMMCEEnableGameID -> 0);
+// with no send ever made there is nothing to settle (0 = settled); arming is a documented
+// no-op when the feature is off.
+static inline int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask)
+{
+    (void)startup;
+    (void)protectMcPath;
+    (void)vmcSlotMask;
+    return 0;
+}
+static inline int mmceGameIdSettle(int timeoutMs)
+{
+    (void)timeoutMs;
+    return 0;
+}
+static inline void mmceArmGameIDTransport(void)
+{
+}
+
 #endif

--- a/include/opl.h
+++ b/include/opl.h
@@ -170,8 +170,8 @@ extern int gVcdHideGameId;     // display-only: hide a leading PS1 game-ID prefi
 extern int gVcdFirstDiscOnly;  // hide discs 2+ of multi-disc PS1 sets
 extern char gBootDir[256];     // boot directory (cwd) OPL launched from; "" if undeterminable
 extern int gEnableBGArt;
-extern int gEnableArtTar; // .tar art packs (item 45); OFF until the Artwork UI returns
-extern int gArtDelay;     // frames of inactivity before art loads (item 45); safe official-like default until gate D
+extern int gEnableArtTar;    // .tar art packs (item 45); OFF until the Artwork UI returns
+extern int gArtDelay;        // frames of inactivity before art loads (item 45); safe official-like default until gate D
 extern int gEnableFolderNav; // folder browsing in game lists (item 34)
 extern unsigned char gDefaultPlasBlendColor[3];
 extern int gEnableILK;

--- a/include/opl.h
+++ b/include/opl.h
@@ -170,6 +170,9 @@ extern int gVcdHideGameId;     // display-only: hide a leading PS1 game-ID prefi
 extern int gVcdFirstDiscOnly;  // hide discs 2+ of multi-disc PS1 sets
 extern char gBootDir[256];     // boot directory (cwd) OPL launched from; "" if undeterminable
 extern int gEnableBGArt;
+extern int gEnableArtTar; // .tar art packs (item 45); OFF until the Artwork UI returns
+extern int gArtDelay;     // frames of inactivity before art loads (item 45); safe official-like default until gate D
+extern int gEnableFolderNav; // folder browsing in game lists (item 34)
 extern unsigned char gDefaultPlasBlendColor[3];
 extern int gEnableILK;
 extern int gEnableMX4SIO;

--- a/src/folderbrowse.c
+++ b/src/folderbrowse.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "include/opl.h" // umbrella: SDK base types (u32/GSTEXTURE) that iosupport.h depends on
+#include "include/iosupport.h"
+#include "include/folderbrowse.h"
+
+// Set by opl.c from the "folder_nav" config key. Folder browsing is entirely inert unless this is
+// on: scanForISO never emits a folder row and every helper below returns the root ("") state.
+extern int gEnableFolderNav;
+
+static char folderSub[MODE_COUNT][FOLDER_SUB_MAX]; // "/"-joined subpath below CD/DVD; "" == root
+static unsigned char folderDirtyFlag[MODE_COUNT];  // 1 = descended/ascended/reset -> force one rescan
+static unsigned char folderLevels[MODE_COUNT];     // pushed segment count (depth)
+
+int folderModeSupported(int mode)
+{
+    // Loose-file tree scanners only (sbReadList/base_game_info_t, "/" separator): BDM (all 8 slots),
+    // MMCE and UDPFS-Files. APA-HDD (HDL), the UDPFS block device and the VCD/POPS view do not scan a
+    // CD/DVD directory tree, so they are excluded. SMB/ETH is deferred (uses "\\").
+    return (mode >= BDM_MODE && mode <= BDM_MODE_LAST) || mode == MMCE_MODE || mode == UDPFS_MODE;
+}
+
+const char *folderGetSub(int mode)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return "";
+    return folderSub[mode];
+}
+
+int folderDepth(int mode)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return 0;
+    return folderLevels[mode];
+}
+
+int folderDescend(int mode, const char *name)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return 0;
+    if (name == NULL || name[0] == '\0' || folderLevels[mode] >= FOLDER_DEPTH_MAX)
+        return 0;
+
+    char joined[FOLDER_SUB_MAX];
+    int len;
+    if (folderSub[mode][0] == '\0')
+        len = snprintf(joined, sizeof(joined), "%s", name);
+    else
+        len = snprintf(joined, sizeof(joined), "%s/%s", folderSub[mode], name);
+
+    // Refuse a join that would not fit: a truncated subpath would scan the WRONG directory, so the
+    // user simply stays where they are (a folder with a name this long is not navigable). snprintf
+    // returns the length it WOULD have written, so len >= buffer size means it did not fit.
+    if (len < 0 || (size_t)len >= sizeof(folderSub[mode]))
+        return 0;
+
+    strcpy(folderSub[mode], joined);
+    folderLevels[mode]++;
+    folderDirtyFlag[mode] = 1;
+    return 1;
+}
+
+int folderAscend(int mode)
+{
+    if (!gEnableFolderNav || mode < 0 || mode >= MODE_COUNT || !folderModeSupported(mode))
+        return 0;
+    if (folderLevels[mode] == 0)
+        return 0;
+
+    char *slash = strrchr(folderSub[mode], '/');
+    if (slash != NULL)
+        *slash = '\0'; // drop the last "/segment"
+    else
+        folderSub[mode][0] = '\0'; // back to root
+
+    folderLevels[mode]--;
+    folderDirtyFlag[mode] = 1;
+    return 1;
+}
+
+void folderReset(int mode)
+{
+    if (mode < 0 || mode >= MODE_COUNT)
+        return;
+    // Reset the raw state even for modes that are not folder-capable / when the toggle is off, so a
+    // stale subpath can never leak across a device switch. Mark dirty only when something changed.
+    if (folderSub[mode][0] != '\0' || folderLevels[mode] != 0) {
+        folderSub[mode][0] = '\0';
+        folderLevels[mode] = 0;
+        folderDirtyFlag[mode] = 1;
+    }
+}
+
+int folderConsumeDirty(int mode)
+{
+    if (mode < 0 || mode >= MODE_COUNT || !folderDirtyFlag[mode])
+        return 0;
+    folderDirtyFlag[mode] = 0;
+    return 1;
+}

--- a/src/gui.c
+++ b/src/gui.c
@@ -511,8 +511,7 @@ void guiShowConfig()
     diaSetString(diaConfig, CFG_EXITTO, gExitPath);
 
     diaSetInt(diaConfig, CFG_LASTPLAYED, gRememberLastPlayed);
-    // NOTE(rebuild): folder browsing returns with checklist item 34 -- hide its row until then.
-    diaSetVisible(diaConfig, CFG_FOLDERNAV, 0);
+    diaSetInt(diaConfig, CFG_FOLDERNAV, gEnableFolderNav);
     diaSetInt(diaConfig, CFG_AUTOSTARTLAST, gAutoStartLastPlayed);
     diaSetVisible(diaConfig, CFG_AUTOSTARTLAST, gRememberLastPlayed);
     diaSetVisible(diaConfig, CFG_LBL_AUTOSTARTLAST, gRememberLastPlayed);
@@ -521,6 +520,7 @@ void guiShowConfig()
     if (ret) {
         diaGetString(diaConfig, CFG_EXITTO, gExitPath, sizeof(gExitPath));
         diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
+        diaGetInt(diaConfig, CFG_FOLDERNAV, &gEnableFolderNav);
         diaGetInt(diaConfig, CFG_AUTOSTARTLAST, &gAutoStartLastPlayed);
 
         DisableCron = 1; // Disable Auto Start Last Played counter (we don't want to call it right after enable it on GUI)

--- a/src/opl.c
+++ b/src/opl.c
@@ -31,6 +31,7 @@
 #include "include/hddsupport.h"
 #include "include/appsupport.h"
 #include "include/favsupport.h"
+#include "include/folderbrowse.h" // folderDepth -- favourites suppression inside subfolders
 #include "include/vcdsupport.h" // vcdViewActive stub -- isVcd stays 0 until item 12 lands
 
 #include "include/cheatman.h"
@@ -168,6 +169,9 @@ int gVcdFirstDiscOnly;             // hide discs 2+ of multi-disc PS1 sets
 char gBootDir[256];                // boot directory (cwd) OPL launched from; "" if undeterminable
 int gEnableILK;
 int gEnableBGArt;
+int gEnableArtTar;    // .tar art packs (item 45); no UI until gate D
+int gArtDelay;        // inactivity frames before art loads; safe default until gate D tunes it
+int gEnableFolderNav; // folder browsing in game lists (item 34)
 unsigned char gDefaultPlasBlendColor[3]; // plasma gradient low end; black = historical look
 volatile int gLastSaveErrno = 0;
 int gEnableMX4SIO;
@@ -366,8 +370,10 @@ static void itemExecFav(struct menu_item *curMenu)
 
     submenu_item_t *it = &curMenu->current->item;
 
-    // Folder rows are not favouritable (checklist item 34; isFolder is always 0 until it lands).
-    if (support->mode != FAV_MODE && it->isFolder)
+    // Folder browsing: on a source list a folder row is not favouritable, and a game favourited
+    // from INSIDE a subfolder would resolve by index against the wrong (root) view later --
+    // suppress both. Root favourites are unchanged; the FAV tab's own removals are unaffected.
+    if (support->mode != FAV_MODE && (it->isFolder || folderDepth(support->mode) > 0))
         return;
 
     if (support->mode == FAV_MODE) {
@@ -1086,6 +1092,11 @@ static void _loadConfig()
                 }
             }
             configGetInt(configOPL, CONFIG_OPL_ENABLE_BGART, &gEnableBGArt);
+            configGetInt(configOPL, CONFIG_OPL_ENABLE_ART_TAR, &gEnableArtTar);
+            configGetInt(configOPL, CONFIG_OPL_ART_DELAY, &gArtDelay);
+            if (gArtDelay < 0 || gArtDelay > 60)
+                gArtDelay = 8;
+            configGetInt(configOPL, CONFIG_OPL_FOLDER_NAV, &gEnableFolderNav);
             configGetColor(configOPL, CONFIG_OPL_PLAS_BLEND_COLOR, gDefaultPlasBlendColor);
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, &gCoverflowCount);
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_SCALE, &gCoverflowCenterScale);
@@ -1292,6 +1303,9 @@ static void _saveConfig()
         configSetInt(configOPL, CONFIG_OPL_NEUTRINO_DEVTYPE, gNeutrinoDevice);
         configSetInt(configOPL, CONFIG_OPL_NEUTRINO_ELF_ARG, gNeutrinoElfArg);
         configSetInt(configOPL, CONFIG_OPL_ENABLE_BGART, gEnableBGArt);
+        configSetInt(configOPL, CONFIG_OPL_ENABLE_ART_TAR, gEnableArtTar);
+        configSetInt(configOPL, CONFIG_OPL_ART_DELAY, gArtDelay);
+        configSetInt(configOPL, CONFIG_OPL_FOLDER_NAV, gEnableFolderNav);
         configSetColor(configOPL, CONFIG_OPL_PLAS_BLEND_COLOR, gDefaultPlasBlendColor);
         configSetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, gCoverflowCount);
         configSetInt(configOPL, CONFIG_OPL_COVERFLOW_SCALE, gCoverflowCenterScale);
@@ -1993,6 +2007,9 @@ static void setDefaults(void)
     gVcdFirstDiscOnly = 1;  // hide discs 2+ of multi-disc PS1 sets by default (POPSLoader parity)
     gBootDir[0] = '\0';
     gEnableBGArt = 1; // inert while gEnableArt stays at the official OFF default
+    gEnableArtTar = 0;
+    gArtDelay = 8; // official-like settle (the fork's aggressive 2-frame default is a gate-D decision, item 45)
+    gEnableFolderNav = 0;
     gDefaultPlasBlendColor[0] = 0x00;
     gDefaultPlasBlendColor[1] = 0x00;
     gDefaultPlasBlendColor[2] = 0x00;

--- a/src/opl.c
+++ b/src/opl.c
@@ -32,7 +32,7 @@
 #include "include/appsupport.h"
 #include "include/favsupport.h"
 #include "include/folderbrowse.h" // folderDepth -- favourites suppression inside subfolders
-#include "include/vcdsupport.h" // vcdViewActive stub -- isVcd stays 0 until item 12 lands
+#include "include/vcdsupport.h"   // vcdViewActive stub -- isVcd stays 0 until item 12 lands
 
 #include "include/cheatman.h"
 #include "include/sound.h"
@@ -169,9 +169,9 @@ int gVcdFirstDiscOnly;             // hide discs 2+ of multi-disc PS1 sets
 char gBootDir[256];                // boot directory (cwd) OPL launched from; "" if undeterminable
 int gEnableILK;
 int gEnableBGArt;
-int gEnableArtTar;    // .tar art packs (item 45); no UI until gate D
-int gArtDelay;        // inactivity frames before art loads; safe default until gate D tunes it
-int gEnableFolderNav; // folder browsing in game lists (item 34)
+int gEnableArtTar;                       // .tar art packs (item 45); no UI until gate D
+int gArtDelay;                           // inactivity frames before art loads; safe default until gate D tunes it
+int gEnableFolderNav;                    // folder browsing in game lists (item 34)
 unsigned char gDefaultPlasBlendColor[3]; // plasma gradient low end; black = historical look
 volatile int gLastSaveErrno = 0;
 int gEnableMX4SIO;


### PR DESCRIPTION
**Rebuild step 10** (re-sequenced plan): folder browsing lands complete (item 34), MMCE launch-id stubs with verified feature-off semantics, and art globals at deliberately safe defaults (`gArtDelay=8`, tar off — the fork's aggressive values are gate-D decisions, item 45). This clears two of the three co-tenant dependencies blocking the device-support wholesale; the network transports (step 11) clear the last.

Local full clean build passes (MAKE_EXIT=0). Merge on CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)