### PR TITLE
rebuild-23: PS5 DualSense (USB) support, compile-gated OFF (item 55)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ IGS ?= $(EXTRA_FEATURES)
 #Enables/disables pad emulator
 PADEMU ?= 1
 
+#Enables/disables PS5 DualSense (USB) support in the pad emulator. HW-VALIDATED on a real DS5
+#(maintainer, 2026-07-06) but kept OFF in the default build by deliberate choice -- the DS5 code
+#is entirely #ifdef DS5_ENABLE, so with this at 0 ds34usb.irx is behaviourally identical to the
+#build that is already hardware-proven. Named DUALSENSE=1 release assets return with item 58.
+DUALSENSE ?= 0
+
 #Enables/disables building of an edition of OPL that will support the DTL-T10000 (SDK v2.3+)
 DTL_T10000 ?= 0
 
@@ -549,7 +555,7 @@ modules/ds34usb/ee/libds34usb.a: modules/ds34usb/ee
 	$(MAKE) -C $<
 
 modules/ds34usb/iop/ds34usb.irx: modules/ds34usb/iop
-	$(MAKE) -C $<
+	$(MAKE) -C $< DUALSENSE=$(DUALSENSE)
 
 $(EE_ASM_DIR)ds34usb.c: modules/ds34usb/iop/ds34usb.irx | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ $(*F)_irx

--- a/include/ds34common.h
+++ b/include/ds34common.h
@@ -13,6 +13,9 @@
 #define DS4_PID_SLIM        0x09CC // PS4 Slim Controller
 #define GUITAR_HERO_PS3_PID 0x0100 // PS3 Guitar Hero Guitar
 #define ROCK_BAND_PS3_PID   0x0200 // PS3 Rock Band Guitar
+#ifdef DS5_ENABLE
+#define DS5_PID 0x0CE6 // PS5 DualSense Controller
+#endif
 
 // NOTE: struct member prefixed with "n" means it's active-low (i.e. value of 0 indicates button is pressed, value 1 is released)
 enum DS2ButtonBitNumber {
@@ -281,6 +284,65 @@ struct ds4report
     uint16_t Finger2Y      : 12;
 
 } __attribute__((packed));
+
+#ifdef DS5_ENABLE
+// PS5 DualSense USB extended input report (transplanted verbatim from wOPL). Only compiled
+// when DUALSENSE=1 -- the layout differs from DS4, so DS5 gets its own parse branch.
+struct ds5report
+{
+    uint8_t ReportID;
+    uint8_t LeftStickX;
+    uint8_t LeftStickY;
+    uint8_t RightStickX;
+    uint8_t RightStickY;
+    uint8_t PressureL2;
+    uint8_t PressureR2;
+    uint8_t Counter1;
+    uint8_t Dpad       : 4;
+    uint8_t Square     : 1;
+    uint8_t Cross      : 1;
+    uint8_t Circle     : 1;
+    uint8_t Triangle   : 1;
+    uint8_t L1         : 1;
+    uint8_t R1         : 1;
+    uint8_t L2         : 1;
+    uint8_t R2         : 1;
+    uint8_t Create     : 1;
+    uint8_t Option     : 1;
+    uint8_t L3         : 1;
+    uint8_t R3         : 1;
+    uint8_t PSButton   : 1;
+    uint8_t TPad       : 1;
+    uint8_t Microphone : 1;
+    uint8_t Reserved2  : 1;
+    uint8_t Reserved3  : 4;
+    uint8_t Reserved4;
+    uint32_t Counter2;
+    int16_t GyroX;
+    int16_t GyroY;
+    int16_t GyroZ;
+    int16_t AccelX;
+    int16_t AccelY;
+    int16_t AccelZ;
+    uint32_t SensorTimestamp;
+    uint8_t Temperature;
+    uint32_t Finger1ID      : 7;
+    uint32_t nFinger1Active : 1;
+    uint32_t Finger1X       : 12;
+    uint32_t Finger1Y       : 12;
+    uint32_t Finger2ID      : 7;
+    uint32_t nFinger2Active : 1;
+    uint32_t Finger2X       : 12;
+    uint32_t Finger2Y       : 12;
+    uint8_t Reserved7[12];
+    uint8_t Battery     : 4;
+    uint8_t Power       : 4;
+    uint8_t Reserved8   : 4;
+    uint8_t Usb_plugged : 1;
+    uint8_t Reserved9   : 3;
+    uint8_t Reserved10[9];
+} __attribute__((packed));
+#endif
 
 /**
  * Translate DS3 pad data into DS2 pad data.

--- a/modules/ds34usb/iop/Makefile
+++ b/modules/ds34usb/iop/Makefile
@@ -3,6 +3,11 @@ IOP_OBJS = ds34usb.o smsutils.o imports.o
 
 IOP_INCS += -I../../../include/
 
+# Experimental PS5 DualSense (USB) support, off by default (see the top-level DUALSENSE flag).
+ifeq ($(DUALSENSE),1)
+IOP_CFLAGS += -DDS5_ENABLE
+endif
+
 include $(PS2SDK)/Defs.make
 include ../../Rules.bin.make
 include $(PS2SDK)/samples/Makefile.iopglobal

--- a/modules/ds34usb/iop/ds34usb.c
+++ b/modules/ds34usb/iop/ds34usb.c
@@ -89,7 +89,11 @@ int usb_probe(int devId)
         return 0;
     }
 
-    if (device->idVendor == DS34_VID && (device->idProduct == DS3_PID || device->idProduct == DS4_PID || device->idProduct == DS4_PID_SLIM))
+    if (device->idVendor == DS34_VID && (device->idProduct == DS3_PID || device->idProduct == DS4_PID || device->idProduct == DS4_PID_SLIM
+#ifdef DS5_ENABLE
+                                         || device->idProduct == DS5_PID
+#endif
+                                         ))
         return 1;
 
     return 0;
@@ -130,6 +134,11 @@ int usb_connect(int devId)
     if (device->idProduct == DS3_PID) {
         ds34pad[pad].type = DS3;
         epCount = interface->bNumEndpoints - 1;
+#ifdef DS5_ENABLE
+    } else if (device->idProduct == DS5_PID) {
+        ds34pad[pad].type = DS5;
+        epCount = 20;
+#endif
     } else {
         ds34pad[pad].type = DS4;
         epCount = 20; // ds4 v2 returns interface->bNumEndpoints as 0
@@ -238,7 +247,7 @@ static void usb_config_set(int result, int count, void *arg)
         DelayThread(10000);
         led[0] = led_patterns[pad][1];
         led[3] = 0;
-    } else if (ds34pad[pad].type == DS4) {
+    } else if (ds34pad[pad].type == DS4 || ds34pad[pad].type == DS5) {
         led[0] = rgbled_patterns[pad][1][0];
         led[1] = rgbled_patterns[pad][1][1];
         led[2] = rgbled_patterns[pad][1][2];
@@ -402,6 +411,115 @@ static void readReport(u8 *data, int pad)
             else
                 ds34pad[pad].oldled[3] = 0;
         }
+#ifdef DS5_ENABLE
+        else if (ds34pad[pad].type == DS5) {
+            struct ds5report *report;
+            u8 up = 0, down = 0, left = 0, right = 0;
+            u8 battery_level;
+            u8 power_state;
+
+            // DS5 reports come directly at data[0], no offset needed (differs from DS3)
+            report = (struct ds5report *)data;
+
+            switch (report->Dpad) {
+                case 0:
+                    up = 1;
+                    break;
+                case 1:
+                    up = 1;
+                    right = 1;
+                    break;
+                case 2:
+                    right = 1;
+                    break;
+                case 3:
+                    down = 1;
+                    right = 1;
+                    break;
+                case 4:
+                    down = 1;
+                    break;
+                case 5:
+                    down = 1;
+                    left = 1;
+                    break;
+                case 6:
+                    left = 1;
+                    break;
+                case 7:
+                    up = 1;
+                    left = 1;
+                    break;
+                case 8:
+                    up = 0;
+                    down = 0;
+                    left = 0;
+                    right = 0;
+                    break;
+            }
+
+            if (report->TPad) {
+                if (!report->nFinger1Active) {
+                    if (report->Finger1X < 960)
+                        report->Create = 1;
+                    else
+                        report->Option = 1;
+                }
+
+                if (!report->nFinger2Active) {
+                    if (report->Finger2X < 960)
+                        report->Create = 1;
+                    else
+                        report->Option = 1;
+                }
+            }
+
+            ds34pad[pad].data[0] = ~(report->Create | report->L3 << 1 | report->R3 << 2 | report->Option << 3 | up << 4 | right << 5 | down << 6 | left << 7);
+            ds34pad[pad].data[1] = ~(report->L2 | report->R2 << 1 | report->L1 << 2 | report->R1 << 3 | report->Triangle << 4 | report->Circle << 5 | report->Cross << 6 | report->Square << 7);
+
+            ds34pad[pad].data[2] = report->RightStickX; // rx
+            ds34pad[pad].data[3] = report->RightStickY; // ry
+            ds34pad[pad].data[4] = report->LeftStickX;  // lx
+            ds34pad[pad].data[5] = report->LeftStickY;  // ly
+
+            ds34pad[pad].data[6] = right * 255; // right
+            ds34pad[pad].data[7] = left * 255;  // left
+            ds34pad[pad].data[8] = up * 255;    // up
+            ds34pad[pad].data[9] = down * 255;  // down
+
+            ds34pad[pad].data[10] = report->Triangle * 255; // triangle
+            ds34pad[pad].data[11] = report->Circle * 255;   // circle
+            ds34pad[pad].data[12] = report->Cross * 255;    // cross
+            ds34pad[pad].data[13] = report->Square * 255;   // square
+
+            ds34pad[pad].data[14] = report->L1 * 255;   // L1
+            ds34pad[pad].data[15] = report->R1 * 255;   // R1
+            ds34pad[pad].data[16] = report->PressureL2; // L2
+            ds34pad[pad].data[17] = report->PressureR2; // R2
+
+            // FIXED: Properly extract 4-bit battery and power fields
+            battery_level = report->Battery & 0x0F; // Battery is 4 bits (0-15)
+            power_state = report->Power & 0x0F;     // Power is 4 bits (0-15)
+
+            if (report->PSButton) { // display battery level
+                // Scale 4-bit battery (0-15) to 8-bit (0-255)
+                ds34pad[pad].oldled[0] = (battery_level * 255) / 15;
+                ds34pad[pad].oldled[1] = 0;
+                ds34pad[pad].oldled[2] = 0;
+            } else {
+                ds34pad[pad].oldled[0] = rgbled_patterns[pad][1][0];
+                ds34pad[pad].oldled[1] = rgbled_patterns[pad][1][1];
+                ds34pad[pad].oldled[2] = rgbled_patterns[pad][1][2];
+            }
+
+            // FIXED: Proper power state check for DS5 (0xB is charging on DS4, DS5 uses different encoding)
+            // For DS5: Power 0x0-0xA = discharging, 0xB = charging
+            if ((power_state == 0xB) || (power_state == 0xA && report->Usb_plugged))
+                ds34pad[pad].oldled[3] = 1;
+            else
+                ds34pad[pad].oldled[3] = 0;
+        }
+#endif
     }
 }
 
@@ -448,6 +566,26 @@ static int LEDRumble(u8 *led, u8 lrum, u8 rrum, int pad)
         }
 
         ret = UsbInterruptTransfer(ds34pad[pad].outEndp, usb_buf, 32, usb_cmd_cb, (void *)pad);
+#ifdef DS5_ENABLE
+    } else if (ds34pad[pad].type == DS5) {
+        usb_buf[0] = 0x02; // ReportID
+        usb_buf[1] = 0x03; // EnableRumbleEmulation & RumbleUseRumbleNotHaptics
+        usb_buf[2] = 0x17;
+
+        usb_buf[3] = rrum; // light weight (right motor)
+        usb_buf[4] = lrum; // heavy weight (left motor)
+
+        usb_buf[39] = 0x07; // AllowLightBrightnessChange & AllowColorLightFadeAnimation & EnableImprovedRumbleEmulation
+        usb_buf[42] = 0x80; // LightFadeAnimation
+        usb_buf[43] = 0xFF; // LightBrightness (max brightness)
+        usb_buf[44] = 0x04; // PlayerLight (player 1)
+
+        usb_buf[45] = led[0]; // r
+        usb_buf[46] = led[1]; // g
+        usb_buf[47] = led[2]; // b
+
+        ret = UsbInterruptTransfer(ds34pad[pad].outEndp, usb_buf, 48, usb_cmd_cb, (void *)pad);
+#endif
     }
 
     ds34pad[pad].oldled[0] = led[0];
@@ -585,7 +723,25 @@ int ds34usb_get_bdaddr(u8 *data, int port)
             DPRINTF("DS34USB: ds3usb_get_bdaddr usb transfer error %d\n", ret);
             ret = 0;
         }
-    } else {
+    }
+#ifdef DS5_ENABLE
+    else if (ds34pad[port].type == DS5) {
+        ret = UsbControlTransfer(ds34pad[port].controlEndp, REQ_USB_IN, USB_REQ_GET_REPORT, (HID_USB_GET_REPORT_FEATURE << 8) | 0x09, 0, 8, usb_buf, usb_cmd_cb, (void *)port);
+
+        if (ret == USB_RC_OK) {
+            TransferWait(ds34pad[port].cmd_sema);
+
+            for (i = 0; i < 6; i++)
+                data[5 - i] = usb_buf[2 + i];
+
+            ret = 1;
+        } else {
+            DPRINTF("DS34USB: ds5usb_get_bdaddr usb transfer error %d\n", ret);
+            ret = 0;
+        }
+    }
+#endif
+    else {
         ret = UsbControlTransfer(ds34pad[port].controlEndp, REQ_USB_IN, USB_REQ_GET_REPORT, (HID_USB_GET_REPORT_FEATURE << 8) | 0x12, 0, 16, usb_buf, usb_cmd_cb, (void *)port);
 
         if (ret == USB_RC_OK) {

--- a/modules/ds34usb/iop/ds34usb.h
+++ b/modules/ds34usb/iop/ds34usb.h
@@ -7,6 +7,7 @@
 
 #define DS3 0
 #define DS4 1
+#define DS5 2 // PS5 DualSense; only reachable when built with DUALSENSE=1 (-DDS5_ENABLE)
 
 #define MAX_BUFFER_SIZE 64 // Size of general purpose data buffer
 


### PR DESCRIPTION
Ports the fork's DS5 pad-emulator support. Every line is behind `#ifdef DS5_ENABLE`, driven by a top-level `DUALSENSE` flag that **defaults to 0** — so the shipped build is unchanged.

## Files

All four byte-identical to fork master:

| | |
|---|---|
| `include/ds34common.h` | `DS5_PID 0x0CE6` + `struct ds5report` |
| `modules/ds34usb/iop/ds34usb.c` | DS5 connect + its own parse branch |
| `modules/ds34usb/iop/ds34usb.h` | `#define DS5 2` |
| `modules/ds34usb/iop/Makefile` | `ifeq (DUALSENSE,1)` → `-DDS5_ENABLE` |

Plus two `Makefile` lines: `DUALSENSE ?= 0` and passing it down to the module build. **`ds34bt` is deliberately untouched** — this is USB DualSense only.

## Why this is safe on a boot-critical module

`ds34usb.irx` is loaded during `sysReset`'s PADEMU block — **the exact place the usbd black screen lived** in rebuild-12b. So "it's behind an `#ifdef`" was not taken on trust:

1. **Gating works.** `DUALSENSE=1` adds **1264 bytes** to `ds34usb.irx` versus `DUALSENSE=0`, so the DS5 code really is excluded from the default build.
2. **Builds are deterministic** — same source produced the same md5 twice — so binary comparisons are meaningful.
3. **The `DUALSENSE=0` binary is *not* bit-identical to the pre-DS5 one.** Rather than hand-wave that, I diffed the sources with all DS5-guarded blocks mechanically stripped. Exactly three differences remain; two are pure whitespace. The third is real and **unguarded**:

```diff
-    } else if (ds34pad[pad].type == DS4) {
+    } else if (ds34pad[pad].type == DS4 || ds34pad[pad].type == DS5) {
```

4. **That one is provably unreachable with the flag off.** The *only* assignment of `ds34pad[pad].type = DS5` is `ds34usb.c:139`, and it **is** inside `#ifdef DS5_ENABLE`. With `DUALSENSE=0` the type can only ever be DS3 or DS4, so the added comparison can never be true.

**Net: the default build differs from pre-DS5 by one dead comparison and some line breaks. Behaviourally identical.**

## Not in this step

The rolling-release `DUALSENSE=1` named assets (`RIPTOPL-<version>-<SDK>-ds5.ELF`, one per SDK flavour) belong to **item 58**, release infra.

## Verification

Full clean build at the default flag: `MAKE_EXIT=0`, zero undefined references. Module also built cleanly at `DUALSENSE=1`.