### PR TITLE
rebuild-13: visual GameID barcode (checklist item 25)

### DIFF
--- a/include/gui.h
+++ b/include/gui.h
@@ -175,6 +175,12 @@ void guiGameHandleDeferedIO(int *ptr, struct UIItem *ui, int type, void *data);
 /** Renders a single frame with a specified message on the screen
  */
 void guiRenderTextScreen(const char *message);
+
+/** Display the visual GameID barcode (CosmicScale scheme) for Pixel FX / RetroGEM / PS2Digital
+ *  HDMI auto-profiles. No-op unless gApplyGameID is set. Call just before launching a game.
+ */
+void guiShowGameID(const char *startup);
+
 void guiRenderGreetingScreen(void);
 // Boot-splash status line (main thread); NULL clears both the line and the sticky label.
 void guiSetBootStatus(const char *status);

--- a/include/opl.h
+++ b/include/opl.h
@@ -130,6 +130,7 @@ extern int bdmCacheSize;
 extern int hddCacheSize;
 extern int smbCacheSize;
 
+extern int gApplyGameID; // Display the visual GameID barcode on launch (Pixel FX / RetroGEM HDMI auto-profiles)
 extern int gEnableUSB;
 // Neutrino Device picker: a driver-accurate device TYPE that holds <root>:/neutrino/neutrino.elf.
 enum { NEUTRINO_DEV_AUTO = 0,  // game device, then mc0/mc1 (legacy behaviour)

--- a/src/gui.c
+++ b/src/gui.c
@@ -1715,6 +1715,7 @@ reselect_video_mode:
     diaSetInt(diaDisplayConfig, UICFG_XOFF, gXOff);
     diaSetInt(diaDisplayConfig, UICFG_YOFF, gYOff);
     diaSetInt(diaDisplayConfig, UICFG_OVERSCAN, gOverscan);
+    diaSetInt(diaDisplayConfig, CFG_APPLYGAMEID, gApplyGameID); // RetroGEM/Pixel FX GameID barcode
 
     int ret = diaExecuteDialog(diaDisplayConfig, -1, 1, guiDisplayUpdater);
 
@@ -1724,6 +1725,7 @@ reselect_video_mode:
         diaGetInt(diaDisplayConfig, UICFG_XOFF, &gXOff);
         diaGetInt(diaDisplayConfig, UICFG_YOFF, &gYOff);
         diaGetInt(diaDisplayConfig, UICFG_OVERSCAN, &gOverscan);
+        diaGetInt(diaDisplayConfig, CFG_APPLYGAMEID, &gApplyGameID);
 
         applyConfig(-1, -1, 1);
     }
@@ -2715,6 +2717,161 @@ void guiRenderTextScreen(const char *message)
     guiDrawOverlays();
 
     guiEndFrame();
+}
+
+// ---- Visual GameID barcode (Pixel FX / RetroGEM / PS2Digital HDMI auto-profile) ----
+// Renders the CosmicScale "GameID" barcode just before a game is handed to its core, so an HDMI
+// scaler can auto-load that game's per-title display profile. Encoding is the canonical CosmicScale
+// scheme (start word 0xA5 / end word 0xD5 / length byte / additive 0x100-sum checksum), drawn with
+// rmDrawRect exactly as CosmicScale's own OPL fork does. Gated behind gApplyGameID, which ships OFF
+// (fork commit cc2cdfed, "GameID defaults OFF") -- the HDMI latch is only verifiable on real GameID
+// hardware, so this stays opt-in until a tester confirms it. The fork's own header comment here still
+// claimed "default ON since 120045d0"; setDefaults() has said 0 since cc2cdfed, so that claim is stale
+// and is not carried over.
+//
+// NOTE (#269): "imperceptible on other displays" was only true once guiShowGameID stopped LEAVING the
+// barcode on screen. It is the last thing OPL draws before the ELF handoff, and on composite the
+// 1-pixel-pitch strip averages to a solid white bar that the GS scans out for the whole game load.
+// The trailing clean-frame loop at the end of guiShowGameID is what makes that premise hold.
+
+#define GAMEID_HOLD_FRAMES 45 // ~0.75s @ 60fps -- enough stable frames for a scaler to sample
+
+// Normalise a startup id into the serial the GameID device expects: drop a POPS "XX."/"SB." prefix and
+// a trailing ".elf"/".ELF", cap at 11 chars (e.g. "SLUS_200.02"). Copied VERBATIM (no case fold) to
+// stay byte-identical to CosmicScale's HW-validated guiSetGameId; retail serials are already uppercase.
+static void gameIDCleanSerial(const char *startup, char *out, int outSize)
+{
+    int i = 0, len;
+    const char *src = startup;
+
+    out[0] = '\0';
+    if (src == NULL)
+        return;
+
+    if (!strncmp(src, "XX.", 3) || !strncmp(src, "SB.", 3))
+        src += 3;
+
+    while (src[i] != '\0' && i < outSize - 1) {
+        out[i] = src[i];
+        i++;
+    }
+    out[i] = '\0';
+
+    len = (int)strlen(out);
+    if (len >= 4 && !strcasecmp(&out[len - 4], ".elf"))
+        out[len - 4] = '\0';
+    if (strlen(out) > 11)
+        out[11] = '\0';
+}
+
+// Build the GameID packet from a cleaned serial; returns its length in bytes.
+static int gameIDBuildPacket(u8 *data, const char *serial)
+{
+    int n = 0, i, sum = 0, crcpos;
+    int gidlen = (int)strlen(serial);
+    if (gidlen > 11)
+        gidlen = 11;
+
+    data[n++] = 0xA5;       // start / detect word
+    data[n++] = 0x00;       // address offset
+    crcpos = n++;           // checksum placeholder (data[2])
+    data[n++] = (u8)gidlen; // payload length
+    for (i = 0; i < gidlen; i++)
+        data[n++] = (u8)serial[i];
+    data[n++] = 0x00;
+    data[n++] = 0xD5; // end word
+    data[n++] = 0x00; // padding
+
+    for (i = 3; i < n; i++) // additive 8-bit checksum over {length byte .. end}
+        sum += data[i];
+    data[crcpos] = (u8)(0x100 - (sum & 0xFF));
+    return n;
+}
+
+// Draw the barcode once: per data bit (MSB-first) a magenta clock column + a cyan(1)/yellow(0) column.
+static void gameIDDrawBars(const char *startup)
+{
+    u8 data[32];
+    char serial[16];
+    int data_len, i, ii, xstart, ystart;
+
+    gameIDCleanSerial(startup, serial, sizeof(serial));
+    if (serial[0] == '\0')
+        return;
+
+    data_len = gameIDBuildPacket(data, serial);
+    xstart = (screenWidth / 2) - (data_len * 8); // centered horizontally
+    ystart = screenHeight - ((screenHeight / 8) * 2 + 20);
+
+    for (i = 0; i < data_len; i++) {
+        for (ii = 7; ii >= 0; ii--) {
+            int x = xstart + (i * 16 + (7 - ii) * 2);
+            rmDrawRect(x, ystart, 1, 2, GS_SETREG_RGBA(0xFF, 0x00, 0xFF, 0x80)); // magenta clock col
+            rmDrawRect(x + 1, ystart, 1, 2,
+                       ((data[i] >> ii) & 1) ? GS_SETREG_RGBA(0x00, 0xFF, 0xFF, 0x80) // cyan = 1
+                                               :
+                                               GS_SETREG_RGBA(0xFF, 0xFF, 0x00, 0x80)); // yellow = 0
+        }
+    }
+}
+
+void guiShowGameID(const char *startup)
+{
+    int frame;
+
+    if (!gApplyGameID || startup == NULL || startup[0] == '\0')
+        return;
+
+    // Hold the barcode on a clean black field for a few frames so an HDMI scaler can latch it.
+    // The loader rides these already-pumped frames (#299): this hold is the one place on the
+    // synchronous launch path that still renders, so drawing the busy animation here makes it
+    // genuinely cycle during launch prep. Bars drawn LAST so the barcode strip stays on top.
+    for (frame = 0; frame < GAMEID_HOLD_FRAMES; frame++) {
+        guiStartFrame();
+        rmDrawRect(0, 0, screenWidth, screenHeight, GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x80));
+        guiDrawBusy(0x80);
+        gameIDDrawBars(startup);
+        guiEndFrame();
+    }
+
+    /*
+      Leave a CLEAN black frame behind (#269) -- clean of the BARCODE, that is; the loader is drawn
+      on these frames on purpose (#299, below).
+
+      This is the last thing the GameID path renders: itemExecSelect() calls us and then goes
+      straight into itemLaunch() -> deinit() -> ExecPS2(), and on a default config nothing in
+      between draws anything (gRememberLastPlayed is off, so there is no save toast; no cheats, no
+      VMC, no MX4SIO warning). Neither deinit() nor sysLaunchLoaderElf() reprograms a GS display
+      register, so whatever buffer rmEndFrame last pointed DISPFB2 at keeps being scanned out until
+      the GAME programs the GS -- which on USB is minutes away.
+
+      Without this, that buffer is "black field + barcode strip", and the strip is drawn at
+      1-virtual-pixel pitch (magenta column immediately followed by cyan/yellow). That is below the
+      chroma bandwidth of composite output, so the columns average to near-white and the user sees
+      a solid ~288x2 white bar, ~71% down an otherwise black screen, for the entire load. Exactly
+      the report: every game, unrelated to Debug Colors, lasting as long as the media takes.
+
+      Two frames because rendering is double-buffered -- one alone leaves the barcode in the OTHER
+      buffer, which is the one a scaler may resync to across the video-mode change.
+
+      #299: the busy animation is drawn onto both clean frames, so nothing but "black field +
+      loader" is left in EITHER buffer -- the loading indicator issue #299 asks for. The themed
+      load*.png pixmaps are ordinary composite-safe art, nothing like the 1-pixel-pitch barcode
+      strip above, so the #269 premise is untouched.
+
+      NOTE(rebuild): the fork's comment here also credited itemExecSelect with hand-pumping a
+      guiRenderBusyFrame() around this call, which is what used to cover the GameID-OFF config.
+      That helper was removed again by fork commit 79865cde ("Restore loading icon piping to
+      official OPL baseline") and does not exist on fork master or here -- so with the barcode
+      off, launch prep still renders nothing. Re-adding the hand-pumped launch-prep loader is
+      checklist item 48's business, not this step's.
+    */
+    for (frame = 0; frame < 2; frame++) {
+        guiStartFrame();
+        rmDrawRect(0, 0, screenWidth, screenHeight, GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x80));
+        guiDrawBusy(0x80);
+        guiEndFrame();
+    }
 }
 
 void guiWarning(const char *text, int count)

--- a/src/opl.c
+++ b/src/opl.c
@@ -155,6 +155,7 @@ int gAPPStartMode;
 int bdmCacheSize;
 int hddCacheSize;
 int smbCacheSize;
+int gApplyGameID;
 int gEnableUSB;
 char gNeutrinoArgs[256];     // extra command-line flags appended to every Neutrino launch
 char gNeutrinoPath[256];     // custom neutrino.elf path; "" -> auto-detect on mc0:/mc1:
@@ -330,6 +331,9 @@ static void itemExecSelect(struct menu_item *curMenu)
                     return;
                 }
                 config_set_t *configSet = menuLoadConfig();
+                // Flash the GameID barcode (Pixel FX/RetroGEM HDMI auto-profile) before handoff; this
+                // single menu chokepoint covers both the Neutrino and OPL-native cores. No-op when off.
+                guiShowGameID(support->itemGetStartup(support, curMenu->current->item.id));
                 support->itemLaunch(support, curMenu->current->item.id, configSet);
             }
         } else {
@@ -1290,6 +1294,7 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_APP_MODE, &gAPPStartMode);
             configGetInt(configOPL, CONFIG_OPL_ENABLE_USB, &gEnableUSB);
             configGetInt(configOPL, CONFIG_OPL_FAV_MODE, &gFAVStartMode);
+            configGetInt(configOPL, CONFIG_OPL_APPLY_GAMEID, &gApplyGameID);
             configGetInt(configOPL, CONFIG_OPL_DEFAULT_GAME_VIEW, &gDefaultGameView);
             if (gDefaultGameView < GAME_VIEW_BOTH || gDefaultGameView > GAME_VIEW_VCD)
                 gDefaultGameView = GAME_VIEW_BOTH;
@@ -1599,6 +1604,7 @@ static void _saveConfig()
         configSetInt(configOPL, CONFIG_OPL_SMB_CACHE, smbCacheSize);
         configSetInt(configOPL, CONFIG_OPL_ENABLE_USB, gEnableUSB);
         configSetInt(configOPL, CONFIG_OPL_FAV_MODE, gFAVStartMode);
+        configSetInt(configOPL, CONFIG_OPL_APPLY_GAMEID, gApplyGameID);
         configSetInt(configOPL, CONFIG_OPL_DEFAULT_GAME_VIEW, gDefaultGameView);
         configSetStr(configOPL, CONFIG_OPL_POPSTARTER_PATH, gPopstarterPath);
         configSetInt(configOPL, CONFIG_OPL_POPSTARTER_DEVICE, gPopstarterDevice);
@@ -2318,6 +2324,9 @@ static void setDefaults(void)
 
     gEnableUSB = 0; // USB block device is opt-in, like the other BDM transports
     gFAVStartMode = START_MODE_DISABLED;
+    // Visual GameID barcode ships OFF, matching fork commit cc2cdfed ("GameID defaults OFF"): the
+    // HDMI auto-profile latch is only verifiable on real GameID hardware, so it stays opt-in.
+    gApplyGameID = 0;
     gNeutrinoArgs[0] = '\0';
     gNeutrinoPath[0] = '\0';
     gNeutrinoDevice = NEUTRINO_DEV_AUTO;


### PR DESCRIPTION
Checkpoint step 13 of the official-base rebuild. Stacked on `rebuild-12b` (the usbd bootfix from #385).

## Scope shrank on inspection

The plan listed step 13 as "GameID visuals (items 20/25)". **Item 20 — RetroGEM PS1 barcode — was already complete** as of rebuild-09a/12: `retrogem.c/h` are byte-identical to the fork, and `vcdPrepareRetroGemBarcode` is wired into `bdmsupport.c`, `hddsupport.c` and `ethsupport.c` at the same line numbers as the fork (fork also has an `mmcesupport.c` call site, which waits with item 1). The config key, global, default, save/load and the VCD dialog row all landed too.

So this is **item 25 only**, matching fork commit `7bc0f117` plus the #269 fix `b470f874`.

## What landed

- `gui.c` — `gameIDCleanSerial` / `gameIDBuildPacket` / `gameIDDrawBars` / `guiShowGameID`, spliced byte-identically out of `origin/master` via `git show` rather than retyped, at the same relative position (between `guiRenderTextScreen` and `guiWarning`)
- `gui.c` — Display page `diaSetInt`/`diaGetInt` round-trip for `CFG_APPLYGAMEID`
- `opl.c` — `gApplyGameID` global, default `0`, config load/save, and `guiShowGameID()` at the single `itemExecSelect` launch chokepoint (covers both the Neutrino and OPL-native cores)

`config.h`, `dialogs.h` and `dialogs.c` needed **no change** — step 06 pre-staged all three, exactly as intended.

## It also fixes a latent hidden-not-lying violation

That same pre-staging left a bug: the Display page rendered an interactive **"Show GameID Barcode (Pixel FX)"** checkbox that no `gui.c` code ever read or wrote, and with no `NOTE(rebuild)` breadcrumb. Toggling it did nothing and the value never persisted. It now round-trips through `saveConfig`/`_loadConfig`.

## Two fork comments corrected rather than carried

Both assert things that are false in this tree:

1. *"default ON since 120045d0"* — `setDefaults()` has said `0` since `cc2cdfed` ("GameID defaults OFF"), which is also what this step ships. Corrected.
2. The #299 credit to `itemExecSelect` for hand-pumping `guiRenderBusyFrame()` — that helper was **removed again** by `79865cde` and exists in neither fork master nor here. Left as-is it would have claimed launch-prep renders a loader when the barcode is off, which it does not. Replaced with a `NOTE(rebuild)` pointing at checklist item 48.

## Feature interaction, checked

A VCD launch now emits the PS2 barcode (from here, in `itemExecSelect`) and then the PS1 one (from `vcdPrepareRetroGemBarcode`, inside `itemLaunch`). That ordering is **exactly fork master's** behaviour — both features ship there together — so this step introduces no new overlap.

## Verification

- Clean build in the `opl340` container on the rebased base: `MAKE_EXIT=0`, no new warnings.
- Bootfix confirmed intact underneath (`[USBD]` load still at `system.c:269`).
- Adversarial review pass (4 lenses — port completeness, cross-file contracts, runtime correctness/buffer arithmetic, UI honesty — each finding attacked by an independent skeptic): **zero confirmed findings**. Everything raised was refuted as either pre-existing on `rebuild/main`, identical on hardware-proven fork master, or on the known-deferred list.

One pre-existing issue surfaced and is **not** fixed here (it predates this step and is unrelated to item 25): our `guiWarning()` never got the fork's `if (gTheme == NULL)` pre-GUI guard, while the Δ8 launch toasts the fork says *rely* on it did land — a NULL-deref on the headless autolaunch path. Logged for a later step.