### PR TITLE
rebuild-18: NBD graceful teardown + DEV9 shutdown before the IOP reset (#307)

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2089,6 +2089,21 @@ static int loadLwnbdSvr(void)
         }
     }
 
+    if (ret != 0) {
+        /* The server is not starting, so nothing will ever consume the network stack a FAILED
+         * bring-up just left resident (netman/smap/ps2ip, DEV9 powered). Tear it down NOW, while
+         * the state is fresh and known (#307): unloadLwnbdSvr reboots the IOP via reset() ->
+         * sysReset(), whose unbounded SifIopReset/SifIopSync waits are the wedge when they run
+         * against a live, half-configured stack. Every other network teardown in the tree
+         * (ethCleanUp/ethShutdown) does deinit + DEV9 shutdown and never reboots afterwards; this
+         * makes the NBD lifecycle match. The loaded-check mirrors ethShutdown: DEV9's refcount is
+         * shared with BDM/HDD, so only release it when the eth path actually holds it. */
+        int ethWasLoaded = ethGetModulesLoaded();
+        ethDeinitModules();
+        if (ethWasLoaded)
+            sysShutdownDev9();
+    }
+
     padInit(0);
 
     // init all pads
@@ -2103,7 +2118,19 @@ static int loadLwnbdSvr(void)
 
 static void unloadLwnbdSvr(void)
 {
+    /* Graceful teardown BEFORE the IOP reboot (#307): reset() -> sysReset() parks the EE in
+     * unbounded SifIopReset/SifIopSync waits, and those wedge when they run against a live,
+     * DEV9-powered, half-configured network stack (failed offline bring-up). An earlier #307
+     * attempt skipped the RPC teardown entirely and the console still froze, proving the reset --
+     * not the teardown -- is the hazardous step. So do here what every other network teardown in
+     * the tree does (ethShutdown: deinit + DEV9 power-off, no reboot after) and let the reset
+     * below reboot a clean IOP. The loaded-check mirrors ethShutdown: DEV9's refcount is shared
+     * with BDM/HDD, so only release it when the eth path actually holds it (a failed bring-up
+     * already released it in loadLwnbdSvr). */
+    int ethWasLoaded = ethGetModulesLoaded();
     ethDeinitModules();
+    if (ethWasLoaded)
+        sysShutdownDev9();
     unloadPads();
 
     reset();
@@ -2114,9 +2141,18 @@ static void unloadLwnbdSvr(void)
     // reinit the input pads
     padInit(0);
 
-    int ret = 0;
-    while (!ret)
+    /* Bounded retry (#307): an unbounded startPads loop turns a half-completed IOP reset into a
+     * hard freeze at exactly the reported "NBD Server unloading..." screen. ~5 s of retries covers
+     * a slow IOP; if pads still won't start, degrade (log + continue, the menu's own pad handling
+     * recovers on later polls) instead of wedging forever. */
+    int ret = 0, tries = 0;
+    while (!ret && tries++ < 100) {
         ret = startPads();
+        if (!ret)
+            delay(50);
+    }
+    if (!ret)
+        LOG("unloadLwnbdSvr: pads did not start after IOP reset (%d tries)\n", tries);
 
     // now start io again
     ioBlockOps(0);


### PR DESCRIPTION
Checkpoint step 18. Closes the last of Zack's three outstanding issues.

> NBD Server error unloading crash still occur ( WHICH WE ALREADY SOLVED )

He's right — it *was* solved, in the fork, by `bdb63b33`. It had simply never been re-added here.

## Mechanism (#307)

`unloadLwnbdSvr` calls `reset()` → `sysReset()`, whose **unbounded** `SifIopReset`/`SifIopSync` waits run against a live, DEV9-powered, half-configured smap/ps2ip stack after a failed offline bring-up. That combination exists nowhere else in the tree — every other network teardown (`ethCleanUp`/`ethShutdown`) does deinit + DEV9 power-off and never reboots the IOP afterwards. Official OPL has the identical unfixed flow (ps2homebrew#1012, same frozen screenshot).

## Three changes, from `bdb63b33`

1. **`loadLwnbdSvr`** — on the failed bring-up branch, tear the stack down immediately (`ethDeinitModules` + `sysShutdownDev9`) while the state is fresh and known.
2. **`unloadLwnbdSvr`** — same sequence *before* `reset()`, so `SifIopReset` reboots a clean, DEV9-off IOP. We already called `ethDeinitModules` here; **the missing half was the DEV9 power-off.** The loaded-check mirrors `ethShutdown` — DEV9's refcount is shared with BDM/HDD, so it's only released when the eth path actually holds it.
3. **`unloadLwnbdSvr`** — **bound the post-reset `startPads` loop.** It was `while (!ret) ret = startPads();` — an unbounded spin that turns a half-completed IOP reset into a hard freeze at *exactly* the reported "NBD Server unloading…" screen. Now ~5 s of retries, then log and continue.

## The "NBD trio" is actually one commit

The inventory listed `bdb63b33` + `2b60e7b4` + `64a3da75` as three fixes to re-add. That's wrong, and porting all three would have caused a regression:

- Ancestry is `bdb63b33 → 2b60e7b4 → 64a3da75` (verified with `merge-base --is-ancestor`, then cross-checked against commit dates — my first read of the blob hashes had the order backwards, so I checked it two ways).
- `2b60e7b4` and `64a3da75` are **exact inverses of each other** on the same two lines: `2b60e7b4` sets the NBD msgbox background to `diaToolsConfig`, `64a3da75` sets it straight back to `NULL`.
- `NULL` is the fork's final state — **and this tree already has it.**

So `64a3da75` is already satisfied, and porting `2b60e7b4` would have *undone* it. Only `bdb63b33` was ever real.

## Not ported, deliberately

The `teardownStarted` flag in `handleLwnbdSrv` comes from `47b5d6d7` *"refactor: simplify runtime loading pipelines"*, not from the #307 fix. It only skips a now-harmless unload after a failed load — harmless precisely *because* this commit makes the pre-reset state clean. Left for whoever ports that refactor.

## Verification

Clean build in the `opl340` container: `MAKE_EXIT=0`, no new warnings. `sysShutdownDev9`, `ethGetModulesLoaded` and `ethDeinitModules` all confirmed present in our headers before use.

This is a hardware-only path — NBD can't be meaningfully exercised in an emulator — so Zack's test is the verification.