### PR TITLE
fix(boot): restore the menu-time usbd.irx load -- rebuild-12 black screen

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -251,6 +251,24 @@ void sysReset(int modload_mask)
     LOG("[POWEROFF]:\n");
     sysLoadModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL);
 
+    /*
+      usbd is the USB HOST STACK, not a storage driver: it must be resident before ANY usbd client
+      loads, and it stays unconditional (independent of gEnableUSB, which gates only usbmass_bd).
+      The PADEMU block ~20 lines below loads ds34usb.irx/ds34bt.irx, and both hard-import usbd
+      (each module's iop/imports.lst carries a usbd_IMPORTS_start block). Without usbd resident their
+      loadcore link stage fails, neither registers its SIF RPC server, and ds34usb_init()'s unbounded
+      "do { SifBindRpc } while (!server)" spin never terminates -- sysReset() never returns, init()
+      never runs, and the console black-screens before the GS is even initialised.
+
+      This lives HERE, matching fork master (src/system.c, after POWEROFF), NOT in bdmLoadModules().
+      Official OPL loads usbd inside bdmsupport.c and steps 01..11 followed official; rebuild-12 then
+      landed the FORK's bdmsupport.c byte-identically -- and the fork's copy has no usbd load, because
+      the fork does it right here. Both halves of that contract now match the fork. Do not move it
+      back into bdmLoadModules() without also removing the fork-parity claim on bdmsupport.c.
+    */
+    LOG("[USBD]:\n");
+    sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
+
     if (modload_mask & SYS_LOAD_USB_MODULES) {
         bdmLoadModules();
     }


### PR DESCRIPTION
## The failure

Zack, on hardware, rebuild-12 (run 31261440150): **"they didnt boot at all — black screen crash"**, all three flavours. rebuild-10b booted and scrolled clean on the same console.

## Root cause — one missing line, same class as the guiLock deadlock

**`usbd.irx` was loaded nowhere at menu time.** A tree-wide `grep usbd_irx src/ include/` on `rebuild/main` returns only `extern_irx.h` (the import declaration) and `system.c`'s `irxptr_tab` — and that table is built at *game launch* for `ee_core`, so it never loads usbd into OPL's own live IOP.

How it went missing:

| | where usbd is loaded |
|---|---|
| official OPL (our base) | `bdmsupport.c` |
| rebuild steps 01–11 | `bdmsupport.c` (followed official; step 01 kept it unconditional, gating only `usbmass_bd` on `gEnableUSB`) |
| **fork master** | **`system.c`** |
| rebuild-12 | **nowhere** |

rebuild-12 landed the fork's `bdmsupport.c` byte-identically — which correctly has no usbd load, because the fork does it in `system.c`. But our `system.c` is official-derived and never had the fork's line. Each half was individually defensible; together they left a hole. Exactly the `themes.c`/`guiLock` lesson: when a fork file lands wholesale, its cross-file contracts must land with it.

## Why that is a deterministic, pre-frame black screen

```
main() -> reset() -> sysReset(SYS_LOAD_MC_MODULES | SYS_LOAD_USB_MODULES | SYS_LOAD_ISOFS_MODULE)
  -> PADEMU block loads ds34usb.irx + ds34bt.irx
     ... both hard-import usbd (each iop/imports.lst has a usbd_IMPORTS_start block),
         so with usbd absent the loadcore link stage fails and neither module
         registers its SIF RPC server
  -> ds34usb_init():  do { if (SifBindRpc(...) < 0) return 0; nopdelay(); } while (!server);
     ... SifBindRpc returns 0, server stays NULL forever -> unbounded spin
  -> sysReset() never returns -> init() never runs -> rmInit()/guiInit() never run
```

The GS is never initialised, so nothing is ever drawn — black screen, not a hang on a visible frame. `PADEMU ?= 1` in the Makefile means all three flavours carry it, and `reset()` always passes `SYS_LOAD_USB_MODULES`, so **no config value or device toggle can influence it**.

That last point also settles a confound: this test was the first one run with transports *enabled*, so "a fault on the device-enabled boot path" was a live hypothesis. It's ruled out — this fires unconditionally. rebuild-12 never booted for anyone.

## The fix

Restore the load in `system.c` at the fork's exact position (after `POWEROFF`, before `bdmLoadModules()` and the PADEMU block), so `bdmsupport.c` stays byte-identical to the fork and both halves of the contract now match it.

## Verification

- Local clean build in the `opl340` container: `MAKE_EXIT=0`, `opl.elf` produced.
- Load order confirmed: POWEROFF (251) → **USBD (270)** → `bdmLoadModules()` (273) → ds34 load (295) → `ds34usb_init()` (300).
- Checked for sibling losses: diffed the full menu-time module-load set for rebuild-11 vs rebuild-12. Five other symbols initially looked missing but are loaded via the fork's `bdmLoadOptionalModule()` helpers and a `(void *)&` cast in `ethsupport.c`. **usbd is the only genuine loss.**

## Follow-up (not in this PR)

`ds34usb_init()` / `ds34bt_init()` have no retry bound, so any future missing-module regression wedges boot the same way. Worth a bounded retry + LOG on give-up — kept out of here so the hardware re-test is a single-variable experiment.