### PR TITLE
rebuild-20: NBD preflight -- never dismantle the menu before the NIC is proven

### DIFF
--- a/include/ioman.h
+++ b/include/ioman.h
@@ -53,6 +53,14 @@ int ioPrintf(const char *format, ...);
 */
 int ioBlockOps(int block);
 
+/** As ioBlockOps, but caps the drain wait at timeoutTicks (< 0 = unbounded).
+ Used by the NBD preflight so a request stuck on a removed/slow device cannot
+ hang the start indefinitely.
+ @param block If nonzero, will issue blocking, otherwise it will unblock
+ @param timeoutTicks Max delay(1) ticks to wait for pending IO; < 0 = unbounded
+*/
+int ioBlockOpsTimed(int block, int timeoutTicks);
+
 #ifdef __DEBUG
 #define PREINIT_LOG(...) printf(__VA_ARGS__)
 #define LOG(...)         ioPrintf(__VA_ARGS__)

--- a/src/ioman.c
+++ b/src/ioman.c
@@ -1,5 +1,6 @@
 #include "include/opl.h"
 #include "include/ioman.h"
+#include "include/util.h" // delay() -- bounded drain in ioBlockOpsTimed
 #include <kernel.h>
 #include <string.h>
 #include <malloc.h>
@@ -333,7 +334,7 @@ int ioPrintf(const char *format, ...)
     return ret;
 }
 
-int ioBlockOps(int block)
+int ioBlockOpsTimed(int block, int timeoutTicks)
 {
     ee_thread_status_t status;
     int ThreadID;
@@ -342,12 +343,24 @@ int ioBlockOps(int block)
         isIOBlocked = 1;
 
         ThreadID = GetThreadId();
-        int haveStatus = (ReferThreadStatus(ThreadID, &status) == 0);
+        // EE ReferThreadStatus() returns the thread status (>= 0) or a negative error, NOT 0 on
+        // success (that is the IOP thbase variant). An `== 0` test is always false, so haveStatus
+        // would always be 0 and the saved priority below would never be restored -- leaving this
+        // (usually the main GUI) thread pinned at priority 90 for the rest of the session.
+        int haveStatus = (ReferThreadStatus(ThreadID, &status) >= 0);
         ChangeThreadPriority(ThreadID, 90);
 
-        // wait for all io to finish
+        // Wait for the in-flight IO handler(s) to finish. timeoutTicks < 0 waits unbounded
+        // (the historical behaviour); a non-negative value caps the wait. The NBD preflight
+        // passes a bound so a request stuck on a removed/slow device fails the start instead
+        // of freezing after audio and pads have already been dismantled.
         while (ioHasPendingRequests()) {
-        };
+            if (timeoutTicks == 0)
+                break;
+            delay(1);
+            if (timeoutTicks > 0)
+                timeoutTicks--;
+        }
 
         // Only restore the saved priority if ReferThreadStatus actually filled it.
         if (haveStatus)
@@ -359,4 +372,10 @@ int ioBlockOps(int block)
     }
 
     return IO_OK;
+}
+
+int ioBlockOps(int block)
+{
+    // Unbounded wait (historical behavior) for all non-teardown callers.
+    return ioBlockOpsTimed(block, -1);
 }

--- a/src/opl.c
+++ b/src/opl.c
@@ -2044,9 +2044,24 @@ int oplUpdateGameCompatSingle(int id, item_list_t *support, config_set_t *config
 // ----------------------------------------------------------
 
 
-static int loadLwnbdSvr(void)
+#define LWNBD_ART_DRAIN_TICKS 500
+#define LWNBD_IO_DRAIN_TICKS  1000
+
+static void shutdownLwnbdNetwork(void)
 {
-    int ret, padStatus;
+    // The loaded-check mirrors ethShutdown: DEV9's refcount is shared with BDM/HDD, so only
+    // release it when the eth path actually holds it.
+    int ethWasLoaded = ethGetModulesLoaded();
+
+    ethDeinitModules();
+    if (ethWasLoaded)
+        sysShutdownDev9();
+}
+
+static int loadLwnbdSvr(int *teardownStarted)
+{
+    int ret, padStatus, padTries;
+    int ethWasLoadedBeforePreflight;
     struct lwnbd_config
     {
         char defaultexport[32];
@@ -2054,20 +2069,7 @@ static int loadLwnbdSvr(void)
     };
     struct lwnbd_config config;
 
-    // deint audio lib while nbd server is running
-    audioEnd();
-
-    // block all io ops, wait for the ones still running to finish
-    ioBlockOps(1);
-    guiExecDeferredOps();
-
-    // Deinitialize all support without shutting down the HDD unit.
-    deinitAllSupport(NO_EXCEPTION, IO_MODE_SELECTED_ALL);
-    clearErrorMessage(); /* At this point, an error might have been displayed (since background tasks were completed).
-                            Clear it, otherwise it will get displayed after the server is closed. */
-
-    unloadPads();
-    // sysReset(0); // usefull ? printf doesn't work with it.
+    *teardownStarted = 0;
 
     /* compat stuff for user not providing name export (useless when there was only one export) */
     ret = strlen(gExportName);
@@ -2078,7 +2080,65 @@ static int loadLwnbdSvr(void)
 
     config.readonly = !gEnableWrite;
 
-    // see gETHStartMode, gNetworkStartup ? this is slow, so if we don't have to do it (like debug build).
+    /*
+     * Prove that the NIC can establish link and configuration while the live menu
+     * is still intact. In particular, an unplugged cable must not send the failure
+     * path through audioEnd(), unloadPads(), or the IOP reset used to restore a
+     * successfully-started server -- that is the reported freeze at the
+     * "NBD Server unloading..." screen (#307).
+     */
+    ethWasLoadedBeforePreflight = ethGetModulesLoaded();
+    ret = ethLoadInitModules();
+    if (ret != 0) {
+        if (!ethWasLoadedBeforePreflight)
+            shutdownLwnbdNetwork();
+        return ret;
+    }
+
+    /*
+     * If preflight brought up the stack solely for this check, return DEV9 to its
+     * prior ownership state. The normal post-teardown load below then starts from
+     * the same clean state as every other NBD launch.
+     */
+    if (!ethWasLoadedBeforePreflight)
+        shutdownLwnbdNetwork();
+
+    /*
+     * Support cleanup invalidates device-owned lists used by art requests.
+     * If the bounded drain cannot make that ownership safe, keep the live menu
+     * intact and let the user retry.
+     */
+    if (!cacheAbortMmceImageLoadsTimed(LWNBD_ART_DRAIN_TICKS) ||
+        !cacheCancelPendingImageLoadsTimed(LWNBD_ART_DRAIN_TICKS))
+        return -1;
+
+    /*
+     * Block new foreground work and bound the drain while the rest of the menu
+     * is still live. A stuck request therefore fails the start instead of
+     * freezing after audio and pads have already been dismantled.
+     */
+    ioBlockOpsTimed(1, LWNBD_IO_DRAIN_TICKS);
+    if (ioHasPendingRequests()) {
+        ioBlockOps(0);
+        return -1;
+    }
+
+    *teardownStarted = 1;
+
+    // deinit audio lib while nbd server is running
+    audioEnd();
+
+    guiExecDeferredOps();
+
+    // Deinitialize all support without shutting down the HDD unit.
+    // NOTE(rebuild): the fork passes a 3rd "spare a second mode" argument here; this tree's
+    // deinitAllSupport is still the 2-arg form, so the call is adapted rather than copied.
+    deinitAllSupport(NO_EXCEPTION, IO_MODE_SELECTED_ALL);
+    clearErrorMessage(); /* At this point, an error might have been displayed (since background tasks were completed).
+                            Clear it, otherwise it will get displayed after the server is closed. */
+
+    unloadPads();
+
     ret = ethLoadInitModules();
     if (ret == 0) {
         ret = sysLoadModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL); /* gHDDStartMode ? */
@@ -2089,48 +2149,35 @@ static int loadLwnbdSvr(void)
         }
     }
 
-    if (ret != 0) {
-        /* The server is not starting, so nothing will ever consume the network stack a FAILED
-         * bring-up just left resident (netman/smap/ps2ip, DEV9 powered). Tear it down NOW, while
-         * the state is fresh and known (#307): unloadLwnbdSvr reboots the IOP via reset() ->
-         * sysReset(), whose unbounded SifIopReset/SifIopSync waits are the wedge when they run
-         * against a live, half-configured stack. Every other network teardown in the tree
-         * (ethCleanUp/ethShutdown) does deinit + DEV9 shutdown and never reboots afterwards; this
-         * makes the NBD lifecycle match. The loaded-check mirrors ethShutdown: DEV9's refcount is
-         * shared with BDM/HDD, so only release it when the eth path actually holds it. */
-        int ethWasLoaded = ethGetModulesLoaded();
-        ethDeinitModules();
-        if (ethWasLoaded)
-            sysShutdownDev9();
-    }
+    if (ret != 0)
+        shutdownLwnbdNetwork();
 
     padInit(0);
 
-    // init all pads
+    // init all pads, but never wedge the status screen on a failed reconnect
     padStatus = 0;
-    while (!padStatus)
+    padTries = 0;
+    while (!padStatus && padTries++ < 100) {
         padStatus = startPads();
+        if (!padStatus)
+            delay(50);
+    }
+    if (!padStatus)
+        LOG("loadLwnbdSvr: pads did not start after teardown (%d tries)\n", padTries);
 
     // now ready to display some status
 
     return ret;
 }
 
+
 static void unloadLwnbdSvr(void)
 {
-    /* Graceful teardown BEFORE the IOP reboot (#307): reset() -> sysReset() parks the EE in
-     * unbounded SifIopReset/SifIopSync waits, and those wedge when they run against a live,
-     * DEV9-powered, half-configured network stack (failed offline bring-up). An earlier #307
-     * attempt skipped the RPC teardown entirely and the console still froze, proving the reset --
-     * not the teardown -- is the hazardous step. So do here what every other network teardown in
-     * the tree does (ethShutdown: deinit + DEV9 power-off, no reboot after) and let the reset
-     * below reboot a clean IOP. The loaded-check mirrors ethShutdown: DEV9's refcount is shared
-     * with BDM/HDD, so only release it when the eth path actually holds it (a failed bring-up
-     * already released it in loadLwnbdSvr). */
-    int ethWasLoaded = ethGetModulesLoaded();
-    ethDeinitModules();
-    if (ethWasLoaded)
-        sysShutdownDev9();
+    // Release the live server stack before resetting the IOP (#307): reset() -> sysReset() parks
+    // the EE in unbounded SifIopReset/SifIopSync waits, which wedge against a live, DEV9-powered
+    // stack. This function is now only reached when loadLwnbdSvr actually dismantled the menu
+    // (teardownStarted), so a failed bring-up never gets here at all.
+    shutdownLwnbdNetwork();
     unloadPads();
 
     reset();
@@ -2169,17 +2216,23 @@ static void unloadLwnbdSvr(void)
 void handleLwnbdSrv()
 {
     char temp[256];
+    int teardownStarted;
+
     // prepare for lwnbd, display screen with info
     guiRenderTextScreen(_l(_STR_STARTINGNBD));
-    if (loadLwnbdSvr() == 0) {
+    if (loadLwnbdSvr(&teardownStarted) == 0) {
         snprintf(temp, sizeof(temp), "%s", _l(_STR_RUNNINGNBD));
         guiMsgBox(temp, 0, NULL);
     } else
         guiMsgBox(_l(_STR_STARTFAILNBD), 0, NULL);
 
-    // restore normal functionality again
-    guiRenderTextScreen(_l(_STR_UNLOADNBD));
-    unloadLwnbdSvr();
+    // Only a path that actually dismantled the menu needs the reset-and-restore cycle. A failed
+    // preflight (no cable/link) leaves the menu live, so it must NOT reach the IOP reset -- that
+    // reset is the reported freeze at the "NBD Server unloading..." screen (#307).
+    if (teardownStarted) {
+        guiRenderTextScreen(_l(_STR_UNLOADNBD));
+        unloadLwnbdSvr();
+    }
 }
 
 // ----------------------------------------------------------


### PR DESCRIPTION
Zack tested **rebuild-19**, which *includes* step 18's NBD fix, and the "NBD Server unloading…" freeze remains. Step 18 was not enough, and the reason is a judgement error I made in it.

## What I got wrong in step 18

I ported `bdb63b33` and explicitly deferred the `teardownStarted` flag as *"just a refactor from 47b5d6d7"*. It is not a refactor — it is the load-bearing half of the fix. The fork's own comment says exactly what it's for:

> Prove that the NIC can establish link and configuration **while the live menu is still intact**. In particular, an unplugged cable must not send the failure path through `audioEnd()`, `unloadPads()`, or the IOP reset used to restore a successfully-started server.

Our `loadLwnbdSvr` called `audioEnd()` + `ioBlockOps(1)` + `deinitAllSupport()` + `unloadPads()` **first**, and only then tried to bring up the network. So a failed bring-up (no cable, no link) had *already* dismantled the menu and **had** to continue into `unloadLwnbdSvr` → `reset()` → `sysReset()`'s unbounded `SifIopReset`/`SifIopSync` waits.

That is the freeze — and it's reached on precisely the path `bdb63b33` alone cannot save.

**Lesson, same as the "NBD trio" mix-up in #393: port the *current* fork state, not the historical commit.** The fork has moved well past `bdb63b33` here, and I was reading the commit instead of the file.

## What landed

The fork's current lifecycle, adapted:

- **Preflight** — `ethLoadInitModules()` runs while the menu is still live. On failure, return immediately with `teardownStarted = 0`: nothing torn down, no IOP reset, no freeze. DEV9 ownership is restored if preflight brought it up.
- **Bounded drains before teardown** — art (`cacheAbort`/`CancelPendingImageLoadsTimed`, 500 ticks) and IO (`ioBlockOpsTimed`, 1000 ticks), so a stuck request *fails the start* instead of freezing after audio and pads are already gone.
- **`teardownStarted` gates `unloadLwnbdSvr`** in `handleLwnbdSrv`.
- **`shutdownLwnbdNetwork()`** helper replaces the inline eth/DEV9 teardown.
- **Bounded `startPads` on the load side too** — step 18 only bounded the unload side.

## It also fixes a bug I introduced in step 16

`ioBlockOps` used `ReferThreadStatus(...) == 0` as its success test. That's the **IOP thbase** convention; the **EE** call returns the thread status (`>= 0`) or a negative error. So the test was *always false* — `haveStatus` never became 1, and the saved priority was never restored. **Every `ioBlockOps(1)` caller left the calling (usually main GUI) thread pinned at priority 90 for the rest of the session.**

I ported that `== 0` form from `da5450f2` in #390 without checking whether the fork had since corrected it. It had. Now `>= 0`, and `ioBlockOps` is a thin wrapper over `ioBlockOpsTimed(block, -1)`.

Worth noting for anyone chasing feel regressions: that bug could leave the GUI thread de-prioritised after any HDD or NBD operation that blocks IO.

## Adaptation

The fork calls `deinitAllSupport` with a 3rd "spare a second mode" argument; this tree still has the 2-arg form, so that call is adapted and marked with a `NOTE(rebuild)`. Verified by function-level diff that this and one extra comment sentence are the *only* divergences from fork master.

## Verification

Clean build, `MAKE_EXIT=0`. One failure en route — `ioman.c` needed `include/util.h` for `delay()` (the fork's includes it, ours didn't) — caught and fixed.

This is a hardware-only path, so Zack's test is the verification. The key behavioural change he should see: **with no cable/link, starting the NBD server now fails with a message and leaves the menu working**, instead of freezing on the unloading screen.