### PR TITLE
rebuild-24: residue sweep -- close the gaps the checklist was hiding

### DIFF
--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1022,3 +1022,7 @@ gui_strings:
   string: Loaded from %s
 - label: POPSTARTER_NET_ERR
   string: Couldn't write POPSTARTER network config to the memory card.
+- label: NEUTRINO_SETTING_NA
+  string: This setting is not used with the Neutrino core.
+- label: DISABLE_ALL
+  string: Disable All

--- a/src/gui.c
+++ b/src/gui.c
@@ -2938,6 +2938,15 @@ void guiShowGameID(const char *startup)
 
 void guiWarning(const char *text, int count)
 {
+    // Pre-GUI callers exist: autolaunch (miniInit) never runs rmInit/thmInit/guiInit, so rendering
+    // here would draw through a NULL gsGlobal/gTheme. Launch-path helpers shared between the menu
+    // and autolaunch (the Neutrino/VMC toasts in bdmsupport/hddsupport/supportbase) rely on this
+    // guard instead of each call site checking the autolaunch globals.
+    if (gTheme == NULL) {
+        LOG("guiWarning (pre-GUI): %s\n", text);
+        return;
+    }
+
     guiStartFrame();
 
     guiShow();
@@ -3068,6 +3077,9 @@ void guiManageCheats(void)
     int selectedCheat = 0;
     int visibleCheats = 10; // Maximum number of cheats visible on screen
 
+    if (gCheats == NULL) // defensive: the menu is only reachable after load_cheats, but never deref NULL
+        return;
+
     while (cheatCount < MAX_CODES && strlen(gCheats[cheatCount].name) > 0)
         cheatCount++;
 
@@ -3092,6 +3104,16 @@ void guiManageCheats(void)
         if (getKeyOn(gSelectButton)) {
             if (!(strncasecmp(gCheats[selectedCheat].name, "mastercode", 10) == 0 || strncasecmp(gCheats[selectedCheat].name, "master code", 11) == 0))
                 gCheats[selectedCheat].enabled = !gCheats[selectedCheat].enabled;
+        }
+
+        if (getKeyOn(KEY_SQUARE)) {
+            // Disable All: clear every cheat's enabled flag in one press. Skip the mastercode (the
+            // per-cheat toggle can't touch it either -- it is the engine enabler, not a cheat).
+            for (int i = 0; i < cheatCount; i++) {
+                if (!(strncasecmp(gCheats[i].name, "mastercode", 10) == 0 || strncasecmp(gCheats[i].name, "master code", 11) == 0))
+                    gCheats[i].enabled = 0;
+            }
+            sfxPlay(SFX_CURSOR);
         }
 
         if (getKeyOn(KEY_START))
@@ -3129,6 +3151,7 @@ void guiManageCheats(void)
         }
 
         guiDrawIconAndText(gSelectButton == KEY_CIRCLE ? CIRCLE_ICON : CROSS_ICON, _STR_SELECT, gTheme->fonts[0], 70, 417, gTheme->selTextColor);
+        guiDrawIconAndText(SQUARE_ICON, _STR_DISABLE_ALL, gTheme->fonts[0], 270, 417, gTheme->selTextColor);
         guiDrawIconAndText(START_ICON, _STR_RUN, gTheme->fonts[0], 500, 417, gTheme->selTextColor);
 
         guiEndFrame();

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -18,6 +18,8 @@
 #include "include/system.h"
 #include "include/ioman.h"
 #include "include/sound.h"
+#include "include/vcdsupport.h" // vcdViewActive() -- VCD launches never use Neutrino
+#include "include/bdmsupport.h" // bdmSupportIsUDPBD() -- UDPBD games are Neutrino-only
 #include <assert.h>
 
 enum MENU_IDs {
@@ -801,9 +803,18 @@ static void menuPrevV()
 static void menuNextPage()
 {
     submenu_list_t *cur = selected_item->item->pagestart;
+    int displayed = ((items_list_t *)gTheme->itemsList->extended)->displayedItems;
 
-    if (cur && cur->next) {
-        int itms = ((items_list_t *)gTheme->itemsList->extended)->displayedItems + 1;
+    // Probe to the item one row past the bottom of the current page. If the end comes first, the
+    // whole list already fits on screen -> R1 is a no-op (don't over-scroll a sub-page list, which
+    // previously collapsed it to just the last item -- #48).
+    submenu_list_t *probe = cur;
+    int n = displayed;
+    while (n-- && probe)
+        probe = probe->next;
+
+    if (cur && probe) {
+        int itms = displayed + 1;
         sfxPlay(SFX_CURSOR);
 
         while (--itms && cur->next)
@@ -811,8 +822,6 @@ static void menuNextPage()
 
         selected_item->item->current = cur;
         selected_item->item->pagestart = selected_item->item->current;
-    } else { // wrap to start
-        menuFirstPage();
     }
 }
 
@@ -1246,6 +1255,30 @@ void menuRenderGameMenu()
     guiDrawSubMenuHints();
 }
 
+// Is the effective launch core for the selected game Neutrino? Per-game Cheats/GSM/PADEMU/OSD are
+// OPL-core features, so under Neutrino they must say so rather than opening a panel that cannot
+// take effect (checklist item 22's guidance half).
+static int gameMenuCoreIsNeutrino(void)
+{
+    int coreLoader = gDefaultCoreLoader; // no per-game $CoreLoader key -> follow the global default core
+    if (itemConfig != NULL)
+        configGetInt(itemConfig, CONFIG_ITEM_CORE_LOADER, &coreLoader);
+    // VCD (PS1) games launch ONLY via POPSTARTER -- never Neutrino -- so a keyless VCD must not
+    // inherit a Neutrino global default here, or its Cheats/GSM/OSD menu entries get blocked with
+    // the wrong "not available under Neutrino" message. SMB is the same shape: ethsupport has no
+    // Neutrino launch leg, the effective core is always <OPL>, so its panels ARE live and must not
+    // be blocked under a Neutrino global default.
+    if (selected_item != NULL && selected_item->item != NULL) {
+        item_list_t *support = (item_list_t *)selected_item->item->userdata;
+        if (support != NULL && (vcdViewActive(support->mode) || support->mode == ETH_MODE))
+            return 0;
+    }
+    // UDPBD games are Neutrino-only even while $CoreLoader is still its OPL default.
+    if (!coreLoader && selected_item != NULL && selected_item->item != NULL)
+        coreLoader = bdmSupportIsUDPBD(selected_item->item->userdata);
+    return coreLoader;
+}
+
 void menuHandleInputGameMenu()
 {
     if (!gameMenu)
@@ -1280,19 +1313,34 @@ void menuHandleInputGameMenu()
         if (menuID == GAME_COMPAT_SETTINGS) {
             guiGameShowCompatConfig(selected_item->item->current->item.id, selected_item->item->userdata, itemConfig);
         } else if (menuID == GAME_CHEAT_SETTINGS) {
-            guiGameShowCheatConfig();
+            if (gameMenuCoreIsNeutrino())
+                guiMsgBox(_l(_STR_NEUTRINO_SETTING_NA), 0, NULL);
+            else
+                guiGameShowCheatConfig();
         } else if (menuID == GAME_GSM_SETTINGS) {
-            guiGameShowGSConfig();
+            if (gameMenuCoreIsNeutrino())
+                guiMsgBox(_l(_STR_NEUTRINO_SETTING_NA), 0, NULL);
+            else
+                guiGameShowGSConfig();
         } else if (menuID == GAME_VMC_SETTINGS) {
             guiGameShowVMCMenu(selected_item->item->current->item.id, selected_item->item->userdata);
 #ifdef PADEMU
         } else if (menuID == GAME_PADEMU_SETTINGS) {
-            guiGameShowPadEmuConfig(0);
+            if (gameMenuCoreIsNeutrino())
+                guiMsgBox(_l(_STR_NEUTRINO_SETTING_NA), 0, NULL);
+            else
+                guiGameShowPadEmuConfig(0);
         } else if (menuID == GAME_PADMACRO_SETTINGS) {
-            guiGameShowPadMacroConfig(0);
+            if (gameMenuCoreIsNeutrino())
+                guiMsgBox(_l(_STR_NEUTRINO_SETTING_NA), 0, NULL);
+            else
+                guiGameShowPadMacroConfig(0);
 #endif
         } else if (menuID == GAME_OSD_LANGUAGE_SETTINGS) {
-            guiGameShowOSDLanguageConfig(0);
+            if (gameMenuCoreIsNeutrino())
+                guiMsgBox(_l(_STR_NEUTRINO_SETTING_NA), 0, NULL);
+            else
+                guiGameShowOSDLanguageConfig(0);
         } else if (menuID == GAME_SAVE_CHANGES) {
             if (guiGameSaveConfig(itemConfig, selected_item->item->userdata))
                 configSetInt(itemConfig, CONFIG_ITEM_CONFIGSOURCE, CONFIG_SOURCE_USER);


### PR DESCRIPTION
The 60-item checklist claimed several things were DONE that were only partly done. This closes the self-contained ones; the rest are recorded rather than fudged.

## Closed here

**1. Item 27 (cheat UX bundle) — was recorded DONE in step 08 and was not.**
`guiManageCheats` lacked the entire "Disable All" affordance:
- the Square handler clearing every cheat's enabled flag (skipping the mastercode, which the per-cheat toggle can't touch either)
- the `SQUARE_ICON` / `_STR_DISABLE_ALL` hint
- a `gCheats == NULL` guard *before* the count loop, which dereferences `gCheats[cheatCount].name` unconditionally

**2. Item 22 residue — the guidance half of core-aware per-game settings.**
`gameMenuCoreIsNeutrino()` plus five guards, so per-game Cheats/GSM/PADEMU/PadMacro/OSD say *"This setting is not used with the Neutrino core"* instead of opening a panel that cannot take effect. The helper's exemptions are the subtle part: VCD launches only via POPSTARTER and SMB has no Neutrino leg, so neither may inherit a Neutrino global default; UDPBD is Neutrino-only even at the OPL default.

**3. `guiWarning()` pre-GUI guard.** The fork's own comment says the shared launch-path toasts *rely* on it. We had the toasts (`bdmsupport`/`hddsupport`/`supportbase`) and not the guard, so the headless autolaunch path could deref a NULL `gTheme`. Pre-existing since at least rebuild-10b — not a recent regression.

**4. #48 over-scroll fix in `menuNextPage`.** R1 on a list that already fits on screen used to collapse the view to just the last item; it's now a no-op. Note this also drops R1's wrap-to-start, matching the fork — a visible behaviour change, so worth calling out.

**5. Two labels appended at the END** of `lng_tmpl/_base.yml` per the positional-`.lng` rule. Dedupe checked: 1 occurrence each.

## Deliberately not done, with reasons

- **`_STR_BOOT_SCANNING_MC`** — its only call site is inside the MMCE init path, so it belongs to item 1 (WAIT), not this sweep.
- **`_STR_BOOT_BUILDING_MENU` / `_STR_BOOT_LOADING_SOUNDS`** — the fork sets these from IO-thread boot steps we haven't restructured; they ride with that work.
- **`_STR_SETTINGS_NO_HOME`** — belongs to the config-home cluster, which is deferred and has already failed on hardware once.
- **`ds34usb_init`/`ds34bt_init` retry bound** — **the fork doesn't bound these either**, so this would be a divergence, not a port. It guards exactly the failure class that caused the rebuild-12 black screen, but `nopdelay()`'s duration isn't something I can measure right now, and a bound set too low would *silently kill PADEMU controllers on the boot path*. Trading a hypothetical freeze for a real regression, with no tester awake, is the wrong trade. It needs a wall-clock bound and a hardware pass.

## Verification

Clean build with regenerated languages, `MAKE_EXIT=0`. The build itself proves both new labels resolve, since the code references `_STR_DISABLE_ALL` and `_STR_NEUTRINO_SETTING_NA`. One failure en route — `menusys.c` needed `vcdsupport.h`/`bdmsupport.h` for the helper's exemption checks — caught and fixed.