### PR TITLE
rebuild-17b: .tar re-arm on settings apply + honest cost documentation

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -33,6 +33,7 @@
 #include "include/appsupport.h"
 #include "include/favsupport.h"
 #include "include/folderbrowse.h" // folderDepth -- favourites suppression inside subfolders
+#include "include/tar.h"          // tarInvalidate -- re-arm the .tar probe on a settings apply
 #include "include/vcdsupport.h"   // vcdViewActive stub -- isVcd stays 0 until item 12 lands
 
 #include "include/cheatman.h"
@@ -1693,6 +1694,16 @@ static void _saveConfig()
 
 void applyConfig(int themeID, int langID, int skipDeviceRefresh)
 {
+    // A deliberate settings apply may make new art available, so clear the .tar "no archive
+    // anywhere" latch and let it be probed once more. That latch (tar.c s_inactive[]) is write-once
+    // and process-wide with no self-clearing path, so without this a user who boots with the loader
+    // already ON and no archive present -- then plugs one in -- keeps getting nothing until a
+    // reboot. The Artwork page's own toggle-flip re-arm only covers the case where the toggle
+    // CHANGES; this covers the rest.
+    // NOTE(rebuild): the fork pairs this with cacheInvalidateFailMemo(), which the rebuild's
+    // official-derived texcache does not have. Only the .tar half applies here.
+    tarInvalidate(TAR_KIND_ART);
+
     if (gDefaultDevice < 0 || gDefaultDevice > APP_MODE)
         gDefaultDevice = APP_MODE;
 

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -21,10 +21,20 @@ typedef struct
 // normal per-file lookup. Opt-in: gEnableArtTar ships 0, so with the toggle off this is a single
 // predictable branch and the art path is byte-for-byte the behaviour hardware has already validated.
 //
-// #340 note: tarFind() lazily probes devices on its FIRST call, which is IO -- but it can only be
-// reached from cacheLoadImage, which the caller already gates behind the art idle delay
-// (guiInactiveFrames < list->delay in cacheGetTexture). So no .tar work can land while the user is
-// holding a direction, and tar.c's own s_inactive[] latch stops a failed probe from repeating.
+// #340 note -- what this actually costs, stated in full because item 45 is a flagged suspect:
+//   WHERE IT RUNS: cacheLoadImage is an ioman handler (ioRegisterHandler/ioPutRequest below), so all
+//   of this executes on the IO worker thread at priority 30 -- never on the GUI/pad thread. The
+//   caller also gates the enqueue behind the art idle delay (guiInactiveFrames < list->delay in
+//   cacheGetTexture), so nothing here is even queued while the user is holding a direction.
+//   ONE-SHOT COSTS on the first request after the toggle goes on:
+//     - tarFind() lazily probes up to 13 devices (mass0-7, mmce0/1, hdd0:, pfs0:, smb0:) with one
+//       open() each; mmce* and smb0: are the slow ones. tar.c's s_inactive[] latch stops a failed
+//       probe from repeating.
+//     - a successful parse then WRITES a sidecar index (art_cache.bin, ~64 bytes per entry) next to
+//       the archive. That is a genuine write on the art path, unlike official's read-only one. It is
+//       non-fatal (tarParseFile ignores the result) and happens only when the archive changes, but it
+//       is the thing to instrument first if a .tar-enabled build ever feels worse than a plain one.
+//   DEFAULT PATH: gEnableArtTar ships 0, so none of the above is reachable unless the user opts in.
 static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *texture)
 {
     char name[64];


### PR DESCRIPTION
Follow-up to #391. The seam-recon verifier pass finished **after** that merge and caught two things — one functional gap, one in my own reporting. Rather than fold them in silently, they land as their own bisectable checkpoint.

## 1. Missing second half — `tarInvalidate` in `applyConfig()`

`tar.c`'s `s_inactive[]` "no archive anywhere" latch is **write-once and process-wide** with no self-clearing path. rebuild-17 re-armed it only on a toggle *flip* in the Artwork page. That covers a user turning the loader on — but not this:

> boot with the loader already ON and no archive present (latch fires) → plug in a device that has one → `art.tar` stays dead for the whole session

The fork clears that latch in **two** places; I had ported one. Now both. A `NOTE(rebuild)` records that the fork pairs this with `cacheInvalidateFailMemo()`, which our official-derived texcache doesn't have — only the `.tar` half applies.

This is the same shape as the bugs that have bitten this rebuild three times already: one half of a contract ported, the other left behind.

## 2. Under-reported cost — documented, deliberately not changed

#391's safety rationale was accurate but incomplete. Now stated in full at the hook:

- **A successful `.tar` parse writes a sidecar index** (`art_cache.bin`, ~64 bytes per entry) next to the archive. That is a genuine *write* on the art path, where official OPL's is read-only. It is non-fatal (`tarParseFile` ignores the result) and only happens when the archive changes — **but it is the first thing to instrument if a `.tar`-enabled build ever feels worse than a plain one.**
- **The first request after enabling probes up to 13 devices** (mass0–7, mmce0/1, hdd0:, pfs0:, smb0:) with one `open()` each. `mmce*` and `smb0:` are the slow ones.

Not changed, on purpose: the fork ships this, the sidecar is what stops large packs re-parsing every boot, and altering the cache format would break compatibility with existing wOPL/sOPL art packs. The right response is disclosure, not a unilateral divergence on a gate step.

## 3. A stronger guarantee than I originally claimed

#391 argued `.tar` work is safe because it sits behind the art idle gate. True — but understated. `cacheLoadImage` is an **ioman handler** (`ioRegisterHandler` + `ioPutRequest`), so all of it runs on the **IO worker thread at priority 30**, never on the GUI/pad thread. Both facts are now in the comment so the next person doesn't have to re-derive them.

## Scope

No behavioural change with the toggle off, which is how it ships. Clean build in the `opl340` container, `MAKE_EXIT=0`, zero undefined references.