### PR TITLE
rebuild-17: art toggles -- .tar art packs + Art Delay (item 45, GATE D)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 
 FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o elfldr_noreset.o elfldr.o lang.o lang_internal.o config.o hdd.o dialogs.o favsupport.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o udpfssupport.o hddsupport.o zso.o lz4.o \
-		appsupport.o vcdsupport.o retrogem.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o
+		appsupport.o vcdsupport.o retrogem.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
 
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
 		bdm.o bdmfs_fatfs.o usbmass_bd.o iLinkman.o IEEE1394_bd.o mx4sio_bd.o \

--- a/include/tar.h
+++ b/include/tar.h
@@ -1,0 +1,79 @@
+#ifndef __TAR_H
+#define __TAR_H
+
+// Lazy .tar archive loader (ART/CFG/CHT), ported from wOPL (author: mystyq).
+// RiptOPL wires ONLY the ART kind, behind the user toggle gEnableArtTar (default OFF);
+// the CFG/CHT kinds are kept intact so they can be wired later with no engine change.
+// On-disk format is plain uncompressed ustar (512-byte blocks) so existing wOPL/sOPL
+// art packs (ART/art.tar of <GAMEID>_<suffix>.png files) are compatible as-is.
+
+#include <tamtypes.h>
+
+#define TAR_BLOCK_SIZE 512
+#define MAX_FILE_SIZE  (4 * 1024 * 1024) // 4 MiB
+#define ARC_MAGIC      "ARC\0"
+#define ARC_VERSION    3
+
+typedef struct
+{
+    char magic[4];
+    u32 version;
+    u64 tarSize;
+    u32 entryCount;
+} TarCacheHeader;
+
+typedef struct
+{
+    u64 offset;     // offset of file data in archive
+    u32 rawSize;    // actual file size from header (octal), capped by MAX_FILE_SIZE
+    u32 paddedSize; // file size rounded up to 512-byte TAR blocks
+} TarEntryBase;
+
+typedef struct
+{
+    TarEntryBase base;
+    // [48], not [41]: the parser derives its copy length from the entry STRIDE, not from this array --
+    // nameMax = entrySize - sizeof(TarEntryBase) - 1 = 64 - 16 - 1 = 47 -- so it memcpy'd 47 bytes and
+    // NUL-terminated at [47], i.e. 7 bytes past the declared size. It landed in this struct's own tail
+    // padding (the stride is exactly 64), so it was benign in practice, but it is out of bounds on the
+    // declared type and would corrupt the next entry the moment anyone resizes this array or grows
+    // TarEntryBase. [48] keeps sizeof(TarEntryArt) == 64, so entrySize, nameMax, copyLen, the on-disk
+    // art_cache.bin layout and wOPL cache compatibility are all unchanged (do NOT widen further without
+    // bumping ARC_VERSION -- 47 is also wOPL-base's cap, and real keys are far shorter,
+    // e.g. "SLUS_203.70_COV.png" = 19).
+    char filename[48]; // ART: filename up to 47 chars + null
+} TarEntryArt;
+
+typedef struct
+{
+    TarEntryBase base;
+    char filename[20]; // CFG: "SLUS_203.70.cfg"
+} TarEntryCfg;
+
+typedef struct
+{
+    TarEntryBase base;
+    char filename[20]; // CHT: "SLUS_203.70.cht"
+} TarEntryCht;
+
+typedef enum {
+    TAR_KIND_ART = 0,
+    TAR_KIND_CFG = 1,
+    TAR_KIND_CHT = 2,
+    TAR_KIND_MAX
+} TarKind;
+
+int tarLoadFromAnyDevice(TarKind kind);
+int tarLoadFile(TarKind kind, const char *path);
+int tarClose(TarKind kind);
+
+TarEntryBase *tarFind(TarKind kind, const char *filename);
+void *tarGet(TarKind kind, const char *filename);
+u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize);
+
+int tarEnsureLoaded(TarKind kind);
+void tarInvalidate(TarKind kind);
+
+const char *tarGetDevicePrefix(TarKind kind);
+
+#endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -26,6 +26,8 @@
 #include "include/cheatman.h"
 #include "include/sound.h"
 #include "include/guigame.h"
+#include "include/appsupport.h" // appGetObject() -- push a live Art Delay change onto the APPS list
+#include "include/tar.h"        // tarInvalidate -- re-arm the .tar probe when the toggle flips
 
 #include <limits.h>
 #include <stdlib.h>
@@ -1597,18 +1599,57 @@ reshow_tools:
     }
 }
 
+static const char *artDelayNames[] = {"0 (Instant)", "2 (Fast)", "5 (Medium)", "8 (Standard)", NULL};
+static const int artDelayValues[] = {0, 2, 5, 8};
+
+static int artDelayToEnum(int delay)
+{
+    if (delay <= 0)
+        return 0;
+    if (delay <= 3)
+        return 1;
+    if (delay <= 6)
+        return 2;
+    return 3;
+}
+
+// Interface -> Artwork Settings (cover art display + ART.TAR loading).
 void guiShowArtworkConfig(void)
 {
     diaSetInt(diaArtworkConfig, UICFG_COVERART, gEnableArt);
     diaSetInt(diaArtworkConfig, UICFG_ENABLE_BGART, gEnableBGArt);
-    // NOTE(rebuild): the Art Delay knob returns with checklist item 45 -- hide its row.
-    diaSetVisible(diaArtworkConfig, UICFG_ART_DELAY, 0);
-    diaSetVisible(diaArtworkConfig, UICFG_ENABLE_ART_TAR, 0); // .tar art packs return with item 45
+    diaSetInt(diaArtworkConfig, UICFG_ENABLE_ART_TAR, gEnableArtTar);
+    diaSetEnum(diaArtworkConfig, UICFG_ART_DELAY, artDelayNames);
+    diaSetInt(diaArtworkConfig, UICFG_ART_DELAY, artDelayToEnum(gArtDelay));
 
     int ret = diaExecuteDialog(diaArtworkConfig, -1, 1, NULL);
     if (ret) {
         diaGetInt(diaArtworkConfig, UICFG_COVERART, &gEnableArt);
         diaGetInt(diaArtworkConfig, UICFG_ENABLE_BGART, &gEnableBGArt);
+        {
+            // Re-arm the .tar probe when the toggle actually flips. tarFind's "no archive anywhere"
+            // latch is write-once and process-wide, so a user who turns the loader on after boot would
+            // otherwise keep getting nothing until a reboot -- which looks exactly like "the toggle
+            // does nothing".
+            int previousArtTar = gEnableArtTar;
+            diaGetInt(diaArtworkConfig, UICFG_ENABLE_ART_TAR, &gEnableArtTar);
+            if (gEnableArtTar != previousArtTar)
+                tarInvalidate(TAR_KIND_ART);
+        }
+        int artDelayIdx = 0;
+        diaGetInt(diaArtworkConfig, UICFG_ART_DELAY, &artDelayIdx);
+        if (artDelayIdx >= 0 && artDelayIdx < 4) {
+            gArtDelay = artDelayValues[artDelayIdx];
+            // Push the new delay onto the already-built lists so it takes effect without a re-init.
+            // NOTE(rebuild): the fork also updates mmceGetObject(1) here -- that joins with item 1.
+            // BDM lists are absent from this list in the fork too: bdmsupport seeds itemList->delay in
+            // bdmInit, so a BDM tab keeps its previous delay until the device is re-initialised.
+            item_list_t *lists[] = {appGetObject(1), hddGetObject(1), ethGetObject(1), udpfsGetObject(1), favGetObject(1)};
+            for (int i = 0; i < 5; i++) {
+                if (lists[i] != NULL)
+                    lists[i]->delay = gArtDelay;
+            }
+        }
 
         applyConfig(-1, -1, 1);
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -1341,7 +1341,10 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_ENABLE_BGART, &gEnableBGArt);
             configGetInt(configOPL, CONFIG_OPL_ENABLE_ART_TAR, &gEnableArtTar);
             configGetInt(configOPL, CONFIG_OPL_ART_DELAY, &gArtDelay);
-            if (gArtDelay < 0 || gArtDelay > 60)
+            // Keep the stored domain identical to the Artwork page's enum {0,2,5,8} (item 45), so a
+            // hand-edited or legacy value cannot render as a delay the UI is unable to express.
+            // Fork parity except the fallback: the fork lands on 2, we land on 8 (see setDefaults).
+            if (gArtDelay != 0 && gArtDelay != 2 && gArtDelay != 5 && gArtDelay != 8)
                 gArtDelay = 8;
             configGetInt(configOPL, CONFIG_OPL_FOLDER_NAV, &gEnableFolderNav);
             configGetColor(configOPL, CONFIG_OPL_PLAS_BLEND_COLOR, gDefaultPlasBlendColor);

--- a/src/tar.c
+++ b/src/tar.c
@@ -1,0 +1,550 @@
+// Lazy .tar archive loader (ART/CFG/CHT). Ported from wOPL (author: mystyq).
+//
+// Plain uncompressed ustar (512-byte blocks). For each kind a single archive holds every
+// game's files for a device (ART/art.tar of <GAMEID>_<suffix>.png, etc.). The header table is
+// indexed ONCE per session (and persisted to a sidecar *_cache.bin keyed on the tar size, so cold
+// boots skip the scan); file bodies are read open->seek->read->close per request, keeping NO fds
+// open (avoids the EE/IOP fd-desync wOPL hit). POSIX IO only -- matches the EE-side newlib convention.
+//
+// RiptOPL wires only TAR_KIND_ART, gated by the user toggle gEnableArtTar (default OFF); when the
+// toggle is off the engine is never called, and even when on a device with no ART/art.tar is marked
+// inactive and costs nothing.
+
+#include <ps2sdkapi.h>
+#include <stdio.h>
+#include <malloc.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include "include/tar.h"
+#include "include/ioman.h" // LOG -- this engine shipped with ZERO tracing, which made every "art.tar
+                           // doesn't work" report unfalsifiable (the CHT path announces its hit at
+                           // supportbase.c; ART said nothing at all).
+
+typedef struct
+{
+    const char *prefix;
+    const char *mountRoot;
+} TarDevice;
+
+typedef struct
+{
+    const char *relPath;
+    const char *cacheName;
+    u32 entrySize;
+} TarKindInfo;
+
+// Probe order (first device that has the archive wins). Widened vs wOPL to RiptOPL's mounts:
+// all 8 BDM mass slots, both MMCE slots, the internal HDD (APA + pfs), and SMB.
+static const TarDevice gDevices[] = {
+    {"mass0:", "mass0:/"},
+    {"mass1:", "mass1:/"},
+    {"mass2:", "mass2:/"},
+    {"mass3:", "mass3:/"},
+    {"mass4:", "mass4:/"},
+    {"mass5:", "mass5:/"},
+    {"mass6:", "mass6:/"},
+    {"mass7:", "mass7:/"},
+    {"mmce0:", "mmce0:/"},
+    {"mmce1:", "mmce1:/"},
+    {"hdd0:", "hdd0:/"},
+    {"pfs0:", "pfs0:/"},
+    {"smb0:", "smb0:/"},
+    {NULL, NULL}};
+
+static const TarKindInfo gTarInfo[TAR_KIND_MAX] = {
+    {"ART/art.tar", "art_cache.bin", sizeof(TarEntryArt)},
+    {"CFG/cfg.tar", "cfg_cache.bin", sizeof(TarEntryCfg)},
+    {"CHT/cht.tar", "cht_cache.bin", sizeof(TarEntryCht)}};
+
+static void *s_index[TAR_KIND_MAX] = {NULL, NULL, NULL};
+static u32 s_count[TAR_KIND_MAX] = {0, 0, 0};
+static u32 s_cap[TAR_KIND_MAX] = {0, 0, 0};
+static const TarDevice *s_dev[TAR_KIND_MAX] = {NULL, NULL, NULL};
+static int s_inactive[TAR_KIND_MAX] = {0, 0, 0};
+
+static const unsigned char s_zeroBlock[TAR_BLOCK_SIZE] __attribute__((aligned(64))) = {0};
+
+static u64 parseOctal(const char *s, int len)
+{
+    u64 val = 0;
+    for (int i = 0; i < len; i++) {
+        char c = s[i];
+        if (c < '0' || c > '7')
+            break;
+        val = (val << 3) + (u64)(c - '0');
+    }
+    return val;
+}
+
+static int isZeroBlock(const unsigned char header[TAR_BLOCK_SIZE])
+{
+    return memcmp(header, s_zeroBlock, TAR_BLOCK_SIZE) == 0;
+}
+
+static void tarCloseInternal(TarKind kind)
+{
+    if (s_index[kind]) {
+        free(s_index[kind]);
+        s_index[kind] = NULL;
+    }
+    s_count[kind] = 0;
+    s_cap[kind] = 0;
+    s_dev[kind] = NULL;
+}
+
+static int buildTarPath(const TarDevice *dev, TarKind kind, char *out, int outSize)
+{
+    if (dev == NULL) // s_dev is NULL if a kind was populated via tarLoadFile (no re-open device); refuse rather than deref
+        return -1;
+
+    int len = snprintf(out, outSize, "%s%s", dev->mountRoot, gTarInfo[kind].relPath);
+
+    return (len > 0 && len < outSize) ? 0 : -1;
+}
+
+static int tarReadCache(const char *cachePath, const char *tarPath, TarKind kind)
+{
+    int fd = open(cachePath, O_RDONLY);
+    if (fd < 0)
+        return -1;
+
+    struct stat stCache;
+    if (fstat(fd, &stCache) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    int fileSize = stCache.st_size;
+    if (fileSize < (int)sizeof(TarCacheHeader)) {
+        close(fd);
+        return -1;
+    }
+
+    void *buf = memalign(64, fileSize);
+    if (!buf) {
+        close(fd);
+        return -1;
+    }
+
+    if (read(fd, buf, fileSize) != fileSize) {
+        free(buf);
+        close(fd);
+        return -1;
+    }
+    close(fd);
+
+    TarCacheHeader *hdr = (TarCacheHeader *)buf;
+
+    if (memcmp(hdr->magic, ARC_MAGIC, 4) != 0 || hdr->version != ARC_VERSION) {
+        free(buf);
+        return -1;
+    }
+
+    struct stat stTar;
+    if (stat(tarPath, &stTar) < 0 || (u64)stTar.st_size != hdr->tarSize) {
+        free(buf);
+        return -1;
+    }
+
+    u32 entrySize = gTarInfo[kind].entrySize;
+    // Guard a corrupt/hostile entryCount: validate by DIVISION so entryCount * entrySize can
+    // never overflow u32. Without this an overflowed product slips past the size check, malloc
+    // and memcpy use the wrapped (small) size, yet s_count keeps the huge original count -- and
+    // tarFind then walks that many entrySize-strides off the small allocation (OOB read).
+    u32 maxEntries = (u32)(fileSize - (int)sizeof(TarCacheHeader)) / entrySize;
+    if (entrySize == 0 || hdr->entryCount > maxEntries) {
+        free(buf);
+        return -1;
+    }
+
+    void *entries = malloc(hdr->entryCount * entrySize);
+    if (!entries) {
+        free(buf);
+        return -1;
+    }
+
+    memcpy(entries, (unsigned char *)buf + sizeof(TarCacheHeader), hdr->entryCount * entrySize);
+
+    // The live parser caps every rawSize at MAX_FILE_SIZE (the tar.h invariant); a corrupt cache could
+    // carry a larger value. Reject such a cache so the caller re-parses the tar (which re-caps and
+    // rewrites a clean cache) instead of trusting an out-of-range size downstream.
+    for (u32 i = 0; i < hdr->entryCount; i++) {
+        TarEntryBase *e = (TarEntryBase *)((unsigned char *)entries + entrySize * i);
+        if (e->rawSize > MAX_FILE_SIZE) {
+            free(entries);
+            free(buf);
+            return -1;
+        }
+    }
+
+    s_index[kind] = entries;
+    s_count[kind] = hdr->entryCount;
+    s_cap[kind] = hdr->entryCount;
+
+    free(buf);
+    return 0;
+}
+
+static int tarWriteCache(const char *cachePath, const char *tarPath, TarKind kind)
+{
+    struct stat stTar;
+    if (stat(tarPath, &stTar) < 0)
+        return -1;
+
+    TarCacheHeader hdr;
+    memcpy(hdr.magic, ARC_MAGIC, 4);
+    hdr.version = ARC_VERSION;
+    hdr.tarSize = stTar.st_size;
+    hdr.entryCount = s_count[kind];
+
+    int fd = open(cachePath, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    if (fd < 0)
+        return -1;
+
+    if (write(fd, &hdr, sizeof(hdr)) != (int)sizeof(hdr)) {
+        close(fd);
+        return -1;
+    }
+
+    u32 entrySize = gTarInfo[kind].entrySize;
+    u32 totalSize = entrySize * s_count[kind];
+    if (totalSize > 0) {
+        if (write(fd, s_index[kind], totalSize) != (int)totalSize) {
+            close(fd);
+            return -1;
+        }
+    }
+
+    close(fd);
+    return 0;
+}
+
+static int tarParseFile(TarKind kind, const char *path)
+{
+    // No stat() existence probe here. It was pure redundancy -- the caller has already proven the file
+    // OPENS, and this function opens it again below -- but its failure latched s_inactive[kind], which is
+    // a process-wide, write-once kill switch with no live way to clear it. Any device driver where open()
+    // succeeds but stat() fails therefore killed art.tar for the whole session with the archive sitting
+    // right there. Let the open() below be the single arbiter of existence.
+    char dirPath[256];
+    strncpy(dirPath, path, sizeof(dirPath));
+    dirPath[sizeof(dirPath) - 1] = '\0';
+
+    for (int i = strlen(dirPath) - 1; i >= 0; i--)
+        if (dirPath[i] == '/') {
+            dirPath[i + 1] = '\0';
+            break;
+        }
+
+    char fullCachePath[256];
+    snprintf(fullCachePath, sizeof(fullCachePath), "%s%s", dirPath, gTarInfo[kind].cacheName);
+
+    if (tarReadCache(fullCachePath, path, kind) == 0)
+        return 0;
+
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return -1;
+
+    free(s_index[kind]);
+    s_index[kind] = NULL;
+    s_count[kind] = 0;
+    s_cap[kind] = 0;
+
+    u32 entrySize = gTarInfo[kind].entrySize;
+    if (entrySize <= sizeof(TarEntryBase) + 1)
+        goto fail;
+
+    u32 nameMax = entrySize - sizeof(TarEntryBase) - 1;
+
+    while (1) {
+        unsigned char header[TAR_BLOCK_SIZE] __attribute__((aligned(64)));
+        int r = read(fd, header, TAR_BLOCK_SIZE);
+        if (r == 0)
+            break;
+
+        if (r < 0)
+            goto fail;
+        if (r != TAR_BLOCK_SIZE)
+            goto fail;
+
+        if (isZeroBlock(header))
+            break;
+
+        char typeflag = (char)header[156];
+        u64 rawSize = parseOctal((char *)header + 124, 12);
+        u64 paddedSize = ((rawSize + 511) / 512) * 512;
+        int oversized = (rawSize > MAX_FILE_SIZE); // too big to serve (rawSize/paddedSize are u32) -> don't index it
+
+        if (typeflag != '\0' && typeflag != '0') {
+            // Skip directory or non-file entries (e.g. typeflag '5')
+            if (lseek64(fd, paddedSize, SEEK_CUR) == (u64)-1)
+                goto fail;
+            continue;
+        }
+
+        u64 dataOffset = lseek64(fd, 0, SEEK_CUR);
+        if (dataOffset == (u64)-1)
+            goto fail;
+
+        if (oversized) {
+            LOG("TAR skip oversized entry (%lu bytes > %d) in %s\n", (unsigned long)rawSize, MAX_FILE_SIZE, path);
+            if (lseek64(fd, paddedSize, SEEK_CUR) == (u64)-1)
+                goto fail;
+            continue;
+        }
+
+        if (s_count[kind] >= s_cap[kind]) {
+            u32 newCap = s_cap[kind] ? (s_cap[kind] + 64) : 64;
+            void *newIndex = realloc(s_index[kind], entrySize * newCap);
+            if (!newIndex)
+                goto fail;
+            s_index[kind] = newIndex;
+            s_cap[kind] = newCap;
+        }
+
+        char *entry = (char *)s_index[kind] + entrySize * s_count[kind];
+        TarEntryBase *base = (TarEntryBase *)entry;
+        base->offset = dataOffset;
+        base->rawSize = rawSize;
+        base->paddedSize = paddedSize;
+
+        // Parse full USTAR path from 100-byte name (offset 0) and 155-byte prefix (offset 345)
+        char nameBuf[101];
+        memcpy(nameBuf, header, 100);
+        nameBuf[100] = '\0';
+        for (int i = 99; i >= 0; i--) {
+            if (nameBuf[i] == ' ')
+                nameBuf[i] = '\0';
+            else if (nameBuf[i] != '\0')
+                break;
+        }
+
+        char prefix[156];
+        memcpy(prefix, header + 345, 155);
+        prefix[155] = '\0';
+        for (int i = 154; i >= 0; i--) {
+            if (prefix[i] == ' ')
+                prefix[i] = '\0';
+            else if (prefix[i] != '\0')
+                break;
+        }
+
+        char fullPath[256];
+        if (prefix[0] != '\0')
+            snprintf(fullPath, sizeof(fullPath), "%s/%s", prefix, nameBuf);
+        else
+            snprintf(fullPath, sizeof(fullPath), "%s", nameBuf);
+        fullPath[sizeof(fullPath) - 1] = '\0';
+
+        // Canonical filename normalization: strip leading directory prefixes
+        const char *cleanName = fullPath;
+        if (!strncasecmp(cleanName, "./", 2))
+            cleanName += 2;
+        if (!strncasecmp(cleanName, "ART/", 4) || !strncasecmp(cleanName, "CFG/", 4) || !strncasecmp(cleanName, "CHT/", 4))
+            cleanName += 4;
+
+        char *fname = entry + sizeof(TarEntryBase);
+        strncpy(fname, cleanName, nameMax);
+        fname[nameMax - 1] = '\0';
+
+        s_count[kind]++;
+
+        if (lseek64(fd, paddedSize, SEEK_CUR) == (u64)-1)
+            goto fail;
+    }
+
+    close(fd);
+    tarWriteCache(fullCachePath, path, kind);
+    return 0;
+
+fail:
+    close(fd);
+    free(s_index[kind]);
+    s_index[kind] = NULL;
+    s_count[kind] = 0;
+    s_cap[kind] = 0;
+    return -1;
+}
+
+int tarLoadFile(TarKind kind, const char *path)
+{
+    s_dev[kind] = NULL;
+    return tarParseFile(kind, path);
+}
+
+int tarLoadFromAnyDevice(TarKind kind)
+{
+    if (s_inactive[kind])
+        return -1;
+
+    if (s_index[kind] && s_dev[kind]) {
+        char tarPath[256];
+        if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) == 0) {
+            int fd = open(tarPath, O_RDONLY);
+            if (fd >= 0) {
+                close(fd);
+                return 0;
+            }
+        }
+        tarCloseInternal(kind);
+    }
+
+    int found = 0;
+
+    for (int i = 0; gDevices[i].prefix; i++) {
+        const TarDevice *dev = &gDevices[i];
+
+        char tarPath[256];
+        if (buildTarPath(dev, kind, tarPath, sizeof(tarPath)) < 0)
+            continue;
+
+        int fd = open(tarPath, O_RDONLY);
+        if (fd < 0)
+            continue;
+        close(fd);
+
+        s_dev[kind] = dev;
+        if (tarParseFile(kind, tarPath) == 0) {
+            LOG("TAR indexed %s (%u entries)\n", tarPath, (unsigned int)s_count[kind]);
+            found = 1;
+            break;
+        }
+        LOG("TAR parse FAILED for %s -- trying the next device\n", tarPath);
+
+        tarCloseInternal(kind);
+    }
+
+    // Latch: no archive on any device -> stop probing for the rest of the session (this is what makes
+    // the loader cheap by default on setups that ship no .tar -- one failed open per device, then zero).
+    // It is write-once and process-wide, so LOG it: a silent latch made every HW report unfalsifiable.
+    if (!found) {
+        LOG("TAR no archive found for kind %d -- probing disabled for this session\n", (int)kind);
+        s_inactive[kind] = 1;
+    }
+
+    return found ? 0 : -1;
+}
+
+int tarClose(TarKind kind)
+{
+    tarCloseInternal(kind);
+    s_inactive[kind] = 0;
+    return 0;
+}
+
+TarEntryBase *tarFind(TarKind kind, const char *filename)
+{
+    if (s_inactive[kind])
+        return NULL;
+
+    if (!s_index[kind] || s_count[kind] == 0)
+        if (tarLoadFromAnyDevice(kind) < 0)
+            return NULL;
+
+    const char *queryClean = filename;
+    if (!strncasecmp(queryClean, "./", 2))
+        queryClean += 2;
+    if (!strncasecmp(queryClean, "ART/", 4) || !strncasecmp(queryClean, "CFG/", 4) || !strncasecmp(queryClean, "CHT/", 4))
+        queryClean += 4;
+
+    u32 entrySize = gTarInfo[kind].entrySize;
+    char *base = (char *)s_index[kind];
+
+    for (u32 i = 0; i < s_count[kind]; i++) {
+        char *entry = base + entrySize * i;
+        char *fname = entry + sizeof(TarEntryBase);
+
+        if (strcasecmp(fname, filename) == 0 || strcasecmp(fname, queryClean) == 0)
+            return (TarEntryBase *)entry;
+
+        const char *baseFname = strrchr(fname, '/');
+        baseFname = baseFname ? baseFname + 1 : fname;
+        if (strcasecmp(baseFname, queryClean) == 0)
+            return (TarEntryBase *)entry;
+    }
+
+    return NULL;
+}
+
+u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize)
+{
+    if (s_inactive[kind])
+        return 0;
+
+    if (!entry || dstSize < entry->rawSize)
+        return 0;
+
+    char tarPath[256];
+    if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) < 0)
+        return 0;
+
+    int fd = open(tarPath, O_RDONLY);
+    if (fd < 0)
+        return 0;
+
+    if (lseek64(fd, entry->offset, SEEK_SET) != entry->offset) {
+        close(fd);
+        return 0;
+    }
+
+    u32 total = 0;
+    while (total < entry->rawSize) {
+        int r = read(fd, (unsigned char *)dst + total, entry->rawSize - total);
+        if (r < 0) {
+            close(fd);
+            return 0;
+        }
+        if (r == 0) {
+            close(fd);
+            return 0;
+        }
+        total += r;
+    }
+
+    close(fd);
+    return total;
+}
+
+void *tarGet(TarKind kind, const char *filename)
+{
+    if (s_inactive[kind])
+        return NULL;
+
+    TarEntryBase *entry = tarFind(kind, filename);
+    if (!entry)
+        return NULL;
+
+    void *buf = memalign(64, entry->rawSize);
+    if (!buf)
+        return NULL;
+
+    if (tarRead(kind, entry, buf, entry->rawSize) != entry->rawSize) {
+        free(buf);
+        return NULL;
+    }
+
+    return buf;
+}
+
+int tarEnsureLoaded(TarKind kind)
+{
+    if (s_inactive[kind])
+        return -1;
+
+    if (!s_index[kind] || s_count[kind] == 0)
+        return tarLoadFromAnyDevice(kind);
+    return 0;
+}
+
+void tarInvalidate(TarKind kind)
+{
+    tarCloseInternal(kind);
+    s_inactive[kind] = 0;
+}
+
+const char *tarGetDevicePrefix(TarKind kind)
+{
+    return s_dev[kind] ? s_dev[kind]->prefix : NULL;
+}

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -5,6 +5,7 @@
 #include "include/gui.h"
 #include "include/util.h"
 #include "include/renderman.h"
+#include "include/tar.h"
 
 typedef struct
 {
@@ -15,6 +16,42 @@ typedef struct
     int cacheUID;
     char *value;
 } load_image_request_t;
+
+// .tar art packs (checklist item 45). Tries "<value>_<suffix>.png" inside ART/art.tar before the
+// normal per-file lookup. Opt-in: gEnableArtTar ships 0, so with the toggle off this is a single
+// predictable branch and the art path is byte-for-byte the behaviour hardware has already validated.
+//
+// #340 note: tarFind() lazily probes devices on its FIRST call, which is IO -- but it can only be
+// reached from cacheLoadImage, which the caller already gates behind the art idle delay
+// (guiInactiveFrames < list->delay in cacheGetTexture). So no .tar work can land while the user is
+// holding a direction, and tar.c's own s_inactive[] latch stops a failed probe from repeating.
+static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *texture)
+{
+    char name[64];
+    TarEntryBase *entry;
+    void *buffer;
+    int result;
+
+    if (snprintf(name, sizeof(name), "%s_%s.png", value, suffix) >= (int)sizeof(name))
+        return -1;
+
+    entry = tarFind(TAR_KIND_ART, name);
+    if (entry == NULL)
+        return -1;
+
+    buffer = malloc(entry->rawSize);
+    if (buffer == NULL)
+        return -1;
+
+    if (tarRead(TAR_KIND_ART, entry, buffer, entry->rawSize) != entry->rawSize) {
+        free(buffer);
+        return -1;
+    }
+
+    result = texLoadFromMemory(texture, buffer, entry->rawSize);
+    free(buffer);
+    return result;
+}
 
 // Io handled action...
 static void cacheLoadImage(void *data)
@@ -37,7 +74,16 @@ static void cacheLoadImage(void *data)
     GSTEXTURE *texture = &req->entry->texture;
     texFree(texture);
 
-    if (handler->itemGetImage(handler, req->cache->prefix, req->cache->isPrefixRelative, req->value, req->cache->suffix, texture, GS_PSM_CT24) < 0)
+    int result = -1;
+
+    if (gEnableArtTar)
+        result = artTarLoadImage(req->value, req->cache->suffix, texture);
+
+    // Fall through to the per-file lookup whenever the archive is off, absent, or lacks this key.
+    if (result < 0)
+        result = handler->itemGetImage(handler, req->cache->prefix, req->cache->isPrefixRelative, req->value, req->cache->suffix, texture, GS_PSM_CT24);
+
+    if (result < 0)
         req->entry->lastUsed = 0;
     else
         req->entry->lastUsed = guiFrameId;


### PR DESCRIPTION
Checkpoint step 17. Clears two of Zack's four remaining "not built yet" items:

> no .tar support
> no art delay option

**This is Gate D**, and item 45 is flagged ⚠️ in the checklist as a #340 suspect — so it lands isolated, on a baseline where hardware scrolling is confirmed perfect.

## What was actually missing

| | state before |
|---|---|
| `src/tar.c`, `include/tar.h` | **absent entirely** |
| `gEnableArtTar` | global, config load/save and default existed — but **no consumer** |
| `gArtDelay` | **already fully live**: bdm/eth/hdd/udpfs seed `itemList->delay`, and [texcache.c](src/texcache.c) gates on `guiInactiveFrames < list->delay`. Only its **UI** was hidden. |

Both rows were already pre-staged in `diaArtworkConfig` by step 06 and explicitly hidden with `diaSetVisible(...,0)` plus `NOTE(rebuild)` breadcrumbs — the honest-hiding pattern working exactly as designed. Un-hiding them is most of the UI work.

## Landed

- `src/tar.c` + `include/tar.h` wholesale from the fork; `tar.o` added to `EE_OBJS`
- `texcache.c`: `artTarLoadImage()` plus a try-tar-then-fall-back hook at the single `itemGetImage` call site — about 10 lines, the fork's shape adapted to official's smaller texcache
- `gui.c`: `artDelayNames`/`artDelayValues`/`artDelayToEnum`, both rows un-hidden and wired set/get, the `tarInvalidate(TAR_KIND_ART)` re-arm when the toggle flips, and live delay propagation onto already-built lists
- `opl.c`: `gArtDelay` validation tightened from `0..60` to the enum's own domain `{0,2,5,8}`, so a hand-edited value can't render as a delay the UI cannot express

## Why this does not reopen #340

This is the part that matters most, so it is spelled out:

1. **`gEnableArtTar` ships `0`.** With the toggle off, the art path is one predictable branch — byte-for-byte the behaviour hardware just validated.
2. **The only IO `.tar` adds is `tarFind`'s lazy device probe**, and that is reachable *only* from `cacheLoadImage`, which the caller already gates behind the art idle delay. **No `.tar` work can land while the user is holding a direction.** `tar.c`'s own `s_inactive[]` latch also stops a failed probe from repeating.
3. **`gArtDelay` default stays `8`, not the fork's `2`.** The #340 analysis specifically implicated an 8→2 idle-gate drop for landing IO inside ~130 ms tap gaps. The user can now choose 2 from the new row; the default will not choose it for them.
4. **No art worker thread.** The fork's `.tar` integration does not require one, so the rebuild keeps official's ~175-line texcache with **zero** worker threads (the fork's is ~1139 lines *with* a prio-0x40 worker).

## Known gap, matching the fork

BDM lists are not in the live-propagation list — `bdmsupport` seeds `delay` in `bdmInit`, so a BDM tab keeps its previous delay until the device is re-initialised. The fork has the same gap (its list is app/hdd/eth/mmce/udpfs/fav, no bdm). I matched fork behaviour rather than inventing new behaviour on a gate step; worth revisiting later since BDM is the primary device. A `NOTE(rebuild)` marks where `mmceGetObject` joins with item 1.

## Verification

Clean build in the `opl340` container: `MAKE_EXIT=0`. One build failure en route — `gui.c` didn't include `appsupport.h` (the fork's does) — caught and fixed. Dialog rows verified byte-identical to the fork's, including `UI_ENUM` for the delay row, which is what `diaSetEnum` requires.

## Gate D test ask

The two new rows live under **Interface → Artwork Settings**. Worth testing in this order: scroll first with everything at defaults (should be identical to rebuild-16), then turn on `.tar` with an `ART/art.tar` pack present, then try Art Delay at 0 (Instant) to confirm the knob does something — and, since it's the aggressive setting, whether scrolling still feels right there.