### PR TITLE
rebuild-19: restore RiptOPL's built-in default theme (misc/conf_theme_OPL.cfg)

### DIFF
--- a/misc/conf_theme_OPL.cfg
+++ b/misc/conf_theme_OPL.cfg
@@ -1,196 +1,320 @@
 main0:
 	type=Background
-	default=background
+	pattern=BG
+main1:
+	type=StaticImage
+	default=incebtion
 	aligned=0
 	scaled=0
 	width=DIM_INF
 	height=DIM_INF
-main1:
-	type=ItemsList
-	x=40
-	y=38
-	width=400
-	height=306
 main2:
-	type=MenuIcon
+	type=StaticImage
+	default=ip
+	x=-132
+	y=20
+	aligned=0
+	width=16
+	height=16
 main3:
-	type=ItemCover
-	default=cover
-	x=-86
-	y=-296
-	overlay=case
-	overlay_ulx=0
-	overlay_uly=9
-	overlay_urx=168
-	overlay_ury=19
-	overlay_llx=0
-	overlay_lly=244
-	overlay_lrx=168
-	overlay_lry=254
-appsMain3:
-	type=ItemCover
-	default=cover
-	x=-86
-	y=-254
-	overlay=apps_case
-	overlay_ulx=0
-	overlay_uly=9
-	overlay_urx=168
-	overlay_ury=19
-	overlay_llx=0
-	overlay_lly=170
-	overlay_lrx=168
-	overlay_lry=180
+	type=MenuIcon
+	devices=bdm
+	x=13
+	y=16
+	aligned=0
+	scaled=0
+	width=623
+	height=464
 main4:
-	type=ItemIcon
-	default=disc
-	x=-220
-	y=-230
-	width=128
-	height=128
-appsMain4:
-	type=ItemIcon
-	width=0
-	height=0
+	type=MenuIcon
+	devices=usb
+	x=14
+	y=437
+	aligned=0
+	scaled=0
+	width=23
+	height=22
 main5:
-	type=ItemText
-	x=-124
-	y=-155
-appsMain5:
-	type=ItemText
-	x=-124
-	y=-185
+	type=MenuIcon
+	devices=ilink
+	x=36
+	y=443
+	aligned=0
+	scaled=0
+	width=18
+	height=18
 main6:
-	type=HintText
-	aligned=1
-	x=POS_MID
+	type=MenuIcon
+	devices=mx4sio
+	x=86
+	y=16
+	aligned=0
+	scaled=0
+	width=57
+	height=21
 main7:
-	type=BdmIndex
-	width=64
-	height=8
+	type=MenuIcon
+	devices=hdd_bd
+	x=70
+	y=446
+	aligned=0
+	scaled=0
+	width=251
+	height=25
 main8:
+	type=MenuIcon
+	devices=hdd
+	x=70
+	y=446
+	aligned=0
+	scaled=0
+	width=251
+	height=25
+main9:
+	type=MenuIcon
+	devices=eth
+	x=509
+	y=386
+	aligned=0
+	scaled=0
+	width=127
+	height=94
+main10:
+	type=MenuIcon
+	devices=mmce
+	x=86
+	y=14
+	aligned=0
+	scaled=0
+	width=56
+	height=23
+main11:
+	type=MenuIcon
+	devices=udpbd
+	x=509
+	y=386
+	aligned=0
+	scaled=0
+	width=127
+	height=94
+main12:
+	type=MenuIcon
+	devices=udpfs
+	x=509
+	y=386
+	aligned=0
+	scaled=0
+	width=127
+	height=94
+main13:
+	type=MenuIcon
+	devices=fav
+	x=422
+	y=16
+	aligned=0
+	scaled=0
+	width=189
+	height=30
+main14:
+	type=MenuIcon
+	x=0
+	y=0
+	aligned=0
+	scaled=0
+	width=DIM_INF
+	height=DIM_INF
+main15:
+	type=ItemsList
+	x=30
+	y=70
+	aligned=0
+	width=400
+	height=350
+main16:
+	type=ItemCover
+	default=cover
+	x=-128
+	y=240
+	width=184
+	height=256
+	overlay=case
+	overlay2=case_overlay
+	overlay_ulx=0
+	overlay_uly=0
+	overlay_urx=184
+	overlay_ury=0
+	overlay_llx=0
+	overlay_lly=256
+	overlay_lrx=184
+	overlay_lry=256
+appsMain16:
+	type=ItemCover
+	default=coverapp
+	x=-128
+	y=240
+	width=184
+	height=185
+	overlay=case
+	overlay2=case_overlay
+	overlay_ulx=0
+	overlay_uly=0
+	overlay_urx=184
+	overlay_ury=0
+	overlay_llx=0
+	overlay_lly=185
+	overlay_lrx=184
+	overlay_lry=185
+main17:
 	type=LoadingIcon
-	y=-80
-	width=32
+	x=-320
+	y=-240
+main18:
+	type=BdmIndex
+	x=7
+	y=-35
+	width=4
 	height=32
 info0:
 	type=Background
 	pattern=BG
 info1:
 	type=StaticImage
-	default=info
+	default=incebtion
 	aligned=0
 	scaled=0
 	width=DIM_INF
 	height=DIM_INF
 info2:
-	type=AttributeText
-	attribute=Title
-	display=0
+	type=StaticImage
+	default=ip
+	x=-132
+	y=20
 	aligned=0
-	x=33
-	y=28
+	width=16
+	height=16
 info3:
 	type=AttributeText
-	attribute=Genre
+	attribute=Title
+	color=#ffffff
 	display=0
 	aligned=0
 	x=33
-	y=47
+	y=70
 info4:
 	type=AttributeText
-	attribute=Release
+	attribute=Developer
+	color=#ffffff
 	display=0
 	aligned=0
 	x=33
-	y=66
+	y=89
 info5:
 	type=AttributeText
-	attribute=Developer
-	display=0
-	aligned=0
-	x=33
-	y=85
-info6:
-	type=AttributeText
 	attribute=#Size
+	color=#ffffff
 	display=0
 	aligned=0
 	x=33
-	y=104
-info7:
+	y=108
+info6:
 	type=AttributeText
 	attribute=Description
 	display=0
+	color=#ffffff
 	aligned=0
 	x=33
-	y=123
-	width=574
-	height=80
+	y=127
+	width=590
+	height=60
 	wrap=1
-info8:
+info7:
 	type=AttributeImage
 	attribute=#Media
-	width=42
-	height=22
+	default=APP
+	width=32
+	height=16
 	x=55
-	y=-242
-info9:
+	y=-252
+info8:
 	type=AttributeImage
 	attribute=#Format
-	width=42
-	height=22
-	x=110
-	y=-242
-info10:
+	default=ELF
+	width=32
+	height=16
+	x=86
+	y=-252
+info9:
 	type=AttributeImage
 	attribute=Vmode
-	width=42
-	height=22
-	x=165
-	y=-242
-info11:
+	default=missing
+	width=32
+	height=16
+	x=117
+	y=-252
+info10:
 	type=AttributeImage
 	attribute=Aspect
-	width=42
-	height=22
-	x=220
-	y=-242
-info12:
+	default=missing
+	width=32
+	height=16
+	x=148
+	y=-252
+info11:
 	type=AttributeImage
 	attribute=Scan
-	width=42
-	height=22
-	x=275
-	y=-242
+	default=missing
+	width=32
+	height=16
+	x=179
+	y=-252
+info12:
+	type=AttributeImage
+	attribute=Players
+	default=missing
+	width=32
+	height=16
+	x=210
+	y=-252
 info13:
 	type=AttributeImage
 	attribute=Rating
-	default=Rating_0
-	x=-74
-	y=-242
+	default=no_Rating
+	x=-76
+	y=-252
+	width=128
+	height=16
 info14:
-	type=AttributeImage
-	attribute=Device
-	x=-74
-	y=38
-info15:
 	type=GameImage
 	pattern=SCR
 	default=screen
-	x=184
-	y=-133
-	width=173
-	height=148
-info16:
+	x=189
+	y=-150
+	scaled=2
+	width=200
+	height=150
+	overlay=screens
+	overlay_ulx=1
+	overlay_uly=1
+	overlay_urx=199
+	overlay_ury=1
+	overlay_llx=1
+	overlay_lly=149
+	overlay_lrx=199
+	overlay_lry=149
+info15:
 	type=GameImage
 	pattern=SCR2
 	default=screen
-	x=-186
-	y=-133
-	width=173
-	height=148
-info17:
-	type=InfoHintText
-	aligned=1
-	x=POS_MID
+	x=-191
+	y=-150
+	width=200
+	height=150
+	overlay=screens
+	overlay_ulx=1
+	overlay_uly=1
+	overlay_urx=199
+	overlay_ury=1
+	overlay_llx=1
+	overlay_lly=149
+	overlay_lrx=199
+	overlay_lry=149


### PR DESCRIPTION
Checkpoint step 19. Fixes the issue Zack photographed.

> game list mode is NOT RIPTOPL'S its main branch opl's in a broken way
>
> when changing from game list mode to CF, riptopls takes in, when changing from CF to game list mode, opl main branch takes in

## One file

`misc/theme_coverflow.cfg` was already the fork's (step 03). `misc/conf_theme_OPL.cfg` — the **built-in default theme** that drives game-list mode — was still **official OPL's**.

So Coverflow rendered as RiptOPL and the list view rendered as stock OPL. That is exactly the behaviour he described, and exactly what his photo shows.

**This was my omission in rebuild-14.** That step restored the identity *assets* (`gfx/` + `audio/`) but not the *config that arranges them* — I diffed the asset directories and never looked at `misc/`.

## It also fixes something rebuild-14 broke

Our official-derived `conf_theme_OPL.cfg` referenced `background` and `info`. Neither is in `PNG_ASSETS` — because `PNG_ASSETS` has been the **fork's** list since step 03, and the fork's theme doesn't use them. rebuild-14 then deleted `background.png`/`info.png` as "unused", which was true for the fork's theme but **not** for the config this tree was actually running.

Restoring the fork's config removes the dangling references rather than resurrecting dead assets — the right direction, since every other identity surface is already the fork's.

## The identity surface is now complete

Byte-identical to fork master across all five pieces, verified by diff:

| | |
|---|---|
| `misc/conf_theme_OPL.cfg` | ✅ |
| `misc/theme_coverflow.cfg` | ✅ |
| `gfx/` | ✅ |
| `audio/` | ✅ |
| `Makefile` `PNG_ASSETS` | ✅ |

I also swept every non-source difference between the trees to make sure nothing else identity-related was hiding. What remains is all deferred by design: `ee_core` GSM (item 29, on WAIT), `asm/*.gz` build outputs, `thirdparty` linkfile, `lang_compiler.py`.

## One thing deliberately not "fixed"

The restored config references `APP` and `no_Rating`, which aren't in `PNG_ASSETS`. That is **fork-normal** — the fork ships this exact config with this exact asset list and runs on hardware, so unresolved names degrade here exactly as they do there. Matching the fork is the standard; diverging to "fix" it would be inventing behaviour on an identity step.

## Verification

Clean build in the `opl340` container, `MAKE_EXIT=0`. This is a data-only change — no C source is touched.