### PR TITLE
rebuild-16: BGM cross-thread flags + menu semaphore lifecycle (fork da5450f2)

### DIFF
--- a/src/ioman.c
+++ b/src/ioman.c
@@ -342,14 +342,16 @@ int ioBlockOps(int block)
         isIOBlocked = 1;
 
         ThreadID = GetThreadId();
-        ReferThreadStatus(ThreadID, &status);
+        int haveStatus = (ReferThreadStatus(ThreadID, &status) == 0);
         ChangeThreadPriority(ThreadID, 90);
 
         // wait for all io to finish
         while (ioHasPendingRequests()) {
         };
 
-        ChangeThreadPriority(ThreadID, status.current_priority);
+        // Only restore the saved priority if ReferThreadStatus actually filled it.
+        if (haveStatus)
+            ChangeThreadPriority(ThreadID, status.current_priority);
 
         // now all io should be blocked
     } else if (!block && isIOBlocked) {

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -81,7 +81,7 @@ static submenu_list_t *gameMenuCurrent;
 static submenu_list_t *appMenu;
 static submenu_list_t *appMenuCurrent;
 
-static s32 menuSemaId;
+static s32 menuSemaId = -1;
 static s32 menuListSemaId = -1;
 static ee_sema_t menuSema;
 
@@ -326,10 +326,13 @@ void menuInit()
     appMenuCurrent = NULL;
     menuInitMainMenu();
 
-    menuSema.init_count = 1;
-    menuSema.max_count = 1;
-    menuSema.option = 0;
-    menuSemaId = CreateSema(&menuSema);
+    // Create once; recreating on a second menuInit would leak the prior semaphore.
+    if (menuSemaId < 0) {
+        menuSema.init_count = 1;
+        menuSema.max_count = 1;
+        menuSema.option = 0;
+        menuSemaId = CreateSema(&menuSema);
+    }
     if (menuListSemaId < 0) {
         menuListSemaId = sbCreateSemaphore();
     }
@@ -362,6 +365,7 @@ void menuEnd()
     }
 
     DeleteSema(menuSemaId);
+    menuSemaId = -1;
     DeleteSema(menuListSemaId);
     menuListSemaId = -1;
 }

--- a/src/sound.c
+++ b/src/sound.c
@@ -424,8 +424,10 @@ extern void *_gp;
 
 static int bgmThreadID, bgmIoThreadID;
 static int outSema, inSema;
-static unsigned char terminateFlag, bgmIsPlaying;
-static unsigned char rdPtr, wrPtr;
+// Shared between the BGM playback thread and the main thread; volatile so updates
+// are observed across threads rather than cached in a register.
+static volatile unsigned char terminateFlag, bgmIsPlaying;
+static volatile unsigned char rdPtr, wrPtr;
 static char bgmBuffer[BGM_RING_BUFFER_COUNT][BGM_RING_BUFFER_SIZE];
 static volatile unsigned char bgmThreadRunning, bgmIoThreadRunning;
 


### PR DESCRIPTION
Checkpoint step 16. Fixes the third real bug from Zack's rebuild-14 report.

> BGM audio shut down if the user clicks on an option and then quickly exits back and click on it again

## Root cause: lost `volatile` on the BGM cross-thread flags

| flag | written by | read by |
|---|---|---|
| `terminateFlag` | `bgmStop()`, GUI thread | `bgmThread` loop `while (!terminateFlag)`; `bgmIoThread` loop `while (!terminateFlag && gEnableBGM)` |
| `rdPtr`, `wrPtr` | BGM writer thread | BGM reader thread (ring-buffer indices) |
| `bgmIsPlaying` | `bgmStart()` | `bgmGetPlaying()` |

All four were plain `unsigned char`. Without `volatile`, the compiler may hoist those loads out of the worker loops, so a stop request is never observed and start/stop state desynchronizes. **A rapid stop → start is the maximum-exposure case — which is precisely his repro.**

Tellingly, `bgmThreadRunning`/`bgmIoThreadRunning` *were* already volatile. That asymmetry explains the exact symptom: `bgmStop()`'s own wait loops behaved correctly while the workers they were waiting on could not see the flag.

**Provenance:** this came from the **official base**, not from any of our steps — it's been there since rebuild-01. The fork fixed it in `da5450f2` and we never re-added that fix. Nobody could have hit it before now, because BGM never played in any rebuild build until `bgm.ogg` landed in rebuild-14.

## Also from `da5450f2` — and the second half matters

- **`menuInit`**: default `menuSemaId` to `-1`, create the semaphore only once, so a second `menuInit` cannot leak the prior one.
- **`menuEnd`**: reset `menuSemaId = -1` after `DeleteSema`. **This half is load-bearing.** Create-once *without* it leaves a stale non-negative id after teardown, so a second `menuInit` skips creation and every `WaitSema` targets a deleted semaphore — the `thmInit`/`guiLock` failure mode exactly. Our `menuEnd` had the `DeleteSema` but not the reset; the fork has both at lines 548–549. I checked for this specifically before landing the create-once guard, because shipping one half of it would have been a fresh boot-killer.
- **`ioBlockOps`**: only restore the saved thread priority if `ReferThreadStatus` actually succeeded — `status.current_priority` was otherwise uninitialized.

## Checked and deliberately skipped

- **`cheatman.c`** — already at fork parity via step 08, in the fork's own newer `digits[CODE_DIGITS + 1]` / `i < CODE_DIGITS` form (which keeps a full-length code instead of truncating a digit). My first grep reported it missing; that was a false negative against the older `da5450f2` text.
- **`dia.c`** — the mask-buffer alloc-failure fallback is already present.
- **`texcache.c`** — N/A. Our texcache is official's and has no `gArtSemaId`, so there is no lock/delete ordering to fix.

## Important non-goal, recorded so nobody undoes it

**Do not "restore `sound.c` to fork parity."** Fork master has **no** async SFX dispatch — our `sound.c` is deliberately *ahead*, carrying the composite dispatch thread (`sfxDispatchThread`, `sfxEnqueue`, `sfxDispatchQuiesce`, `sfxDispatchStart`) that moved the synchronous `audsrv` RPC off the GUI thread. Reverting to the fork would reintroduce the 352 ms stalls behind #340 — the very thing Zack just called *"perfect"*.

Our `sound.c` differs from the fork's by 173 lines for that reason. The fork's `sfxGetCursorChannel`/`sfxSetCursorChannelsVolume` remain unported and are logged, not forgotten.

## Also logged, not taken

The fork has refactored `ioBlockOps` into `ioBlockOpsTimed(block, -1)` with a bounded-wait variant for teardown callers — that belongs with the NBD teardown work, not here. Our wait loop is also a bare spin where the fork delays; noted for the same step.

## Verification

Clean build in the `opl340` container: `MAKE_EXIT=0`. Semaphore lifecycle verified symmetric: init `-1` → create-if-negative → delete → reset `-1`.