### PR TITLE
rebuild-12: device support wholesale (bdm/hdd/eth) -- VCD views, network pages, folder rows

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -7,6 +7,9 @@
 
 #include "include/mcemu.h"
 
+#define BDM_DEVICE_ROOT_MAX 32
+#define BDM_PREFIX_MAX      96
+
 typedef struct
 {
     int active;       /* Activation flag */
@@ -15,8 +18,7 @@ typedef struct
     vmc_spec_t specs; /* Card specifications */
 } bdm_vmc_infos_t;
 
-#define MAX_BDM_DEVICES     5
-#define BDM_DEVICE_ROOT_MAX 32
+#define MAX_BDM_DEVICES BDM_MODE_COUNT
 
 #define BDM_TYPE_UNKNOWN -1
 #define BDM_TYPE_USB     0
@@ -25,27 +27,43 @@ typedef struct
 #define BDM_TYPE_ATA     3
 #define BDM_TYPE_UDPBD   4
 
+// Network-backed BDM devices (UDPBD/UDPFS) open over the wire, so a single failed presence poll is
+// usually a transient stall, not a real removal. Debounce: hide a NETWORK page only after this many
+// consecutive failed ~1s polls (local USB/SDC/ATA still hide on the first miss = an actual unplug).
+#define BDM_NET_HIDE_MISSES 5
+
 typedef struct
 {
-    int massDeviceIndex; // Underlying device index backing the mass fs partition, ex: usb0 = 0, usb1 = 1, etc.
-    char bdmPrefix[40];  // Contains the full path to the folder where all the games are.
+    int massDeviceIndex;                     // Underlying device index backing the block device. This is not the same as the typed-path unit.
+    char bdmDeviceRoot[BDM_DEVICE_ROOT_MAX]; // Device root used for filesystem access, currently the massN: compatibility root.
+    char bdmPrefix[BDM_PREFIX_MAX];          // Full path to the folder where all the games are.
     int bdmULSizePrev;
     time_t bdmModifiedCDPrev;
     time_t bdmModifiedDVDPrev;
     int bdmGameCount;
     base_game_info_t *bdmGames;
+    // #120: the PS2 (ISO) and PS1 (VCD) views must NOT share one backing store -- BDM was the last
+    // device still doing so (MMCE/HDD were split long ago). With one array, a VCD scan that returns
+    // "failure" left bdmGameCount untouched while the array still held the ISO list, so the VCD view
+    // re-published the ISO games and the L3 toggle looked dead ("the list never changes" -- Nathan, HW,
+    // ATA/HDD_BD). A device with NO POPS folder hits that EVERY time: vcdScanOpenDir cannot tell an
+    // absent dir from a contended one (opendir just fails) and returns -1 = preserve-last-good. Separate
+    // arrays make a failed scan of one view preserve only THAT view's last-good (empty if never scanned),
+    // so it can never resurrect the other view's contents. Mirrors mmceGames/mmceVcdGames.
+    int bdmVcdGameCount;
+    base_game_info_t *bdmVcdGames;
     char bdmDriver[32];
     int bdmDeviceType;      // Type of BDM device, see BDM_TYPE_* above
     int bdmDeviceTick;      // Used alongside BdmGeneration to tell if device data needs to be refreshed
+    int bdmMissCount;       // Consecutive failed presence polls; debounces hiding a network page (BDM_NET_HIDE_MISSES)
     int bdmHddIsLBA48;      // 1 if the HDD supports LBA48, 0 if the HDD only supports LBA28
     int ataHighestUDMAMode; // Highest UDMA mode supported by the HDD
     unsigned char ThemesLoaded;
     unsigned char LanguagesLoaded;
+    unsigned char FoldersCreated;
     unsigned char ForceRefresh;
 } bdm_device_data_t;
 
-void bdmInit(item_list_t *itemList);
-int bdmFindPartition(char *target, const char *name, int write);
 void bdmLoadModules(void);
 void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
 
@@ -54,17 +72,45 @@ void bdmEnumerateDevices();
 
 void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData);
 int bdmHDDIsPresent(u32 timeoutMs);
-
-// First mounted device of a BDM_TYPE_*: writes its massN:/ root; 1 = found.
+// Find the first mounted BDM device whose driver matches bdmType (BDM_TYPE_*); write its massN:
+// filesystem root with a trailing slash (e.g. "mass0:/") to root. Returns 1 if found. Mount-readiness
+// check. Always the legacy massN: mount, never a typed ata0:/usb0: root -- newer SDKs register typed
+// roots as real filesystems, but every consumer of this path (POPSTARTER, the BDMA equip, the boot-dir
+// resolver, the Neutrino pickers) must stay on massN:.
 int bdmGetDeviceRootByType(int bdmType, char *root, int rootLen);
+// Fill `slots` with the massN: slot index of EVERY mounted device whose driver matches bdmType (root =
+// "mass<i>:/"), up to maxSlots; returns the count. The BDMA equip searches all same-type slots so a
+// source family with two same-type devices is covered when the files sit on the second.
+int bdmGetDeviceSlotsByType(int bdmType, int *slots, int maxSlots);
+// Force-load the BDM transport for bdmType (even if its games toggle is off) and wait up to timeoutMs
+// for a device of that type to mount, so the BDMA equip can read a source device that isn't enabled for
+// games. Returns 1 if a device is present afterwards, 0 otherwise. Idempotent + instant when already up.
+int bdmEnsureSourceModules(int bdmType, u32 timeoutMs);
+// Resolve a boot directory that names a BDM device ("ata0:/APPS", "usb0:/...", "mass0:/APPS", "mass:")
+// to the device's mounted massN: root, force-loading the needed driver stack first (the gEnable* config
+// gates are ignored -- the config is what cannot be read until this succeeds). elfName (argv[0]'s
+// basename; may be empty) verifies the slot: the device holding <bootdir>/<elfName> IS the boot device.
+// *ioBdmType: pass the known boot-device BDM_TYPE_* to pin the search (save-path re-resolve) or
+// BDM_TYPE_UNKNOWN to classify from the prefix; on success it returns the resolved device's type.
+// Returns 1 with bootDir rewritten in place, 0 when bootDir is not a BDM path (untouched), -1 when the
+// boot device never mounted in time (untouched -- caller drops it so legacy discovery re-arms).
+int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType);
 
-int bdmSupportIsUDPBD(item_list_t *support); // 1 if this support is the UDPBD block device (Neutrino-only games)
-int bdmIsUDPBDLoaded(void);                  // 1 if the UDPBD NIC stack is loaded (the SMB stack must not load on top)
-int bdmGetLoadedNetProtocol(void);           // NET_BOOT_* actually resident, else the live gNetBootProtocol
-void bdmForceDeviceRefresh(void);            // bump the device generation so the next refresh re-evaluates visibility
-int bdmEffectiveStartMode(void);             // gBDMStartMode floored to Auto while a UDPBD/UDPFSBD protocol is selected
+int bdmFindPartition(char *target, const char *name, int write);
+int bdmIsUDPBDLoaded(void); // 1 if the UDPBD NIC stack is loaded (the SMB stack must not load on top)
+// Which network block transport is actually resident (NET_BOOT_UDPBD / NET_BOOT_UDPFS). Use this,
+// not gNetBootProtocol, for anything DESCRIBING the live device -- the picker can change without a
+// reboot while the loaded IRX cannot.
+int bdmGetLoadedNetProtocol(void);
+int bdmSupportIsUDPBD(item_list_t *support); // 1 if this support is the UDPBD block device (its games are Neutrino-only)
 
-int bdmEnsureSourceModules(int bdmType, u32 timeoutMs);             // force-load a source transport + wait for a mount
-int bdmGetDeviceSlotsByType(int bdmType, int *slots, int maxSlots); // every mounted slot of a type
-
+// Re-evaluate every BDM device's presence + page visibility on the next refresh (bumps the latch
+// generation). Call after a device-enable toggle so a latched-hidden tab re-shows without a replug.
+void bdmForceDeviceRefresh(void);
+// Effective BDM start mode: floors to AUTO while a BDM network transport (UDPBD/UDPFSBD) is the
+// selected protocol so its hotplug tab can exist; never modifies/persists the saved gBDMStartMode.
+int bdmEffectiveStartMode(void);
+// Current BDM device-change generation (bumped on hotplug / Device-Settings apply). The menu hook
+// reads this to bypass its background SIO2 rescan throttle when a real device change occurs.
+unsigned int bdmGetGeneration(void);
 #endif

--- a/include/ethsupport.h
+++ b/include/ethsupport.h
@@ -9,7 +9,7 @@
 typedef struct
 {
     int active;       /* Activation flag */
-    char fname[64];   /* File name (memorycard?.bin) */
+    char fname[80];   /* File name (memorycard?.bin): worst-case = 31(prefix)+5(\\VMC\\)+31(name)+4(.bin)+1(NUL) = 72 bytes; rounded up to 80 */
     u16 fid;          /* SMB File ID */
     int flags;        /* Card flag */
     vmc_spec_t specs; /* Card specifications */

--- a/include/gui.h
+++ b/include/gui.h
@@ -150,6 +150,13 @@ void guiShowNeutrinoArgsConfig(char *argsBuf, int bufSize);
 void guiShowAudioConfig();
 void guiShowControllerConfig();
 void guiShowNetConfig();
+void guiShowVcdConfig(void); // POPStarter settings hub (device/path/RetroGEM; chains BDMA/List/Net sub-pages)
+// One-shot POPSTARTER USB driver pick (FAT32 vs exFAT), shown on EVERY USB VCD launch
+// (maintainer directive 2026-08-01: the user picks per launch, never a sticky default).
+int guiShowVcdUsbMode(void);
+void guiShowBdmaConfig(void);    // BDMA (exFAT driver stack) source/mode equip page
+void guiShowVcdListConfig(void); // VCD list options (hide game-id prefix, first-disc-only)
+void guiShowPopsNetConfig(void); // POPSTARTER's OWN IPCONFIG.DAT/SMBCONFIG.DAT editor
 void guiShowParentalLockConfig();
 
 void guiCheckNotifications(int checkTheme, int checkLang);

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -32,6 +32,15 @@ typedef struct
     hdl_game_info_t *games;
 } hdl_games_list_t;
 
+// HDD PS1/VCD sources: exact __.POPS / __.POPS0..9 containers (many named .VCD files) plus
+// partition-installed PP.<name> / __.<name> games (one root IMAGE0.VCD). This is the sorted,
+// deduped list of matching main PFS partitions enumerated from the APA partition table.
+typedef struct
+{
+    int count;
+    char (*names)[APA_IDMAX + 1]; // malloc'd labels, e.g. "__.POPS3", "PP.Game", "__.Hidden"
+} hdd_pops_list_t;
+
 typedef struct
 {
     u32 start;
@@ -57,6 +66,12 @@ typedef enum {
     HDD_LOADMODULES_STATUS_COUNT,
 } hdd_loadmodules_status;
 
+// See hddLoadModulesReady() below the prototypes -- the single evaluate-once way to ask "is the ATA
+// stack actually resident?". Callers used to test `hddLoadModules() >= 0`, which also accepted
+// BUSYLOADING(2) -- returned for the whole session after a FAILED first load consumed the one-shot
+// count -- so "nothing is loaded" read as success and the APA page sat silently empty under both
+// Auto and Manual (Vapor). Pair with the retryable-failure change in hddLoadModules.
+
 int hddCheck(void);
 u32 hddGetTotalSectors(void);
 int hddIs48bit(void);
@@ -65,12 +80,34 @@ void hddSetIdleTimeout(int timeout);
 void hddSetIdleImmediate(void);
 int hddGetHDLGamelist(hdl_games_list_t *game_list);
 void hddFreeHDLGamelist(hdl_games_list_t *game_list);
+// True for a one-game PP.<name> / __.<name> partition label, excluding the exact __.POPS[0-9]?
+// container names. Matching is case-sensitive, like POPSTARTER's partition selector.
+int hddIsPopsPartitionGame(const char *name);
+// Enumerate the present classic-container and one-game APA/PFS partitions. Fills a sorted, deduped
+// list; returns the count (0 on none/error). Free via hddFreePopsPartitionList.
+int hddGetPopsPartitionList(hdd_pops_list_t *list);
+void hddFreePopsPartitionList(hdd_pops_list_t *list);
 int hddSetHDLGameInfo(hdl_game_info_t *ginfo);
 int hddDeleteHDLGame(hdl_game_info_t *ginfo);
+
+// Drop the once-per-session HDD VCD list cache so the next VCD-view update re-walks the partitions.
+// Needed only when a SCAN-TIME filter changes (gVcdFirstDiscOnly); view flips reuse the built list.
+void hddVcdInvalidateCache(void);
 
 void hddInit(item_list_t *itemList);
 item_list_t *hddGetObject(int initOnly);
 int hddLoadModules(void);
+
+// Load (or confirm) the ATA stack and report residency, evaluating hddLoadModules EXACTLY ONCE.
+// A function, not a macro taking the call as its argument: the earlier HDD_LOADMODULES_OK(
+// hddLoadModules()) macro double-evaluated on any non-NOERROR first result -- and with the
+// retryable-failure change, a FAILED load would have immediately re-run the whole load (second
+// dev9 init + second error toast) inside one condition (CodeRabbit review of #241; vetted).
+static inline int hddLoadModulesReady(void)
+{
+    int r = hddLoadModules();
+    return r == HDD_LOADMODULES_STATUS_NOERROR || r == HDD_LOADMODULES_STATUS_ALREADYLOADED;
+}
 void hddLoadSupportModules(void);
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
 int hddIsPresent();

--- a/include/menusys.h
+++ b/include/menusys.h
@@ -94,6 +94,9 @@ typedef struct menu_list
 
 void menuInit();
 void menuEnd();
+// True once the global menu list contains a registered device/mode tab; initSupport uses the FALSE
+// case to spot "user enabled the FIRST tab from the start menu" (#254).
+int menuHasRegisteredItems(void);
 void menuReinitMainMenu(void);
 void menuInitGameMenu(void);
 void menuInitAppMenu(void);

--- a/include/opl.h
+++ b/include/opl.h
@@ -81,6 +81,10 @@ void handleLwnbdSrv();
 void deinit(int exception, int modeSelected);
 // Neutrino keep-IOP handoff: deinit that spares a SECOND mode's mounts (the neutrino.elf device).
 void deinitEx(int exception, int modeSelected, int modeSelected2);
+extern int gDeinitTerminal; // 1 while deinit() runs for exit/poweroff, 0 for a game/app LAUNCH teardown.
+// Enqueue a deferred list rebuild for every enabled VCD-capable page (vcdMarkAllDirty is
+// side-effect-free by design; runtime view changes must explicitly queue the rebuilds).
+void oplQueueVcdDeviceUpdates(void);
 
 // Shutdown minimal services initiated for auto loading.
 void miniDeinit(config_set_t *configSet);

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -54,6 +54,7 @@ int sbReadList(base_game_info_t **list, const char *prefix, const char *sub, int
 void sbSetBrowseSub(const char *sub);
 int sbCheatsMissingContinue(void *pCommon, int cheatResult);
 int sbLoadImage(const char *path, const char *file);
+void sbSetDiscAttributes(config_set_t *config, int isPS1, int isCD); // #System/#Media/#DiscType identity stamp
 int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman, void **cdvdman_irx, int *patchindex);
 void sbUnprepare(void *pCommon);
 void sbRebuildULCfg(base_game_info_t **list, const char *prefix, int gamecount, int excludeID);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -968,3 +968,57 @@ gui_strings:
   string: Network (UDP) games can only boot via the Neutrino core. Check that neutrino.elf is present and the format is supported.
 - label: VCD_NOT_ON_NET
   string: 'PS1 (.VCD) games can''t be launched over the network device.'
+- label: MX4SIO_PADEMU_WARN
+  string: MX4SIO and pad emulation share the SIO2 bus and the game may fail to boot.
+- label: MMCE_GAMEID_UNSETTLED
+  string: MMCE card switch not confirmed -- launching anyway
+- label: UDPFSBD_GAMES
+  string: UDPFSBD Games
+- label: UDPBD_GAMES
+  string: UDPBD Games
+- label: BOOT_LOADING_DRIVERS
+  string: Loading storage drivers...
+- label: BOOT_LOADING_USB
+  string: Loading USB storage driver...
+- label: POPSTARTER_NOT_FOUND
+  string: Missing POPSTARTER.ELF
+- label: POPSTARTER_SMB_MISSING
+  string: Missing POPSTARTER SMB requirements
+- label: NEUTRINO_SMB_FALLBACK
+  string: SMB games have no Neutrino support -- launching with the OPL core.
+- label: NEUTRINO_VMC_HDD_UNSUPPORTED
+  string: Neutrino cannot use a VMC on APA HDD (no pfs support) -- launching without it.
+- label: VCD
+  string: VCD
+- label: VCD_ON
+  string: Showing VCD games
+- label: VCD_OFF
+  string: Showing disc games
+- label: BOOT_SCANNING_BDM
+  string: Scanning USB / card / network drives...
+- label: BOOT_SCANNING_NET
+  string: Starting network...
+- label: BOOT_SCANNING_HDD
+  string: Scanning HDD...
+- label: BDMA_SRC_USB
+  string: USB
+- label: BDMA_SRC_MX4SIO
+  string: MX4SIO
+- label: BDMA_SRC_MMCE
+  string: MMCE
+- label: BDMA_SRC_HDD
+  string: Internal HDD
+- label: BDMA_MODE_FAT32
+  string: USB (FAT32)
+- label: BDMA_MODE_USBEXFAT
+  string: USB (exFAT)
+- label: BDMA_MODE_MX4SIO
+  string: MX4SIO (exFAT)
+- label: BDMA_MODE_MMCE
+  string: MMCE (exFAT)
+- label: BDMA_MODE_ATA
+  string: HDD (exFAT)
+- label: POPS_LOADED_FROM
+  string: Loaded from %s
+- label: POPSTARTER_NET_ERR
+  string: Couldn't write POPSTARTER network config to the memory card.

--- a/modules/mcemu/mcemu.h
+++ b/modules/mcemu/mcemu.h
@@ -114,7 +114,7 @@ typedef struct _McImageSpec
 #endif
 
 #ifdef SMB_DRIVER
-    char fname[64]; /* Vmc file name (memorycard?.bin) */
+    char fname[80]; /* Vmc file name (memorycard?.bin): worst-case = 31+5+31+4+1 = 72 bytes; must match smb_vmc_infos_t.fname in include/ethsupport.h */
     u16 fid;        /* SMB Vmc file id */
 #endif
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -3,17 +3,19 @@
 #include "include/gui.h"
 #include "include/supportbase.h"
 #include "include/bdmsupport.h"
+#include "include/vcdsupport.h"
+#include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/themes.h"
 #include "include/textures.h"
 #include "include/ioman.h"
 #include "include/system.h"
+#include "include/ethsupport.h"   // ethGetModulesLoaded() for the UDPBD<->SMB NIC interlock
+#include "include/udpfssupport.h" // udpfsGetModulesLoaded() -- symmetric backstop vs the udpfs_ioman filesystem stack
+#include "include/mmcesupport.h"  // mmceSendGameID() cross-device game-id (#261)
 #include "include/extern_irx.h"
 #include "include/cheatman.h"
 #include "include/sound.h"
-#include "include/ethsupport.h"   // ethGetModulesLoaded() for the UDPBD<->SMB NIC interlock
-#include "include/udpfssupport.h" // udpfsGetModulesLoaded() for the UDPBD<->UDPFS-filesystem NIC interlock
-#include "include/folderbrowse.h" // folderGetSub() -- browse subpath for the game-list scan
 #include "modules/iopcore/common/cdvd_config.h"
 
 #include <usbhdfsd-common.h>
@@ -22,8 +24,12 @@
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioIoctl, fileXioDevctl
 #include <delaythread.h>
+#include <sys/stat.h> // mkdir() -- create the config folder before a BDM save probe
 
+static int iUSBModLoaded = 0;
 static int iLinkModLoaded = 0;
+static int iLinkManModLoaded = 0;
+static int ieee1394ModLoaded = 0;
 static int mx4sioModLoaded = 0;
 static int hddModLoaded = 0;
 static int udpbdModLoaded = 0;
@@ -34,9 +40,11 @@ static int udpbdModLoaded = 0;
   udpbdModLoaded alone is protocol-agnostic: both branches of the loader set it to 1, so once
   either chain is up the module gate short-circuits. But the tab label, the tab icon and the
   Neutrino -bsd backend all read the LIVE gNetBootProtocol. Change the picker without rebooting and
-  those three start describing a transport that is NOT the one loaded. (A restart notice is shown on
-  protocol change, but nothing enforces it.) Consumers use bdmGetLoadedNetProtocol() instead, so
-  they always describe what is really loaded.
+  those three start describing a transport that is NOT the one loaded -- e.g. a tab labelled UDPFSBD
+  and a "-bsd=udpfsbd" launch arg while the smap_udpbd monolith is what is actually resident.
+  (A restart notice is shown on protocol change, but nothing enforces it.)
+
+  Consumers below use this instead, so they always describe what is really loaded.
 */
 static int udpbdLoadedProtocol = -1;
 static s32 bdmLoadModuleLock;
@@ -48,142 +56,112 @@ static int bdmDeviceListInitialized = 0;
 void bdmInitDevicesData();
 int bdmUpdateDeviceData(item_list_t *itemList);
 
-// Identifies the partition that the specified file is stored on and generates a full path to it.
-int bdmFindPartition(char *target, const char *name, int write)
-{
-    int i, fd;
-    char path[256];
-
-    for (i = 0; i < MAX_BDM_DEVICES; i++) {
-        if (gBDMPrefix[0] != '\0')
-            sprintf(path, "mass%d:%s/%s", i, gBDMPrefix, name);
-        else
-            sprintf(path, "mass%d:%s", i, name);
-        if (write)
-            fd = open(path, O_WRONLY | O_TRUNC | O_CREAT, 0666);
-        else
-            fd = open(path, O_RDONLY);
-
-        if (fd >= 0) {
-            if (gBDMPrefix[0] != '\0')
-                sprintf(target, "mass%d:%s/", i, gBDMPrefix);
-            else
-                sprintf(target, "mass%d:", i);
-            close(fd);
-            return 1;
-        }
-    }
-
-    // default to first partition (for themes, ...)
-    if (gBDMPrefix[0] != '\0')
-        sprintf(target, "mass0:%s/", gBDMPrefix);
-    else
-        sprintf(target, "mass0:");
-    return 0;
-}
-
 static unsigned int BdmGeneration = 0;
 
-static void bdmEventHandler(void *packet, void *opt)
+static int bdmDriverIsUSB(const char *driverName)
 {
-    BdmGeneration++;
+    return driverName != NULL && strcmp(driverName, "usb") == 0;
 }
 
-// Manual generation bump for Device-Settings applies: bdmNeedsUpdate short-circuits while the
-// generation is unchanged, so a tab hidden by a disabled enable-flag would otherwise stay hidden
-// until a physical replug even after the user re-enables the device. Bumping here makes the next
-// refresh re-evaluate visibility immediately.
-void bdmForceDeviceRefresh(void)
+static int bdmDriverIsIlink(const char *driverName)
 {
-    BdmGeneration++;
+    return driverName != NULL && (strcmp(driverName, "sd") == 0 || strcmp(driverName, "ilink") == 0);
 }
 
-static void bdmLoadBlockDeviceModules(void)
+static int bdmDriverIsMx4sio(const char *driverName)
 {
-    WaitSema(bdmLoadModuleLock);
-
-    if (gEnableILK && !iLinkModLoaded) {
-        // Load iLink Block Device drivers
-        LOG("[ILINKMAN]:\n");
-        sysLoadModuleBuffer(&iLinkman_irx, size_iLinkman_irx, 0, NULL);
-        LOG("[IEEE1394_BD]:\n");
-        sysLoadModuleBuffer(&IEEE1394_bd_irx, size_IEEE1394_bd_irx, 0, NULL);
-
-        iLinkModLoaded = 1;
-    }
-
-    if (gEnableMX4SIO && !mx4sioModLoaded) {
-        // Load MX4SIO Block Device drivers
-        LOG("[MX4SIO_BD]:\n");
-        sysLoadModuleBuffer(&mx4sio_bd_irx, size_mx4sio_bd_irx, 0, NULL);
-
-        mx4sioModLoaded = 1;
-    }
-
-    if (gEnableBdmHDD && !hddModLoaded) {
-        // Load dev9 and atad device drivers.
-        LOG("bdmLoadBlockDeviceModules loading hdd drivers...\n");
-        hddLoadModules();
-
-        hddModLoaded = 1;
-    }
-
-    // Network block device (UDPBD or UDPFS, picked by gNetBootProtocol). NIC-exclusive with the SMB/ETH
-    // stack (smap registers "SMAP_driver") and the udpfs FILESYSTEM chain, so only load when neither is
-    // up. dev9 is refcounted (shared with ATA-HDD). Both need the PS2's static IP as an "ip=" arg --
-    // the ministack has no DHCP client.
-    if (gEnableUDPBD && !udpbdModLoaded && !ethGetModulesLoaded() && !udpfsGetModulesLoaded()) {
-        char ipArg[24];
-        sysInitDev9();
-        snprintf(ipArg, sizeof(ipArg), "ip=%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
-        if (gNetBootProtocol == NET_BOOT_UDPFS) {
-            // UDPFS: a 3-IRX chain loaded in dependency order -- smap (exports to ministack + bd), then
-            // ministack (gets the ip= arg, exports to bd), then udpfs_bd (registers the "udp" BDM device).
-            LOG("[UDPFS_SMAP]:\n");
-            if (sysLoadModuleBuffer(&udpfs_smap_irx, size_udpfs_smap_irx, 0, NULL) >= 0) {
-                LOG("[UDPFS_MINISTACK]:\n");
-                if (sysLoadModuleBuffer(&udpfs_ministack_irx, size_udpfs_ministack_irx, (int)strlen(ipArg) + 1, ipArg) >= 0) {
-                    LOG("[UDPFS_BD]:\n");
-                    if (sysLoadModuleBuffer(&udpfs_bd_irx, size_udpfs_bd_irx, 0, NULL) >= 0) {
-                        udpbdModLoaded = 1;
-                        udpbdLoadedProtocol = NET_BOOT_UDPFS;
-                    }
-                }
-            }
-        } else {
-            // UDPBD: the self-contained smap_udpbd monolith (smap + ministack + udpbd in one irx).
-            LOG("[SMAP_UDPBD]:\n");
-            if (sysLoadModuleBuffer(&smap_udpbd_irx, size_smap_udpbd_irx, (int)strlen(ipArg) + 1, ipArg) >= 0) {
-                udpbdModLoaded = 1;
-                udpbdLoadedProtocol = NET_BOOT_UDPBD;
-            }
-        }
-        // Release the dev9 reference taken above if the load failed -- otherwise a failing/retrying
-        // UDPBD/UDPFS load inflates the refcounted dev9InitCount and a later HDD/ETH teardown can
-        // never power dev9 down. On success the reference is intentionally kept (the device stays
-        // mounted). Mirrors the ETH/HDD pairing.
-        if (!udpbdModLoaded)
-            sysShutdownDev9();
-    }
-
-    SignalSema(bdmLoadModuleLock);
+    return driverName != NULL && (strcmp(driverName, "sdc") == 0 || strcmp(driverName, "mx4sio") == 0);
 }
 
-// BDM device identity helpers (Neutrino device-TYPE picker; trimmed to the identity
-// surface only -- the fork's wider slot-search/equip machinery arrives with items 14/16).
+static int bdmDriverIsATA(const char *driverName)
+{
+    return driverName != NULL && strcmp(driverName, "ata") == 0;
+}
+
+static int bdmDriverIsUDPBD(const char *driverName)
+{
+    return driverName != NULL && strcmp(driverName, "udp") == 0;
+}
+
 static int bdmDetermineDeviceType(const char *driverName)
 {
-    if (!strcmp(driverName, "usb"))
+    if (bdmDriverIsUSB(driverName))
         return BDM_TYPE_USB;
-    if (!strcmp(driverName, "sd") && strlen(driverName) == 2)
+    if (bdmDriverIsIlink(driverName))
         return BDM_TYPE_ILINK;
-    if (!strcmp(driverName, "sdc") && strlen(driverName) == 3)
+    if (bdmDriverIsMx4sio(driverName))
         return BDM_TYPE_SDC;
-    if (!strcmp(driverName, "ata") && strlen(driverName) == 3)
+    if (bdmDriverIsATA(driverName))
         return BDM_TYPE_ATA;
-    if (!strcmp(driverName, "udp"))
+    if (bdmDriverIsUDPBD(driverName))
         return BDM_TYPE_UDPBD;
-    return -1;
+
+    return BDM_TYPE_UNKNOWN;
+}
+
+// Parse the leading "<device><unit>:" token of a boot path into its digit-stripped stem ("ata0" ->
+// "ata", "mass1" -> "mass") and unit number (-1 when the token carries no digits, e.g. uLE's "mass:").
+// Anchored to the FIRST ':' so it can never match a folder name deeper in the path. Returns 1 on a
+// well-formed device token, 0 otherwise. Used by bdmResolveBootDir to classify boot directories.
+static int bdmParseBootStem(const char *bootPath, char *stem, size_t stemSize, int *unit)
+{
+    if (bootPath == NULL)
+        return 0;
+
+    const char *colon = strchr(bootPath, ':');
+    if (colon == NULL || colon == bootPath)
+        return 0; // no "<device>:" segment
+
+    size_t n = (size_t)(colon - bootPath);
+    if (n >= stemSize)
+        return 0;
+    memcpy(stem, bootPath, n);
+    stem[n] = '\0';
+
+    *unit = -1;
+    size_t digits = 0;
+    while (n > 0 && stem[n - 1] >= '0' && stem[n - 1] <= '9') { // "ata0" -> "ata", "mx4sio0" -> "mx4sio"
+        stem[--n] = '\0';
+        digits++;
+    }
+    // Bound the unit parse: no real device token carries more than 2 digits, and an unbounded
+    // accumulate over launcher-controlled argv[0] bytes would run signed arithmetic into UB on a
+    // mangled path ("mass4294967296:"). Longer runs keep the stem valid but leave unit = -1
+    // ("unspecified"), which the resolver already treats as slot 0 with verification.
+    if (digits > 0 && digits <= 2) {
+        *unit = 0;
+        for (const char *d = bootPath + n; *d != ':'; d++)
+            *unit = *unit * 10 + (*d - '0');
+    }
+
+    return n > 0; // require a non-empty alpha stem ("0:" is not a device token)
+}
+
+static void bdmSetLaunchDeviceBinding(struct cdvdman_settings_bdm *settings, const char *driverName, int deviceIndex)
+{
+    settings->bdDeviceId = deviceIndex;
+    // Match the IOP-side block device by its exported driver token, not the EE typed mount alias.
+    if (driverName != NULL && driverName[0] != '\0')
+        snprintf(settings->bdDeviceDriver, sizeof(settings->bdDeviceDriver), "%s", driverName);
+    else
+        settings->bdDeviceDriver[0] = '\0';
+}
+
+static void bdmBuildGamePrefix(char *target, int targetLength, const char *deviceRoot)
+{
+    if (gBDMPrefix[0] != '\0')
+        snprintf(target, targetLength, "%s%s/", deviceRoot, gBDMPrefix);
+    else
+        snprintf(target, targetLength, "%s", deviceRoot);
+}
+
+// The VCD (PS1/POPSTARTER) view is anchored to the DEVICE ROOT ("mass<N>:/"), never to the gBDMPrefix
+// library folder: POPSTARTER's own BDMA driver always reads <root>/POPS/<name>.VCD, so a prefixed scan
+// ("mass0:<prefix>/POPS") would list VCDs that POPSTARTER can never boot -- they'd all drop to OSDSYS.
+// gBDMPrefix stays a PS2-game-library concept only.
+static void bdmBuildVcdPrefix(char *target, int targetLength, int massSlot)
+{
+    snprintf(target, targetLength, "mass%d:/", massSlot);
 }
 
 static int bdmReadDeviceIdentity(const char *path, char *driverName, int driverNameLength, int *deviceIndex)
@@ -202,141 +180,52 @@ static int bdmReadDeviceIdentity(const char *path, char *driverName, int driverN
     if (result >= 0)
         result = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, deviceIndex, sizeof(*deviceIndex));
 
-
     fileXioDclose(dir);
     return result;
 }
-// True when this support's device is the UDPBD block device (its games are Neutrino-only).
-// Returns 0 for non-BDM supports (incl. FAV-wrapped items, which have no source lookup here).
-int bdmSupportIsUDPBD(item_list_t *support)
+
+// Find the first mounted BDM device whose driver matches bdmType (BDM_TYPE_*) and write its massN:
+// FILESYSTEM root WITH a trailing slash (e.g. "mass0:/") to root. Returns 1 if such a device is mounted,
+// 0 otherwise. Used by bdmEnsureSourceModules as a mount-readiness check for a transport type.
+// The root is ALWAYS the legacy mass<slot>: mount, NEVER a typed root (ata0:/usb0:/mx4sio0:/ilink0:):
+// on the pinned SDK those are launch-binding identities with no filesystem behind them, and on newer
+// SDKs (ps2sdk 2026-02-26 "typed devices": bdmfs_fatfs registers them as real iomanX filesystems) a
+// typed root here would leak ata0:-rooted paths into consumers that must stay on massN: -- POPSTARTER,
+// the BDMA equip, the boot-dir resolver and the Neutrino pickers all read files through massN: only.
+// Launch binding keeps using the raw driver token via bdmSetLaunchDeviceBinding, which is unaffected.
+// The BDMA equip itself uses bdmGetDeviceSlotsByType to search EVERY same-type slot, not just the first.
+int bdmGetDeviceRootByType(int bdmType, char *root, int rootLen)
 {
-    if (support == NULL || support->priv == NULL)
+    if (root == NULL || rootLen <= 0)
         return 0;
-    if (support->mode < BDM_MODE || support->mode > BDM_MODE_LAST)
-        return 0;
-    return ((bdm_device_data_t *)support->priv)->bdmDeviceType == BDM_TYPE_UDPBD;
-}
 
-// Exposed for the NIC mutual-exclusion: UDPBD and the SMB/udpfs stacks all own the single SMAP adapter.
-int bdmIsUDPBDLoaded(void)
-{
-    return udpbdModLoaded;
-}
+    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+        char path[16], driver[32];
+        int devIndex = -1;
 
-/*
-  The network block transport actually resident (NET_BOOT_UDPBD / NET_BOOT_UDPFS). Falls back to the
-  live gNetBootProtocol before anything has loaded, so first-boot labelling is unchanged.
-*/
-int bdmGetLoadedNetProtocol(void)
-{
-    return (udpbdLoadedProtocol >= 0) ? udpbdLoadedProtocol : gNetBootProtocol;
-}
+        snprintf(path, sizeof(path), "mass%d:/", i);
+        // Identify the device by its DRIVER NAME only. Do NOT gate on the full bdmReadDeviceIdentity
+        // return: GET_DEVICE_NUMBER can fail on a perfectly usable device (seen on some USB drives), and
+        // the device pages already tolerate that (they keep the device by driver name, bdmsupport.c
+        // ~1219). Requiring it here made the equip report "no device matching" for a connected source.
+        bdmReadDeviceIdentity(path, driver, sizeof(driver), &devIndex);
+        if (driver[0] == '\0')
+            continue;
+        if (bdmDetermineDeviceType(driver) != bdmType)
+            continue;
 
-// Effective BDM device start mode. The UDPBD tab is not a mode-level tab like SMB -- it is a
-// hotplug-published BDM mass page, which needs the BDM pages initialized, polled, and the bdm core
-// modules loaded before smap_udpbd can even LINK. The unified network-protocol picker couples SMB to
-// gETHStartMode and UDPFS to its own derived start mode, but selecting UDPBD/UDPFSBD writes NOTHING to
-// gBDMStartMode -- with a Manual (or Off) BDM row, the UDPBD tab could NEVER appear unless the user
-// happened to enter the generic BDM placeholder tab first. Floor the EFFECTIVE mode at AUTO while a
-// BDM network transport is the selected protocol, mirroring the UDPFS_MODE derivation; the user's
-// saved gBDMStartMode is never modified or persisted.
-int bdmEffectiveStartMode(void)
-{
-    if (gEnableUDPBD && gBDMStartMode != START_MODE_AUTO)
-        return START_MODE_AUTO;
-    return gBDMStartMode;
-}
-
-// Force-load the BDM transport for a BDMA source type if it is not already up (equip-time
-// force-load; the games tab stays hidden because page visibility gates on gEnable* independently).
-// Adapted to this tree's load latches; returns 1 when the transport modules are loaded.
-static int iUSBMassModLoaded = 0; // usbmass_bd load latch for the equip's force-load path
-
-static int bdmEnsureTransportLoaded(int bdmType)
-{
-    switch (bdmType) {
-        case BDM_TYPE_USB:
-            if (gEnableUSB)
-                iUSBMassModLoaded = 1; // bdmLoadModules already loaded it at BDM start
-            if (!iUSBMassModLoaded) {
-                LOG("[USBMASS_BD]:\n");
-                if (sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL) >= 0)
-                    iUSBMassModLoaded = 1;
-            }
-            return iUSBMassModLoaded;
-        case BDM_TYPE_SDC:
-            if (!mx4sioModLoaded) {
-                LOG("[MX4SIO_BD]:\n");
-                sysLoadModuleBuffer(&mx4sio_bd_irx, size_mx4sio_bd_irx, 0, NULL);
-                mx4sioModLoaded = 1;
-            }
-            return mx4sioModLoaded;
-        case BDM_TYPE_ILINK:
-            if (!iLinkModLoaded) {
-                LOG("[ILINKMAN]:\n");
-                sysLoadModuleBuffer(&iLinkman_irx, size_iLinkman_irx, 0, NULL);
-                LOG("[IEEE1394_BD]:\n");
-                sysLoadModuleBuffer(&IEEE1394_bd_irx, size_IEEE1394_bd_irx, 0, NULL);
-                iLinkModLoaded = 1;
-            }
-            return iLinkModLoaded;
-        case BDM_TYPE_ATA:
-            if (!hddModLoaded) {
-                hddLoadModules();
-                hddModLoaded = 1;
-            }
-            return hddModLoaded;
-        default:
-            return 0;
+        snprintf(root, rootLen, "mass%d:/", i);
+        return 1;
     }
+
+    return 0;
 }
 
-// Ensure the BDM transport for a BDMA source type is loaded AND a device of that type is mounted,
-// so the equip can read modules from a source device even when that family is NOT enabled for
-// games. Idempotent + instant when the transport is already up. Returns 1 if a device of the
-// type is present afterwards, 0 otherwise.
-int bdmEnsureSourceModules(int bdmType, u32 timeoutMs)
-{
-    int wasLoaded;
-    char root[BDM_DEVICE_ROOT_MAX + 2];
-    // u64, NOT u32: GetTimerSystemTime() returns a u64 bus-clock count that passes 2^32 after
-    // ~29 s of uptime; truncating the start makes the elapsed math explode.
-    u64 start;
-
-    WaitSema(bdmLoadModuleLock);
-    switch (bdmType) {
-        case BDM_TYPE_USB:
-            wasLoaded = iUSBMassModLoaded || gEnableUSB;
-            break;
-        case BDM_TYPE_SDC:
-            wasLoaded = mx4sioModLoaded;
-            break;
-        case BDM_TYPE_ILINK:
-            wasLoaded = iLinkModLoaded;
-            break;
-        case BDM_TYPE_ATA:
-            wasLoaded = hddModLoaded;
-            break;
-        default:
-            SignalSema(bdmLoadModuleLock);
-            return 0;
-    }
-    bdmEnsureTransportLoaded(bdmType);
-    SignalSema(bdmLoadModuleLock);
-
-    start = GetTimerSystemTime();
-    while (!bdmGetDeviceRootByType(bdmType, root, sizeof(root))) {
-        if (wasLoaded)
-            return 0;
-        if ((GetTimerSystemTime() - start) / (kBUSCLK / 1000) > timeoutMs)
-            return 0;
-        DelayThread(100 * 1000);
-    }
-    return 1;
-}
-
-// List EVERY mounted slot whose driver matches bdmType into slots (mass<i>:/ roots); returns the
-// count. The BDMA equip searches every same-type slot, not just the first.
+// Fill `slots` with the massN: slot index of EVERY mounted device whose driver matches bdmType, up to
+// maxSlots; returns the count. The filesystem root for slot i is "mass<i>:/" (OPL never mounts a typed
+// ata0:/usb0: filesystem -- block-device identities only). The BDMA equip uses this to search a source
+// family that has more than one device of the same type: the variant files may sit on the second one,
+// which bdmGetDeviceRootByType (first-match) would miss.
 int bdmGetDeviceSlotsByType(int bdmType, int *slots, int maxSlots)
 {
     int n = 0;
@@ -357,35 +246,173 @@ int bdmGetDeviceSlotsByType(int bdmType, int *slots, int maxSlots)
     return n;
 }
 
-
-// Find the first mounted BDM device whose driver matches bdmType (BDM_TYPE_*) and write its
-// massN: FILESYSTEM root WITH a trailing slash (e.g. "mass0:/") to root. Returns 1 if such a
-// device is mounted, 0 otherwise. The root is ALWAYS the legacy mass<slot>: mount, never a
-// typed root -- consumers (Neutrino picker, future POPSTARTER equip) must stay on massN:.
-int bdmGetDeviceRootByType(int bdmType, char *root, int rootLen)
+static int bdmLoadOptionalModule(const char *name, void *module, int moduleSize)
 {
-    if (root == NULL || rootLen <= 0)
+    int result;
+
+    LOG("[%s]:\n", name);
+    result = sysLoadModuleBuffer(module, moduleSize, 0, NULL);
+    if (result < 0)
+        LOG("%s failed to load: %d\n", name, result);
+
+    return result;
+}
+
+// Like bdmLoadOptionalModule, but passes IOP module args (arglen = byte length of the packed,
+// NUL-terminated args buffer). smap_udpbd requires an "ip=A.B.C.D" arg; the base loader passes none.
+static int bdmLoadOptionalModuleArgs(const char *name, void *module, int moduleSize, int arglen, char *args)
+{
+    int result;
+
+    LOG("[%s]:\n", name);
+    result = sysLoadModuleBuffer(module, moduleSize, arglen, args);
+    if (result < 0)
+        LOG("%s failed to load: %d\n", name, result);
+
+    return result;
+}
+
+// Exposed for ethsupport's NIC mutual-exclusion: UDPBD and the SMB stack both own the SMAP adapter.
+int bdmIsUDPBDLoaded(void)
+{
+    return udpbdModLoaded;
+}
+
+/*
+  The network block transport actually resident (NET_BOOT_UDPBD / NET_BOOT_UDPFS). Falls back to the
+  live gNetBootProtocol before anything has loaded, so first-boot labelling is unchanged.
+*/
+int bdmGetLoadedNetProtocol(void)
+{
+    return (udpbdLoadedProtocol >= 0) ? udpbdLoadedProtocol : gNetBootProtocol;
+}
+
+// True when this support's device is the UDPBD block device (its games are Neutrino-only).
+// Returns 0 for non-BDM supports (incl. FAV-wrapped items, which have no source lookup here).
+int bdmSupportIsUDPBD(item_list_t *support)
+{
+    if (support == NULL || support->priv == NULL)
         return 0;
+    if (support->mode < BDM_MODE || support->mode > BDM_MODE_LAST)
+        return 0;
+    return ((bdm_device_data_t *)support->priv)->bdmDeviceType == BDM_TYPE_UDPBD;
+}
 
-    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
-        char path[16], driver[32];
-        int devIndex = -1;
+static void bdmEventHandler(void *packet, void *opt)
+{
+    BdmGeneration++;
+}
 
-        snprintf(path, sizeof(path), "mass%d:/", i);
-        // Identify the device by its DRIVER NAME only; GET_DEVICE_NUMBER can fail on a
-        // perfectly usable device and the device pages already tolerate that.
-        bdmReadDeviceIdentity(path, driver, sizeof(driver), &devIndex);
-        if (driver[0] == '\0')
-            continue;
-        if (bdmDetermineDeviceType(driver) != bdmType)
-            continue;
+// Bump the device generation the per-device refresh latch keys off, exactly as a real hotplug event
+// (bdmEventHandler) does. This invalidates every device's bdmDeviceTick so the next bdmNeedsUpdate
+// pass re-evaluates presence + page visibility instead of short-circuiting on the latch. Called when
+// the user applies Device Settings, so a BDM page that was force-hidden while its enable flag read 0
+// (e.g. an exFAT ATA tab, or a UDPBD tab) re-shows as soon as the device is re-enabled and present --
+// without needing a physical replug.
+void bdmForceDeviceRefresh(void)
+{
+    BdmGeneration++;
+}
 
-        snprintf(root, rootLen, "mass%d:/", i);
+// Read-only accessor so the menu hook can detect a real BDM device change (hotplug via bdmEventHandler
+// or a Device-Settings apply) and bypass its background-rescan throttle for immediate detection.
+// Plain single-word read, matching the existing non-atomic BdmGeneration read at bdmNeedsUpdate.
+unsigned int bdmGetGeneration(void)
+{
+    return BdmGeneration;
+}
+
+static int bdmShouldQueueModuleLoad(void)
+{
+    if (gEnableUSB && !iUSBModLoaded)
         return 1;
-    }
+    if (gEnableILK && !iLinkModLoaded)
+        return 1;
+    if (gEnableMX4SIO && !mx4sioModLoaded)
+        return 1;
+    if (gEnableBdmHDD && !hddModLoaded)
+        return 1;
+    if (gEnableUDPBD && !udpbdModLoaded && !ethGetModulesLoaded() && !udpfsGetModulesLoaded())
+        return 1; // mirror the load gate -- if the SMB or udpfs-filesystem NIC is up, the block chain can't load
+
     return 0;
 }
 
+static void bdmLoadBlockDeviceModules(void)
+{
+    // Boot-step localizer: this runs on the IO thread and can wedge on a real drive with no timeout,
+    // freezing the splash. Publish the step so a hang here names it instead of the main thread's "Ready.".
+    // (brenotomaz exFAT-USB boot hang investigation.)
+    guiSetBootStatusSticky(_l(_STR_BOOT_LOADING_DRIVERS));
+
+    WaitSema(bdmLoadModuleLock);
+
+    if (gEnableUSB && !iUSBModLoaded) {
+        // Load USB Block Device drivers -- the prime suspect for a real exFAT/USB boot wedge.
+        guiSetBootStatusSticky(_l(_STR_BOOT_LOADING_USB));
+        if (bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx) >= 0)
+            iUSBModLoaded = 1;
+    }
+
+    if (gEnableILK && !iLinkModLoaded) {
+        // Load iLink Block Device drivers
+        if (!iLinkManModLoaded && bdmLoadOptionalModule("ILINKMAN", &iLinkman_irx, size_iLinkman_irx) >= 0)
+            iLinkManModLoaded = 1;
+        if (iLinkManModLoaded && !ieee1394ModLoaded && bdmLoadOptionalModule("IEEE1394_BD", &IEEE1394_bd_irx, size_IEEE1394_bd_irx) >= 0)
+            ieee1394ModLoaded = 1;
+
+        iLinkModLoaded = iLinkManModLoaded && ieee1394ModLoaded;
+    }
+
+    if (gEnableMX4SIO && !mx4sioModLoaded) {
+        // Load MX4SIO Block Device drivers
+        if (bdmLoadOptionalModule("MX4SIO_BD", &mx4sio_bd_irx, size_mx4sio_bd_irx) >= 0)
+            mx4sioModLoaded = 1;
+    }
+
+    if (gEnableBdmHDD && !hddModLoaded) {
+        // Load dev9 and atad device drivers.
+        LOG("bdmLoadBlockDeviceModules loading hdd drivers...\n");
+        // Only mark loaded on success -- a failure (no HDD/interface) must not
+        // suppress future retries via bdmShouldQueueModuleLoad() (matches the
+        // conditional pattern used for USB/MX4SIO and opl.c's hddLoadModules gate).
+        if (hddLoadModulesReady())
+            hddModLoaded = 1;
+    }
+
+    // Network block device (UDPBD or UDPFS, picked by gNetBootProtocol). NIC-exclusive with the SMB/ETH
+    // stack (smap registers "SMAP_driver"), so only load when SMB isn't up. dev9 is refcounted (shared
+    // with ATA-HDD). Both need the PS2's static IP as an "ip=" arg -- the ministack has no DHCP client.
+    if (gEnableUDPBD && !udpbdModLoaded && !ethGetModulesLoaded() && !udpfsGetModulesLoaded()) {
+        char ipArg[24];
+        sysInitDev9();
+        snprintf(ipArg, sizeof(ipArg), "ip=%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
+        if (gNetBootProtocol == NET_BOOT_UDPFS) {
+            // UDPFS: a 3-IRX chain loaded in dependency order -- smap (exports to ministack + bd), then
+            // ministack (gets the ip= arg, exports to bd), then udpfs_bd (registers the "udp" BDM device).
+            if (bdmLoadOptionalModule("UDPFS_SMAP", &udpfs_smap_irx, size_udpfs_smap_irx) >= 0 &&
+                bdmLoadOptionalModuleArgs("UDPFS_MINISTACK", &udpfs_ministack_irx, size_udpfs_ministack_irx, (int)strlen(ipArg) + 1, ipArg) >= 0 &&
+                bdmLoadOptionalModule("UDPFS_BD", &udpfs_bd_irx, size_udpfs_bd_irx) >= 0) {
+                udpbdModLoaded = 1;
+                udpbdLoadedProtocol = NET_BOOT_UDPFS;
+            }
+        } else {
+            // UDPBD: the self-contained smap_udpbd monolith (smap + ministack + udpbd in one irx).
+            if (bdmLoadOptionalModuleArgs("SMAP_UDPBD", &smap_udpbd_irx, size_smap_udpbd_irx, (int)strlen(ipArg) + 1, ipArg) >= 0) {
+                udpbdModLoaded = 1;
+                udpbdLoadedProtocol = NET_BOOT_UDPBD;
+            }
+        }
+        // Release the dev9 reference taken above if the load failed -- otherwise a failing/retrying
+        // UDPBD/UDPFS (both gates re-enter on every device refresh while !udpbdModLoaded) inflates the
+        // refcounted dev9InitCount and a later HDD/ETH teardown can never power dev9 down. On success
+        // the reference is intentionally kept (the device stays mounted). Mirrors ETH/HDD pairing.
+        if (!udpbdModLoaded)
+            sysShutdownDev9();
+    }
+
+    SignalSema(bdmLoadModuleLock);
+}
 
 void bdmLoadModules(void)
 {
@@ -399,15 +426,6 @@ void bdmLoadModules(void)
     LOG("[BDMFS_FATFS]:\n");
     sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
 
-    // Load USB Block Device drivers. usbd stays unconditional (USB pads need the host
-    // stack); only the mass-storage block device honours the opt-in toggle.
-    LOG("[USBD]:\n");
-    sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
-    if (gEnableUSB) {
-        LOG("[USBMASS_BD]:\n");
-        sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL);
-    }
-
     // Load Optional Block Device drivers
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
 
@@ -418,7 +436,7 @@ void bdmLoadModules(void)
     LOG("BDMSUPPORT Modules loaded\n");
 }
 
-void bdmInit(item_list_t *itemList)
+static void bdmInit(item_list_t *itemList)
 {
     LOG("BDMSUPPORT Init\n");
 
@@ -428,8 +446,50 @@ void bdmInit(item_list_t *itemList)
     pDeviceData->bdmModifiedDVDPrev = 0;
     pDeviceData->bdmGameCount = 0;
     pDeviceData->bdmGames = NULL;
-    configGetInt(configGetByType(CONFIG_OPL), "usb_frames_delay", &itemList->delay);
+    pDeviceData->bdmVcdGameCount = 0; // #120: separate VCD store (see bdm_device_data_t)
+    pDeviceData->bdmVcdGames = NULL;
+    pDeviceData->FoldersCreated = 0;
+    pDeviceData->bdmDeviceType = BDM_TYPE_UNKNOWN;
+    pDeviceData->bdmHddIsLBA48 = -1;
+    pDeviceData->ataHighestUDMAMode = -1;
+    itemList->delay = gArtDelay;
+    bdmLoadModules();
     itemList->enabled = 1;
+}
+
+// Effective BDM device start mode. The UDPBD tab is not a mode-level tab like SMB -- it is a
+// hotplug-published BDM mass page, which needs the BDM pages initialized, polled, and the bdm core
+// modules loaded before smap_udpbd can even LINK. The unified network-protocol picker couples SMB to
+// gETHStartMode and UDPFS to its own derived start mode, but selecting UDPBD/UDPFSBD wrote NOTHING to
+// gBDMStartMode -- with the shipped Manual default (or Off), the UDPBD tab could NEVER appear unless
+// the user happened to enter the generic BDM placeholder tab first ("UDPBD tab never shows", 2026-07-13).
+// Floor the EFFECTIVE mode at AUTO while a BDM network transport is the selected protocol, mirroring
+// the UDPFS_MODE derivation; the user's saved gBDMStartMode is never modified or persisted.
+int bdmEffectiveStartMode(void)
+{
+    if (gEnableUDPBD && gBDMStartMode != START_MODE_AUTO)
+        return START_MODE_AUTO;
+    return gBDMStartMode;
+}
+
+// Per-transport enable flag for a classified BDM device type.
+// Returns 1 = enabled, 0 = disabled, -1 = unclassifiable (generic/unknown driver: never force-hidden).
+static int bdmTransportEnabled(int bdmDeviceType)
+{
+    switch (bdmDeviceType) {
+        case BDM_TYPE_USB:
+            return gEnableUSB ? 1 : 0;
+        case BDM_TYPE_ILINK:
+            return gEnableILK ? 1 : 0;
+        case BDM_TYPE_SDC:
+            return gEnableMX4SIO ? 1 : 0;
+        case BDM_TYPE_ATA:
+            return gEnableBdmHDD ? 1 : 0;
+        case BDM_TYPE_UDPBD:
+            return gEnableUDPBD ? 1 : 0;
+        default:
+            return -1;
+    }
 }
 
 static int bdmNeedsUpdate(item_list_t *itemList)
@@ -442,12 +502,10 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     bdmDeviceModeStarted = 1;
 
     // If bdm mode is disabled bail out as we don't want to update the visibility state of the device pages.
-    if (gBDMStartMode == START_MODE_DISABLED)
+    if (bdmEffectiveStartMode() == START_MODE_DISABLED)
         return 0;
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
-
-    ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
 
     // Check for forced refresh from deleting or renaming a game.
     if (pDeviceData->ForceRefresh != 0) {
@@ -459,37 +517,91 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     // to off for a bdm device we want to hide the menu even though the drivers are still loaded and the device is being detected by bdm.
     opl_io_module_t *pOwner = (opl_io_module_t *)itemList->owner;
     if (pOwner != NULL && pOwner->menuItem.visible == 1) {
-        int deviceEnabled = 0;
-        switch (pDeviceData->bdmDeviceType) {
-            case BDM_TYPE_USB:
-                deviceEnabled = gEnableUSB;
-                break;
-            case BDM_TYPE_ILINK:
-                deviceEnabled = gEnableILK;
-                break;
-            case BDM_TYPE_SDC:
-                deviceEnabled = gEnableMX4SIO;
-                break;
-            case BDM_TYPE_ATA:
-                deviceEnabled = gEnableBdmHDD;
-                break;
-            default:
-                deviceEnabled = 0;
-                break;
-        }
-
         // If the device page is visible but the device support is not enabled, hide the device page.
-        if (deviceEnabled == 0)
+        if (bdmTransportEnabled(pDeviceData->bdmDeviceType) == 0)
             pOwner->menuItem.visible = 0;
     }
 
-    if (pDeviceData->bdmULSizePrev != -2 && pDeviceData->bdmDeviceTick == BdmGeneration)
-        return 0;
+    // VCD view: an L3 toggle marks the mode dirty but does NOT bump BdmGeneration or reset
+    // bdmULSizePrev, so consume the dirty flag BEFORE the device-tick cache gate below (mirrors how
+    // mmceNeedsUpdate checks it first). Otherwise a device already scanned this BdmGeneration -- which
+    // every USB stick is, the moment its ISO list loads -- short-circuits at the gate and never
+    // rescans, leaving the VCD (PS1/POPSTARTER) list permanently empty on USB/BDM while MMCE worked.
+    if (vcdConsumeDirty(itemList->mode))
+        return 1;
+
+    // Folder browsing: a descend/ascend marks the mode dirty but bumps nothing the tick gate below
+    // watches, so consume it here (same discipline as vcdConsumeDirty) or the deeper/shallower list
+    // never rebuilds on a device already scanned this BdmGeneration.
+    if (folderConsumeDirty(itemList->mode))
+        return 1;
+
+    // NEVER-SCANNED (-2) DEFEATS EVERY SHORT-CIRCUIT IN HERE -- note the condition, not just the body.
+    // bdmULSizePrev starts at -2 and only leaves it once a scan has actually run, so while it is -2
+    // this device has published no list yet and must be let through, INCLUDING while the page is still
+    // invisible -- exactly the state a device sits in between attaching and being shown. (The invisible
+    // bail below used to run first, making the old `!= -2` test on the miss-count line unreachable for
+    // a never-visible page; that test is now redundant and gone.)
+    //
+    // Why this reaches far past the invisible case: the BDM list scans essentially ONCE, on the publish
+    // pass. Every later refresh hits bdmUpdateDeviceData's "no change to the device state" return 0
+    // below, so whatever the list held at that single instant is what the user has for the rest of the
+    // boot -- and sbReadList preserves its last-good list on a failed read, which on a FIRST scan
+    // means an empty list with no error shown. A network block device (UDPBD) is
+    // precisely where that instant can be too early: the volume is mounted but the server round-trip
+    // behind the CD/DVD opendir can still fail, and the page then reads "0 games" permanently and
+    // silently. UDPFS already rescues itself with the identical idea (udpfssupport.c:134-135,
+    // `if (udpfsULSizePrev == -2) result = 1;` -- deliberately above every gate); BDM had no
+    // equivalent. Same class as the PR #151 tab bug, one layer down.
+    if (pDeviceData->bdmDeviceTick == BdmGeneration && pDeviceData->bdmULSizePrev != -2) {
+        if (pOwner != NULL && pOwner->menuItem.visible == 0)
+            return 0;
+        // While a network page is inside its disconnect grace window (bdmMissCount > 0, set by the
+        // presence-poll debounce in bdmUpdateDeviceData), keep re-polling each refresh so the debounce
+        // advances to the hide threshold -- otherwise it would stall at the single disconnect event and
+        // a truly-gone network page would never hide. Local devices always have bdmMissCount == 0 here.
+        if (pDeviceData->bdmMissCount == 0)
+            return 0;
+    }
     pDeviceData->bdmDeviceTick = BdmGeneration;
 
+    if (bdmShouldQueueModuleLoad())
+        ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
+
     // Check if the device has been connected or removed.
-    if ((result = bdmUpdateDeviceData(itemList)) == 0)
-        return 0;
+    result = bdmUpdateDeviceData(itemList);
+    // "No change to the device state" normally means there is nothing to do -- but a device that has
+    // NEVER scanned (bdmULSizePrev == -2) has no list to leave alone, and bdmUpdateDeviceData reports
+    // 0 on every poll once the device is connected and its identity is populated. Returning here would
+    // make the -2 bypass at the device-tick gate above a NO-OP, which is exactly what it was before
+    // this line changed (Gemini review of #186 -- it caught that my first cut fixed nothing).
+    //
+    // Falling through is safe and needs no new scan logic: result stays 0 past the connect/disconnect
+    // sfx branches, and the sbIsSameSize(bdmPrefix, bdmULSizePrev) check further down cannot match a
+    // sentinel of -2, so it sets result = 1 and the first scan publishes through the existing path.
+    // ... but ONLY for a slot that has actually CONNECTED (bdmPrefix populated by the connect pass).
+    // A NEVER-connected slot also sits at the -2 sentinel with result == 0, and letting it fall
+    // through reached sbCreateFolders() with an EMPTY prefix -- mkdir("CFG")/mkdir("THM")/... resolve
+    // relative to the CWD, i.e. the BOOT FOLDER, so an enabled-but-absent BDM device recreated the
+    // whole OPL library tree inside mmce0:/RIPTOPL/ (or wherever OPL lives) on every startup
+    // (AndrewBento, #214; FifthFox reported the same class). The #186 first-scan rescue only ever
+    // needed MOUNTED devices, which always have bdmPrefix set before any 0-result poll.
+    if (result == 0) {
+        // The -2 rescue applies ONLY to a device that is CONNECTED **and PUBLISHED**. Two #214-class
+        // holes otherwise: a NEVER-connected slot (bdmPrefix empty) reached sbCreateFolders("") --
+        // bare mkdir("CFG")/mkdir("THM")/... resolve against the CWD, i.e. the BOOT FOLDER
+        // (AndrewBento, #214); and a PRESENT but transport-WITHHELD device would get folders + scans
+        // on a page the user disabled, because bdmUpdateDeviceData populates bdmPrefix BEFORE its
+        // explicit-BDM-off/transport-disabled 0-returns (CodeRabbit review of #239 -- vetted against
+        // bdmUpdateDeviceData: the withhold paths run after bdmBuildGamePrefix). The #186 first-scan
+        // rescue only ever needed MOUNTED devices, whose connect pass sets BOTH the prefix and
+        // menuItem.visible before any 0-result poll.
+        int neverScanned = (pDeviceData->bdmULSizePrev == -2);
+        int connectedAndPublished = pDeviceData->bdmPrefix[0] != '\0' &&
+                                    itemList->owner != NULL && ((opl_io_module_t *)itemList->owner)->menuItem.visible;
+        if (!(neverScanned && connectedAndPublished))
+            return 0;
+    }
 
     // If a device was added or removed play the appropriate UI sound.
     if (result == -1) {
@@ -498,7 +610,19 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     } else if (result == 1)
         sfxPlay(SFX_BD_CONNECT);
 
-    sprintf(path, "%sCD", pDeviceData->bdmPrefix);
+    // Belt-and-suspenders: never create the library tree at an empty prefix (= the CWD/boot folder).
+    if (!pDeviceData->FoldersCreated && pDeviceData->bdmPrefix[0] != '\0') {
+        sbCreateFolders(pDeviceData->bdmPrefix, 1);
+        pDeviceData->FoldersCreated = 1;
+    }
+
+    // VCD view: while this device shows its VCD list, skip the disc-folder heuristics (it refreshes on
+    // L3 toggle / manual refresh only). The toggle's forced rescan is consumed ABOVE the device-tick
+    // gate (see vcdConsumeDirty near the top) so the per-generation cache can't swallow it.
+    if (vcdViewActive(itemList->mode))
+        return 0;
+
+    snprintf(path, sizeof(path), "%sCD", pDeviceData->bdmPrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
     if (pDeviceData->bdmModifiedCDPrev != st.st_mtime) {
@@ -506,7 +630,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
         result = 1;
     }
 
-    sprintf(path, "%sDVD", pDeviceData->bdmPrefix);
+    snprintf(path, sizeof(path), "%sDVD", pDeviceData->bdmPrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
     if (pDeviceData->bdmModifiedDVDPrev != st.st_mtime) {
@@ -531,8 +655,6 @@ static int bdmNeedsUpdate(item_list_t *itemList)
             pDeviceData->LanguagesLoaded = 1;
     }
 
-    sbCreateFolders(pDeviceData->bdmPrefix, 1);
-
     return result;
 }
 
@@ -540,6 +662,18 @@ static int bdmUpdateGameList(item_list_t *itemList)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
+    // #120: each view scans into its OWN array (see bdm_device_data_t). Previously both shared
+    // bdmGames, so a VCD scan reporting failure (r < 0) left the ISO list published under the VCD
+    // view -- the L3 toggle then "never changed the list" (Nathan, HW, ATA/HDD_BD), and a device with
+    // no POPS folder hit that on every single toggle.
+    if (vcdViewActive(itemList->mode)) {
+        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
+        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode); // device root, NOT gBDMPrefix
+        int r = vcdFillGameList(vcdPrefix, &pDeviceData->bdmVcdGames);
+        if (r >= 0) // r < 0: transient scan failure -> keep THIS view's last-good (empty if never scanned)
+            pDeviceData->bdmVcdGameCount = r;
+        return pDeviceData->bdmVcdGameCount;
+    }
     sbReadList(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, folderGetSub(itemList->mode), &pDeviceData->bdmULSizePrev, &pDeviceData->bdmGameCount);
     return pDeviceData->bdmGameCount;
 }
@@ -548,41 +682,67 @@ static int bdmGetGameCount(item_list_t *itemList)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    return pDeviceData->bdmGameCount;
+    return vcdViewActive(itemList->mode) ? pDeviceData->bdmVcdGameCount : pDeviceData->bdmGameCount;
+}
+
+// Toggle-window guard (mirrors mmceActiveGame). The L3 toggle flips vcdViewActive() SYNCHRONOUSLY
+// (vcdToggleView) but rebuilds the submenu on the DEFERRED IO thread, so for a window the OLD submenu's
+// ids are still live while vcdViewActive() already reports the NEW view -- and an id from the old view
+// can index the freshly-switched other-view array, which may be NULL (never scanned), shorter, or
+// mid-scan. Resolve EVERY id through here: an out-of-range id yields a STATIC EMPTY entry, so a stale-id
+// READ is safe empty data instead of an OOB deref, and launch/delete/rename treat &bdmEmptyGame as
+// "nothing there". (The shared store this replaced could not OOB: one array + one count stayed
+// self-consistent -- splitting them is what makes this guard mandatory.)
+static base_game_info_t bdmEmptyGame = {0};
+static base_game_info_t *bdmActiveGame(item_list_t *itemList, int id)
+{
+    bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    int vcd = vcdViewActive(itemList->mode);
+    base_game_info_t *arr = vcd ? pDeviceData->bdmVcdGames : pDeviceData->bdmGames;
+    int count = vcd ? pDeviceData->bdmVcdGameCount : pDeviceData->bdmGameCount;
+
+    if (arr == NULL || id < 0 || id >= count)
+        return &bdmEmptyGame;
+    return &arr[id];
 }
 
 static void *bdmGetGame(item_list_t *itemList, int id)
 {
-    bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
-
-    return (void *)&pDeviceData->bdmGames[id];
+    return (void *)bdmActiveGame(itemList, id);
 }
 
 static char *bdmGetGameName(item_list_t *itemList, int id)
 {
-    bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
-
-    return pDeviceData->bdmGames[id].name;
+    return bdmActiveGame(itemList, id)->name;
 }
 
 static int bdmGetGameNameLength(item_list_t *itemList, int id)
 {
-    bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    base_game_info_t *g = bdmActiveGame(itemList, id);
 
-    return ((pDeviceData->bdmGames[id].format != GAME_FORMAT_USBLD) ? ISO_GAME_NAME_MAX + 1 : UL_GAME_NAME_MAX + 1);
+    return ((g->format != GAME_FORMAT_USBLD) ? ISO_GAME_NAME_MAX + 1 : UL_GAME_NAME_MAX + 1);
 }
 
 static char *bdmGetGameStartup(item_list_t *itemList, int id)
 {
-    bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    base_game_info_t *g = bdmActiveGame(itemList, id);
 
-    return pDeviceData->bdmGames[id].startup;
+    // VCD view: identity is the filename, not a disc ID -> per-game data (CFG/art) keys off the
+    // VCD name (matches sbPopulateConfig).
+    if (vcdViewActive(itemList->mode))
+        return g->name;
+    return g->startup;
 }
 
 static void bdmDeleteGame(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
+    if (vcdViewActive(itemList->mode))
+        return; // #120: a VCD is not an ISO game -- no delete in VCD view (mirrors mmceDeleteGame)
+    if (bdmActiveGame(itemList, id) == &bdmEmptyGame)
+        return;                                   // stale id in the toggle window: sbDelete does NOT bounds-check -> avoid an OOB/wrong unlink
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // delete inside the current subfolder, not the root
     sbDelete(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, "/", pDeviceData->bdmGameCount, id);
     pDeviceData->bdmULSizePrev = -2;
     pDeviceData->ForceRefresh = 1;
@@ -592,13 +752,93 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
+    if (vcdViewActive(itemList->mode))
+        return; // #120: no rename in VCD view
+    if (bdmActiveGame(itemList, id) == &bdmEmptyGame)
+        return;                                   // stale id in the toggle window (see bdmDeleteGame) -> avoid sbRename OOB
+    sbSetBrowseSub(folderGetSub(itemList->mode)); // rename inside the current subfolder, not the root
     sbRename(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, "/", pDeviceData->bdmGameCount, id, newName);
     pDeviceData->bdmULSizePrev = -2;
     pDeviceData->ForceRefresh = 1;
 }
-// Neutrino frag budget: neutrino only discovers a blown fragment budget after its own IOP
-// reset (debug printf + exit = black screen). Count it now. i_bdm's GET_FRAGLIST with a NULL
-// buffer returns the fragment COUNT for the open file.
+
+// Launch a PS1/.VCD entry BY NAME via POPSTARTER (the view-independent entry point used by both the
+// in-view menu launch below and the Favourites tab). Every BDM device is a massN: mount at runtime,
+// so the ELF + selector both use the live prefix; UNMOUNT_EXCEPTION keeps it mounted across the reset.
+static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_t *configSet)
+{
+    bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    char vcdPrefix[64], vcdElf[256], vcdSelector[320];
+
+    if (pDeviceData == NULL || vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
+        return;
+    // POPSTARTER does its own IOP reset and reloads its block drivers from the MC -- it can't bring up
+    // the network (udp) block device (no BDMA variant for it), so a PS1 VCD on the udp device would just
+    // drop to OSDSYS. Abort cleanly with a message instead of a dead launch.
+    if (pDeviceData->bdmDeviceType == BDM_TYPE_UDPBD) {
+        guiMsgBox(_l(_STR_VCD_NOT_ON_NET), 0, NULL);
+        return;
+    }
+    bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode); // device root, NOT gBDMPrefix -- POPSTARTER reads <root>/POPS only
+    if (!vcdResolvePopstarter(vcdPrefix, vcdElf, sizeof(vcdElf))) {
+        guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    // vcdBuildSelector emits the BARE POPSTARTER label ("mass:/POPS/XX.<name>.ELF"), NOT this live
+    // unit-numbered mount -- POPSTARTER remounts under "mass:" after its own IOP reset (see the function).
+    vcdBuildSelector(vcdPrefix, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
+
+    // Populate mc?:/POPSTARTER from this game's own direct POPS/ folder. Best effort: local VCD
+    // launches keep their existing handoff behavior when optional files are absent or the card is full.
+    (void)vcdInstallPopstarterMc(vcdPrefix);
+
+    // Best-effort card prep: POPSTARTER reloads its block-device driver pair from the MC after its OWN
+    // IOP reset, so try to equip the device-matching BDMAssault variant first. NEVER a launch gate --
+    // the handoff below always proceeds (POPSTARTER owns everything past the exec); a failed equip just
+    // toasts its diagnostic in passing. iLink/UDPBD/unknown have no BDMA variant and are left as-is.
+    switch (pDeviceData->bdmDeviceType) {
+        case BDM_TYPE_USB: {
+            // USB is special: the PS2 cannot detect whether the stick is fat32 or exFAT formatted,
+            // so the user picks the POPSTARTER USB driver on EVERY USB VCD launch (maintainer
+            // directive 2026-08-01). fat32 = POPSTARTER's built-in USB stack (recommended for
+            // non-exFAT users); exFAT = the BDMAssault usbexfat pair. Back cancels the launch.
+            int usbMode = guiShowVcdUsbMode();
+            if (usbMode == VCDUSB_BTN_FAT32)
+                vcdApplyUsbModeForLaunch(VCD_BDMA_FAT32);
+            else if (usbMode == VCDUSB_BTN_EXFAT)
+                vcdApplyUsbModeForLaunch(VCD_BDMA_USBEXFAT);
+            else
+                return; // dialog cancelled -- abort the launch, nothing equipped
+            break;
+        }
+        case BDM_TYPE_SDC:
+            vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MX4SIO, VCD_BDMA_MX4SIO);
+            break;
+        case BDM_TYPE_ATA:
+            vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_HDD, VCD_BDMA_ATA);
+            break;
+        default:
+            break;
+    }
+
+    char vcdFullPath[256];
+    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS/%s.VCD", vcdPrefix, vcdName);
+    vcdPrepareRetroGemBarcode(vcdFullPath);
+
+    deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the VCD device mounted across the IOP reset
+    sysLaunchPopstarter(vcdElf, vcdSelector);
+}
+
+// Δ9 (NHDDL parity): Neutrino's bd backend packs the ISO and BOTH -mc VMCs into ONE shared
+// 64-entry fragment table (BDM_MAX_FRAGS in neutrino's fhi_bd_config.h; fhi_config.c's
+// backend_bd_add_file_fd errors past it). That packing runs AFTER neutrino's own IOP reset,
+// where its only error output is a debug printf -- from the couch, a black screen. So pre-count
+// the same budget here, while the menu can still explain the abort, using the count-only form
+// of the same ioctl (NULL buffer: bdmfs_fatfs's get_frag_list gates only the WRITE on capacity,
+// the count is unconditional -- it returns the file's TOTAL fragment count and writes nothing).
+// Every device this helper can see is bdmfs_fatfs-backed (mmce/udpfs launches live in their own
+// support files), including both udp block transports (udpbd + udpfsbd depend on i_bdm), so the
+// ioctl is always valid here. NOT OPL's BDM_MAX_FRAGS: same value today, different owner.
 #define NEUTRINO_BDM_MAX_FRAGS 64
 
 static int bdmNeutrinoFragBudgetOk(const char *isoPath, const neutrino_vmc_args_t *vmcArgs, int isUdp)
@@ -610,7 +850,7 @@ static int bdmNeutrinoFragBudgetOk(const char *isoPath, const neutrino_vmc_args_
     for (i = 0; i < NEUTRINO_VMC_SLOTS; i++) {
         const char *eq = vmcArgs->arg[i][0] ? strchr(vmcArgs->arg[i], '=') : NULL;
         if (eq != NULL && eq[1] != '\0')
-            paths[nPaths++] = eq + 1; // "-mcN=<path>"; the builder already verified the file exists
+            paths[nPaths++] = eq + 1; // "-mcN=<path>"; Δ2 already verified the file exists
     }
 
     for (i = 0; i < nPaths; i++) {
@@ -631,9 +871,9 @@ static int bdmNeutrinoFragBudgetOk(const char *isoPath, const neutrino_vmc_args_
     if (total > NEUTRINO_BDM_MAX_FRAGS) { // == is fine: neutrino packs exactly-full tables
         char msg[256];                    // headroom for the lng_fork overlay's longer translations
         LOG("[NEUTRINO] frag budget exceeded: %d/%d across ISO + VMCs\n", total, NEUTRINO_BDM_MAX_FRAGS);
-        // The udp outcome is a consumed launch (no native fallback exists); the local outcome is a
-        // native-core fallback (which usually boots: OPL's own 64-frag table holds the ISO only --
-        // VMCs go through mcemu's contiguity check instead). Use the message that says what happens.
+        // Match the Δ8 abort-message convention: the udp outcome is a consumed launch, the
+        // local outcome is a native-core fallback (which usually boots: OPL's own 64-frag
+        // table holds the ISO only -- VMCs go through mcemu's contiguity check instead).
         snprintf(msg, sizeof(msg), _l(isUdp ? _STR_NEUTRINO_TOO_FRAGMENTED_NET : _STR_NEUTRINO_TOO_FRAGMENTED), total, NEUTRINO_BDM_MAX_FRAGS);
         guiWarning(msg, 6);
         return 0;
@@ -641,12 +881,16 @@ static int bdmNeutrinoFragBudgetOk(const char *isoPath, const neutrino_vmc_args_
     return 1;
 }
 
-// Neutrino core launch leg: everything the native path below prepares (VMC/mcemu patching,
-// cdvdman patch, fraglists, layer-1 probing, cheats, ATA DMA setup) exists for the EMBEDDED
-// cdvdman core; Neutrino re-derives all of it from -bsd/-dvd after its own IOP reset.
+// Δ8 (NHDDL parity): the LEAN Neutrino launch path. Everything bdmLaunchGame's native flow
+// prepares -- VMC superblock prompts + mcemu patching, sbPrepare's cdvdman patch, per-part
+// fragment lists (with a hard abort past 64 frags), layer-1 probing, cheats (with dialogs),
+// PS2RD images, ATA DMA setup -- exists for the EMBEDDED cdvdman core; Neutrino re-derives all
+// of it from -bsd/-dvd after its own IOP reset. Paying for that work meant a Neutrino launch
+// could DIE on native-only failures (the fragmented-ISO abort, an interactive cheats dialog
+// mid-launch, a VMC-superblock cancel whose result the launch then ignored). NHDDL's whole
+// pre-handoff is ~3 file operations; this is ours.
 // Returns 1 = handled (handed off, or aborted with the user informed -- caller returns);
-// 0 = proceed with the native launch.
-// NOTE(rebuild): the MMCE cross-device GameID send returns with item 3.
+// 0 = proceed with the native launch (core is OPL, or Neutrino unavailable on a non-udp device).
 static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, bdm_device_data_t *pDeviceData, config_set_t *configSet)
 {
     int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
@@ -654,58 +898,74 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
     // UDPBD/UDPFS have no embedded cdvdman backend -- the "udp" BDM device can ONLY boot via
     // Neutrino, so force the core and treat every Neutrino failure below as a clean abort
     // (falling through to the native path would deinit into a no-op = black screen).
-    int isUdp = (pDeviceData->bdmDeviceType == BDM_TYPE_UDPBD);
+    int isUdp = bdmDriverIsUDPBD(pDeviceData->bdmDriver);
     if (isUdp)
         coreLoader = 1;
     if (!coreLoader)
         return 0;
 
-    // Abort contract: on udp the launch is unbootable without Neutrino -- consume the launch
-    // (return 1, caller stops); on local devices fall back to native (return 0).
+    // Abort helper contract: on udp the launch is unbootable without Neutrino -- consume the
+    // launch (autolaunch mirrors its normal teardown); on local devices fall back to native.
     int failResult = isUdp ? 1 : 0;
 
     if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
-        // Neutrino cannot run UL or ZSO images.
-        guiWarning(_l(_STR_NEUTRINO_BAD_FORMAT), 6);
-        return failResult;
+        // isValidIsoName() admits .zso case-insensitively and game->extension is stored verbatim,
+        // so an upper/mixed-case ".ZSO" must reject here too (Neutrino can't run it).
+        guiWarning(_l(isUdp ? _STR_NET_NEEDS_NEUTRINO : _STR_NEUTRINO_BAD_FORMAT), 6);
+        goto fail;
     }
 
-    const char *neutrinoPath = sbResolveNeutrinoPath(pDeviceData->bdmPrefix); // AUTO probes this device for a co-located install
+    const char *neutrinoPath = sbResolveNeutrinoPath(pDeviceData->bdmPrefix); // #300: AUTO probes this device for a co-located install
     if (neutrinoPath == NULL) {
-        guiWarning(_l(_STR_NEUTRINO_NOT_FOUND), 6);
-        return failResult;
+        guiWarning(_l(isUdp ? _STR_NET_NEEDS_NEUTRINO : _STR_NEUTRINO_NOT_FOUND), 6);
+        goto fail;
     }
 
     // Everything Neutrino actually needs from the config/device, copied to THIS stack frame
-    // (deinit below frees configSet's owner + pDeviceData). Absent per-game keys = follow the
-    // global defaults.
+    // (deinit below frees configSet's owner + pDeviceData).
+    // Absent per-game $NeutrinoVideo/$NeutrinoGsmComp keys = follow the global defaults (the
+    // per-game picker's "Default" row removes the keys; explicit values -- including Off=0 --
+    // persist and override).
     int compatmask = 0, neutrinoVideo = gNeutrinoVideoDefault, neutrinoGsmComp = gNeutrinoGsmCompDefault, neutrinoBsdfs = 0;
     char neutrinoExtraArgs[256] = "";
     neutrino_vmc_args_t neutrinoVmc = {0};
     char partname[256], bdmCurrentDriver[32];
-    configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatmask);
+    configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatmask); // same source sbPrepare reads; no IRX patch needed
     configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
     configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
     configGetInt(configSet, CONFIG_ITEM_NEUTRINO_GSMCOMP, &neutrinoGsmComp);
-    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_BSDFS, &neutrinoBsdfs);
-    sbBuildVmcNeutrinoArgs(configSet, pDeviceData->bdmPrefix, &neutrinoVmc);
-    sbCreatePath(game, partname, pDeviceData->bdmPrefix, "/", 0); // -dvd target
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_BSDFS, &neutrinoBsdfs);     // #11: bdm legs (incl. udpbd/udpfsbd) are the block-backed consumers
+    sbBuildVmcNeutrinoArgs(configSet, pDeviceData->bdmPrefix, &neutrinoVmc); // Δ2-validated -mc args
+    sbCreatePath(game, partname, pDeviceData->bdmPrefix, "/", 0);            // -dvd target (multi-part was rejected above)
     snprintf(bdmCurrentDriver, sizeof(bdmCurrentDriver), "%s", pDeviceData->bdmDriver);
 
+    // Δ9: neutrino only discovers a blown fragment budget after its own IOP reset (debug
+    // printf + exit = black screen). Count it now: udp consumes the launch, local falls native.
     if (!bdmNeutrinoFragBudgetOk(partname, &neutrinoVmc, isUdp))
-        return failResult; // local: stay native (embedded core handles fragmentation via fraglists); udp: consumed
+        goto fail;
 
     if (gRememberLastPlayed) {
         configSetStr(configGetByType(CONFIG_LAST), "last_played", game->startup);
         saveConfig(CONFIG_LAST, 0);
     }
 
-    // Preflight (driver token validation) -- abort stays in a live menu.
+    // Δ6 preflight (driver token + network toml sync) -- abort stays in a live menu.
     if (sysNeutrinoPreflight(bdmCurrentDriver, neutrinoPath) < 0)
-        return failResult;
+        goto fail;
 
-    // game->startup lives inside bdmGames / gAutoLaunchBDMGame, both freed below. Copy it
-    // before the teardown so sysLaunchNeutrino's -elf build reads valid stack memory.
+    // MMCE cross-device game-id (#261) with the Δ3 -mc-covered-slot guard. Before deinit (uses game).
+    // Same MX4SIO settle gate as the native leg below (CodeRabbit review of #248, vetted): a switch
+    // still in flight through the IOP reboot can starve the SD enumeration on the shared SIO2.
+    if (mmceSendGameID(game->startup, neutrinoPath,
+                       (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)) < 0 &&
+        bdmDriverIsMx4sio(bdmCurrentDriver)) {
+        if (mmceGameIdSettle(5000) < 0)
+            guiWarning(_l(_STR_MMCE_GAMEID_UNSETTLED), 6);
+    }
+
+    // game->startup lives inside bdmGames / gAutoLaunchBDMGame, both freed below (deinitEx's
+    // itemCleanUp, or the explicit free in the autolaunch branch). Copy it before the teardown so
+    // sysLaunchNeutrino's -elf build reads valid stack memory instead of freed heap (UAF).
     char bdmStartup[GAME_STARTUP_MAX + 1];
     snprintf(bdmStartup, sizeof(bdmStartup), "%s", game->startup);
 
@@ -723,11 +983,20 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
     }
 
     // gPS2Logo passes the user's preference straight through: Neutrino performs its own logo
-    // read/validation for -logo.
+    // read/validation for -logo, so the native path's CheckPS2Logo disc pass is not needed here.
     sysLaunchNeutrino(bdmCurrentDriver, partname, bdmStartup, compatmask, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, neutrinoBsdfs, &neutrinoVmc);
     return 1;
-}
 
+fail:
+    if (failResult && gAutoLaunchBDMGame != NULL) {
+        miniDeinit(configSet); // mirror the normal autolaunch teardown (ioEnd/configEnd + frees configSet)
+        free(gAutoLaunchBDMGame);
+        gAutoLaunchBDMGame = NULL;
+        free(gAutoLaunchDeviceData);
+        gAutoLaunchDeviceData = NULL;
+    }
+    return failResult;
+}
 
 void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 {
@@ -746,13 +1015,34 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
     if (gAutoLaunchBDMGame == NULL) {
         pDeviceData = (bdm_device_data_t *)itemList->priv;
-        game = &pDeviceData->bdmGames[id];
+        // Resolve through the ACTIVE view's array (#120 split): in the VCD view this yields the VCD
+        // entry whose name the POPSTARTER handoff below uses, and a stale toggle-window id yields the
+        // empty entry rather than indexing the other view's (possibly NULL/shorter) array.
+        game = bdmActiveGame(itemList, id);
+        if (game == &bdmEmptyGame)
+            return; // nothing there (stale id / not scanned) -- never launch a blank entry
     } else {
         pDeviceData = gAutoLaunchDeviceData;
         game = gAutoLaunchBDMGame;
     }
 
-    // Neutrino core gets its own lean path FIRST -- everything below is native-core prep it
+    // Folder browsing: a folder row is never launchable (the dispatch descends instead of reaching
+    // here); guard defensively. Otherwise pin the path composers to the current subfolder so a game
+    // inside it resolves to <prefix>CD|DVD/<sub>/<name>.
+    if (game != NULL && game->format == GAME_FORMAT_FOLDER)
+        return;
+    sbSetBrowseSub(folderGetSub(itemList->mode));
+
+    // VCD view: this device is showing PS1 VCDs -> hand off to POPSTARTER (by name) instead of the
+    // disc / Neutrino path below (which is entirely disc-specific). The BDM_TYPE_ATA internal exFAT HDD
+    // still launches off the live massN: prefix, NOT ata0:/ (OPL never mounts an ata0: filesystem -- a
+    // re-point there made LoadELFFromFile fail into an already-deinit'd OPL = black-screen freeze).
+    if (gAutoLaunchBDMGame == NULL && game != NULL && vcdViewActive(itemList->mode)) {
+        bdmLaunchVcd(itemList, game->name, configSet);
+        return;
+    }
+
+    // Δ8: Neutrino core gets its own lean path FIRST -- everything below is native-core prep it
     // neither needs nor should be able to die on (see bdmTryNeutrinoLaunch).
     if (bdmTryNeutrinoLaunch(itemList, game, pDeviceData, configSet))
         return;
@@ -833,7 +1123,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
     void *irx = NULL;
     int irx_size = 0;
-    if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3) {
+    if (bdmDriverIsATA(pDeviceData->bdmDriver)) {
         irx = &bdm_ata_cdvdman_irx;
         irx_size = size_bdm_ata_cdvdman_irx;
     } else {
@@ -842,9 +1132,20 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     }
 
     compatmask = sbPrepare(game, configSet, irx_size, irx, &index);
+    if (compatmask < 0) // sbPrepare failed (patch zone not found): `index` is unset -- bail before using
+        return;         // it. (The old `if (settings == NULL)` guard was dead: irx + index is never NULL.)
+
+#ifdef PADEMU
+    // MX4SIO reads the SD card over the SIO2 / memory-card bus -- the SAME bus pad emulation hooks
+    // (modules/pademu installs a sio2man hook while pad emulation is enabled). With both active they
+    // contend on SIO2 and the game frequently fails to boot (black screen, issue #53). It is an
+    // inherent shared-bus conflict, not fixable here, so warn instead of leaving a mystery black
+    // screen. sbPrepare() above resolved gEnablePadEmu for this game (global or per-game).
+    if (pDeviceData->bdmDeviceType == BDM_TYPE_SDC && gEnablePadEmu)
+        guiWarning(_l(_STR_MX4SIO_PADEMU_WARN), 6);
+#endif
+
     settings = (struct cdvdman_settings_bdm *)((u8 *)irx + index);
-    if (settings == NULL)
-        return;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
     memset(&settings->frags[0], 0, sizeof(bd_fragment_t) * BDM_MAX_FRAGS);
@@ -861,17 +1162,19 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         // Open file
         sbCreatePath(game, partname, pDeviceData->bdmPrefix, "/", i);
         fd = open(partname, O_RDONLY);
-        iop_fd = ps2sdk_get_iop_fd(fd);
         if (fd < 0) {
             sbUnprepare(&settings->common);
             guiMsgBox(_l(_STR_ERR_FILE_INVALID), 0, NULL);
             return;
         }
+        iop_fd = ps2sdk_get_iop_fd(fd); // only valid after confirming fd >= 0
 
         // Get fragment list
         int iFragCount = fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_FRAGLIST, NULL, 0, (void *)&settings->frags[iTotalFragCount], sizeof(bd_fragment_t) * (BDM_MAX_FRAGS - iTotalFragCount));
-        if (iFragCount > BDM_MAX_FRAGS) {
-            // Too many fragments
+        if (iFragCount < 0 || iFragCount > BDM_MAX_FRAGS - iTotalFragCount) {
+            // Negative (ioctl error) or more fragments than the remaining frags[] slots.
+            // A negative value would underflow the u8 iTotalFragCount and corrupt the next
+            // iteration's destination offset and size.
             close(fd);
             sbUnprepare(&settings->common);
             guiMsgBox(_l(_STR_ERR_FRAGMENTED), 0, NULL);
@@ -914,17 +1217,12 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     settings->common.zso_cache = bdmCacheSize;
 
     if ((result = sbLoadCheats(pDeviceData->bdmPrefix, game->startup)) < 0) {
-        if (gAutoLaunchBDMGame == NULL) {
-            switch (result) {
-                case -ENOENT:
-                    guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
-                    break;
-                default:
-                    guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-            }
-        } else
-            LOG("Cheats error\n");
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        if (!sbCheatsMissingContinue(&settings->common, result))
+            return;
     }
+    sbLoadImage(pDeviceData->bdmPrefix, game->startup);
 
     if (gRememberLastPlayed) {
         configSetStr(configGetByType(CONFIG_LAST), "last_played", game->startup);
@@ -937,14 +1235,15 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // deinit will free per device data.. copy driver name before free to compare for launch
     char bdmCurrentDriver[32];
     snprintf(bdmCurrentDriver, sizeof(bdmCurrentDriver), "%s", pDeviceData->bdmDriver);
-    settings->bdDeviceId = pDeviceData->massDeviceIndex;
-    // Match the IOP-side block device by its exported driver token, not just the device index,
-    // so the in-game reader can never attach to the wrong transport when several are active.
-    snprintf(settings->bdDeviceDriver, sizeof(settings->bdDeviceDriver), "%s", bdmCurrentDriver);
+    bdmSetLaunchDeviceBinding(settings, bdmCurrentDriver, pDeviceData->massDeviceIndex);
 
-    if (!strcmp(bdmCurrentDriver, "ata") && strlen(bdmCurrentDriver) == 3) {
+    if (bdmDriverIsATA(bdmCurrentDriver)) {
         // Get DMA settings for ATA mode.
         int dmaType = 0, dmaMode = 7;
+
+        if (pDeviceData->bdmHddIsLBA48 < 0 || pDeviceData->ataHighestUDMAMode < 0)
+            bdmResolveLBA_UDMA(pDeviceData);
+
         configGetInt(configSet, CONFIG_ITEM_DMA, &dmaMode);
 
         // Set DMA mode and spindown time.
@@ -952,10 +1251,14 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
             dmaType = 0x20;
         else {
             dmaType = 0x40;
-            if (pDeviceData->ataHighestUDMAMode > 0)
+            dmaMode -= 3;
+            // Use the user's configured UDMA mode, only CLAMPED to the drive's max -- don't FORCE the
+            // highest, which is unstable on some drives/SATA adapters (wOPL 0f7443e, KrahJohlito). NB:
+            // RiptOPL already avoids the worse scan-time UDMA push -- bdmResolveLBA_UDMA only queries
+            // (never sets) the mode and caps it to UDMA 4 -- so the reported exFAT-HDD corruption from a
+            // max-UDMA scan does not apply here; this just respects a user's lower-DMA stability choice.
+            if (pDeviceData->ataHighestUDMAMode > 0 && dmaMode > pDeviceData->ataHighestUDMAMode)
                 dmaMode = pDeviceData->ataHighestUDMAMode;
-            else
-                dmaMode -= 3;
         }
 
         hddSetTransferMode(dmaType, dmaMode);
@@ -964,9 +1267,28 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         settings->hddIsLBA48 = pDeviceData->bdmHddIsLBA48;
     }
 
-    if (gAutoLaunchBDMGame == NULL)
+    // Δ8: Neutrino never reaches this point (bdmTryNeutrinoLaunch handled it at the top), so
+    // everything from here on is the NATIVE (embedded cdvdman) launch only -- including the udp
+    // impossibility: the udp device is Neutrino-only and its aborts happen inside the helper.
+
+    // MMCE cross-device game-id (#261): push the disc id to a present SD2PSX/MemCard PRO2 (either slot)
+    // so it switches its per-game folder, even though this game is not on the MMCE. Self-probes +
+    // no-ops if no card answers / feature off. Must run BEFORE deinit frees `game`.
+    //
+    // MX4SIO settle gate (HW batch S7): MX4SIO shares SIO2 with the MMCE, and an mmce card switch
+    // still in flight during the IOP reboot can starve the SD enumeration cdvdman then waits on
+    // FOREVER (the lime-green hang -- ee_core's marker right before LoadElf from cdrom0:). When the
+    // send reports "switched but settle NOT confirmed" (-1), re-probe the exact slot it targeted for
+    // up to 5 s; on expiry, warn and LAUNCH ANYWAY (the gate mitigates, never blocks -- and other
+    // BDM transports don't share SIO2, so only the SDC leg pays it).
+    if (mmceSendGameID(game->startup, NULL, 0) < 0 && bdmDriverIsMx4sio(bdmCurrentDriver)) {
+        if (mmceGameIdSettle(5000) < 0)
+            guiWarning(_l(_STR_MMCE_GAMEID_UNSETTLED), 6);
+    }
+
+    if (gAutoLaunchBDMGame == NULL) {
         deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
-    else {
+    } else {
         miniDeinit(configSet);
 
         free(gAutoLaunchBDMGame);
@@ -977,16 +1299,16 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     }
 
     LOG("bdm pre sysLaunchLoaderElf\n");
-    if (!strcmp(bdmCurrentDriver, "usb")) {
+    if (bdmDriverIsUSB(bdmCurrentDriver)) {
         settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_USBD;
         sysLaunchLoaderElf(filename, "BDM_USB_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(bdmCurrentDriver, "sd") && strlen(bdmCurrentDriver) == 2) {
+    } else if (bdmDriverIsIlink(bdmCurrentDriver)) {
         settings->common.fakemodule_flags |= 0 /* TODO! fake ilinkman ? */;
         sysLaunchLoaderElf(filename, "BDM_ILK_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(bdmCurrentDriver, "sdc") && strlen(bdmCurrentDriver) == 3) {
+    } else if (bdmDriverIsMx4sio(bdmCurrentDriver)) {
         settings->common.fakemodule_flags |= 0;
         sysLaunchLoaderElf(filename, "BDM_M4S_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(bdmCurrentDriver, "ata") && strlen(bdmCurrentDriver) == 3) {
+    } else if (bdmDriverIsATA(bdmCurrentDriver)) {
         settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;
         settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_ATAD;
         sysLaunchLoaderElf(filename, "BDM_ATA_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
@@ -996,7 +1318,9 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 static config_set_t *bdmGetConfig(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
-    return sbPopulateConfig(&pDeviceData->bdmGames[id], pDeviceData->bdmPrefix, "/");
+    // Active view's array (#120 split) -- a VCD's per-game CFG keys off its own entry, and a stale
+    // toggle-window id resolves to the empty entry instead of the other view's array.
+    return sbPopulateConfig(bdmActiveGame(itemList, id), pDeviceData->bdmPrefix, "/");
 }
 
 static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
@@ -1005,11 +1329,22 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
+    // OPL's own ART/<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
+    // with a strict PS1 ID).
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", pDeviceData->bdmPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1);
+    int r = texDiscoverLoad(resultTex, path, -1);
+    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD --
+    // ROOT-anchored (bdmBuildVcdPrefix), the SAME prefix the VCD scan uses, since the POPS layout lives at
+    // the device root, outside gBDMPrefix. Cover/icon only, VCD view only.
+    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode)) {
+        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
+        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
+        r = vcdLoadPopsCover(vcdPrefix, value, suffix, resultTex);
+    }
+    return r;
 }
 
 static int bdmGetTextId(item_list_t *itemList)
@@ -1018,14 +1353,16 @@ static int bdmGetTextId(item_list_t *itemList)
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (!strcmp(pDeviceData->bdmDriver, "usb"))
+    if (bdmDriverIsUSB(pDeviceData->bdmDriver))
         mode = _STR_USB_GAMES;
-    else if (!strcmp(pDeviceData->bdmDriver, "sd") && strlen(pDeviceData->bdmDriver) == 2)
+    else if (bdmDriverIsIlink(pDeviceData->bdmDriver))
         mode = _STR_ILINK_GAMES;
-    else if (!strcmp(pDeviceData->bdmDriver, "sdc") && strlen(pDeviceData->bdmDriver) == 3)
+    else if (bdmDriverIsMx4sio(pDeviceData->bdmDriver))
         mode = _STR_MX4SIO_GAMES;
-    else if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3)
+    else if (bdmDriverIsATA(pDeviceData->bdmDriver))
         mode = _STR_HDD_GAMES;
+    else if (bdmDriverIsUDPBD(pDeviceData->bdmDriver))
+        mode = (bdmGetLoadedNetProtocol() == NET_BOOT_UDPFS) ? _STR_UDPFSBD_GAMES : _STR_UDPBD_GAMES; // BLOCK: UDPFSBD vs UDPBD (the udpfs FILESYSTEM tab is _STR_UDPFS_GAMES, a separate device); mirror bdmGetIconId
 
     return mode;
 }
@@ -1036,14 +1373,16 @@ static int bdmGetIconId(item_list_t *itemList)
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (!strcmp(pDeviceData->bdmDriver, "usb"))
+    if (bdmDriverIsUSB(pDeviceData->bdmDriver))
         mode = USB_ICON;
-    else if (!strcmp(pDeviceData->bdmDriver, "sd") && strlen(pDeviceData->bdmDriver) == 2)
+    else if (bdmDriverIsIlink(pDeviceData->bdmDriver))
         mode = ILINK_ICON;
-    else if (!strcmp(pDeviceData->bdmDriver, "sdc") && strlen(pDeviceData->bdmDriver) == 3)
+    else if (bdmDriverIsMx4sio(pDeviceData->bdmDriver))
         mode = MX4SIO_ICON;
-    else if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3)
+    else if (bdmDriverIsATA(pDeviceData->bdmDriver))
         mode = HDD_BD_ICON;
+    else if (bdmDriverIsUDPBD(pDeviceData->bdmDriver))
+        mode = (bdmGetLoadedNetProtocol() == NET_BOOT_UDPFS) ? UDPFS_ICON : UDP_ICON;
 
     return mode;
 }
@@ -1056,6 +1395,7 @@ static void bdmCleanUp(item_list_t *itemList, int exception)
 
         bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
         free(pDeviceData->bdmGames);
+        free(pDeviceData->bdmVcdGames); // #120: free the separate VCD store too
         free(pDeviceData);
         itemList->priv = NULL;
 
@@ -1067,19 +1407,18 @@ static void bdmCleanUp(item_list_t *itemList, int exception)
 // This may be called, even if bdmInit() was not.
 static void bdmShutdown(item_list_t *itemList)
 {
-    char path[16];
-
+    char path[BDM_DEVICE_ROOT_MAX];
     LOG("BDMSUPPORT Shutdown\n");
 
-    // Format the device path.
-    // Getting the device number is only relevant per module ie usb0 and mx40 will result in both being massDeviceIndex = 0 or mass0, use mode to determine instead.
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
     snprintf(path, sizeof(path), "mass%d:", itemList->mode);
 
     // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
-    fileXioDevctl(path, USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+    // pDeviceData may be NULL here (shutdown without init, or a second deinit pass after priv was freed below),
+    // so guard the dereference and fall back to the constructed mass%d: path.
+    fileXioDevctl((pDeviceData != NULL && pDeviceData->bdmDeviceRoot[0] != '\0') ? pDeviceData->bdmDeviceRoot : path, USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
 
-    if (itemList->enabled) {
+    if (itemList->enabled && pDeviceData != NULL) {
         LOG("BDMSUPPORT Shutdown free data\n");
 
         // Free device data.
@@ -1104,7 +1443,7 @@ static char *bdmGetPrefix(item_list_t *itemList)
 static item_list_t bdmGameList = {
     BDM_MODE, 2, 0, 0, MENU_MIN_INACTIVE_FRAMES, BDM_MODE_UPDATE_DELAY, NULL, NULL, &bdmGetTextId, &bdmGetPrefix, &bdmInit, &bdmNeedsUpdate,
     &bdmUpdateGameList, &bdmGetGameCount, &bdmGetGame, &bdmGetGameName, &bdmGetGameNameLength, &bdmGetGameStartup, &bdmDeleteGame, &bdmRenameGame,
-    &bdmLaunchGame, &bdmGetConfig, &bdmGetImage, &bdmCleanUp, &bdmShutdown, &bdmCheckVMC, &bdmGetIconId};
+    &bdmLaunchGame, &bdmGetConfig, &bdmGetImage, &bdmCleanUp, &bdmShutdown, &bdmCheckVMC, &bdmGetIconId, &bdmLaunchVcd};
 
 void bdmInitSemaphore()
 {
@@ -1130,7 +1469,8 @@ void bdmInitDevicesData()
 
             // Setup the per-device data.
             bdm_device_data_t *pDeviceData = (bdm_device_data_t *)malloc(sizeof(bdm_device_data_t));
-            memset(pDeviceData, 0, sizeof(bdm_device_data_t));
+            if (pDeviceData != NULL) // guard the memset on OOM; bdmShutdown tolerates a NULL priv
+                memset(pDeviceData, 0, sizeof(bdm_device_data_t));
             pDeviceSupport->priv = pDeviceData;
         }
     }
@@ -1145,9 +1485,10 @@ void bdmInitDevicesData()
         if (bdmDeviceList[i].owner != NULL) {
             opl_io_module_t *pOwner = (opl_io_module_t *)bdmDeviceList[i].owner;
 
-            if (gBDMStartMode == START_MODE_DISABLED) {
+            int effectiveMode = bdmEffectiveStartMode();
+            if (effectiveMode == START_MODE_DISABLED) {
                 pOwner->menuItem.visible = 0;
-            } else if (gBDMStartMode == START_MODE_MANUAL) {
+            } else if (effectiveMode == START_MODE_MANUAL) {
                 // If BDM has already been started then make the page invisible and reset the bdm tick counter so visibility status is refreshed
                 // according to device state.
                 if (bdmDeviceModeStarted == 1) {
@@ -1155,7 +1496,7 @@ void bdmInitDevicesData()
                     ((bdm_device_data_t *)bdmDeviceList[i].priv)->bdmDeviceTick = -1;
                 } else
                     pOwner->menuItem.visible = (i == 0 ? 1 : 0);
-            } else if (gBDMStartMode == START_MODE_AUTO) {
+            } else if (effectiveMode == START_MODE_AUTO) {
                 pOwner->menuItem.visible = 0;
                 ((bdm_device_data_t *)bdmDeviceList[i].priv)->bdmDeviceTick = -1;
             }
@@ -1200,17 +1541,15 @@ void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData)
         LOG("Mass device %d supports up to UDMA mode %d, limiting to UDMA 4\n", pDeviceData->massDeviceIndex, pDeviceData->ataHighestUDMAMode);
         pDeviceData->ataHighestUDMAMode = 4;
     }
-
-    // Set the UDMA mode to highest available.
-    hddSetTransferMode(0x40, pDeviceData->ataHighestUDMAMode);
 }
 
 int bdmUpdateDeviceData(item_list_t *itemList)
 {
-    char path[16] = {0};
+    char path[BDM_DEVICE_ROOT_MAX + 2] = {0};
+    int driverResult, deviceResult;
 
     // If bdm mode is disabled bail out as we don't want to update the visibility state of the device pages.
-    if (gBDMStartMode == START_MODE_DISABLED)
+    if (bdmEffectiveStartMode() == START_MODE_DISABLED)
         return 0;
 
     // LOG("bdmUpdateDeviceData: %d\n", itemList->mode);
@@ -1220,44 +1559,79 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     int visible = itemList->owner != NULL ? ((opl_io_module_t *)itemList->owner)->menuItem.visible : 0;
 
     // Format the device path and try to open the device.
-    sprintf(path, "mass%d:/", itemList->mode);
+    snprintf(path, sizeof(path), "mass%d:/", itemList->mode);
     int dir = fileXioDopen(path);
     // LOG("opendir %s -> %d\n", path, dir);
 
+    // Device reachable this poll -> clear the debounce miss counter (see the hide branch below).
+    if (dir >= 0)
+        pDeviceData->bdmMissCount = 0;
+
     // If we opened the device and the menu isn't visible (OR is visible but hasn't been initialized ex: manual device start) initialize device info.
-    if (dir >= 0 && (visible == 0 || pDeviceData->bdmPrefix[0] == '\0')) {
-        if (gBDMPrefix[0] != '\0')
-            snprintf(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), "mass%d:%s/", itemList->mode, gBDMPrefix);
-        else
-            snprintf(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), "mass%d:", itemList->mode);
+    if (dir >= 0 && (visible == 0 || pDeviceData->bdmDeviceRoot[0] == '\0' || pDeviceData->bdmDriver[0] == '\0' || pDeviceData->bdmDeviceType == BDM_TYPE_UNKNOWN)) {
+        snprintf(pDeviceData->bdmDeviceRoot, sizeof(pDeviceData->bdmDeviceRoot), "mass%d:", itemList->mode);
+        bdmBuildGamePrefix(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), pDeviceData->bdmDeviceRoot);
+        pDeviceData->FoldersCreated = 0;
+
+        memset(pDeviceData->bdmDriver, 0, sizeof(pDeviceData->bdmDriver));
+        pDeviceData->massDeviceIndex = -1;
+        pDeviceData->bdmDeviceType = BDM_TYPE_UNKNOWN;
+        pDeviceData->bdmHddIsLBA48 = -1;
+        pDeviceData->ataHighestUDMAMode = -1;
 
         // Get the name of the underlying device driver that backs the fat fs.
-        fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &pDeviceData->bdmDriver, sizeof(pDeviceData->bdmDriver) - 1);
-        fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &pDeviceData->massDeviceIndex, sizeof(pDeviceData->massDeviceIndex));
+        driverResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, pDeviceData->bdmDriver, sizeof(pDeviceData->bdmDriver) - 1);
+        deviceResult = -1;
+        if (driverResult >= 0)
+            deviceResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &pDeviceData->massDeviceIndex, sizeof(pDeviceData->massDeviceIndex));
 
         itemList->flags = 0;
 
-        // Determine the bdm device type based on the underlying device driver.
-        if (!strcmp(pDeviceData->bdmDriver, "usb"))
-            pDeviceData->bdmDeviceType = BDM_TYPE_USB;
-        else if (!strcmp(pDeviceData->bdmDriver, "sd") && strlen(pDeviceData->bdmDriver) == 2)
-            pDeviceData->bdmDeviceType = BDM_TYPE_ILINK;
-        else if (!strcmp(pDeviceData->bdmDriver, "sdc") && strlen(pDeviceData->bdmDriver) == 3)
-            pDeviceData->bdmDeviceType = BDM_TYPE_SDC;
-        else if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3) {
-            pDeviceData->bdmDeviceType = BDM_TYPE_ATA;
-            itemList->flags = MODE_FLAG_COMPAT_DMA;
-        } else if (!strcmp(pDeviceData->bdmDriver, "udp"))
-            pDeviceData->bdmDeviceType = BDM_TYPE_UDPBD;
-        else
-            pDeviceData->bdmDeviceType = BDM_TYPE_UNKNOWN;
+        if (driverResult < 0) {
+            LOG("Mass device: %d identity lookup failed for driver name: %d, using %s\n", itemList->mode, driverResult, pDeviceData->bdmDeviceRoot);
+        } else {
+            pDeviceData->bdmDeviceType = bdmDetermineDeviceType(pDeviceData->bdmDriver);
 
-        // If the device is backed by the ATA driver then get the supported LBA size for the drive.
+            if (deviceResult < 0) {
+                LOG("Mass device: %d driver %s failed to report device number: %d, using %s\n", itemList->mode, pDeviceData->bdmDriver, deviceResult, pDeviceData->bdmDeviceRoot);
+            }
+        }
+
         if (pDeviceData->bdmDeviceType == BDM_TYPE_ATA) {
-            bdmResolveLBA_UDMA(pDeviceData);
-            LOG("Mass device: %d (%d LBA%d UDMA%d) %s -> %s\n", itemList->mode, pDeviceData->massDeviceIndex, (pDeviceData->bdmHddIsLBA48 == 1 ? 48 : 28), pDeviceData->ataHighestUDMAMode, pDeviceData->bdmPrefix, pDeviceData->bdmDriver);
-        } else
-            LOG("Mass device: %d (%d) %s -> %s\n", itemList->mode, pDeviceData->massDeviceIndex, pDeviceData->bdmPrefix, pDeviceData->bdmDriver);
+            itemList->flags = MODE_FLAG_COMPAT_DMA;
+        }
+
+        if (pDeviceData->bdmDeviceType == BDM_TYPE_ATA)
+            LOG("Mass device: %d (%d) ATA device %s (compat root %s)\n", itemList->mode, pDeviceData->massDeviceIndex, pDeviceData->bdmPrefix, pDeviceData->bdmDeviceRoot);
+        else if (pDeviceData->bdmDriver[0] != '\0')
+            LOG("Mass device: %d (%d) %s -> %s (compat root %s)\n", itemList->mode, pDeviceData->massDeviceIndex, pDeviceData->bdmPrefix, pDeviceData->bdmDriver, pDeviceData->bdmDeviceRoot);
+        else
+            LOG("Mass device: %d using generic BDM path %s\n", itemList->mode, pDeviceData->bdmPrefix);
+
+        // Publish-time enable gate (#120 audit F-13): the visible-page filter in bdmNeedsUpdate only
+        // hides a page that is ALREADY showing, i.e. one refresh pass too late. Without this gate a
+        // mounted slot on a DISABLED transport (e.g. an ATA-backed mass slot left over from the
+        // boot-resolver escalation or a BDMA-equip force-load, with BDM HDD OFF) flashes its tab,
+        // plays the connect sound and folder-writes the device on every BdmGeneration bump. Identity
+        // stays populated above: the BDMA equip and the device pickers read it through
+        // bdmGetDeviceSlotsByType/bdmReadDeviceIdentity independent of page visibility.
+        if (bdmTransportEnabled(pDeviceData->bdmDeviceType) == 0) {
+            LOG("bdmUpdateDeviceData: device %d is %s-backed but that transport is disabled; not publishing\n",
+                itemList->mode, pDeviceData->bdmDriver);
+            fileXioDclose(dir);
+            return 0;
+        }
+
+        // An EXPLICIT BDM = Off is only overridden by the UDPBD floor (bdmEffectiveStartMode) so
+        // the selected UDPBD protocol can publish ITS tab -- every other transport's page stays
+        // hidden exactly as the user asked (their sticks would otherwise resurface with the dialog
+        // still showing "Off").
+        if (gBDMStartMode == START_MODE_DISABLED && pDeviceData->bdmDeviceType != BDM_TYPE_UDPBD) {
+            LOG("bdmUpdateDeviceData: device %d withheld -- BDM is explicitly Off (UDPBD floor active)\n",
+                itemList->mode);
+            fileXioDclose(dir);
+            return 0;
+        }
 
         // Make the menu item visible.
         if (itemList->owner != NULL) {
@@ -1269,6 +1643,15 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         fileXioDclose(dir);
         return 1;
     } else if (dir < 0 && visible == 1) {
+        // Device open failed while the page is showing. For a network-backed device (UDPBD/UDPFS) one
+        // missed poll is usually a transient stall, not a real removal -- debounce so the tab doesn't
+        // flicker away on a blip. Local devices (USB/SDC/ATA) hide on the first miss = a real unplug.
+        int hideThreshold = (pDeviceData->bdmDeviceType == BDM_TYPE_UDPBD) ? BDM_NET_HIDE_MISSES : 1;
+        if (++pDeviceData->bdmMissCount < hideThreshold) {
+            LOG("bdmUpdateDeviceData: device %d miss %d/%d (debounce, keeping page)\n", itemList->mode, pDeviceData->bdmMissCount, hideThreshold);
+            return 0; // within the grace window -- keep the page, re-poll next cycle
+        }
+
         // Device has been removed, make the menu item invisible. We can't really cleanup resources (like the game list) just yet
         // as we don't know if the data is being used asynchronously.
         if (itemList->owner != NULL) {
@@ -1276,6 +1659,8 @@ int bdmUpdateDeviceData(item_list_t *itemList)
             ((opl_io_module_t *)itemList->owner)->menuItem.visible = 0;
         }
 
+        pDeviceData->FoldersCreated = 0;
+        pDeviceData->bdmMissCount = 0;
         LOG("Mass device: %d (%d) disconnected\n", itemList->mode, pDeviceData->massDeviceIndex);
         return -1;
     }
@@ -1327,6 +1712,291 @@ static int bdmDeviceIsPresent(int deviceId)
     return 0;
 }
 
+// Load the block-device transport driver for one BDM type, IGNORING the gEnable* config gates (the
+// callers exist precisely because the wanted device may not be enabled for games -- or, for the boot-dir
+// resolver, because the config that holds the gates cannot be read until the transport is up). Caller
+// must hold bdmLoadModuleLock. Idempotent. Returns 1 when the transport is (already) loaded, 0 on
+// failure or an unsupported type. MMCE is a separate subsystem with its own namespace + loader.
+static int bdmEnsureTransportLoaded(int bdmType)
+{
+    switch (bdmType) {
+        case BDM_TYPE_USB:
+            if (!iUSBModLoaded && bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx) >= 0)
+                iUSBModLoaded = 1;
+            return iUSBModLoaded;
+        case BDM_TYPE_SDC:
+            if (!mx4sioModLoaded && bdmLoadOptionalModule("MX4SIO_BD", &mx4sio_bd_irx, size_mx4sio_bd_irx) >= 0)
+                mx4sioModLoaded = 1;
+            return mx4sioModLoaded;
+        case BDM_TYPE_ILINK:
+            if (!iLinkModLoaded) {
+                if (!iLinkManModLoaded && bdmLoadOptionalModule("ILINKMAN", &iLinkman_irx, size_iLinkman_irx) >= 0)
+                    iLinkManModLoaded = 1;
+                if (iLinkManModLoaded && !ieee1394ModLoaded && bdmLoadOptionalModule("IEEE1394_BD", &IEEE1394_bd_irx, size_IEEE1394_bd_irx) >= 0)
+                    ieee1394ModLoaded = 1;
+                iLinkModLoaded = iLinkManModLoaded && ieee1394ModLoaded;
+            }
+            return iLinkModLoaded;
+        case BDM_TYPE_ATA:
+            if (!hddModLoaded && hddLoadModulesReady())
+                hddModLoaded = 1;
+            return hddModLoaded;
+        default:
+            return 0;
+    }
+}
+
+// Ensure the BDM transport for a BDMA source type is loaded AND a device of that type is mounted, so
+// the equip can read modules from a source device even when that device family is NOT enabled for games
+// (e.g. BDMA files kept on a USB stick you never browse). Force-loads the driver -- the games tab stays
+// hidden because bdmNeedsUpdate gates page visibility on gEnable* independently -- then waits up to
+// timeoutMs for the just-loaded device to mount. Idempotent + instant when the transport is already up.
+// Returns 1 if a device of the type is present afterwards, 0 otherwise.
+int bdmEnsureSourceModules(int bdmType, u32 timeoutMs)
+{
+    int wasLoaded;
+    char root[BDM_DEVICE_ROOT_MAX + 2];
+    // u64, NOT u32: GetTimerSystemTime() returns a u64 bus-clock count that passes 2^32 after ~29 s of
+    // uptime. Truncating the start into a u32 while subtracting it from the full u64 makes the elapsed
+    // math explode on the first check for any call after that -- the wait budget silently collapses.
+    u64 start;
+
+    WaitSema(bdmLoadModuleLock);
+    switch (bdmType) {
+        case BDM_TYPE_USB:
+            wasLoaded = iUSBModLoaded;
+            break;
+        case BDM_TYPE_SDC:
+            wasLoaded = mx4sioModLoaded;
+            break;
+        case BDM_TYPE_ILINK:
+            wasLoaded = iLinkModLoaded;
+            break;
+        case BDM_TYPE_ATA:
+            wasLoaded = hddModLoaded;
+            break;
+        default:
+            SignalSema(bdmLoadModuleLock);
+            return 0;
+    }
+    bdmEnsureTransportLoaded(bdmType);
+    SignalSema(bdmLoadModuleLock);
+
+    // Already loaded -> any connected device is already mounted, so the first probe returns with no stall
+    // (and if nothing is connected we bail immediately). Just loaded -> poll until the IOP detects and
+    // mounts the device, or timeoutMs elapses.
+    start = GetTimerSystemTime();
+    while (!bdmGetDeviceRootByType(bdmType, root, sizeof(root))) {
+        if (wasLoaded)
+            return 0;
+        if ((GetTimerSystemTime() - start) / (kBUSCLK / 1000) > timeoutMs)
+            return 0;
+        DelayThread(100 * 1000);
+    }
+    return 1;
+}
+
+// True when the booted ELF's own folder exists on mass<slot>: -- the weak boot-device evidence.
+static int bdmBootDirPresent(int slot, const char *tail)
+{
+    char path[288];
+    int dir;
+
+    if (tail[0] == '\0')
+        snprintf(path, sizeof(path), "mass%d:/", slot);
+    else if (tail[0] == '/')
+        snprintf(path, sizeof(path), "mass%d:%s", slot, tail);
+    else
+        snprintf(path, sizeof(path), "mass%d:/%s", slot, tail);
+
+    dir = fileXioDopen(path);
+    if (dir < 0)
+        return 0;
+    fileXioDclose(dir);
+    return 1;
+}
+
+// True when the booted ELF itself exists at <tail>/<elfName> on mass<slot>: -- the definitive
+// boot-device evidence (OPL is running from that very file).
+static int bdmBootElfPresent(int slot, const char *tail, const char *elfName)
+{
+    char path[320];
+    int fd;
+
+    if (tail[0] == '\0' || tail[0] == '/')
+        snprintf(path, sizeof(path), "mass%d:%s/%s", slot, tail, elfName);
+    else
+        snprintf(path, sizeof(path), "mass%d:/%s/%s", slot, tail, elfName);
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return 0;
+    close(fd);
+    return 1;
+}
+
+// Rewrite ONLY the device prefix of the boot dir, preserving the boot folder ("ata0:/APPS" ->
+// "mass1:/APPS"). tail points INTO bootDir, so compose into a local buffer before writing back.
+static void bdmRewriteBootDir(char *bootDir, int bootDirSize, int slot, const char *tail)
+{
+    char resolved[256];
+
+    if (tail[0] == '\0' || tail[0] == '/')
+        snprintf(resolved, sizeof(resolved), "mass%d:%s", slot, tail);
+    else
+        snprintf(resolved, sizeof(resolved), "mass%d:/%s", slot, tail);
+
+    snprintf(bootDir, bootDirSize, "%s", resolved);
+}
+
+// Resolve a boot directory that names a BDM device into that device's mounted massN: filesystem root,
+// force-loading whatever driver stack the boot device needs FIRST. Called from the deferred config
+// load -- after ioInit()/bdmInitSemaphore(), before the first configReadMulti() -- because at boot time
+// the IOP has NO BDM modules at all (sysReset loads none; the BDM page only loads them on tab entry),
+// so a "mass0:/APPS" or "ata0:/APPS" boot dir is unreadable exactly when settings must load. Two input
+// families are handled:
+//   - launch-binding identities (usb0:/ilink0:/sd0:/mx4sio0:/sdc0:/ata0:) -- device names with no
+//     filesystem OPL reads; remapped to the SAME device's massN: mount.
+//   - massN:/mass: -- the right namespace, but the launcher's slot numbering need not match OPL's (and
+//     the device isn't mounted yet); verified/renumbered by probing for the booted ELF itself.
+// elfName (argv[0]'s basename; may be empty for a getcwd()-derived boot dir) anchors the verification:
+// the slot that actually holds <tail>/<elfName> IS the boot device, immune to slot renumbering. The
+// gEnable* config flags are deliberately ignored when loading transports -- the config is precisely
+// what cannot be read yet (the exFAT-HDD chicken-and-egg: mounting it needs gEnableBdmHDD, which lives
+// in the unreadable config); the caller reconciles the flags after the config loads.
+// *ioBdmType is in/out: pass the boot device's BDM_TYPE_* when already known (the save-path re-resolve)
+// to pin the search to that transport, or BDM_TYPE_UNKNOWN to classify from the prefix; on success it
+// holds the resolved device's type.
+// Returns 1 with bootDir rewritten in place on success; 0 when bootDir is not a BDM path (left
+// untouched -- mc/mmce/host/pfs/hdd/... prefixes are not ours); -1 when the boot device never mounted
+// within the budget (bootDir left untouched -- the caller drops it so legacy discovery re-arms).
+int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType)
+{
+    char stem[16];
+    int unit;
+
+    // *ioBdmType must never ERASE the caller's knowledge of the boot device's type -- the save-path
+    // retry keys on it. It is written on success, and also on the -1 (never-mounted) paths with the
+    // PREFIX CLASSIFICATION: that is not an erase (for an untyped massN: boot filterType IS knownType,
+    // so it round-trips unchanged; for a typed usb0:/ata0:/... boot the prefix is authoritative). This
+    // matters now that a failed resolve KEEPS the boot dir instead of dropping it to legacy discovery:
+    // the caller zeroes this to UNKNOWN before every call, so without writing it back a slow-to-mount
+    // boot device left gBootDirBdmType == UNKNOWN and _saveConfig's re-resolve-and-retry -- gated on
+    // exactly that -- could never fire, so the settings never reached the device once it did mount
+    // (CodeRabbit review of #202).
+    int knownType = *ioBdmType;
+
+    if (!bdmParseBootStem(bootDir, stem, sizeof(stem), &unit))
+        return 0;
+
+    int isMass = (strcmp(stem, "mass") == 0);
+    int filterType = isMass ? knownType : bdmDetermineDeviceType(stem);
+    if (!isMass && filterType == BDM_TYPE_UNKNOWN)
+        return 0; // mc/mmce/host/pfs/hdd/cdrom/... -- not a BDM boot path, leave it alone
+    if (filterType == BDM_TYPE_UDPBD) {
+        *ioBdmType = filterType; // keep the classification so a later save retry stays pinned to it
+        return -1;               // network block device: no local mount to resolve at config-load time
+    }
+
+    const char *tail = strchr(bootDir, ':') + 1; // "" | "/APPS" | "APPS" (bdmParseBootStem proved the ':')
+    // The boot token's unit digit doubles as the scan-order hint for BOTH families: mass1: names the
+    // slot outright, and a typed usb1:/ata1: unit usually tracks same-type enumeration order too.
+    int literalSlot = (unit >= 0 && unit < MAX_BDM_DEVICES) ? unit : 0;
+    int haveElf = (elfName != NULL && elfName[0] != '\0');
+
+    // Bring-up: the BDM core (bdm.irx + bdmfs_fatfs + hotplug events; idempotent -- every bdmInit calls
+    // it too) plus the transport(s) the boot prefix implies. An untyped massN: names the shared BDM
+    // filesystem, not a transport, so start with the cheap common ones (USB, MX4SIO) and only escalate
+    // to iLink + the ATA stack (iLinkman is known to break PCSX2, where a virtual-USB mass: boot is
+    // possible; ATA means dev9 power + drive spin-up) if nothing turns up holding the boot folder.
+    bdmLoadModules();
+    WaitSema(bdmLoadModuleLock);
+    if (filterType != BDM_TYPE_UNKNOWN) {
+        bdmEnsureTransportLoaded(filterType);
+    } else {
+        bdmEnsureTransportLoaded(BDM_TYPE_USB);
+        bdmEnsureTransportLoaded(BDM_TYPE_SDC);
+    }
+    SignalSema(bdmLoadModuleLock);
+
+    u32 budgetMs = (filterType == BDM_TYPE_ATA) ? 10000 : 3000; // ATA = dev9 power-up + platter spin-up
+    int escalated = (filterType != BDM_TYPE_UNKNOWN);           // typed searches never escalate
+    // u64: GetTimerSystemTime() passes 2^32 bus ticks ~29 s after boot; a u32 start would make every
+    // POST-BOOT resolve (the _saveConfig hotplug retry, a settings reload) compute a bogus huge elapsed
+    // and give up after a single scan instead of waiting the budget out.
+    u64 start = GetTimerSystemTime();
+
+    for (;;) {
+        int matchSlot = -1, fallbackSlot = -1;
+        int matchType = BDM_TYPE_UNKNOWN, fallbackType = BDM_TYPE_UNKNOWN;
+
+        for (int scan = 0; scan < MAX_BDM_DEVICES; scan++) {
+            // Probe the boot dir's LITERAL slot first, then the rest in order: with duplicate OPL
+            // installs on two same-type devices the ELF probe matches both, and first-match-wins
+            // must prefer the slot the launcher actually named over an arbitrary lower one.
+            int i = (scan == 0) ? literalSlot : (scan <= literalSlot ? scan - 1 : scan);
+            char path[16], driver[32];
+            int devIndex = -1;
+
+            snprintf(path, sizeof(path), "mass%d:/", i);
+            bdmReadDeviceIdentity(path, driver, sizeof(driver), &devIndex);
+            if (driver[0] == '\0')
+                continue; // slot not mounted (yet)
+
+            int slotType = bdmDetermineDeviceType(driver);
+            if (filterType != BDM_TYPE_UNKNOWN && slotType != filterType)
+                continue; // wrong device family for a typed/pinned search
+
+            if (haveElf && bdmBootElfPresent(i, tail, elfName)) {
+                matchSlot = i; // definitive: the ELF we are running from is right here
+                matchType = slotType;
+                break;
+            }
+            int dirOk = bdmBootDirPresent(i, tail);
+            if (!haveElf && dirOk && (!isMass || i == literalSlot)) {
+                matchSlot = i; // getcwd-derived boot dir: folder presence is the best evidence there is
+                matchType = slotType;
+                break;
+            }
+            if (fallbackSlot < 0 && dirOk && (!isMass || i == literalSlot)) {
+                fallbackSlot = i; // boot folder exists but the ELF probe missed -- hold as weak fallback
+                fallbackType = slotType;
+            }
+        }
+
+        if (matchSlot >= 0) {
+            *ioBdmType = matchType;
+            bdmRewriteBootDir(bootDir, bootDirSize, matchSlot, tail);
+            return 1;
+        }
+
+        if ((GetTimerSystemTime() - start) / (kBUSCLK / 1000) > budgetMs) {
+            if (fallbackSlot >= 0) {
+                *ioBdmType = fallbackType;
+                bdmRewriteBootDir(bootDir, bootDirSize, fallbackSlot, tail);
+                return 1;
+            }
+            if (!escalated) {
+                // Nothing cheap matched a massN: boot dir -- the boot device may be the internal exFAT
+                // HDD handed in massN: form (HDD-OSD launchers do this) or an iLink drive. One
+                // escalation: the remaining transports, with extra budget for ATA spin-up.
+                escalated = 1;
+                WaitSema(bdmLoadModuleLock);
+                bdmEnsureTransportLoaded(BDM_TYPE_ILINK);
+                bdmEnsureTransportLoaded(BDM_TYPE_ATA);
+                SignalSema(bdmLoadModuleLock);
+                budgetMs += 8000;
+                continue;
+            }
+            *ioBdmType = filterType; // never mounted in time, but keep the classification: the caller
+                                     // now KEEPS the boot dir, and _saveConfig's retry is gated on this
+                                     // being != UNKNOWN (see the header comment)
+            return -1;
+        }
+        DelayThread(100 * 1000);
+    }
+}
+
 static int bdmDeviceIsATA(int deviceId)
 {
     char path[16];
@@ -1337,7 +2007,13 @@ static int bdmDeviceIsATA(int deviceId)
     if (dir < 0)
         return 0;
 
-    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &data.bdmDriver, sizeof(data.bdmDriver) - 1);
+    /* Zero the buffer before the ioctl: if the call fails, strcmp would read
+     * uninitialised stack bytes. Pattern mirrors bdmReadDeviceIdentity(). */
+    memset(&data.bdmDriver, 0, sizeof(data.bdmDriver));
+    if (fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &data.bdmDriver, sizeof(data.bdmDriver) - 1) < 0) {
+        fileXioDclose(dir);
+        return 0;
+    }
     fileXioDclose(dir);
 
     return (!strcmp(data.bdmDriver, "ata") && strlen(data.bdmDriver) == 3);
@@ -1367,7 +2043,7 @@ int bdmHDDIsPresent(u32 timeoutMs)
         return 1;
 
     // 2. try to scan as fast as possible if the previous scan fails...
-    hdd_id = 0;
+    hdd_id = -1;
 
     for (int i = 0; i < MAX_BDM_DEVICES; i++) {
         // find the first inaccessible device - this one should be the HDD once it's mounted (we don't have access to device data at this point yet!)
@@ -1377,7 +2053,11 @@ int bdmHDDIsPresent(u32 timeoutMs)
         }
     }
 
-    if (bdmWaitForDevice(hdd_id, timeoutMs)) {
+    if (hdd_id < 0) {
+        // All slots are already accessible; no inaccessible slot to poll.
+        // Skip the targeted wait and rescan immediately.
+        timedout = 1;
+    } else if (bdmWaitForDevice(hdd_id, timeoutMs)) {
         // double-check to see if this indeed is the HDD, and if it is, we can exit early without stalling any further
         if (bdmDeviceIsATA(hdd_id)) {
             return 1;
@@ -1391,9 +2071,66 @@ int bdmHDDIsPresent(u32 timeoutMs)
     // 3. last resort - time out (if needed) and scan again...
     if (!timedout) {
         // if we haven't timed out already, then we need to wait for the devices to wake up... wait for the timeout...
-        LOG("bdmHDDIsPresent: waiting for timeout before scanning again...\n", hdd_id);
+        LOG("bdmHDDIsPresent: waiting for timeout before scanning again (id %d)...\n", hdd_id);
         DelayThread(timeoutMs * 1000);
     }
 
     return bdmGetATADeviceId() >= 0;
+}
+
+
+int bdmFindPartition(char *target, const char *name, int write)
+{
+    int i, fd;
+    char path[256];
+
+    /* Probe massN:/<prefix>/<name> on each BDM device for the config file, and
+     * return the matching device directory prefix in target so configInit()/
+     * configSetMove() can compose "<target>/<filename>".  The format strings
+     * MUST carry %d/%s specifiers: the previous version used literal "mass0:/"
+     * strings with leftover varargs, which the compiler silently discards, so
+     * the loop never iterated devices and the prefix/filename were never
+     * appended (BDM per-device config load/save was non-functional and only
+     * ever touched mass0's root).  gBDMPrefix is a bounded folder name
+     * (char[32]) and target buffers are 64 bytes, so the device-prefix writes
+     * cannot overflow. */
+    for (i = 0; i < MAX_BDM_DEVICES; i++) {
+        if (gBDMPrefix[0] != '\0')
+            snprintf(path, sizeof(path), "mass%d:/%s/%s", i, gBDMPrefix, name);
+        else
+            snprintf(path, sizeof(path), "mass%d:/%s", i, name);
+        if (write) {
+            /* O_CREAT makes the config FILE but never the gBDMPrefix FOLDER.  On a freshly
+             * formatted drive (e.g. an exFAT HDD whose OPL folder doesn't exist yet) the very
+             * first save would therefore fail with the folder absent, and only start working
+             * once sbCreateFolders() happened to create it on a later device refresh -- exactly
+             * the "save errored, then saved fine after a try or two" symptom.  Create the prefix
+             * directory up front (mkdir is a harmless no-op when it already exists) so the first
+             * save succeeds.  Probe with O_CREAT but WITHOUT O_TRUNC: this open only tests for a
+             * writable device, so it must never truncate an existing config -- configWrite()
+             * truncates when it actually commits the data. */
+            if (gBDMPrefix[0] != '\0') {
+                char dir[256];
+                snprintf(dir, sizeof(dir), "mass%d:/%s", i, gBDMPrefix);
+                mkdir(dir, 0777);
+            }
+            fd = open(path, O_WRONLY | O_CREAT, 0666);
+        } else
+            fd = open(path, O_RDONLY);
+
+        if (fd >= 0) {
+            if (gBDMPrefix[0] != '\0')
+                sprintf(target, "mass%d:/%s", i, gBDMPrefix);
+            else
+                sprintf(target, "mass%d:", i);
+            close(fd);
+            return 1;
+        }
+    }
+
+    if (gBDMPrefix[0] != '\0')
+        sprintf(target, "mass0:/%s", gBDMPrefix);
+    else
+        sprintf(target, "mass0:");
+    return 0;
 }

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -3,6 +3,7 @@
 #include "include/gui.h"
 #include "include/supportbase.h"
 #include "include/ethsupport.h"
+#include "include/vcdsupport.h"
 #include "include/util.h"
 #include "include/renderman.h"
 #include "include/themes.h"
@@ -11,8 +12,9 @@
 #include "include/system.h"
 #include "include/extern_irx.h"
 #include "include/cheatman.h"
-#include "include/udpfssupport.h" // udpfsGetModulesLoaded() for the SMB<->UDPFS-filesystem NIC interlock
 #include "include/bdmsupport.h"   // bdmIsUDPBDLoaded() for the SMB<->UDPBD NIC interlock
+#include "include/udpfssupport.h" // udpfsGetModulesLoaded() for the SMB<->UDPFS-filesystem NIC interlock
+#include "include/mmcesupport.h"  // mmceSendGameID() cross-device game-id (#261)
 #include "modules/iopcore/common/cdvd_config.h"
 
 #define NEWLIB_PORT_AWARE
@@ -213,7 +215,7 @@ static int ethInitApplyConfig(void)
         }
     } while (ethApplyNetIFConfig() != 0);
 
-    // Before the network configuration is applied, wait for a valid link status.
+    // Wait for the link to re-establish after applying the NIF link-mode setting.
     if (ethWaitValidNetIFLinkState() != 0) {
         gNetworkStartup = ERROR_ETH_LINK_FAIL;
         return ERROR_ETH_LINK_FAIL;
@@ -316,10 +318,11 @@ static int ethLoadModules(void)
                     LOG("[PS2IPS]:\n");
                     sysLoadModuleBuffer(&ps2ips_irx, size_ps2ips_irx, 0, NULL);
                     LOG("[HTTPCLIENT]:\n");
-                    sysLoadModuleBuffer(&httpclient_irx, size_httpclient_irx, 0, NULL);
+                    if (sysLoadModuleBuffer(&httpclient_irx, size_httpclient_irx, 0, NULL) >= 0) {
+                        if (HttpInit() < 0)
+                            LOG("ETHSUPPORT: httpclient RPC bind failed; compat update unavailable\n");
+                    }
                     ps2ip_init();
-                    HttpInit();
-
                     LOG("ETHSUPPORT Modules loaded\n");
                     return 0;
                 }
@@ -422,8 +425,22 @@ static void smbLoadModules(void)
 
     if (ret == 0) {
         gNetworkStartup = ERROR_ETH_MODULE_SMBMAN_FAILURE;
-        LOG("[SMBMAN]:\n");
-        if (sysLoadModuleBuffer(&smbman_irx, size_smbman_irx, 0, NULL) >= 0) {
+        /*
+          Load ONE SMB filesystem driver, chosen by the SMB Version picker. Both register the same
+          iomanX device name ("smb", hence the "smb0:" paths everywhere), so only one may ever be
+          resident -- and every path in OPL stays identical whichever one it is.
+
+            smbman  -- PS2SDK's SMB1 driver, consumed prebuilt. Unchanged, still the default.
+            smb2man -- our SMB2/SMB3 driver over vendored libsmb2 (modules/network/smb2man).
+
+          Anything other than an explicit SMB2 selection falls back to smbman: losing SMB2 is
+          recoverable, booting with no filesystem driver at all is not.
+        */
+        // NOTE(rebuild): SMB2 (smb2man + gSMBDialect) returns with checklist item 4 -- until then
+        // this build speaks SMBv1 unconditionally, exactly like every pre-dialect build.
+        const int useSmb2 = 0;
+        LOG(useSmb2 ? "[SMB2MAN]:\n" : "[SMBMAN]:\n");
+        if (sysLoadModuleBuffer((void *)&smbman_irx, size_smbman_irx, 0, NULL) >= 0) {
             LOG("[NBNS]:\n");
             sysLoadModuleBuffer(&nbns_irx, size_nbns_irx, 0, NULL);
             nbnsInit();
@@ -456,7 +473,7 @@ void ethInit(item_list_t *itemList)
         ethModifiedDVDPrev = 0;
         ethGameCount = 0;
         ethGames = NULL;
-        configGetInt(configGetByType(CONFIG_OPL), "eth_frames_delay", &ethGameList.delay);
+        ethGameList.delay = gArtDelay;
         gNetworkStartup = ERROR_ETH_NOT_STARTED;
         ioPutRequest(IO_CUSTOM_SIMPLEACTION, &smbLoadModules);
         ethGameList.enabled = 1;
@@ -475,6 +492,13 @@ static int ethNeedsUpdate(item_list_t *itemList)
     int result;
 
     result = 0;
+
+    // VCD view: force a rescan once on toggle; once a share is selected, the VCD list refreshes on
+    // toggle only (skip disc heuristics). With no share yet, fall through so the share list updates.
+    if (vcdConsumeDirty(itemList->mode))
+        return 1;
+    if (gPCShareName[0] && vcdViewActive(itemList->mode))
+        return 0;
 
     if (ethULSizePrev == -2)
         result = 1;
@@ -512,7 +536,13 @@ static int ethUpdateGameList(item_list_t *itemList)
         if (gNetworkStartup != 0)
             return 0;
 
-        if ((sbReadList(&ethGames, ethPrefix, /* sub: */ NULL, &ethULSizePrev, &ethGameCount)) < 0) {
+        if (vcdViewActive(itemList->mode)) {
+            int r = vcdFillGameList(ethPrefix, &ethGames);
+            if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
+                ethGameCount = r;
+            // NULL sub opts SMB/ETH out of folder-row collection: it uses a "\\" separator and does not
+            // participate in folder browsing (see the folderlist gate in sbReadList).
+        } else if ((sbReadList(&ethGames, ethPrefix, /* sub: */ NULL, &ethULSizePrev, &ethGameCount)) < 0) {
             gNetworkStartup = ERROR_ETH_SMB_LISTGAMES;
             ethDisplayErrorStatus();
         }
@@ -531,6 +561,10 @@ static int ethUpdateGameList(item_list_t *itemList)
         if (count > 0) {
             free(ethGames);
             ethGames = (base_game_info_t *)malloc(sizeof(base_game_info_t) * count);
+            // On allocation failure, skip population so the loop below never
+            // dereferences NULL; ethGameCount is then set to 0 after the loop.
+            if (ethGames == NULL)
+                count = 0;
             for (i = 0; i < count; i++) {
                 LOG("ETHSUPPORT Share found: %s\n", sharelist[i].ShareName);
                 base_game_info_t *g = &ethGames[i];
@@ -544,7 +578,11 @@ static int ethUpdateGameList(item_list_t *itemList)
                 g->sizeMB = 0;
             }
             ethGameCount = count;
-        } else if (count < 0) {
+        } else if (count == 0) {
+            free(ethGames);
+            ethGames = NULL;
+            ethGameCount = 0;
+        } else {
             gNetworkStartup = ERROR_ETH_SMB_LISTSHARES;
             ethDisplayErrorStatus();
         }
@@ -577,6 +615,9 @@ static int ethGetGameNameLength(item_list_t *itemList, int id)
 
 static char *ethGetGameStartup(item_list_t *itemList, int id)
 {
+    // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
+    if (vcdViewActive(itemList->mode))
+        return ethGames[id].name;
     return ethGames[id].startup;
 }
 
@@ -592,6 +633,37 @@ static void ethRenameGame(item_list_t *itemList, int id, char *newName)
     ethULSizePrev = -2;
 }
 
+// Launch a PS1/.VCD entry BY NAME via POPSTARTER over SMB (view-independent entry point: the in-view
+// menu launch below and the Favourites tab both use it). ethPrefix is static and smb: paths use '\'
+// (auto-detected by vcdSep); UNMOUNT_EXCEPTION keeps the share mounted across the IOP reset.
+static void ethLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_t *configSet)
+{
+    char vcdElf[256], vcdSelector[320];
+
+    if (!gPCShareName[0] || vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
+        return;
+    if (!vcdResolvePopstarter(ethPrefix, vcdElf, sizeof(vcdElf))) {
+        guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    // Fill every missing external from this share's direct POPS/ folder, including optional icons
+    // and utility IRX even when the required network stack was already complete. SMB keeps its hard
+    // gate: all four network modules must exist after this best-effort install.
+    (void)vcdInstallPopstarterMc(ethPrefix);
+    if (!vcdSmbModulesPresent()) {
+        guiMsgBox(_l(_STR_POPSTARTER_SMB_MISSING), 0, NULL);
+        return;
+    }
+    vcdBuildSelector(ethPrefix, VCD_PREFIX_SMB, vcdName, vcdSelector, sizeof(vcdSelector));
+    size_t prefixLen = strlen(ethPrefix);
+    char separator = (prefixLen > 0 && ethPrefix[prefixLen - 1] == '\\') ? '\\' : '/';
+    char vcdFullPath[256];
+    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS%c%s.VCD", ethPrefix, separator, vcdName);
+    vcdPrepareRetroGemBarcode(vcdFullPath);
+    deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the SMB mount alive across the IOP reset
+    sysLaunchPopstarter(vcdElf, vcdSelector);
+}
+
 static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 {
     int i, compatmask;
@@ -603,6 +675,12 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
     u32 layer1_start, layer1_offset;
     unsigned short int layer1_part;
 
+    // VCD view (SMB): hand off to POPSTARTER by name, only once a share is selected.
+    if (gPCShareName[0] && game != NULL && vcdViewActive(itemList->mode)) {
+        ethLaunchVcd(itemList, game->name, configSet);
+        return;
+    }
+
     if (!gPCShareName[0]) {
         memcpy(gPCShareName, game->name, sizeof(gPCShareName));
         ethULSizePrev = -2;
@@ -611,6 +689,20 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
         ioPutRequest(IO_CUSTOM_SIMPLEACTION, &ethInitSMB);
         ioPutRequest(IO_MENU_UPDATE_DEFFERED, &ethGameList.mode); // reload the game list
         return;
+    }
+
+    // $CoreLoader honesty: SMB has no Neutrino launch leg (nothing here builds -bsd/-dvd args),
+    // so a per-game Neutrino selection -- or a Neutrino global default -- silently resolves to the
+    // OPL core. Toast once at launch instead of leaving the setting looking honored. Pre-deinit,
+    // so the toast renders; the launch then proceeds normally. Covers Favourites-origin launches
+    // too (they delegate to this leg), which the compat-dialog lock in guigame.c cannot reach.
+    {
+        int coreLoader = gDefaultCoreLoader;
+        configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+        if (coreLoader == 2)                 // "Default" sentinel: the dialog never persists it (index 2 removes the
+            coreLoader = gDefaultCoreLoader; // key), but a hand-edited cfg can carry it (Gemini, #161)
+        if (coreLoader)
+            guiWarning(_l(_STR_NEUTRINO_SMB_FALLBACK), 6);
     }
 
     char vmc_name[32];
@@ -660,14 +752,13 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
     compatmask = sbPrepare(game, configSet, size_smb_cdvdman_irx, smb_cdvdman_irx, &i);
 
     if ((result = sbLoadCheats(ethPrefix, game->startup)) < 0) {
-        switch (result) {
-            case -ENOENT:
-                guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
-                break;
-            default:
-                guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-        }
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        // `settings` is not assigned until below, so derive the common block from the IRX base.
+        if (!sbCheatsMissingContinue((u8 *)(&smb_cdvdman_irx) + i, result))
+            return;
     }
+    sbLoadImage(ethPrefix, game->startup);
 
     settings = (struct cdvdman_settings_smb *)((u8 *)(&smb_cdvdman_irx) + i);
 
@@ -682,6 +773,21 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
             snprintf(settings->filename, sizeof(settings->filename), "ul.%08X.%s", USBA_crc32(game->name), game->startup);
             settings->common.flags |= IOPCORE_SMB_FORMAT_USBLD;
     }
+
+    /*
+      Hand the chosen dialect to the in-game reader. smbdisp.c reads these bits once, at negotiate
+      time, to pick between smb.c (SMB1) and smb2.c (SMB2).
+
+      They live in common.flags because cdvdman_settings_smb's SMB fields share a union with FIDs[]
+      and cannot grow; common.flags already carries IOPCORE_SMB_FORMAT_USBLD for the same reason.
+      Note this must come AFTER the format switch above, which also ORs into common.flags.
+
+      Only SMB1/SMB2 are emitted -- gSMBDialect is clamped to those on load, and the picker offers
+      no third value. Leaving the bits clear for SMB1 keeps the wire format identical to every
+      build that predates the dialect field.
+    */
+    // NOTE(rebuild): the in-game SMB2 dialect flag (IOPCORE_SMB_DIALECT_V2) returns with item 4;
+    // leaving the bits clear keeps the wire format identical to every pre-dialect build.
 
     sprintf(settings->smb_ip, "%u.%u.%u.%u", pc_ip[0], pc_ip[1], pc_ip[2], pc_ip[3]);
     settings->smb_port = gPCPort;
@@ -725,7 +831,10 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
 
     if (configGetStrCopy(configSet, CONFIG_ITEM_ALTSTARTUP, filename, sizeof(filename)) == 0)
         strcpy(filename, game->startup);
-    deinit(NO_EXCEPTION, ETH_MODE); // CAREFUL: deinit will call ethCleanUp, so ethGames/game will be freed
+    // MMCE cross-device game-id (#261): push the disc id to a present MMCE card before the SMB teardown
+    // (self-probes mmce0/mmce1; no-ops if no card / feature off). Read `game` before deinit frees it.
+    mmceSendGameID(game->startup, NULL, 0); // SMB has no Neutrino branch -> nothing to protect, no -mc args
+    deinit(NO_EXCEPTION, ETH_MODE);         // CAREFUL: deinit will call ethCleanUp, so ethGames/game will be freed
 
     settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;
     settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_SMAP;
@@ -744,11 +853,19 @@ static config_set_t *ethGetConfig(item_list_t *itemList, int id)
 static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     char path[256];
+
+    // OPL's own ART\<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
+    // with a strict PS1 ID).
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s\\%s_%s", ethPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1);
+    int r = texDiscoverLoad(resultTex, path, -1);
+    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD.
+    // ethPrefix ends in '\\', so vcdLoadPopsCover auto-detects the SMB separator. Cover/icon, VCD view only.
+    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode))
+        r = vcdLoadPopsCover(ethPrefix, value, suffix, resultTex);
+    return r;
 }
 
 static int ethGetTextId(item_list_t *itemList)
@@ -791,10 +908,11 @@ static void ethShutdown(item_list_t *itemList)
     }
 
     // UI may have initialized modules outside of ETH mode, so deinitialize regardless of the enabled status.
+    int ethWasLoaded = ethModulesLoaded; // capture BEFORE ethDeinitModules() clears ethModulesLoaded
     ethDeinitModules();
 
     // Only shut down dev9 from here, if it was initialized from here before.
-    if (ethModulesLoaded)
+    if (ethWasLoaded)
         sysShutdownDev9();
 }
 
@@ -811,7 +929,7 @@ static char *ethGetPrefix(item_list_t *itemList)
 static item_list_t ethGameList = {
     ETH_MODE, 1, 0, 0, MENU_MIN_INACTIVE_FRAMES, ETH_MODE_UPDATE_DELAY, NULL, NULL, &ethGetTextId, &ethGetPrefix, &ethInit, &ethNeedsUpdate,
     &ethUpdateGameList, &ethGetGameCount, &ethGetGame, &ethGetGameName, &ethGetGameNameLength, &ethGetGameStartup, &ethDeleteGame, &ethRenameGame,
-    &ethLaunchGame, &ethGetConfig, &ethGetImage, &ethCleanUp, &ethShutdown, &ethCheckVMC, &ethGetIconId};
+    &ethLaunchGame, &ethGetConfig, &ethGetImage, &ethCleanUp, &ethShutdown, &ethCheckVMC, &ethGetIconId, &ethLaunchVcd};
 
 static int ethReadNetConfig(void)
 {

--- a/src/gui.c
+++ b/src/gui.c
@@ -20,6 +20,7 @@
 #include "include/ethsupport.h"
 #include "include/udpfssupport.h" // udpfsGetModulesLoaded() -- network-protocol restart-notice check
 #include "include/bdmsupport.h"   // bdmIsUDPBDLoaded() + bdmForceDeviceRefresh()
+#include "include/vcdsupport.h"   // POPStarter pages: BDMA equip, list options, POPS net config
 #include "include/compatupd.h"
 #include "include/pggsm.h"
 #include "include/cheatman.h"
@@ -732,6 +733,7 @@ reshow_ui:
     diaSetVisible(diaUIConfig, UICFG_COVERFLOW_BUTTON, gTheme->coverflow != NULL);
     const char *gameViewNames[] = {"Both", "ISO", "VCD", NULL};
     diaSetEnum(diaUIConfig, UICFG_GAMEVIEW, gameViewNames);
+    diaSetInt(diaUIConfig, UICFG_GAMEVIEW, gDefaultGameView);
 
     int ret = diaExecuteDialog(diaUIConfig, -1, 1, NULL);
 
@@ -761,11 +763,24 @@ reshow_ui:
         diaGetInt(diaUIConfig, UICFG_AUTOSORT, &gAutosort);
         diaGetInt(diaUIConfig, UICFG_AUTOREFRESH, &gAutoRefresh);
         diaGetInt(diaUIConfig, UICFG_NOTIFICATIONS, &gEnableNotifications);
+        int previousGameView = gDefaultGameView;
+        diaGetInt(diaUIConfig, UICFG_GAMEVIEW, &gDefaultGameView);
+        int gameViewChanged = gDefaultGameView != previousGameView;
+        if (gameViewChanged) {
+            vcdMarkAllDirty(); // rebuild every VCD-capable page so the new default view takes effect
+        }
 
         if (previousTheme != themeID && isBgmPlaying())
             bgmStop();
 
         applyConfig(themeID, langID, 1);
+        if (gameViewChanged) {
+            // applyConfig(..., skipDeviceRefresh=1) deliberately avoids device scans. Queue after it
+            // returns so HDD (which has no automatic refresh) cannot retain PS2 rows while rendering
+            // uses the new VCD view, without racing the theme/menu bookkeeping above.
+            oplQueueVcdDeviceUpdates();
+            loadFavourites(); // queued after source pages so the FAV resolver sees their rebuilt rows
+        }
         sfxInit(0);
 
         if (gEnableBGM && !isBgmPlaying())
@@ -979,6 +994,329 @@ void guiShowNetConfig(void)
             gNetworkStartup = ERROR_ETH_SMB_LOGON;
 
         applyConfig(-1, -1, 0);
+    }
+}
+
+// POPStarter page live-updater: reveal the free-text POPSTARTER.ELF Path field only when the
+// device picker is "Custom".
+static int guiVcdUpdater(int modified)
+{
+    int popsDev;
+
+    if (modified) {
+        diaGetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, &popsDev);
+        diaSetVisible(diaVcdConfig, CFG_LBL_POPSTARTER_PATH, popsDev == POPS_DEV_CUSTOM);
+        diaSetVisible(diaVcdConfig, CFG_POPSTARTER_PATH, popsDev == POPS_DEV_CUSTOM);
+    }
+    return 0;
+}
+
+// BDMA Settings live-updater: hide the manual BDMA Source/Mode pickers while "VCD BDMA Apply on
+// Launch" is ON (it auto-equips); re-reveal them live when toggled off.
+static int guiBdmaUpdater(int modified)
+{
+    int bdmaApply;
+
+    if (modified) {
+        diaGetInt(diaBdmaConfig, CFG_BDMA_APPLY, &bdmaApply);
+        diaSetVisible(diaBdmaConfig, CFG_LBL_BDMASOURCE, !bdmaApply);
+        diaSetVisible(diaBdmaConfig, CFG_BDMASOURCE, !bdmaApply);
+        diaSetVisible(diaBdmaConfig, CFG_LBL_BDMAMODE, !bdmaApply);
+        diaSetVisible(diaBdmaConfig, CFG_BDMAMODE, !bdmaApply);
+    }
+    return 0;
+}
+
+// USB .VCD launches only: force the fat32/exFAT POPSTARTER driver pick EVERY launch -- the PS2
+// cannot detect the filesystem a USB stick is actually formatted with, so the user chooses per
+// launch. Returns the pressed button's id (VCDUSB_BTN_FAT32 / VCDUSB_BTN_EXFAT) or UIID_BTN_CANCEL.
+int guiShowVcdUsbMode(void)
+{
+    return diaExecuteDialog(diaVcdUsbMode, -1, 1, NULL);
+}
+
+// POPStarter page (settings-layout restructure, was VCD Settings): PS1-via-POPSTARTER launch
+// config (POPSTARTER.ELF device/path). The BDMA equip, VCD list display options and POPStarter
+// network settings are chained sub-dialogs (guiShowBdmaConfig / guiShowVcdListConfig /
+// guiShowPopsNetConfig). CFG ids are shared with the old rows, so saved config values map through
+// unchanged.
+void guiShowVcdConfig(void)
+{
+    // POPSTARTER.ELF device TYPE (POPS_DEV_*). MUST stay in sync with vcdResolvePopstarter() (vcdsupport.c).
+    const char *popsDevStrs[] = {_l(_STR_DEFAULT), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", "Custom", _l(_STR_GAMES_DEVICE), NULL}; // "Game's Device" (POPS_DEV_GAME) appended last to match the enum tail
+    diaSetEnum(diaVcdConfig, CFG_POPSTARTER_DEVICE, popsDevStrs);
+    diaSetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, gPopstarterDevice);
+    diaSetString(diaVcdConfig, CFG_POPSTARTER_PATH, gPopstarterPath);
+    diaSetShowDefaultWhenEmpty(diaVcdConfig, CFG_POPSTARTER_PATH, 1);
+    diaSetInt(diaVcdConfig, CFG_POPSTARTER_RETROGEM_GAMEID, gPopstarterRetroGemGameID);
+
+    // POPSTARTER Path is the Custom-only escape hatch (guiVcdUpdater re-reveals it live).
+    diaSetVisible(diaVcdConfig, CFG_LBL_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
+    diaSetVisible(diaVcdConfig, CFG_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
+
+    int ret;
+reshow_vcd:
+    ret = diaExecuteDialog(diaVcdConfig, -1, 1, &guiVcdUpdater);
+    if (ret == VCD_BDMA_BUTTON) {
+        guiShowBdmaConfig();
+        goto reshow_vcd;
+    }
+    if (ret == VCD_LIST_BUTTON) {
+        guiShowVcdListConfig();
+        goto reshow_vcd;
+    }
+    if (ret == VCD_NET_BUTTON) {
+        guiShowPopsNetConfig();
+        goto reshow_vcd;
+    }
+    if (ret) {
+        diaGetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, &gPopstarterDevice);
+        diaGetInt(diaVcdConfig, CFG_POPSTARTER_RETROGEM_GAMEID, &gPopstarterRetroGemGameID);
+
+        {
+            // The dialog field is char[32]; only adopt the typed value if it actually changed, so
+            // opening+saving this page never truncates a longer path stored via the cfg.
+            char tmpPop[sizeof(gPopstarterPath)];
+            diaGetString(diaVcdConfig, CFG_POPSTARTER_PATH, tmpPop, sizeof(tmpPop));
+            if (strncmp(tmpPop, gPopstarterPath, 31) != 0)
+                snprintf(gPopstarterPath, sizeof(gPopstarterPath), "%s", tmpPop);
+        }
+        applyConfig(-1, -1, 0);
+        menuReinitMainMenu();
+    }
+}
+
+// POPStarter -> BDMA Settings (BDMAssault exFAT-driver equip). MODE reflects what's ACTUALLY on the
+// card (marker read), so the page is honest even if POPSLoader or a prior session set it.
+void guiShowBdmaConfig(void)
+{
+    const char *bdmaSourceStrs[] = {_l(_STR_BDMA_SRC_USB), _l(_STR_BDMA_SRC_MX4SIO), _l(_STR_BDMA_SRC_MMCE), _l(_STR_BDMA_SRC_HDD), NULL};
+    const char *bdmaModeStrs[] = {_l(_STR_BDMA_MODE_FAT32), _l(_STR_BDMA_MODE_USBEXFAT), _l(_STR_BDMA_MODE_MX4SIO), _l(_STR_BDMA_MODE_MMCE), _l(_STR_BDMA_MODE_ATA), NULL};
+    gBdmaMode = vcdReadBdmaMode();
+    diaSetEnum(diaBdmaConfig, CFG_BDMASOURCE, bdmaSourceStrs);
+    diaSetEnum(diaBdmaConfig, CFG_BDMAMODE, bdmaModeStrs);
+    diaSetInt(diaBdmaConfig, CFG_BDMASOURCE, gBdmaSource);
+    diaSetInt(diaBdmaConfig, CFG_BDMAMODE, gBdmaMode);
+    diaSetInt(diaBdmaConfig, CFG_BDMA_APPLY, gBdmaApplyOnLaunch);
+    // "VCD BDMA Apply on Launch" ON auto-equips, so hide the manual SOURCE/MODE pickers
+    // (guiBdmaUpdater re-reveals them live when toggled off).
+    diaSetVisible(diaBdmaConfig, CFG_LBL_BDMASOURCE, !gBdmaApplyOnLaunch);
+    diaSetVisible(diaBdmaConfig, CFG_BDMASOURCE, !gBdmaApplyOnLaunch);
+    diaSetVisible(diaBdmaConfig, CFG_LBL_BDMAMODE, !gBdmaApplyOnLaunch);
+    diaSetVisible(diaBdmaConfig, CFG_BDMAMODE, !gBdmaApplyOnLaunch);
+
+    int ret = diaExecuteDialog(diaBdmaConfig, -1, 1, &guiBdmaUpdater);
+    if (ret) {
+        diaGetInt(diaBdmaConfig, CFG_BDMA_APPLY, &gBdmaApplyOnLaunch);
+        {
+            // Equip BDMA modules only when SOURCE or MODE actually changed (the equip copies files to
+            // the memory card). vcdEquipBdma is free-space-gated + truncation-safe, so a failure never
+            // corrupts the card; report it and resync MODE to what's really equipped.
+            int oldSrc = gBdmaSource, oldMode = gBdmaMode; // baselines (MODE = card's actual state)
+            int newSrc = oldSrc, newMode = oldMode;
+            diaGetInt(diaBdmaConfig, CFG_BDMASOURCE, &newSrc);
+            diaGetInt(diaBdmaConfig, CFG_BDMAMODE, &newMode);
+            // Re-equip on any MODE change, and on a SOURCE change only when MODE installs modules. FAT32
+            // ignores the source, so a SOURCE-only move while already FAT32 must NOT re-run the pointless work.
+            if (newMode != oldMode || (newMode != VCD_BDMA_FAT32 && newSrc != oldSrc)) {
+                char bdmaDiag[160];
+                int er = vcdEquipBdma(newSrc, newMode, bdmaDiag, sizeof(bdmaDiag));
+                if (er == -4) {
+                    char msg[256];
+                    snprintf(msg, sizeof(msg), "%s\n%s", _l(_STR_BDMA_ERR_SRC), bdmaDiag);
+                    guiMsgBox(msg, 0, NULL);
+                } else if (er == -2)
+                    guiMsgBox(_l(_STR_BDMA_ERR_SPACE), 0, NULL);
+                else if (er == -3)
+                    guiMsgBox(_l(_STR_BDMA_ERR_IO), 0, NULL);
+                gBdmaMode = vcdReadBdmaMode(); // MODE = what is now actually equipped
+            }
+            gBdmaSource = newSrc; // remember the source preference regardless of equip outcome
+        }
+        applyConfig(-1, -1, 0);
+    }
+}
+
+// POPStarter -> Game List Settings (VCD list display options).
+void guiShowVcdListConfig(void)
+{
+    diaSetInt(diaVcdListConfig, CFG_VCD_HIDE_GAMEID, gVcdHideGameId);
+    diaSetInt(diaVcdListConfig, CFG_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
+
+    int rebuildVcdLists = 0;
+    int ret = diaExecuteDialog(diaVcdListConfig, -1, 1, NULL);
+    if (ret) {
+        {
+            // #195: hide-gameid is NO LONGER purely cosmetic -- it is now a SORT KEY. The menu sort
+            // (submenuSort) orders by the DISPLAYED title, i.e. past the hidden prefix, so a change must
+            // re-sort every VCD-capable page. vcdMarkAllDirty() + rebuildVcdLists forces that menu rebuild
+            // and its submenuSort re-runs against the new vcdDisplayName key -- WITHOUT re-reading any
+            // device. Do NOT invalidate the HDD VCD cache here (unlike first-disc-only below): this toggle
+            // changes only the DISPLAY ORDER, not the list CONTENTS, and submenuSort reorders the cached
+            // rows in place. hddVcdInvalidateCache() would force an unnecessary full re-walk of every
+            // __.POPS partition (pfs1: remount) plus a transient empty HDD VCD page on every flip (audit
+            // 2026-07-17 of the CodeRabbit #200 fix -- my "sorted with the old key" note was true but
+            // irrelevant, the menu sort fixes the order regardless of the backing array).
+            int previousHideGameId = gVcdHideGameId;
+            diaGetInt(diaVcdListConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId);
+            if (gVcdHideGameId != previousHideGameId) {
+                vcdMarkAllDirty();
+                rebuildVcdLists = 1;
+            }
+        }
+        {
+            // #118: first-disc-only changes the VCD list CONTENTS (discs hidden/shown), so unlike the
+            // cosmetic hide-gameid it must rebuild every VCD-capable device page when toggled. Device
+            // lists only -- Favourites are intentionally left unfiltered (an explicit user pick).
+            int previousFirstDiscOnly = gVcdFirstDiscOnly;
+            diaGetInt(diaVcdListConfig, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
+            if (gVcdFirstDiscOnly != previousFirstDiscOnly) {
+                vcdMarkAllDirty();
+                hddVcdInvalidateCache(); // scan-time filter changed -> the cached HDD VCD list is stale
+                rebuildVcdLists = 1;
+            }
+        }
+        applyConfig(-1, -1, 0);
+        menuReinitMainMenu();
+        // Queue after applyConfig/menu reinit so the IO worker cannot rebuild a submenu concurrently
+        // with their support/menu bookkeeping on the GUI thread.
+        if (rebuildVcdLists)
+            oplQueueVcdDeviceUpdates();
+    }
+}
+
+// POPStarter -> Network Settings live-updater: DHCP = no static IP/mask/gateway triple.
+static int guiPopsNetUpdater(int modified)
+{
+    int isPopsDhcp, i;
+
+    if (modified) {
+        diaGetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, &isPopsDhcp);
+        for (i = 0; i < 4; i++) {
+            diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, !isPopsDhcp);
+            diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, !isPopsDhcp);
+            diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, !isPopsDhcp);
+        }
+    }
+
+    return 0;
+}
+
+// POPStarter -> Network Settings (VCD over SMB). Shows POPSTARTER's OWN IPCONFIG.DAT /
+// SMBCONFIG.DAT contents. Absent files leave the fields blank with the notice visible -- absence
+// means unknown/unconfigured, NEVER "use OPL's values". Only an explicit edit or the Import button
+// fills them, and only an actual change vs the read-time snapshot is written back on OK (the save
+// matrix below). Moved out of guiShowNetConfig by the settings-layout restructure; the Import
+// source is now the SAVED OPL network globals (the OPL fields no longer share this dialog).
+void guiShowPopsNetConfig(void)
+{
+    size_t i;
+    const char *ipAddrConfModes[] = {_l(_STR_IP_ADDRESS_TYPE_STATIC), _l(_STR_IP_ADDRESS_TYPE_DHCP), NULL};
+    // POPStarter read-time snapshot for the change-detection save matrix, + static storage for the
+    // "Loaded from %s" notice (diaSetLabel stores a RAW POINTER -- it must outlive the dialog).
+    static vcd_popsnet_t popsOriginal;
+    static char popsNotice[128];
+    diaSetEnum(diaPopsNetConfig, NETCFG_POPS_IPTYPE, ipAddrConfModes); // same Static/DHCP index convention
+
+    vcdReadPopstarterNet(&popsOriginal);
+    diaSetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, popsOriginal.ipDhcp);
+    for (i = 0; i < 4; ++i) {
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, popsOriginal.ps2Ip[i]);
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, popsOriginal.ps2Mask[i]);
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, popsOriginal.ps2Gw[i]);
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_IP_0 + i, popsOriginal.smbIp[i]);
+
+        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, !popsOriginal.ipDhcp);
+        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, !popsOriginal.ipDhcp);
+        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, !popsOriginal.ipDhcp);
+    }
+    diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_PORT, popsOriginal.smbPort);
+    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_SHARE, popsOriginal.smbShare);
+    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, popsOriginal.smbUser);
+    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, popsOriginal.smbPass);
+
+    if (popsOriginal.smbExists || popsOriginal.ipExists) {
+        snprintf(popsNotice, sizeof(popsNotice), _l(_STR_POPS_LOADED_FROM),
+                 popsOriginal.smbExists ? popsOriginal.smbDir : popsOriginal.ipDir);
+        diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, popsNotice);
+    } else {
+        diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, _l(_STR_POPS_NONE_DETECTED));
+    }
+
+    int result;
+    do {
+        result = diaExecuteDialog(diaPopsNetConfig, -1, 1, &guiPopsNetUpdater);
+        if (result == NETCFG_POPS_IMPORT) {
+            // IMPORT: the ONE sanctioned path that copies OPL's saved Network Settings into the
+            // POPStarter fields. Pressing the button exits the dialog with its id; the dialog
+            // struct keeps every field's value across the re-execution, so nothing the user typed
+            // elsewhere is lost.
+            char s[32];
+
+            diaSetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, ps2_ip_use_dhcp);
+            for (i = 0; i < 4; ++i) {
+                diaSetInt(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, ps2_ip[i]);
+                diaSetInt(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, ps2_netmask[i]);
+                diaSetInt(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, ps2_gateway[i]);
+
+                diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, !ps2_ip_use_dhcp);
+                diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, !ps2_ip_use_dhcp);
+                diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, !ps2_ip_use_dhcp);
+            }
+
+            // A NetBIOS share name can't be turned into an IP -- leave the POPStarter server IP
+            // untouched in that case instead of importing a wrong value.
+            if (!gPCShareAddressIsNetBIOS) {
+                for (i = 0; i < 4; ++i)
+                    diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_IP_0 + i, pc_ip[i]);
+            }
+            diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_PORT, gPCPort);
+            snprintf(s, sizeof(s), "%s", gPCShareName);
+            diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_SHARE, s);
+            snprintf(s, sizeof(s), "%s", gPCUserName);
+            diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, s);
+            snprintf(s, sizeof(s), "%s", gPCPassword);
+            diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, s);
+        }
+    } while (result == NETCFG_POPS_IMPORT);
+
+    if (result) {
+        // POPStarter save matrix (POPSLoader parity): compare the dialog's POPStarter fields against
+        // the read-time snapshot and write ONLY what actually changed -- and only when the file
+        // already exists (overwrite at its origin dir) or the user supplied complete values (create
+        // at createDir). Blank/incomplete fields with no existing file create NOTHING: absence must
+        // never turn into a fabricated configuration.
+        vcd_popsnet_t popsCur = popsOriginal; // carries the origin dirs + exists flags over
+        diaGetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, &popsCur.ipDhcp);
+        for (i = 0; i < 4; ++i) {
+            diaGetInt(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, &popsCur.ps2Ip[i]);
+            diaGetInt(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, &popsCur.ps2Mask[i]);
+            diaGetInt(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, &popsCur.ps2Gw[i]);
+            diaGetInt(diaPopsNetConfig, NETCFG_POPS_SMB_IP_0 + i, &popsCur.smbIp[i]);
+        }
+        diaGetInt(diaPopsNetConfig, NETCFG_POPS_SMB_PORT, &popsCur.smbPort);
+        diaGetString(diaPopsNetConfig, NETCFG_POPS_SMB_SHARE, popsCur.smbShare, sizeof(popsCur.smbShare));
+        diaGetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, popsCur.smbUser, sizeof(popsCur.smbUser));
+        diaGetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, popsCur.smbPass, sizeof(popsCur.smbPass));
+
+        int popsMask = vcdPopsNetChanged(&popsOriginal, &popsCur);
+        int popsSmbComplete = popsCur.smbShare[0] != '\0' &&
+                              (popsCur.smbIp[0] | popsCur.smbIp[1] | popsCur.smbIp[2] | popsCur.smbIp[3]) != 0;
+        int popsIpComplete = (popsCur.ps2Ip[0] | popsCur.ps2Ip[1] | popsCur.ps2Ip[2] | popsCur.ps2Ip[3]) != 0 &&
+                             (popsCur.ps2Mask[0] | popsCur.ps2Mask[1] | popsCur.ps2Mask[2] | popsCur.ps2Mask[3]) != 0 &&
+                             (popsCur.ps2Gw[0] | popsCur.ps2Gw[1] | popsCur.ps2Gw[2] | popsCur.ps2Gw[3]) != 0;
+        int writeSmb = (popsMask & 1) && (popsOriginal.smbExists || popsSmbComplete);
+        int writeIp = (popsMask & 2) && (popsOriginal.ipExists || popsCur.ipDhcp || popsIpComplete);
+        // Creating a fresh SMBCONFIG.DAT with no IPCONFIG.DAT anywhere: create the pair -- POPStarter
+        // expects IPCONFIG.DAT to exist even when blank (DHCP). An incomplete static entry becomes a
+        // BLANK file (never garbage); the user can complete it later and it will overwrite.
+        if (writeSmb && !popsOriginal.smbExists && !popsOriginal.ipExists) {
+            writeIp = 1;
+            if (!popsCur.ipDhcp && !popsIpComplete)
+                popsCur.ipDhcp = 1;
+        }
+        if ((writeSmb || writeIp) && vcdWritePopstarterNetFiles(&popsCur, writeSmb, writeIp) != 0)
+            guiMsgBox(_l(_STR_POPSTARTER_NET_ERR), 0, NULL);
     }
 }
 

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -270,6 +270,100 @@ void hddFreeHDLGamelist(hdl_games_list_t *game_list)
 }
 
 //-------------------------------------------------------------------------
+static int hddPopsNameCompare(const void *a, const void *b)
+{
+    return strcmp((const char *)a, (const char *)b);
+}
+
+#define HDD_APA_ATTR_MAIN_PARTITION 0x0000
+#define HDD_APA_FS_TYPE_PFS         0x0100
+
+// POPS' pooled HDD layout recognizes exactly eleven container labels: __.POPS and __.POPS0..9.
+// A looser prefix match misclassifies labels such as __.POPS12, which POPSLoader treats as a possible
+// one-game hidden partition and accepts only after finding IMAGE0.VCD at its root.
+static int hddIsPopsContainerName(const char *name)
+{
+    if (name == NULL || strncmp(name, "__.POPS", 7) != 0)
+        return 0;
+    return name[7] == '\0' || (name[7] >= '0' && name[7] <= '9' && name[8] == '\0');
+}
+
+int hddIsPopsPartitionGame(const char *name)
+{
+    if (name == NULL)
+        return 0;
+    if (strncmp(name, "PP.", 3) != 0 && strncmp(name, "__.", 3) != 0)
+        return 0;
+    if (name[3] == '\0')
+        return 0; // require a non-empty tail after PP. / __.
+    return !hddIsPopsContainerName(name);
+}
+
+// Enumerate the HDD's PS1/VCD APA partitions: exact __.POPS / __.POPS0..9 multi-VCD containers and
+// PP.<name> / __.<name> one-game installs. Mirror POPSLoader's APA-table filter: only main PFS records
+// can be mounted and scanned. In particular, ordinary HDL games also commonly use PP.* labels but have
+// mode 0x1337; filtering them here avoids a failed PFS mount for every PS2 game during a VCD refresh.
+int hddGetPopsPartitionList(hdd_pops_list_t *list)
+{
+    iox_dirent_t dirent;
+    int fd, i, count = 0;
+    char(*names)[APA_IDMAX + 1] = NULL;
+
+    list->count = 0;
+    list->names = NULL;
+
+    if ((fd = fileXioDopen("hdd0:")) < 0)
+        return 0;
+
+    while (fileXioDread(fd, &dirent) > 0) {
+        if (dirent.stat.attr != HDD_APA_ATTR_MAIN_PARTITION || dirent.stat.mode != HDD_APA_FS_TYPE_PFS)
+            continue; // skip APA sub-partitions and HDL/raw/system formats
+        if (!hddIsPopsContainerName(dirent.name) && !hddIsPopsPartitionGame(dirent.name))
+            continue; // not an HDD-resident PS1/VCD source
+
+        int dup = 0;
+        for (i = 0; i < count; i++) {
+            if (!strncmp(names[i], dirent.name, APA_IDMAX)) {
+                dup = 1;
+                break;
+            }
+        }
+        if (dup)
+            continue;
+
+        char(*grown)[APA_IDMAX + 1] = realloc(names, (count + 1) * sizeof(*names));
+        if (grown == NULL)
+            break; // OOM: keep what we already collected
+        names = grown;
+        strncpy(names[count], dirent.name, APA_IDMAX);
+        names[count][APA_IDMAX] = '\0';
+        count++;
+    }
+    fileXioDclose(fd);
+
+    if (count == 0) {
+        free(names);
+        return 0;
+    }
+
+    qsort(names, count, sizeof(*names), hddPopsNameCompare);
+
+    list->names = names;
+    list->count = count;
+    return count;
+}
+
+//-------------------------------------------------------------------------
+void hddFreePopsPartitionList(hdd_pops_list_t *list)
+{
+    if (list != NULL) {
+        free(list->names);
+        list->names = NULL;
+        list->count = 0;
+    }
+}
+
+//-------------------------------------------------------------------------
 int hddSetHDLGameInfo(hdl_game_info_t *ginfo)
 {
     if (hddReadSectors(ginfo->start_sector, 2, IOBuffer) != 0)

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -4,13 +4,16 @@
 #include "include/gui.h"
 #include "include/supportbase.h"
 #include "include/hddsupport.h"
+#include "include/vcdsupport.h" // HDD VCD view: vcdScanDirRoot/vcdViewActive + vcd_entry_t
 #include "include/util.h"
 #include "include/themes.h"
 #include "include/textures.h"
 #include "include/ioman.h"
+#include "include/texcache.h" // cache quiesce before the POPSTARTER launch remounts pfs0:
 #include "include/system.h"
 #include "include/extern_irx.h"
 #include "include/cheatman.h"
+#include "include/mmcesupport.h" // mmceSendGameID() cross-device game-id (#261)
 #include "modules/iopcore/common/cdvd_config.h"
 
 #define NEWLIB_PORT_AWARE
@@ -32,9 +35,20 @@ static unsigned char hddHDProKitDetected = 0;
 static unsigned char hddModulesLoadCount = 0;
 static unsigned char hddModulesLoaded = 0;
 static unsigned char hddSupportModulesLoaded = 0;
+// One toast per failure streak: hddUpdateGameList now RETRIES the support-module load every refresh
+// while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
+// success so a later, different failure toasts again.
+static unsigned char hddSupportErrToasted = 0;
 
 static char *hddPrefix = "pfs0:";
 static hdl_games_list_t hddGames;
+
+// HDD VCD view: PS1 games gathered from pooled __.POPS[0-9]? partitions and one-game PP. / __.
+// partitions. hddVcdParts is index-parallel to hddVcdGames -- it records the full owning partition
+// label for the launch handoff.
+static base_game_info_t *hddVcdGames = NULL;
+static int hddVcdGameCount = 0;
+static char (*hddVcdParts)[APA_IDMAX + 1] = NULL;
 
 // forward declaration
 static item_list_t hddGameList;
@@ -49,10 +63,10 @@ static void hddInitModules(void)
 
     // update Themes
     char path[256];
-    sprintf(path, "%sTHM", gHDDPrefix);
+    snprintf(path, sizeof(path), "%sTHM", gHDDPrefix);
     thmAddElements(path, "/", 1);
 
-    sprintf(path, "%sLNG", gHDDPrefix);
+    snprintf(path, sizeof(path), "%sLNG", gHDDPrefix);
     lngAddLanguages(path, "/", hddGameList.mode);
 
     sbCreateFolders(gHDDPrefix, 0);
@@ -202,6 +216,8 @@ int hddLoadModules(void)
             LOG("[XHDD]:\n");
             sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-hdpro");
         } else {
+            LOG("[BDM]:\n");
+            sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
             LOG("[ATAD]:\n");
             retLoadModule = sysLoadModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL);
             LOG("[XHDD]:\n");
@@ -212,6 +228,15 @@ int hddLoadModules(void)
             LOG("HDD: No HardDisk Drive detected.\n");
             setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_IF_NOT_DETECTED);
             retStatus = HDD_LOADMODULES_STATUS_ERROR;
+            // Make the failure RETRYABLE. Leaving the count consumed turned one bad first probe into a
+            // whole-session poison: every later call took the else branch and returned BUSYLOADING(2),
+            // which the >= 0 caller tests read as SUCCESS while nothing was loaded -- so the APA page
+            // sat silently empty under BOTH Auto and Manual (Vapor's report; the drive lists fine in
+            // wOPL/upstream because their earliest callers run at tab entry, when the drive is ready --
+            // our fork adds boot-time callers like bdmResolveBootDir's ATA escalation, seconds after
+            // power-on). sysInitDev9/sysLoadModuleBuffer are safe to re-run; a later caller (e.g. the
+            // HDD tab) now gets a real second attempt instead of a poisoned latch.
+            hddModulesLoadCount = 0;
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;
             hddModulesLoaded = 1;
@@ -281,7 +306,14 @@ void hddLoadSupportModules(void)
                            "-n"
                            "\0"
                            "20";
-    static char pfsarg[] = "\0"
+    // No leading "\0": LOADFILE already supplies argv[0] ("LBbyEE") for buffer loads, so the first
+    // string here is argv[1]. PFS stops parsing at the first token that doesn't start with '-', so a
+    // leading empty string silently discarded EVERY option below (upstream OPL carries the same dead
+    // byte) -- leaving PFS at its defaults (-m 1, -o 2, -n 8) and making the pfs1: scan mount fail.
+    static char pfsarg[] = "-m" // max mounts: keep pfs0: on OPL data while pfs1: scans POPS partitions
+                           "\0"
+                           "2"
+                           "\0"
                            "-o" // max open
                            "\0"
                            "10" // Default value: 2
@@ -294,9 +326,21 @@ void hddLoadSupportModules(void)
 
     // Check if the drive contains MBR/GPT partition data before we load the APA/PFS modules. If the drive is not
     // APA then loading the APA irx modules can corrupt the drive as it will try to write APA partition data.
-    if (hddDetectNonSonyFileSystem() != 0) {
+    int nonSony = hddDetectNonSonyFileSystem();
+    if (nonSony != 0) {
         // Drive is MBR/GPT style, or unknown, bail out or risk corrupting the drive.
-        LOG("HDDSUPPORT LoadSupportModules bailing out early...\n");
+        LOG("HDDSUPPORT LoadSupportModules bailing out early (%d)...\n", nonSony);
+        // A PROBE FAILURE (-1: the xhdd0: partition-sector devctl errored -- drive not ready, module
+        // missing, transient bus fault) was completely SILENT: no error box, no list, an APA page that
+        // just looks like a dead drive for the whole session. Surface it. The 1 (genuine MBR/GPT/exFAT)
+        // branch stays silent on purpose -- that is the NORMAL coexistence case for BDM-HDD users and
+        // must not toast at every boot.
+        if (nonSony < 0 && !hddSupportErrToasted) {
+            setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_NOT_DETECTED);
+            hddSupportErrToasted = 1;
+        } else if (nonSony > 0) {
+            hddSupportErrToasted = 0; // probe SUCCEEDED (genuine MBR/GPT) -- a future failure is new news
+        }
         return;
     }
 
@@ -305,14 +349,20 @@ void hddLoadSupportModules(void)
         int ret = sysLoadModuleBuffer(&ps2hdd_irx, size_ps2hdd_irx, sizeof(hddarg), hddarg);
         if (ret < 0) {
             LOG("HDD: No HardDisk Drive detected.\n");
-            setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_MODULE_HDD_FAILURE);
+            if (!hddSupportErrToasted) {
+                setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_MODULE_HDD_FAILURE);
+                hddSupportErrToasted = 1;
+            }
             return;
         }
 
         // Check if a HDD unit is connected
         if (hddCheck() < 0) {
             LOG("HDD: No HardDisk Drive detected.\n");
-            setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_NOT_DETECTED);
+            if (!hddSupportErrToasted) {
+                setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_NOT_DETECTED);
+                hddSupportErrToasted = 1;
+            }
             return;
         }
 
@@ -320,11 +370,15 @@ void hddLoadSupportModules(void)
         ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: HardDisk Drive not formatted (PFS).\n");
-            setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
+            if (!hddSupportErrToasted) {
+                setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
+                hddSupportErrToasted = 1;
+            }
             return;
         }
 
         hddSupportModulesLoaded = 1;
+        hddSupportErrToasted = 0; // recovered -- a future, different failure gets its own toast
         LOG("HDDSUPPORT modules loaded\n");
 
         if (gOPLPart[0] == '\0')
@@ -350,7 +404,7 @@ void hddInit(item_list_t *itemList)
 {
     LOG("HDDSUPPORT Init\n");
     hddForceUpdate = 0; // Use cache at initial startup.
-    configGetInt(configGetByType(CONFIG_OPL), "hdd_frames_delay", &hddGameList.delay);
+    hddGameList.delay = gArtDelay;
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &hddInitModules);
     hddGameList.enabled = 1;
 }
@@ -362,18 +416,200 @@ item_list_t *hddGetObject(int initOnly)
     return &hddGameList;
 }
 
+// ---- HDD VCD view (PS1 games on APA/PFS partitions) ---------------------------------------
+
+// Once-per-session latch (POPSLoader's HAS_CHECKED parity: "HDD is checked only once since it cannot
+// be removed/replaced without damaging the console"). While set, hddUpdateGameList's VCD branch reuses
+// the built arrays so an L3 toggle rebuilds only the submenu, never re-walks the partitions. A latch
+// (not hddVcdGames != NULL) so a drive whose candidates scanned to ZERO VCDs is also remembered. The
+// no-candidates early return deliberately does NOT latch: hddGetPopsPartitionList returns 0 for a
+// transient hdd0: dopen failure too, and that walk is one mount-free APA pass -- cheap to repeat.
+// Cleared by hddFreeVcdGameList (covers rebuilds + hddCleanUp/hddShutdown teardown) and by
+// hddVcdInvalidateCache (the first-disc-only setting filters at scan time, so its change must rescan).
+// The generation counter keeps an invalidation from being SWALLOWED by a build already in flight on
+// the IO worker (GUI-thread dialog save during a cold scan): the build re-latches only if no
+// invalidation arrived since it started.
+static unsigned char hddVcdListBuilt = 0;
+static volatile unsigned int hddVcdCacheGen = 0;
+
+void hddVcdInvalidateCache(void)
+{
+    hddVcdCacheGen++;
+    hddVcdListBuilt = 0;
+}
+
+static void hddFreeVcdGameList(void)
+{
+    free(hddVcdGames);
+    hddVcdGames = NULL;
+    free(hddVcdParts);
+    hddVcdParts = NULL;
+    hddVcdGameCount = 0;
+    hddVcdListBuilt = 0;
+}
+
+// Build the HDD VCD game list from both supported APA/PFS shapes. Exact __.POPS / __.POPS0..9
+// containers contribute every root *.VCD; PP.<name> / __.<name> candidates contribute one entry each.
+// A one-game candidate whose label carries a STRICT PS1 disc-ID (PP.SLUS_005.51.Name -- the
+// POPStarter/BatchKitManager convention) is accepted from the APA table alone, ZERO mounts: every
+// documented PP.* false-positive family fails that pattern (HDDOSD apps like CodeBreaker have no
+// '_' at [4]; HDL games are mode-0x1337-filtered upstream), and the launch never needs the probe
+// (POPSTARTER boots by literal partition label). Only ID-less labels (PP.CASTLEVANIA) pay the
+// mount + IMAGE0.VCD probe that filters HDDOSD apps. This is what makes a 40-partition drive load
+// in one APA pass instead of 40 PFS mount/probe/umount cycles (~35 s on a mechanical drive).
+// Mounts use the dedicated pfs1: scan slot; pfs0: stays on the OPL data partition throughout.
+
+static int hddBuildVcdGameList(void)
+{
+    hdd_pops_list_t parts;
+    int total = 0;
+    unsigned int genAtEntry = hddVcdCacheGen; // re-latch below only if no invalidation raced this build
+
+    hddFreeVcdGameList();
+
+    // Best-effort cleanup from an interrupted prior scan. This never touches pfs0:, which remains the
+    // live OPL data mount used by both PS2 and VCD config/art lookups.
+    fileXioUmount("pfs1:");
+
+    if (hddGetPopsPartitionList(&parts) <= 0)
+        return 0; // no candidates OR a transient dopen failure -- deliberately NOT latched (see above)
+
+    for (int p = 0; p < parts.count; p++) {
+        char mountSrc[64];
+        snprintf(mountSrc, sizeof(mountSrc), "hdd0:%s", parts.names[p]);
+
+        // PP.<name> / __.<name> one-game install: display the label without its three-character
+        // prefix and retain the FULL label for launch. The name predicate excludes the exact
+        // __.POPS[0-9]? pooled containers handled below.
+        if (hddIsPopsPartitionGame(parts.names[p])) {
+            char discId[12]; // validation only -- the entry keys off the full label, never the ID
+            if (!vcdExtractGameId(parts.names[p] + 3, discId, sizeof(discId))) {
+                // ID-less label (e.g. PP.CASTLEVANIA): require ONE exact IMAGE0.VCD at the partition
+                // root. This probe is what keeps PP.* HDDOSD apps off the PS1 list; ID-shaped labels
+                // above skip it because no documented app family matches the strict ID pattern.
+                if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0)
+                    continue; // can't mount this partition -> skip it
+                int imgfd = open("pfs1:/IMAGE0.VCD", O_RDONLY);
+                if (imgfd >= 0)
+                    close(imgfd); // close before unmount; ps2fs may reject an unmount with a live fd
+                fileXioUmount("pfs1:");
+                if (imgfd < 0)
+                    continue; // candidate name alone is insufficient (PP.* HDDOSD apps are common)
+            }
+
+            base_game_info_t *grownGames = realloc(hddVcdGames, (total + 1) * sizeof(base_game_info_t));
+            if (grownGames == NULL)
+                break;
+            hddVcdGames = grownGames;
+            char(*grownParts)[APA_IDMAX + 1] = realloc(hddVcdParts, (total + 1) * sizeof(*hddVcdParts));
+            if (grownParts == NULL)
+                break;
+            hddVcdParts = grownParts;
+
+            base_game_info_t *g = &hddVcdGames[total];
+            memset(g, 0, sizeof(base_game_info_t));
+            snprintf(g->name, sizeof(g->name), "%s", parts.names[p] + 3); // strip PP. / __. for display
+            snprintf(g->startup, sizeof(g->startup), "%s", g->name);      // keep VCD identity = name (pooled entries do the same)
+            snprintf(g->extension, sizeof(g->extension), ".VCD");
+            g->parts = 1;
+            g->format = GAME_FORMAT_ISO;                                       // harmless; VCD flag gates the launch
+            snprintf(hddVcdParts[total], APA_IDMAX + 1, "%s", parts.names[p]); // case-preserved full label
+            total += 1;
+            continue;
+        }
+
+        // __.POPS[0-9]? pooled container: mount and scan its root for *.VCD entries.
+        if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0)
+            continue; // can't mount this partition -> skip it
+
+        vcd_entry_t *vcds = NULL;
+        int n = vcdScanDirRoot("pfs1:/", &vcds);
+        fileXioUmount("pfs1:");
+        if (n <= 0) {
+            free(vcds);
+            continue;
+        }
+
+        base_game_info_t *grownGames = realloc(hddVcdGames, (total + n) * sizeof(base_game_info_t));
+        if (grownGames == NULL) {
+            free(vcds);
+            break;
+        }
+        hddVcdGames = grownGames;
+        char(*grownParts)[APA_IDMAX + 1] = realloc(hddVcdParts, (total + n) * sizeof(*hddVcdParts));
+        if (grownParts == NULL) {
+            free(vcds);
+            break;
+        }
+        hddVcdParts = grownParts;
+
+        int kept = 0;
+        for (int i = 0; i < n; i++) {
+            if (gVcdFirstDiscOnly && vcdIsHiddenDisc(vcds[i].name))
+                continue; // #118: hide discs 2+ of a multi-disc PS1 set (device lists only)
+            base_game_info_t *g = &hddVcdGames[total + kept];
+            memset(g, 0, sizeof(base_game_info_t));
+            snprintf(g->name, sizeof(g->name), "%s", vcds[i].name);
+            snprintf(g->startup, sizeof(g->startup), "%s", vcds[i].name);
+            snprintf(g->extension, sizeof(g->extension), ".VCD");
+            g->parts = 1;
+            g->format = GAME_FORMAT_ISO; // harmless; the per-mode VCD flag gates the launch path
+            snprintf(hddVcdParts[total + kept], APA_IDMAX + 1, "%s", parts.names[p]);
+            kept++;
+        }
+        free(vcds);
+        total += kept; // realloc over-allocated to (total+n); hidden discs leave harmless unused slots
+    }
+
+    hddFreePopsPartitionList(&parts);
+
+    fileXioUmount("pfs1:");
+
+    hddVcdGameCount = total;
+    // Remember a scanned-to-zero result too (candidates existed, none were VCDs) so toggles don't
+    // re-probe them. Skip the latch if an invalidation arrived while this build was running.
+    hddVcdListBuilt = (genAtEntry == hddVcdCacheGen);
+    return total;
+}
+
 static int hddNeedsUpdate(item_list_t *itemList)
 { /* Auto refresh is disabled by setting HDD_MODE_UPDATE_DELAY to MENU_UPD_DELAY_NOUPDATE, within hddsupport.h.
        Hence any update request would be issued by the user, which should be taken as an explicit request to re-scan the HDD. */
+    if (vcdConsumeDirty(itemList->mode))
+        return 1; // L3 toggle / default-view change -> rebuild the submenu (the ARRAY may be cached)
+    if (vcdViewActive(itemList->mode))
+        return 0; // in VCD view: skip the HDL re-scan churn
     return 1;
 }
 
 static int hddUpdateGameList(item_list_t *itemList)
 {
+    // Self-heal (wLaunchELF-R3Z3N parity: latch only on success, retry per use): a boot-time first
+    // touch that raced drive spin-up used to leave the APA page EMPTY for the whole session -- the
+    // one-shot hddInitModules never retried, and nothing else reloads the support stack. Both calls
+    // are idempotent (hddLoadModules dedupes via ALREADYLOADED and its failed count is retryable
+    // post-#241; hddLoadSupportModules no-ops once hddSupportModulesLoaded), so tab entry / refresh
+    // becomes a real second attempt. Runs on the IO worker like the original init.
+    if (!hddSupportModulesLoaded) {
+        // Only chase the support stack when the base modules are actually resident -- calling it
+        // anyway made a failed base load toast TWICE (base failure + the doomed non-Sony probe's)
+        // on the first pass (Gemini + CodeRabbit review of #249, vetted).
+        if (hddLoadModulesReady())
+            hddLoadSupportModules();
+    }
+
+    if (vcdViewActive(itemList->mode))
+        // Reuse the session's built list on view flips; hddBuildVcdGameList runs only when never
+        // built, invalidated (first-disc-only change), or freed by teardown (hddFreeVcdGameList).
+        return hddVcdListBuilt ? hddVcdGameCount : hddBuildVcdGameList();
+
     hdl_games_list_t hddGamesNew;
     int ret;
 
-    if (((ret = hddLoadGameListCache(&hddGames)) != 0) || (hddForceUpdate)) {
+    // Force a live APA scan not only when the cache fails to load (ret != 0) or a prior build asked for it
+    // (hddForceUpdate), but ALSO when the cache loaded EMPTY (count 0). A missing/empty/stale games.bin
+    // otherwise left the first HDD page blank until a second manual refresh (provato's HW report).
+    if (((ret = hddLoadGameListCache(&hddGames)) != 0) || (hddForceUpdate) || (hddGames.count == 0)) {
         hddGamesNew.count = 0;
         hddGamesNew.games = NULL;
         ret = hddGetHDLGamelist(&hddGamesNew);
@@ -391,41 +627,281 @@ static int hddUpdateGameList(item_list_t *itemList)
 
 static int hddGetGameCount(item_list_t *itemList)
 {
-    return hddGames.count;
+    return vcdViewActive(itemList->mode) ? hddVcdGameCount : (int)hddGames.count;
+}
+
+// Toggle-window guard (Codex/Fable audit), mirroring mmceActiveGame. HDD_MODE is vcdModeSupported, so the L3
+// toggle flips vcdViewActive() SYNCHRONOUSLY ahead of the DEFERRED per-__.POPS pfs rebuild -- a WIDER window
+// than MMCE. During it an OLD-view id can index the freshly-switched other array (hddGames.games is {NULL,0}
+// on a PS1-only HDD; hddVcdGames NULL/shorter if that view never scanned) -> NULL/OOB deref + crash. Resolve
+// every id through these: an out-of-range id returns a static empty entry so a stale READ is safe empty data
+// and LAUNCH/delete/rename early-return on the sentinel. HDD needs TWO resolvers -- ISO is hdl_game_info_t,
+// VCD is base_game_info_t.
+static base_game_info_t hddEmptyVcd = {.extension = ".VCD"};
+static hdl_game_info_t hddEmptyHdl = {0};
+static base_game_info_t *hddActiveVcd(int id)
+{
+    if (hddVcdGames == NULL || id < 0 || id >= hddVcdGameCount)
+        return &hddEmptyVcd;
+    return &hddVcdGames[id];
+}
+static hdl_game_info_t *hddActiveHdl(int id)
+{
+    if (hddGames.games == NULL || id < 0 || id >= (int)hddGames.count)
+        return &hddEmptyHdl;
+    return &hddGames.games[id];
 }
 
 static void *hddGetGame(item_list_t *itemList, int id)
 {
-    return (void *)&hddGames.games[id];
+    return vcdViewActive(itemList->mode) ? (void *)hddActiveVcd(id) : (void *)hddActiveHdl(id);
 }
 
 static char *hddGetGameName(item_list_t *itemList, int id)
 {
-    return hddGames.games[id].name;
+    return vcdViewActive(itemList->mode) ? hddActiveVcd(id)->name : hddActiveHdl(id)->name;
 }
 
 static int hddGetGameNameLength(item_list_t *itemList, int id)
 {
-    return HDL_GAME_NAME_MAX + 1;
+    return vcdViewActive(itemList->mode) ? VCD_NAME_MAX : (HDL_GAME_NAME_MAX + 1);
 }
 
 static char *hddGetGameStartup(item_list_t *itemList, int id)
 {
-    return hddGames.games[id].startup;
+    // VCD view keys per-game CFG/art off the VCD filename (game->name), not a disc id.
+    return vcdViewActive(itemList->mode) ? hddActiveVcd(id)->name : hddActiveHdl(id)->startup;
 }
 
 static void hddDeleteGame(item_list_t *itemList, int id)
 {
-    hddDeleteHDLGame(&hddGames.games[id]);
+    if (vcdViewActive(itemList->mode))
+        return; // a VCD is not an HDL partition -- no delete in VCD view
+    hdl_game_info_t *game = hddActiveHdl(id);
+    if (game == &hddEmptyHdl)
+        return; // stale id in the VCD->ISO toggle window -> don't delete a wrong/OOB HDL partition
+    hddDeleteHDLGame(game);
     hddForceUpdate = 1;
 }
 
 static void hddRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    hdl_game_info_t *game = &hddGames.games[id];
+    if (vcdViewActive(itemList->mode))
+        return; // a VCD is not an HDL partition -- no rename in VCD view
+    hdl_game_info_t *game = hddActiveHdl(id);
+    if (game == &hddEmptyHdl)
+        return; // stale id in the VCD->ISO toggle window -> don't rename a wrong/OOB HDL partition
     strcpy(game->name, newName);
-    hddSetHDLGameInfo(&hddGames.games[id]);
+    hddSetHDLGameInfo(game);
     hddForceUpdate = 1;
+}
+
+// Index of the VCD whose basename matches vcdName in the current hddVcdGames list, or -1.
+static int hddFindVcdByName(const char *vcdName)
+{
+    for (int i = 0; i < hddVcdGameCount; i++) {
+        if (strcmp(hddVcdGames[i].name, vcdName) == 0)
+            return i;
+    }
+    return -1;
+}
+
+// Resolve POPSTARTER.ELF for an HDD VCD launch: search hdd0:__common then hdd0:+OPL, each at its ROOT
+// /POPS/ (NOT the OPL/POPS/ data subfolder). On success returns 1 with elfOut = "pfs0:/POPS/POPSTARTER.ELF"
+// and LEAVES pfs0: mounted on that partition so the caller can load the ELF from it; on failure returns 0
+// with pfs0: restored to the OPL data partition. The CALLER must quiesce the art + IO workers first --
+// this remounts the single pfs0: slot, and umounting it under a live cover read is the HDD-freeze hazard.
+static int hddResolveHddPopstarter(char *elfOut, int elfLen)
+{
+    static const char *cands[2] = {"hdd0:__common", "hdd0:+OPL"};
+
+    for (int i = 0; i < 2; i++) {
+        fileXioUmount(hddPrefix);
+        if (fileXioMount(hddPrefix, cands[i], FIO_MT_RDONLY) < 0)
+            continue; // partition absent / unmountable -> try the next
+        // The APA contract is hdd0:__common/POPS/ (with +OPL retained as the existing fallback).
+        // Install directly from whichever candidate is mounted before checking its POPSTARTER.ELF.
+        (void)vcdInstallPopstarterMc("pfs0:/");
+        int fd = open("pfs0:/POPS/POPSTARTER.ELF", O_RDONLY);
+        if (fd >= 0) {
+            close(fd);
+            snprintf(elfOut, elfLen, "pfs0:/POPS/POPSTARTER.ELF");
+            return 1; // keep pfs0: on this partition for the ELF load
+        }
+    }
+
+    // Not found: restore the default OPL data-partition mount so normal HDD IO keeps working.
+    fileXioUmount(hddPrefix);
+    fileXioMount(hddPrefix, gOPLPart, FIO_MT_RDWR);
+    return 0;
+}
+
+// Shared POPSTARTER handoff for an HDD VCD. argv[0] differs by partition shape: PP.<name> / __.<name>
+// one-game installs boot by their literal partition label; a pooled __.POPS[0-9]? entry boots by its
+// VCD name. POPSTARTER derives the HDD route from that selector, so it must remain target argv[0].
+// Everything is built on stack before deinit() frees the VCD list.
+static void hddDoLaunchVcd(item_list_t *itemList, const char *name, const char *part)
+{
+    char vcdElf[256], vcdSelector[320];
+
+    if (name == NULL || name[0] == '\0' || part == NULL || part[0] == '\0')
+        return;
+
+    if (hddIsPopsPartitionGame(part))
+        snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", part); // literal PP.Game.ELF / __.Hidden.ELF
+    else
+        snprintf(vcdSelector, sizeof(vcdSelector), "%s.ELF", name); // GAME.ELF (pooled-container VCD)
+
+    // Resolve + keep pfs0: on the POPSTARTER.ELF partition. Quiesce art+IO first (this remounts pfs0:).
+    cacheAbortMmceImageLoadsTimed(0);
+    (void)cacheCancelPendingImageLoadsTimed(0);
+    ioBlockOps(1);
+    if (!hddResolveHddPopstarter(vcdElf, sizeof(vcdElf))) {
+        ioBlockOps(0); // resolver already restored pfs0: to the OPL data partition on failure
+        guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    // Success: leave IO blocked (deinit re-blocks anyway) and pfs0: on the POPSTARTER partition for the
+    // argv-preserving load below. POPSTARTER takes over and performs its own IOP reset.
+    char vcdFullPath[256];
+    snprintf(vcdFullPath, sizeof(vcdFullPath), "%s/%s.VCD", part, name);
+    vcdPrepareRetroGemBarcode(vcdFullPath);
+    deinit(UNMOUNT_EXCEPTION, itemList->mode);
+    sysLaunchPopstarter(vcdElf, vcdSelector);
+}
+
+// Launch an HDD PS1/.VCD entry BY NAME -- the Favourites tab's view-independent entry point. The
+// per-game __.POPS* partition lives in hddVcdParts, which is only populated while the HDD page is in
+// its VCD view; from Favourites it may be empty/stale, so (re)scan via the SAME safe partition walk the
+// VCD view uses (hddBuildVcdGameList mounts each __.POPS on the dedicated pfs1: scan slot) to resolve
+// name -> partition, then hand off exactly as the in-view launch does.
+static void hddLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_t *configSet)
+{
+    char resolvedName[VCD_NAME_MAX];
+    char resolvedPart[APA_IDMAX + 1];
+
+    if (vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
+        return;
+
+    // Serialize against a queued HDD refresh that can use the same pfs1: slot and shared list. No art
+    // cancellation is needed because the live pfs0: mount is not disturbed. Copy the result while the
+    // worker remains blocked so a later refresh cannot invalidate the list storage passed to launch.
+    ioBlockOps(1);
+    int idx = hddFindVcdByName(vcdName);
+    if (idx < 0) {
+        // Cold path: the per-game __.POPS partition is unknown (hddVcdGames is only built while the HDD
+        // page is in VCD view), so rebuild it through the dedicated pfs1: scan slot.
+        hddBuildVcdGameList();
+        idx = hddFindVcdByName(vcdName);
+    }
+    if (idx >= 0) {
+        snprintf(resolvedName, sizeof(resolvedName), "%s", hddVcdGames[idx].name);
+        snprintf(resolvedPart, sizeof(resolvedPart), "%s", hddVcdParts[idx]);
+    }
+    ioBlockOps(0);
+    if (idx < 0) {
+        guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    hddDoLaunchVcd(itemList, resolvedName, resolvedPart);
+}
+
+// Δ8 (NHDDL parity): the LEAN Neutrino launch path for HDL games -- see bdmTryNeutrinoLaunch's
+// rationale in bdmsupport.c. The native flow's VMC block-chain prompts + mcemu patching, DMA
+// setup, sbPrepare, cheats (with dialogs), PS2RD images and CheckPS2Logo all exist for the
+// embedded cdvdman core; Neutrino re-derives everything from -bsd=ata -bsdfs=hdl -dvd=hdl:<part>
+// after its own IOP reset. The one probe Neutrino DOES need is the ZSO header check (its hdl
+// backend can't run ZSO) -- a single sector read, kept here.
+// Returns 1 = handled (handed off; caller returns); 0 = proceed with the native launch (core is
+// OPL, or any Neutrino-side failure -- ZSO, no install, preflight -- since HDL always boots natively).
+static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
+{
+    int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
+    configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+    if (!coreLoader)
+        return 0;
+
+    // ZSO probe (one sector): Neutrino's hdl backend can't run ZSO -- fall back to the native
+    // core, which can. Same read the native path performs for its layer-1 setup.
+    hddReadSectors(game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET, 1, IOBuffer);
+    if (*(u32 *)IOBuffer == ZSO_MAGIC) {
+        guiWarning(_l(_STR_NEUTRINO_BAD_FORMAT), 6);
+        return 0;
+    }
+
+    const char *neutrinoPath = sbResolveNeutrinoPath(NULL); // #300: HDD keeps custom-path + mc0/mc1 + Device-picker resolution (raw APA isn't POSIX-reachable; pfs0 probe = shared-slot risk)
+    if (neutrinoPath == NULL) {
+        guiWarning(_l(_STR_NEUTRINO_NOT_FOUND), 6);
+        return 0;
+    }
+
+    // Everything Neutrino needs, copied to THIS frame (deinit below frees `game`).
+    int compatMode = 0, neutrinoVideo = gNeutrinoVideoDefault, neutrinoGsmComp = gNeutrinoGsmCompDefault; // absent per-game keys = follow the globals
+    char neutrinoExtraArgs[256] = "";
+    char apaPart[APA_IDMAX + 1];
+    configGetInt(configSet, CONFIG_ITEM_COMPAT, &compatMode);
+    configGetStrCopy(configSet, CONFIG_ITEM_NEUTRINO_ARGS, neutrinoExtraArgs, sizeof(neutrinoExtraArgs));
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_VIDEO, &neutrinoVideo);
+    configGetInt(configSet, CONFIG_ITEM_NEUTRINO_GSMCOMP, &neutrinoGsmComp);
+    snprintf(apaPart, sizeof(apaPart), "%s", game->partition_name);
+
+    if (gRememberLastPlayed) {
+        configSetStr(configGetByType(CONFIG_LAST), "last_played", game->startup);
+        saveConfig(CONFIG_LAST, 0);
+    }
+
+    // Δ6 pre-teardown validation. On failure fall back to the native core (same contract as
+    // bdmTryNeutrinoLaunch's non-udp legs): HDL always boots natively, and the native path owns
+    // the autolaunch teardown -- aborting here instead would leak gAutoLaunchGame/configSet.
+    if (sysNeutrinoPreflight("apa", neutrinoPath) < 0)
+        return 0;
+
+    // Honesty toast: the OPL core honors $VMC_N on HDD (mcemu over pfs0:VMC/), but Neutrino has no
+    // APA/pfs backing store to open the .bin from post-reset -- its APA support is -bsd=ata
+    // -bsdfs=hdl, game image only (NHDDL's HDL backend has the same no-VMC rule). No -mc args can
+    // be emitted here; warn instead of silently booting without the card the user configured.
+    // Runs pre-deinit so the toast still renders.
+    {
+        int slot;
+        char vmcName[32];
+        for (slot = 0; slot < NEUTRINO_VMC_SLOTS; slot++) {
+            int slotDisabled = 0;
+            vmcName[0] = '\0';
+            configGetVMC(configSet, vmcName, sizeof(vmcName), slot);
+            configGetVMCDisable(configSet, slot, &slotDisabled);
+            if (vmcName[0] != '\0' && !slotDisabled) {
+                LOG("[NEUTRINO] apa: VMC slot %d (%s) configured but unsupported -- launching without it\n", slot, vmcName);
+                guiWarning(_l(_STR_NEUTRINO_VMC_HDD_UNSUPPORTED), 6);
+                break;
+            }
+        }
+    }
+
+    // MMCE cross-device game-id (#261); HDD emits no -mc args (no APA/pfs backing store, above), mask 0.
+    mmceSendGameID(game->startup, neutrinoPath, 0);
+
+    // game->startup lives in hddGames / gAutoLaunchGame, freed below (deinitEx's itemCleanUp or the
+    // explicit free). Copy it before the teardown so sysLaunchNeutrino's -elf build is not a UAF read.
+    char apaStartup[sizeof(game->startup)];
+    snprintf(apaStartup, sizeof(apaStartup), "%s", game->startup);
+
+    if (gAutoLaunchGame == NULL) {
+        // Keep-IOP handoff: keep the HDD stack up (NHDDL hands off with its full ATA stack
+        // resident) AND the neutrino.elf device (-cwd config/module reads).
+        int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+        deinitEx(UNMOUNT_EXCEPTION, HDD_MODE, neutrinoDevMode); // CAREFUL: itemCleanUp frees hddGames/game
+    } else {
+        miniDeinit(configSet);
+        free(gAutoLaunchGame);
+        gAutoLaunchGame = NULL;
+        fileXioUmount("pfs0:");
+        fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
+    }
+
+    LOG("[NEUTRINO] apa partition_name=[%s]\n", apaPart);
+    // gPS2Logo passes the preference straight through (Neutrino does its own logo work).
+    sysLaunchNeutrino("apa", apaPart, apaStartup, compatMode, gPS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11 inert: APA is always -bsdfs=hdl */, NULL /* HDD VMC->neutrino deferred (APA/pfs) */);
+    return 1;
 }
 
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
@@ -438,10 +914,31 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     hdl_game_info_t *game;
     struct cdvdman_settings_hdd *settings;
 
-    if (gAutoLaunchGame == NULL)
-        game = &hddGames.games[id];
-    else
+    // HDD VCD view: hand off to POPSTARTER instead of the HDL/Neutrino path below. Menu-launch only
+    // (HDD-VCD autolaunch is out of scope). POPSTARTER's argv[0] is just the VCD name -- that name is
+    // all it needs to find <name>.VCD; the __.POPS* partition the VCD lives on is passed OUT OF BAND so
+    // POPSTARTER self-mounts it after the loader's IOP reset. HW-VALIDATE: POPSTARTER's exact HDD
+    // selector/partition contract is hardware-testable -- POPSLoader proved the shape with a vendored
+    // loader; we use the stock ps2sdk loader, the same one the shipping USB/MMCE/SMB VCD launch uses.
+    if (gAutoLaunchGame == NULL && vcdViewActive(itemList->mode)) {
+        base_game_info_t *vcd = hddActiveVcd(id);
+        if (vcd == &hddEmptyVcd)
+            return; // stale id in the L3 toggle window -> nothing to launch (hddVcdParts[id] would also OOB)
+        hddDoLaunchVcd(itemList, vcd->name, hddVcdParts[id]);
+        return;
+    }
+
+    if (gAutoLaunchGame == NULL) {
+        game = hddActiveHdl(id);
+        if (game == &hddEmptyHdl)
+            return; // stale id in the L3 toggle window -> nothing to launch
+    } else
         game = gAutoLaunchGame;
+
+    // D8: Neutrino core gets its own lean path FIRST -- everything below is native-core prep it
+    // neither needs nor should be able to die on (see hddTryNeutrinoLaunch).
+    if (hddTryNeutrinoLaunch(game, configSet))
+        return;
 
     apa_sub_t parts[APA_MAXSUB + 1];
     char vmc_name[2][32];
@@ -558,17 +1055,13 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     sbPrepare(NULL, configSet, size_irx, irx, &i);
 
     if ((result = sbLoadCheats(gHDDPrefix, game->startup)) < 0) {
-        if (gAutoLaunchGame == NULL) {
-            switch (result) {
-                case -ENOENT:
-                    guiWarning(_l(_STR_NO_CHEATS_FOUND), 10);
-                    break;
-                default:
-                    guiWarning(_l(_STR_ERR_CHEATS_LOAD_FAILED), 10);
-            }
-        } else
-            LOG("Cheats error\n");
+        // #265: let the user back out instead of sitting through the whole load. The helper does
+        // the sbUnprepare itself -- see include/supportbase.h; skipping it breaks the NEXT launch.
+        // `settings` is not assigned until below, so derive the common block from the IRX base.
+        if (!sbCheatsMissingContinue((u8 *)irx + i, result))
+            return;
     }
+    sbLoadImage(gHDDPrefix, game->startup);
 
     settings = (struct cdvdman_settings_hdd *)((u8 *)irx + i);
 
@@ -598,9 +1091,16 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         }
     }
 
-    if (gAutoLaunchGame == NULL)
+    // D8: Neutrino never reaches this point (hddTryNeutrinoLaunch handled it at the top) --
+    // everything from here on is the NATIVE (embedded cdvdman) launch only.
+
+    // MMCE cross-device game-id (#261): push the HDL disc id to a present MMCE card before the HDD
+    // teardown (self-probes mmce0/mmce1; no-ops if no card / feature off). Read `game` before deinit.
+    mmceSendGameID(game->startup, NULL, 0);
+
+    if (gAutoLaunchGame == NULL) {
         deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
-    else {
+    } else {
         miniDeinit(configSet);
 
         free(gAutoLaunchGame);
@@ -622,7 +1122,16 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 static config_set_t *hddGetConfig(item_list_t *itemList, int id)
 {
     char path[256];
-    hdl_game_info_t *game = &hddGames.games[id];
+
+    // VCD (PS1) view: `id` indexes hddVcdGames, NOT hddGames (which stays at its zero/ISO-view state --
+    // {games=NULL,count=0} on a PS1-only HDD). Mirror the other VCD-aware accessors and key the per-game
+    // CFG off the VCD basename, instead of dereferencing &hddGames.games[id] off a NULL base (crash).
+    if (vcdViewActive(itemList->mode)) {
+        base_game_info_t *g = hddActiveVcd(id); // toggle-window safe: empty entry on a stale id (no OOB)
+        return sbPopulateConfig(g, gHDDPrefix, "/");
+    }
+
+    hdl_game_info_t *game = hddActiveHdl(id); // toggle-window safe: empty entry on a stale id (no OOB)
 
     snprintf(path, sizeof(path), "%sCFG/%s.cfg", gHDDPrefix, game->startup);
     config_set_t *config = configAlloc(0, NULL, path);
@@ -631,7 +1140,10 @@ static config_set_t *hddGetConfig(item_list_t *itemList, int id)
     configSetStr(config, CONFIG_ITEM_NAME, game->name);
     configSetInt(config, CONFIG_ITEM_SIZE, game->total_size_in_kb >> 10);
     configSetStr(config, CONFIG_ITEM_FORMAT, "HDL");
-    configSetStr(config, CONFIG_ITEM_MEDIA, game->disctype == SCECdPS2CD ? "CD" : "DVD");
+    // HDD bypasses sbPopulateConfig, so set #System/#Media/#DiscType via the shared helper (FR #49) --
+    // without it a theme's #DiscType / #System AttributeImage badge never rendered on HDD games. HDL
+    // titles are always PS2; reuse game->disctype for the CD-vs-DVD axis.
+    sbSetDiscAttributes(config, 0, game->disctype == SCECdPS2CD);
     configSetStr(config, CONFIG_ITEM_STARTUP, game->startup);
 
     return config;
@@ -640,6 +1152,9 @@ static config_set_t *hddGetConfig(item_list_t *itemList, int id)
 static int hddGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     char path[256];
+
+    // PS1 (VCD) art uses this same ART path as PS2. The cache supplies the filename first and may retry
+    // once with a strict PS1 ID after a genuine miss; pfs0: remains the current OPL data mount.
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", gHDDPrefix, folder, value, suffix);
     else
@@ -664,6 +1179,8 @@ static void hddCleanUp(item_list_t *itemList, int exception)
 
     if (hddGameList.enabled) {
         hddFreeHDLGamelist(&hddGames);
+        hddFreeVcdGameList();
+        fileXioUmount("pfs1:");
 
         if ((exception & UNMOUNT_EXCEPTION) == 0)
             fileXioUmount(hddPrefix);
@@ -689,6 +1206,8 @@ static void hddShutdown(item_list_t *itemList)
 
     if (hddGameList.enabled) {
         hddFreeHDLGamelist(&hddGames);
+        hddFreeVcdGameList();
+        fileXioUmount("pfs1:");
         fileXioUmount(hddPrefix);
     }
 
@@ -708,8 +1227,16 @@ static void hddShutdown(item_list_t *itemList)
             hddSetIdleImmediate();
         }
 
-        // Only shut down dev9 from here, if it was initialized from here before.
-        sysShutdownDev9();
+        // Only shut down dev9 from here, if it was initialized from here before -- and only on a
+        // TERMINAL teardown (exit/poweroff). On the launch path this shutdown runs for every
+        // non-selected page, and powering DEV9 off here kills the ATA bus BEFORE bdmLaunchVcd's
+        // post-deinit POPSTARTER.ELF read from the ATA-backed massN: mount -- the elf-loader then
+        // returns into deinit'd OPL: the 4236edf6-class black-screen freeze (PCSX2 masks it; its
+        // emulated DEV9 power-off is inert). ee_core/POPSTARTER reset the IOP right after, so the
+        // launch path needs no power-off. Note the refcount asymmetry this also softens: N
+        // hddLoadModules calls take ONE dev9 reference, but every hddShutdown used to drop it.
+        if (gDeinitTerminal)
+            sysShutdownDev9();
     }
 }
 
@@ -831,4 +1358,4 @@ static char *hddGetPrefix(item_list_t *itemList)
 static item_list_t hddGameList = {
     HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, NULL, NULL, &hddGetTextId, &hddGetPrefix, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
     &hddGetGameCount, &hddGetGame, &hddGetGameName, &hddGetGameNameLength, &hddGetGameStartup, &hddDeleteGame, &hddRenameGame,
-    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId};
+    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId, &hddLaunchVcd};

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -26,6 +26,7 @@ enum MENU_IDs {
     MENU_INTERFACE,
     MENU_DISPLAY,
     MENU_GAME_LAUNCHING,
+    MENU_POPSTARTER, // NOTE(rebuild): MENU_MMCE joins with checklist item 1
     MENU_NETWORK,
     MENU_CONTROLLER,
     MENU_AUDIO,
@@ -250,6 +251,7 @@ static void menuInitMainMenu(void)
     submenuAppendItem(&mainMenu, -1, NULL, MENU_INTERFACE, _STR_INTERFACE_SETTINGS);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_DISPLAY, _STR_DISPLAY_SETTINGS);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_GAME_LAUNCHING, _STR_GAME_LAUNCHING);
+    submenuAppendItem(&mainMenu, -1, NULL, MENU_POPSTARTER, _STR_POPSTARTER);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_NETWORK, _STR_MENU_NETWORK);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_CONTROLLER, _STR_MENU_CONTROLLER);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_AUDIO, _STR_MENU_AUDIO);
@@ -437,6 +439,14 @@ void submenuRebuildCache(submenu_list_t *submenu)
 
         submenu = submenu->next;
     }
+}
+
+// True once the global menu list contains a registered device/mode tab (returns menu != NULL).
+// initSupport uses the FALSE case to spot "user enabled the FIRST tab from the start menu",
+// where nothing would otherwise take them to it (#254).
+int menuHasRegisteredItems(void)
+{
+    return menu != NULL;
 }
 
 static submenu_list_t *submenuAllocItem(int icon_id, char *text, int id, int text_id)
@@ -939,6 +949,9 @@ void menuHandleInputMenu()
         } else if (id == MENU_GAME_LAUNCHING) {
             if (menuCheckParentalLock() == 0)
                 guiShowLaunchConfig();
+        } else if (id == MENU_POPSTARTER) {
+            if (menuCheckParentalLock() == 0)
+                guiShowVcdConfig();
         } else if (id == MENU_NETWORK) {
             if (menuCheckParentalLock() == 0)
                 guiShowNetConfig();

--- a/src/opl.c
+++ b/src/opl.c
@@ -973,12 +973,12 @@ void menuDeferredUpdate(void *data)
     }
 }
 
-#define MENU_GENERAL_UPDATE_DELAY 60
+#define MENU_GENERAL_UPDATE_DELAY          60
 // Minimum wall-clock gap between background rescans of the SAME updateDelay==0 device (Fix B). At
 // ~2 s this drops the steady SIO2/mass enumeration rate well below the old every-60-frames cadence,
 // cutting MX4SIO bus contention, while a real device change still refreshes immediately
 // (BdmGeneration bypass below). clock() = microseconds.
-#define MENU_BG_RESCAN_MIN_INTERVAL_TICKS (2 * CLOCKS_PER_SEC)
+#define MENU_BG_RESCAN_MIN_INTERVAL_TICKS  (2 * CLOCKS_PER_SEC)
 /*
   Idle time required before STEADY-STATE background probes may run at all, in frames (~1 s NTSC).
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -114,6 +114,11 @@ static void deferredAudioInit(void);
 
 // frame counter
 static unsigned int frameCounter;
+// Per-mode background-rescan throttle (Fix B): the every-frame (updateDelay==0) device rescans
+// enumerate the SIO2/mass bus; space them by a minimum wall-clock interval so they don't run
+// unthrottled. A real device change bypasses the throttle via bdmGetGeneration().
+static clock_t lastBgRescan[MODE_COUNT];
+static unsigned int lastSeenBdmGeneration;
 
 static char errorMessage[256];
 
@@ -285,6 +290,11 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
 
         if (gFAVStartMode)
             menuAddHint(&mod->menuItem, _STR_FAV_HINT, R3_ICON);
+
+        // L3 toggles the device's disc list <-> its VCD (PS1-via-POPSTARTER) list -- only under the
+        // "Both" default-view setting; ISO/VCD lock the page, so the toggle and its hint go away.
+        if (vcdModeSupported(mod->support->mode) && gDefaultGameView == GAME_VIEW_BOTH)
+            menuAddHint(&mod->menuItem, _STR_VCD, L3_ICON);
     }
 
     // refresh Cache
@@ -326,7 +336,7 @@ static void itemExecSelect(struct menu_item *curMenu)
             // If we're trying to enable BDM support we need to enable it for all BDM menu slots.
             if (support->mode == BDM_MODE) {
                 // Initialize support for all bdm modules.
-                for (int i = 0; i <= BDM_MODE4; i++) {
+                for (int i = BDM_MODE; i <= BDM_MODE_LAST; i++) {
                     opl_io_module_t *mod = &list_support[i];
                     itemInitSupport(mod->support);
                 }
@@ -347,6 +357,26 @@ static void itemExecRefresh(struct menu_item *curMenu)
         ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
         sfxPlay(SFX_CONFIRM);
     }
+}
+
+// L3: toggle the device's list between its disc games and its VCD (PS1-via-POPSTARTER) list. Only
+// device classes that have a VCD view (vcdModeSupported) respond. vcdToggleView marks the mode
+// dirty; the deferred update + the support's NeedsUpdate (vcdConsumeDirty) then force the rescan.
+static void itemExecToggleView(struct menu_item *curMenu)
+{
+    item_list_t *support = curMenu->userdata;
+    if (!support || !vcdModeSupported(support->mode))
+        return;
+    if (gDefaultGameView != GAME_VIEW_BOTH)
+        return; // the global default-view setting locks the page to one type -> L3 is inert
+
+    // Folder browsing: the VCD/POPS list has no folder tree, so drop any ISO-view subfolder position
+    // back to root on a view toggle (the deferred rebuild below restores the plain device title).
+    folderReset(support->mode);
+    vcdToggleView(support->mode);
+    sfxPlay(SFX_CONFIRM);
+    guiWarning(vcdViewActive(support->mode) ? _l(_STR_VCD_ON) : _l(_STR_VCD_OFF), 2);
+    ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
 }
 
 // Folder browsing: the cancel button (whichever of Cross/Circle is not Select) ascends a level.
@@ -482,16 +512,18 @@ static void initMenuForListSupport(opl_io_module_t *mod)
     mod->menuItem.execSquare = &itemExecSquare;
     mod->menuItem.execCircle = &itemExecCircle;
     mod->menuItem.fav = &itemExecFav;
-    mod->menuItem.toggleView = NULL; // VCD view toggle arrives with checklist item 12
+    mod->menuItem.toggleView = &itemExecToggleView;
 
     mod->menuItem.hints = NULL;
 
     moduleUpdateMenuInternal(mod, 0, 0);
 
     struct gui_update_t *mc = guiOpCreate(GUI_OP_ADD_MENU);
-    mc->menu.menu = &mod->menuItem;
-    mc->menu.subMenu = &mod->subMenu;
-    guiDeferUpdate(mc);
+    if (mc) { // guiOpCreate returns NULL on OOM -- skip the deferred op rather than deref NULL
+        mc->menu.menu = &mod->menuItem;
+        mc->menu.subMenu = &mod->subMenu;
+        guiDeferUpdate(mc);
+    }
 }
 
 static void clearMenuGameList(opl_io_module_t *mdl)
@@ -541,6 +573,21 @@ void initSupport(item_list_t *itemList, int mode, int force_reinit)
             mod->support = itemList;
             mod->support->owner = mod;
             initMenuForListSupport(mod);
+
+            // First-ever tab while the GUI sits on the start menu (fresh/default config, every
+            // mode OFF): take the user TO the new tab, or they stay on the "default interface"
+            // with no visible way to it (#254 follow-up: "Apps section does not appear in the
+            // default interface even if enabled, until a theme is applied" -- the theme apply was
+            // just the thing that returned them to the tab screen). Boot is unaffected:
+            // deferredInit's default-device select queues AFTER this one and wins; multi-mode
+            // enables land on the last registered tab.
+            if (!menuHasRegisteredItems()) {
+                struct gui_update_t *sel = guiOpCreate(GUI_OP_SELECT_MENU);
+                if (sel) {
+                    sel->menu.menu = &mod->menuItem;
+                    guiDeferUpdate(sel);
+                }
+            }
         } else {
             // Re-enable after a prior disable: the support + its menu item already exist (registered on
             // an earlier enable), so the !mod->support branch above -- the ONLY place that sets
@@ -565,13 +612,27 @@ void initSupport(item_list_t *itemList, int mode, int force_reinit)
     }
 }
 
+// Boot-splash status (#297): true only across init()'s synchronous boot device-load, so the
+// in-initAllSupport greeting redraws fire ONLY during boot -- not on a post-boot settings refresh
+// (which runs on the IO thread with the menu showing; an ungated redraw would flash the boot logo).
+static int gBootInProgress = 0;
+
 static void initAllSupport(int force_reinit)
 {
+    guiSetBootStatus(_l(_STR_BOOT_SCANNING_BDM));
+    if (gBootInProgress)
+        guiRenderGreetingScreen();
     bdmEnumerateDevices();
+    guiSetBootStatus(_l(_STR_BOOT_SCANNING_NET));
+    if (gBootInProgress)
+        guiRenderGreetingScreen();
     initSupport(ethGetObject(0), ETH_MODE, force_reinit || (gNetworkStartup >= ERROR_ETH_SMB_CONN));
     // UDPFS filesystem shares the single NIC with SMB/UDPBD; its start-mode gate (initSupport) is live
     // only when gNetworkProtocol == NET_PROTO_UDPFS, so exactly one network tab is ever enabled.
     initSupport(udpfsGetObject(0), UDPFS_MODE, force_reinit);
+    guiSetBootStatus(_l(_STR_BOOT_SCANNING_HDD));
+    if (gBootInProgress)
+        guiRenderGreetingScreen();
     initSupport(hddGetObject(0), HDD_MODE, force_reinit);
     initSupport(appGetObject(0), APP_MODE, force_reinit);
     initSupport(favGetObject(0), FAV_MODE, force_reinit);
@@ -582,6 +643,19 @@ static void deinitAllSupport(int exception, int modeSelected)
     for (int i = 0; i < MODE_COUNT; i++) {
         if (list_support[i].support != NULL)
             moduleCleanup(&list_support[i], exception, modeSelected);
+    }
+}
+
+void oplQueueVcdDeviceUpdates(void)
+{
+    // vcdMarkAllDirty() is intentionally side-effect-free because it also runs during early config
+    // loading, before the IO worker and device modules are ready. Runtime callers must explicitly
+    // enqueue the enabled pages. This matters most for HDD, whose updateDelay=-1 means a dirty view
+    // otherwise keeps displaying the old submenu indefinitely while rendering uses the new view.
+    for (int i = 0; i < MODE_COUNT; i++) {
+        item_list_t *support = list_support[i].support;
+        if (support != NULL && support->enabled && support->mode != FAV_MODE && vcdModeSupported(support->mode))
+            ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
     }
 }
 
@@ -900,6 +974,27 @@ void menuDeferredUpdate(void *data)
 }
 
 #define MENU_GENERAL_UPDATE_DELAY 60
+// Minimum wall-clock gap between background rescans of the SAME updateDelay==0 device (Fix B). At
+// ~2 s this drops the steady SIO2/mass enumeration rate well below the old every-60-frames cadence,
+// cutting MX4SIO bus contention, while a real device change still refreshes immediately
+// (BdmGeneration bypass below). clock() = microseconds.
+#define MENU_BG_RESCAN_MIN_INTERVAL_TICKS (2 * CLOCKS_PER_SEC)
+/*
+  Idle time required before STEADY-STATE background probes may run at all, in frames (~1 s NTSC).
+
+  The short gate (MENU_MIN_INACTIVE_FRAMES = 8, ~133 ms) is tuned for "the user paused between
+  inputs" -- right for waking cover-art loads, and WRONG for device probes. Frame analysis of a
+  tester capture (#271) showed why: tapping through the list at a steady ~4.3 taps/s leaves
+  ~130 ms release gaps, which sit exactly AT the short gate, so throttled probes leaked into
+  active navigation and a probe firing into a tap gap contends with the pads on SIO2 -- the tap
+  landing inside the resulting read-miss burst is eaten.
+
+  60 frames of REAL idleness is far above any tap gap, so probes never fire mid-navigation, and a
+  parked console still probes within a second of the user stopping. Hotplug stays immediate-ish:
+  the BdmGeneration bypass below keeps the SHORT gate, so a plugged device is picked up in the
+  next tap gap rather than after a full second.
+*/
+#define MENU_BG_RESCAN_MIN_INACTIVE_FRAMES 60
 
 static void menuUpdateHook()
 {
@@ -908,20 +1003,68 @@ static void menuUpdateHook()
     // if timer exceeds some threshold, schedule updates of the available input sources
     frameCounter++;
 
+    // Keep background refresh work out of the shared IO queue while the user is actively navigating.
+    if (guiInactiveFrames < MENU_MIN_INACTIVE_FRAMES)
+        return;
+
+    // Let the current queue drain before adding background refresh work.
+    if (ioHasPendingRequests())
+        return;
+
+    // NOTE(rebuild): the fork also yields to pending cover-art work here (cacheHasPendingArt);
+    // that gate returns with the art-cache rework (item 45).
+
+    // Steady-state probes additionally require REAL idleness (see the define): a tap gap passes the
+    // short gate above, and a probe fired into it contends with the pads on SIO2 and eats the next
+    // tap (#271). Event-driven work (the genChanged hotplug bypass below) keeps the short gate.
+    int longIdle = (guiInactiveFrames >= MENU_BG_RESCAN_MIN_INACTIVE_FRAMES);
+
     // schedule updates of all the list handlers
-    if (gAutoRefresh) {
+    // Periodic background rescans. Both steady-state rescans enqueue standard requests and are
+    // rendered with the unified busy overlay.
+    if (gAutoRefresh && longIdle) {
         for (i = 0; i < MODE_COUNT; i++) {
             if ((list_support[i].support && list_support[i].support->enabled) && ((list_support[i].support->updateDelay > 0) && (frameCounter % list_support[i].support->updateDelay == 0)))
                 ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
         }
     }
 
-    // Schedule updates of all list handlers that are to run every frame, regardless of whether auto refresh is active or not.
+    // Schedule updates of the every-frame (updateDelay==0) list handlers -- all BDM/MX4SIO. These
+    // enumerate the SIO2/mass bus, so throttle each to a minimum wall-clock interval instead of
+    // firing every MENU_GENERAL_UPDATE_DELAY frames. A genuine BDM device change (hotplug/removal
+    // via BdmGeneration, or a Device-Settings apply) bypasses the throttle so detection stays
+    // immediate.
     if (frameCounter % MENU_GENERAL_UPDATE_DELAY == 0) {
+        unsigned int gen = bdmGetGeneration();
+        int genChanged = (gen != lastSeenBdmGeneration);
+        clock_t now = clock();
+        // Consume the generation bump only if every hotplug-driven enqueue is ACCEPTED:
+        // ioPutRequest can fail (queue blocked during teardown, allocation failure), and
+        // committing lastSeenBdmGeneration up front would silently eat the one immediate-rescan
+        // event a hotplug gets. Leaving the generation unconsumed makes the next 1 s tick retry
+        // the whole event instead.
+        int genConsumed = 1;
         for (i = 0; i < MODE_COUNT; i++) {
-            if ((list_support[i].support && list_support[i].support->enabled) && (list_support[i].support->updateDelay == 0))
-                ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode);
+            if ((list_support[i].support && list_support[i].support->enabled) && (list_support[i].support->updateDelay == 0)) {
+                int mode = list_support[i].support->mode;
+                // elapsed form is single-wrap-safe; zero-initialized timestamp allows one immediate rescan.
+                // genChanged (hotplug / Device-Settings apply) deliberately requires NEITHER longIdle:
+                // it fires precisely BECAUSE a device changed, the scan populates a page the
+                // user is waiting on, and a plugged device should be noticed in the
+                // next tap gap rather than after a second of stillness (#271).
+                if (genChanged || (longIdle && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
+                    // Stamp the throttle only on an accepted request, so a rejected one retries on
+                    // the next tick instead of being silently skipped for a full interval.
+                    int accepted = (ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);
+                    if (accepted)
+                        lastBgRescan[mode] = now;
+                    else if (genChanged)
+                        genConsumed = 0;
+                }
+            }
         }
+        if (genConsumed)
+            lastSeenBdmGeneration = gen;
     }
 }
 
@@ -1150,6 +1293,14 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_DEFAULT_GAME_VIEW, &gDefaultGameView);
             if (gDefaultGameView < GAME_VIEW_BOTH || gDefaultGameView > GAME_VIEW_VCD)
                 gDefaultGameView = GAME_VIEW_BOTH;
+            // A boot default-view locked to one type (VCD or ISO) must force the same one-shot
+            // rescan the settings dialog does on a view change (gui.c). Without it, vcdViewActive()
+            // short-circuits bdm/hdd/eth NeedsUpdate before the initial-scan trigger and the
+            // list stays blank on boot -- a manual SELECT does not recover it (NeedsUpdate still
+            // returns 0), only re-toggling the view does. This runs before applyConfig()'s first
+            // support scans, so each VCD-capable page consumes the dirty flag on its first refresh.
+            if (gDefaultGameView != GAME_VIEW_BOTH)
+                vcdMarkAllDirty();
             configGetStrCopy(configOPL, CONFIG_OPL_POPSTARTER_PATH, gPopstarterPath, sizeof(gPopstarterPath));
             // POPSTARTER device TYPE (POPS_DEV_*). Absent in legacy configs: a non-empty custom
             // popstarter_path migrates to Custom (honour the old override); otherwise Default (cwd).
@@ -2002,11 +2153,19 @@ static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected)
     clearMenuGameList(mod);
 }
 
+// 1 while deinit() tears down for exit/poweroff, 0 for a game/app launch. Consumed by device shutdowns
+// that must behave differently on the launch path (hddShutdown keeps DEV9 powered so the post-deinit
+// POPSTARTER.ELF read from the ATA-backed massN: mount still works; ee_core/POPSTARTER reset the IOP
+// themselves, so skipping the power-off on launches leaks nothing).
+int gDeinitTerminal = 0;
+
 // deinitEx: deinit for the Neutrino keep-IOP handoff -- spares TWO modes' mounts (the game
 // device AND the device holding neutrino.elf), since Neutrino reads its -cwd config/modules
 // and the ISO through OPL's live mounts before performing its own IOP reset.
 void deinitEx(int exception, int modeSelected, int modeSelected2)
 {
+    gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
+
     // block all io ops, wait for the ones still running to finish
     ioBlockOps(1);
     guiExecDeferredOps();
@@ -2036,6 +2195,8 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 
 void deinit(int exception, int modeSelected)
 {
+    gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
+
     // block all io ops, wait for the ones still running to finish
     ioBlockOps(1);
     guiExecDeferredOps();
@@ -2244,6 +2405,7 @@ static void init(void)
     while (!padStatus)
         padStatus = startPads();
     readPads();
+    gBootInProgress = 1; // gate the in-initAllSupport greeting redraws to the boot pass only (#297)
     if (!getKeyPressed(KEY_START)) {
         // Show the boot splash (not guiRenderTextScreen(), which calls guiShow()
         // and would draw the not-yet-ready main menu as a garbled landing page
@@ -2257,6 +2419,7 @@ static void init(void)
     }
     guiSetBootStatus(_l(_STR_BOOT_READY));
     guiRenderGreetingScreen();
+    gBootInProgress = 0;
 
 
     // queue deffered init of sound effects, which will take place after the preceding initialization steps within the queue are complete.
@@ -2462,6 +2625,45 @@ static void autoLaunchBDMGame(char *argv[])
 }
 
 // --------------------- Main --------------------
+// Basename of the ELF OPL was booted as (argv[0]); pairs with gBootDir. Static: consumers
+// outside this file go through gBootDir only.
+static char gBootElfName[64];
+
+static void setBootDir(const char *bootPath)
+{
+    gBootDir[0] = '\0';
+    gBootElfName[0] = '\0';
+    if (bootPath == NULL || bootPath[0] == '\0')
+        return;
+
+    // Launchers are not consistent about separators (wLaunchELF variants can hand backslash paths);
+    // normalize to '/' before splitting so the folder/basename split can't misfire.
+    char path[sizeof(gBootDir)];
+    snprintf(path, sizeof(path), "%s", bootPath);
+    for (char *p = path; *p != '\0'; p++) {
+        if (*p == '\\')
+            *p = '/';
+    }
+
+    const char *slash = strrchr(path, '/');
+    if (slash != NULL) {
+        size_t len = (size_t)(slash - path); // keep the folder, drop the trailing '/' + filename
+        if (len > 0 && len < sizeof(gBootDir)) {
+            memcpy(gBootDir, path, len);
+            gBootDir[len] = '\0';
+            snprintf(gBootElfName, sizeof(gBootElfName), "%s", slash + 1);
+        }
+    } else {
+        const char *colon = strrchr(path, ':'); // "mass0:X.ELF" -> device root "mass0:"
+        if (colon != NULL && (size_t)(colon - path) + 1 < sizeof(gBootDir)) {
+            size_t len = (size_t)(colon - path) + 1;
+            memcpy(gBootDir, path, len);
+            gBootDir[len] = '\0';
+            snprintf(gBootElfName, sizeof(gBootElfName), "%s", colon + 1);
+        }
+    }
+}
+
 int main(int argc, char *argv[])
 {
 #ifdef __DECI2_DEBUG
@@ -2476,6 +2678,21 @@ int main(int argc, char *argv[])
     // reset, load modules
     reset();
     ResetDeckardXParams();
+
+    // Settings live in the boot directory (cwd). Resolve it once, before any config init -- the
+    // autolaunch path below calls miniInit() -> configInit(). argv[0] is the launcher's boot path;
+    // getcwd() backs it up. Empty only if both are unusable, in which case configInit falls back to
+    // the memory-card default.
+    setBootDir(argc >= 1 ? argv[0] : NULL);
+    if (gBootDir[0] == '\0') {
+        char cwd[256];
+        if (getcwd(cwd, sizeof(cwd)) != NULL && cwd[0] != '\0') {
+            int n = (int)strlen(cwd);
+            while (n > 0 && cwd[n - 1] == '/') // configInit appends '/', so drop any trailing one
+                cwd[--n] = '\0';
+            snprintf(gBootDir, sizeof(gBootDir), "%s", cwd);
+        }
+    }
 
     if (argc >= 5) {
         /* argv[0] boot path

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1045,6 +1045,16 @@ int sbLoadImage(const char *path, const char *file)
     return 0;
 }
 
+// Stamp the console/media identity attributes every game config carries. #System is the console
+// axis a theme maps to a PS1/PS2 glyph; #Media stays the disc axis; #DiscType is the combined
+// console+media token so one AttributeImage glyph can distinguish PS1-CD from PS2-CD (issue #49).
+void sbSetDiscAttributes(config_set_t *config, int isPS1, int isCD)
+{
+    configSetStr(config, CONFIG_ITEM_SYSTEM, isPS1 ? "PS1" : "PS2");
+    configSetStr(config, CONFIG_ITEM_MEDIA, isCD ? "CD" : "DVD");
+    configSetStr(config, CONFIG_ITEM_DISCTYPE, isPS1 ? "PS1CD" : (isCD ? "PS2CD" : "PS2DVD"));
+}
+
 int sbLoadCheats(const char *path, const char *file)
 {
     char cheatfile[64];


### PR DESCRIPTION
**The payoff drop.** bdm/hdd/eth land byte-identical to the fork (sole adaptation: SMBv1 pin — item 4 WAIT). Brings VCD views (items 12/13/19) with the full POPStarter settings surface, the #271 background-rescan throttle, first-tab select (#254), boot banners, and the launch-vs-exit teardown flag. One real landmine defused: an EE/IOP struct-width mismatch (fname 80 vs 64) that would overshoot the mcemu marker memcpy by 16 bytes.

Recon-driven port: a 4-lens workflow mapped every absent symbol before the first fix; the compiler's residual list matched it. MMCE stays exactly stubbed (gate E); grep NOTE(rebuild) for the deferred seams.

**HW note for Zack's next pass:** this is the first build where scroll should be tested WITH devices enabled — the rebuild-10b seamless result was measured with all transports off, and this step carries the fork's SIO2-contention throttle precisely for that case.

Full clean local build passes. Merge on CI green; tag rebuild-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)