### PR TITLE
rebuild-22: stop the Menu Rumble toggle lying (item 43 blocked)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1894,6 +1894,16 @@ void guiShowControllerConfig(void)
     diaSetInt(diaControllerConfig, CFG_SELECTBUTTON, gSelectButton == KEY_CIRCLE ? 0 : 1);
     diaSetInt(diaControllerConfig, CFG_XSENSITIVITY, gXSensitivity);
     diaSetInt(diaControllerConfig, CFG_YSENSITIVITY, gYSensitivity);
+    // NOTE(rebuild): Menu Rumble returns with checklist item 43 -- show its row greyed at Off until
+    // then. The row, its config key (CONFIG_OPL_RUMBLE) and its labels were all pre-staged by the
+    // settings-layout step, but gEnableRumble and the whole padRumble* engine are absent, so the
+    // toggle was rendering as an interactive control wired to nothing.
+    // Greyed rather than hidden ON PURPOSE: diaSetVisible targets the CONTROL id, and the caption is
+    // a separate {UI_LABEL, 0, ...} row, so hiding leaves an orphan label with nothing beside it
+    // (the defect rebuild-17 had to clean up on the Artwork page). Greying keeps the pair together,
+    // matching the MMCE Start Mode row.
+    diaSetInt(diaControllerConfig, CFG_RUMBLE, 0);
+    diaSetEnabled(diaControllerConfig, CFG_RUMBLE, 0);
 
     int result = diaExecuteDialog(diaControllerConfig, -1, 1, NULL);
     if (result) {


### PR DESCRIPTION
## The lying row

The Controller settings page rendered an interactive **Menu Rumble** checkbox wired to nothing. [dialogs.c:1635](src/dialogs.c:1635) has `{UI_BOOL, CFG_RUMBLE, ...}` with a hint, and `gui.c` referenced `CFG_RUMBLE` **zero** times — no `diaSetInt`, no `diaGetInt`, and `gEnableRumble` doesn't exist in this tree at all. Toggling it did nothing and nothing persisted.

Same class as the `CFG_APPLYGAMEID` checkbox rebuild-13 fixed. The row, its config key and its `RUMBLE`/`HINT_RUMBLE` labels were all pre-staged by the settings-layout step; only the engine was missing.

Now pinned Off and greyed with a `NOTE(rebuild)`, matching the MMCE Start Mode row.

**Greyed rather than hidden, on purpose:** `diaSetVisible` targets the *control* id, but the caption is a separate `{UI_LABEL, 0, ...}` row — so hiding leaves an orphan label with nothing beside it, exactly the defect rebuild-17 had to clean up on the Artwork page. Greying keeps the pair together.

## Swept for the rest

I checked every `UI_BOOL`/`INT`/`ENUM`/`STRING` row in `dialogs.c` for the same defect. The only other hits are the `CFG_MMCE*` rows, and those live in `diaMmceConfig` — which **no `guiShow*` function references**. That's an unreachable page joining with item 1; rows can't lie to a user who can't open them. `CFG_RUMBLE` was the only real one.

## Why item 43 is not landing yet — a real blocker

The three-lens recon found something I would very likely have shipped. The rumble decay tick is:

```c
pad->rumbleMsLeft -= (int)time_since_last;
```

and this tree still runs official's **divide-then-difference** clock:

```c
u32 newtime = cpu_ticks() / CLOCKS_PER_MILISEC;   // src/pad.c:334
time_since_last = newtime - curtime;
```

`cpu_ticks()` is 32-bit and `CLOCKS_PER_MILISEC` is 147456, so it wraps every **~29.1 seconds**. At each wrap `time_since_last` becomes garbage — which would **add ~29 s to an in-flight pulse: a stuck, continuously buzzing motor.**

The fork fixed this by differencing **raw** ticks and carrying the sub-millisecond remainder, with the comment: *"This keeps repeat and rumble timing correct across the ~29 second `cpu_ticks()` rollover."*

**That rework also changes `delaycnt[i] -= time_since_last`** — the key-repeat path that the just-validated "creamy" scrolling runs on. So it needs its own isolated checkpoint and its own hardware pass *before* rumble stacks on it, rather than being smuggled in as a sub-change of a feature.

Worth noting the clock bug is inherited from the official base (identical line in `rebuild/official-base`), so it is pre-existing, not a rebuild regression — and official is reportedly smooth, so it is not the #340 cause. It is still a genuine ~29 s glitch in the repeat interval.

## Verification

Clean build, `MAKE_EXIT=0`.