### PR TITLE
bootfix: guiLock before guiInit deadlock (rebuild-03 regression, HW-confirmed)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -39,7 +39,7 @@ static int gInitComplete;
 static gui_callback_t gFrameHook;
 
 static s32 gSemaId;
-static s32 gGUILockSemaId;
+static s32 gGUILockSemaId = -1; // -1 = not created yet (guiLock/guiUnlock no-op; see guiLock)
 static ee_sema_t gQueueSema;
 
 static int screenWidth;
@@ -182,15 +182,23 @@ void guiEnd()
 
     DeleteSema(gSemaId);
     DeleteSema(gGUILockSemaId);
+    gGUILockSemaId = -1; // post-shutdown callers no-op instead of waiting on a deleted id
 }
 
 void guiLock(void)
 {
+    // Not-ready guard: lngInit/thmInit rebuild the GUI name lists BEFORE guiInit creates this
+    // semaphore (opl.c init order), and everything is single-threaded until the GUI/IO threads
+    // exist -- a no-op lock is correct there, and WaitSema on id 0/garbage is not.
+    if (gGUILockSemaId < 0)
+        return;
     WaitSema(gGUILockSemaId);
 }
 
 void guiUnlock(void)
 {
+    if (gGUILockSemaId < 0)
+        return;
     SignalSema(gGUILockSemaId);
 }
 


### PR DESCRIPTION
**Hardware-confirmed boot regression fix.** Zack's gate bisect isolated total boot failure (all 3 flavours) to rebuild-03: the fork's `themes.c` takes `guiLock()` in `thmInit()`, which runs before `guiInit()` creates the semaphore — official `gui.c` WaitSema's the uncreated id unconditionally, deadlocking every boot before the first frame. rebuild-02a/02b boot clean and scroll clean on hardware; rebuild-03+ never reached the menu.

Fix = the fork's own guard for this exact boot order, ported verbatim: `-1` initializer, no-op guards, reset after `DeleteSema`. Three hunks in `src/gui.c`. Full clean local build passes.

Found via 7-lens adversarial review of the step-03 diff — 5 lenses converged on this defect independently; nothing else confirmed at boot severity.

Tag on merge: `rebuild-10b`. Zack re-tests the tip build (one boot re-validates gates B+C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)