### PR TITLE
rebuild-21: give status and error screens their own opaque backdrop

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2700,7 +2700,11 @@ int guiMsgBox(const char *text, int addAccept, struct UIItem *ui)
         else
             guiShow();
 
-        rmDrawRect(0, 0, screenWidth, screenHeight, gColDarker);
+        // With a `ui` the CALLER chose what sits behind this box, so keep that context visible.
+        // With ui == NULL the backdrop is just whichever menu happened to be on screen -- it carries
+        // no information and, at gColDarker's ~75%, left the menu legible straight through the
+        // message. Errors get their own background in that case.
+        rmDrawRect(0, 0, screenWidth, screenHeight, ui ? gColDarker : gColBlack);
 
         rmDrawLine(50, 75, screenWidth - 50, 75, gColWhite);
         rmDrawLine(50, 410, screenWidth - 50, 410, gColWhite);
@@ -2751,7 +2755,14 @@ void guiRenderTextScreen(const char *message)
 
     guiShow();
 
-    rmDrawRect(0, 0, screenWidth, screenHeight, gColDarker);
+    // Opaque backdrop, not gColDarker. This is a non-interactive STATUS screen ("Please wait",
+    // "NBD Server unloading..."), and gColDarker is only alpha 0x60 of a 0x80 maximum -- i.e. ~75%
+    // -- so the menu underneath stayed clearly legible through the message. On a CRT that reads as
+    // a transparent error with the settings menu showing through it, which is exactly what the
+    // tester reported (and photographed) three times. Whatever is behind a status screen carries no
+    // information, so it is hidden. Interactive dialogs deliberately KEEP the translucent overlay
+    // (see guiConfirmVideoMode, where seeing the mode behind the prompt is the entire point).
+    rmDrawRect(0, 0, screenWidth, screenHeight, gColBlack);
 
     fntRenderString(gTheme->fonts[0], screenWidth >> 1, gTheme->usedHeight >> 1, ALIGN_CENTER, 0, 0, message, gTheme->textColor);
 
@@ -2921,7 +2932,9 @@ void guiWarning(const char *text, int count)
 
     guiShow();
 
-    rmDrawRect(0, 0, screenWidth, screenHeight, gColDarker);
+    // Same reasoning as guiRenderTextScreen: a warning is a non-interactive surface shown for a
+    // fixed number of frames, so it gets an opaque backdrop rather than a ~75% wash.
+    rmDrawRect(0, 0, screenWidth, screenHeight, gColBlack);
 
     rmDrawLine(50, 75, screenWidth - 50, 75, gColWhite);
     rmDrawLine(50, 410, screenWidth - 50, 410, gColWhite);


### PR DESCRIPTION
Zack, three times now — most recently with a photo of "NBD Server unloading…" readable straight through the settings menu:

> errors dont have their OWN background … see how the error is transparent ? u could see the settings menu from the error screen

## Cause

`guiRenderTextScreen`, `guiWarning` and `guiMsgBox` all draw the live screen (`guiShow` / `diaRenderUI`), then wash it with `gColDarker`, then the text.

`gColDarker` is `GS_SETREG_RGBA(0, 0, 0, 0x60)` — and the GS treats **`0x80`** as fully opaque. So that wash is only ~75%, leaving the menu clearly legible underneath. On a CRT it reads exactly as he describes.

**This is not a rebuild regression, and not fork-specific.** Fork master's `guiRenderTextScreen` is byte-identical to ours, and he has reported the same behaviour on official OPL and sOPL. It's an upstream-wide defect — which is why there was no commit to port. This is a deliberate divergence, not a port.

## Rule applied

Non-interactive status/error/warning surfaces get an opaque backdrop; interactive dialogs keep the translucent overlay.

| | |
|---|---|
| **changed** `guiRenderTextScreen` | status screens ("Please wait", NBD load/unload) |
| **changed** `guiWarning` | fixed-duration warning toasts |
| **changed** `guiMsgBox` | **only when `ui == NULL`** |
| unchanged `guiConfirmVideoMode` | seeing the mode behind the prompt is the entire point of that dialog |
| unchanged `guiGameShowRemoveSettings`, `guiManageCheats` | interactive menus |
| unchanged `gui.c:288` | menu-item highlight, not a backdrop |

`guiMsgBox` is conditional on purpose. When a caller passes a `ui`, it has chosen what sits behind the box and wants that context visible. When `ui == NULL` the backdrop is just whichever menu happened to be on screen — no information, and precisely the case he photographed.

No new colour constant was needed: `gColBlack` (alpha `0x80`) already existed.

## Verification

Clean build, `MAKE_EXIT=0`. Confirmed by grep that exactly three fills changed and the three interactive dialogs plus the menu highlight are untouched.