### PR TITLE
rebuild-15: complete the Coverflow port -- nav rotation + slide animation

### DIFF
--- a/src/menusys.c
+++ b/src/menusys.c
@@ -732,6 +732,9 @@ static void menuNextV()
     if (cur && cur->next) {
         selected_item->item->current = cur->next;
         sfxPlay(SFX_CURSOR);
+        // coverflow slide animation; the wrap branch below stays instant
+        if (gTheme->coverflow)
+            thmTriggerCoverflowAnim(1);
 
         // if the current item is beyond the page start, move the page start one page down
         cur = selected_item->item->pagestart;
@@ -745,6 +748,23 @@ static void menuNextV()
         selected_item->item->pagestart = selected_item->item->current;
     } else { // wrap to start
         menuFirstPage();
+        /*
+          Animate the wrap too, but ONLY in coverflow (#271).
+
+          The carousel's visible window already wraps -- drawCoverFlow fans covers[] out through
+          menu->item->last / ->submenu -- so last->first is a single VISUAL step there, exactly like
+          every other move. Leaving it instant (10c19f1b's documented intent) therefore singled out
+          the two entries at the seam: stepping onto the first game, and the step immediately after
+          it, got no slide and no scale transfer while every other step did. That is what the
+          reporter sees as the selection "clipping/skipping on the first game and the one following
+          it", and it is also the most likely source of "the 3D effect drops to a flat 2D scroll" --
+          because at the seam it literally does.
+
+          The flat list views keep the instant jump: there the wrap really is an N-item page jump,
+          not one step, so a one-step slide would misrepresent it.
+        */
+        if (gTheme->coverflow)
+            thmTriggerCoverflowAnim(1);
     }
 }
 
@@ -762,8 +782,15 @@ static void menuPrevV()
             while (--itms && selected_item->item->pagestart->prev)
                 selected_item->item->pagestart = selected_item->item->pagestart->prev;
         }
+
+        // coverflow slide animation; the wrap branch below stays instant
+        if (gTheme->coverflow)
+            thmTriggerCoverflowAnim(-1);
     } else { // wrap to end
         menuLastPage();
+        // Mirror of the wrap in menuNextV -- see the rationale there (#271).
+        if (gTheme->coverflow)
+            thmTriggerCoverflowAnim(-1);
     }
 }
 
@@ -1032,16 +1059,51 @@ void menuRenderMain(void)
     }
 }
 
+// Coverflow rotates the nav axis on the MAIN screen only: Left/Right step through the
+// carousel (a vertical list move) while Up/Down switch device menus. Non-coverflow themes
+// behave exactly as before. The info screen is intentionally NOT rotated (menuHandleInputInfo).
+static void menuNavigateLeft()
+{
+    if (gTheme->coverflow)
+        menuPrevV();
+    else
+        menuPrevH();
+}
+
+static void menuNavigateRight()
+{
+    if (gTheme->coverflow)
+        menuNextV();
+    else
+        menuNextH();
+}
+
+static void menuNavigateUp()
+{
+    if (gTheme->coverflow)
+        menuPrevH();
+    else
+        menuPrevV();
+}
+
+static void menuNavigateDown()
+{
+    if (gTheme->coverflow)
+        menuNextH();
+    else
+        menuNextV();
+}
+
 void menuHandleInputMain()
 {
     if (getKey(KEY_LEFT)) {
-        menuPrevH();
+        menuNavigateLeft();
     } else if (getKey(KEY_RIGHT)) {
-        menuNextH();
+        menuNavigateRight();
     } else if (getKey(KEY_UP)) {
-        menuPrevV();
+        menuNavigateUp();
     } else if (getKey(KEY_DOWN)) {
-        menuNextV();
+        menuNavigateDown();
     } else if (getKeyOn(KEY_CROSS)) {
         selected_item->item->execCross(selected_item->item);
     } else if (getKeyOn(KEY_TRIANGLE)) {


### PR DESCRIPTION
Checkpoint step 15. Fixes two of the three real bugs in Zack's rebuild-14 hardware report.

## The reports

> CF navigates with up and down buttons which is weird ( its supposed to be left and right buttons )

> NO 3D CAROUSEL EFFECT IN CF ( static 2D animation )

Two symptoms, **one root cause.**

## Root cause: step 03 landed half the Coverflow port

`thmTriggerCoverflowAnim()` was **defined** at [themes.c:935](src/themes.c:935) and **declared** at [themes.h:175](include/themes.h:175) — with **zero callers anywhere in the tree.** Step 03 brought the fork's `themes.c` wholesale, which *draws* the carousel, but not the `menusys.c` half, which *tells it to move* and rotates the nav axis. The animation code has been shipping, dead, since rebuild-03.

That single omission produces both symptoms exactly:

- no `thmTriggerCoverflowAnim` call → the carousel never slides → **static 2D**
- no `menuNavigate*` wrappers → Left/Right keep their flat-list meaning → **up/down navigation**

This is the **third** instance of the same class as the `thmInit`/`guiLock` boot deadlock and the `usbd` black screen: a fork file landed wholesale without the cross-file contract its counterpart owned.

## What landed

Ported from fork commit `10c19f1b` *("coverflow(D): main-screen nav rotation + slide-anim trigger")* — the commit that introduced this feature:

- **`menuNavigateLeft/Right/Up/Down`** + the `menuHandleInputMain` dispatch. In a coverflow theme, Left/Right step the carousel (a vertical list move) while Up/Down switch device menus; non-coverflow themes are untouched. The info screen is deliberately **not** rotated, matching the fork.
- **`thmTriggerCoverflowAnim(±1)` at all four sites** in `menuNextV`/`menuPrevV`, including the wrap branches. The wrap matters: in the carousel `last → first` is a single *visual* step, so leaving it instant is what made the seam entries drop to a flat 2D jump — plausibly part of what Zack is seeing.

`menuNextV` and `menuPrevV` are now **byte-identical to fork master**, and the four nav wrappers are byte-identical to the fork's (verified by extracting and diffing the functions, not by eye).

## Scope discipline

Our `menusys.c` is 532 lines lighter than the fork's, but most of that belongs to other steps — `menuSaveConfig`, `gameMenuCoreIsNeutrino`, `menuCanRequestItemConfig`, `_menuResolveInfoSize`/`menuRequestInfoSize`, `menuFolderResetLeaving`. I mapped the fork-only functions first and took **only** the Coverflow slice rather than the file wholesale, which is what created this bug in the first place.

Also spotted and **not** taken: the fork's `menuNextPage` carries an over-scroll probe fix (#48) our copy lacks. Unrelated to Coverflow; logged for its own step.

## Deliberately deferred to its own checkpoint

Zack's third real bug — BGM cutting out on a quick option enter/exit/re-enter — is not here. `src/sound.c` is 173 lines behind fork master and lacks the `thmPath != NULL` guards that handle the built-in `<Coverflow>` theme. That needs its own investigation, and folding an unknown-scope audit into a known 3-part fix would muddy the bisect. Next step.

Note that bug is *brand new* in the sense that nobody could have hit it before: BGM never played in any rebuild build until `bgm.ogg` landed in rebuild-14.

## Verification

Clean build in the `opl340` container: `MAKE_EXIT=0`. All four animation call sites and all four nav wrappers confirmed wired by grep. Function-level diffs against fork master are byte-identical.

## Standing check this suggests

After any wholesale file port, grep the new file's exported symbols for ones with **zero callers**. That single check would have caught this on the day step 03 landed.