### PR TITLE
rebuild-25: fork translation overlay -- lng_fork (item 57)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ EE_SRC_DIR = src/
 EE_OBJS_DIR = obj/
 EE_ASM_DIR = asm/
 LNG_SRC_DIR = lng_src/
+# Fork-maintained translation overlay (item 57). Fills gaps in the upstream language files for
+# labels this fork added, without ever touching lng_src/ (which download_lng.sh rewrites).
+LNG_FORK_DIR = lng_fork/
 LNG_TMPL_DIR = lng_tmpl/
 LNG_DIR = lng/
 PNG_ASSETS_DIR = gfx/
@@ -896,6 +899,7 @@ download_cfla:
 	./download_cfla.sh
 
 $(TRANSLATIONS_LNG): $(LNG_DIR)lang_%.lng: $(LNG_SRC_DIR)%.yml $(BASE_LANGUAGE) $(LANG_COMPILER)
+	@if [ -f $(LNG_FORK_DIR)$*.yml ]; then python3 $(LANG_COMPILER) --overlay_translation_yml --base $(BASE_LANGUAGE) --translation $< --overlay $(LNG_FORK_DIR)$*.yml; fi
 	python3 $(LANG_COMPILER) --make_lng --base $(BASE_LANGUAGE) --translation $< $@
 
 $(TRANSLATIONS_YML): %.yml: $(BASE_LANGUAGE) $(LANG_COMPILER)

--- a/lang_compiler.py
+++ b/lang_compiler.py
@@ -108,6 +108,25 @@ def update_translation_yml(base_obj: Dict[str, Any], translation_obj: Dict[str, 
     yaml.dump(translation_obj, output_file, **YAML_DUMP_ARGS)
 
 
+def overlay_translation_yml(translation_obj: Dict[str, Any], overlay_obj: Dict[str, Any], output_file: TextIOWrapper) -> None:
+    # Fork-maintained overlay: fill in translations for labels this fork added
+    # (or that upstream hasn't translated yet) without touching the upstream
+    # language files in lng_src/. Only GAPS are filled -- a label that already
+    # carries a plain-string (human) translation is left untouched, so once
+    # upstream translates a label the overlay quietly steps aside. Re-running is
+    # idempotent (a filled label becomes a plain string and is skipped next time).
+    translations = translation_obj.setdefault('translations', {})
+    overlay = (overlay_obj or {}).get('translations', {}) or {}
+    for label, value in overlay.items():
+        if not isinstance(value, str):
+            continue  # only plain-string overlay entries are applied
+        if isinstance(translations.get(label), str):
+            continue  # already translated (don't clobber a human translation)
+        translations[label] = value
+
+    yaml.dump(translation_obj, output_file, **YAML_DUMP_ARGS)
+
+
 def make_lng(
     base_obj: Dict[str, Any],
     translation_obj: Dict[str, Any],
@@ -141,22 +160,29 @@ if __name__ == '__main__':
     action_group.add_argument('--make_source', action='store_true')
     action_group.add_argument('--make_template_yml', action='store_true')
     action_group.add_argument('--update_translation_yml', action='store_true')
+    action_group.add_argument('--overlay_translation_yml', action='store_true')
     action_group.add_argument('--make_lng', action='store_true')
 
     parser.add_argument('--base', type=argparse.FileType('r', encoding='utf-8'), required=True, metavar="BASE_YML")
     parser.add_argument('--translation', type=argparse.FileType('r+', encoding='utf-8'), metavar="LANG_YML")
+    parser.add_argument('--overlay', type=argparse.FileType('r', encoding='utf-8'), metavar="OVERLAY_YML")
     parser.add_argument('output_file', nargs='?', type=argparse.FileType('w', encoding='utf-8'), default=sys.stdout)
 
     args = parser.parse_args()
     if args.translation is None:
-        if args.make_lng or args.update_translation_yml:
+        if args.make_lng or args.update_translation_yml or args.overlay_translation_yml:
             option = ''
             if args.make_lng:
                 option = 'make_lng'
             elif args.update_translation_yml:
                 option = 'update_translation_yml'
+            elif args.overlay_translation_yml:
+                option = 'overlay_translation_yml'
 
             raise KeyError(f"Translation YML is required when --{option} option is selected")
+
+    if args.overlay_translation_yml and args.overlay is None:
+        raise KeyError("Overlay YML is required when --overlay_translation_yml option is selected")
 
     base_obj = yaml.safe_load(args.base)
     if args.make_header:
@@ -169,6 +195,12 @@ if __name__ == '__main__':
         translation_obj = yaml.safe_load(args.translation)
         args.translation.seek(0)
         update_translation_yml(base_obj, translation_obj, args.translation)
+        args.translation.truncate()
+    elif args.overlay_translation_yml:
+        translation_obj = yaml.safe_load(args.translation)
+        overlay_obj = yaml.safe_load(args.overlay)
+        args.translation.seek(0)
+        overlay_translation_yml(translation_obj, overlay_obj, args.translation)
         args.translation.truncate()
     elif args.make_lng:
         translation_obj = yaml.safe_load(args.translation)

--- a/lng_fork/Albanian.yml
+++ b/lng_fork/Albanian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Rendit lojrat alfabetikisht
+  RUMBLE: Dridhje e komandës në menu
+  HINT_RUMBLE: Dridhje e shkurtër kur lëviz kursorin, konfirmon ose kthehesh -- kërkon një DualShock në modalitet analog
+  FOLDER_NAV: Shfleto dosjet në listën e lojrave
+  HINT_FOLDER_NAV: Shfaq nëndosjet e CD/DVD si hyrje të shfletueshme; zgjidh për të hapur, anulo për t'u kthyer
+  SETTINGS_NO_HOME: Nuk u gjet kartë memorie -- cilësimet nuk mund të ruhen. OPL u nis nga një pajisje rrjeti, cilësimet e së cilës duhet të qëndrojnë në një kartë lokale.
+  ERROR_SAVING_SETTINGS_TO: Cilësimet nuk u shkruan dot te %s (gabimi %d)
+  GENERAL_SETTINGS: Cilësimet e Përgjithshme
+  DEVICE_SETTINGS: Cilësimet e Pajisjes
+  LAUNCH_PS2_DISC: Nisja e Diskut PS2
+  DISC_LAUNCH_ERR: Nuk ka disk PS2 në lexues.
+  DEFAULT: Parazgjedhje
+  HINT_MODE7: Vetëm Neutrino -- rregullon lojërat që tejkalojnë një bufer IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: Imazhi i Mashtrimit PS2RD
+  HINT_ENABLEIMAGE: Zbato një patch të parandërtuar PS2RD .img në lojën tënde.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Modaliteti i Nisjes MMCE
+  MMCE_PREFIX: Shtegu i Prefiksit MMCE
+  MMCE_SLOT: Foleja MMCE
+  MMCEIGR_SLOT: Foleja/et e Kartës IGR
+  HINT_MMCEIGR_SLOT: Komanda e kalimit në kartë do t'i dërgohet folejeve të zgjedhura gjatë IGR
+  MMCE_ADVANCED: Të Avancuara
+  MMCE_SETTINGS: Cilësimet MMCE
+  MMCE_SEMA: Metoda e Radhës së Bllokimit Sema
+  HINT_MMCE_SEMA: THFIFO mund të ndihmojë me përputhshmërinë por të përkeqësojë performancën
+  MMCE_WAIT_CYCLES: Ciklet e pritjes pas /ACK të ulët
+  HINT_MMCE_WAIT_CYCLES: Vlerat më të ulëta mund të përmirësojnë performancën por shkaktojnë paqëndrueshmëri
+  MMCE_USE_ALARMS: Përdor alarme me afat kohor
+  HINT_MMCE_USE_ALARMS: OFF mund të ndihmojë performancën por mund të shkaktojë ngecje nga afatet kohore MMCE
+  CORE_LOADER: Bërthama e Ngarkuesit
+  NEUTRINO_BAD_FORMAT: Neutrino nuk e mbështet këtë format skedari, niset me bërthamën <OPL>
+  NEUTRINO_NOT_FOUND: ELF i Neutrino nuk u gjet, niset me bërthamën <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD kërkon një IP statike të PS2. Vendoseni në Konfigurimin e Rrjetit (DHCP është aktiv).
+  NEUTRINO_SETTING_NA: Kjo cilësim nuk përdoret me bërthamën Neutrino.
+  POPSTARTER_NOT_FOUND: Mungon POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Mungojnë kërkesat SMB të POPSTARTER
+  WRITE_POPSTARTER_NET: Shkruaj Konfigurimin e Rrjetit POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Ruaj gjithashtu këto vlera IP + SMB në IPCONFIG.DAT / SMBCONFIG.DAT të POPSTARTER në kartën e memories (për VCD mbi SMB).
+  POPSTARTER_NET_ERR: Nuk u shkrua konfigurimi i rrjetit POPSTARTER në kartën e memories.
+  VCD: VCD
+  VCD_ON: Po shfaq lojërat VCD
+  VCD_OFF: Po shfaq lojërat e diskut
+  NEUTRINO_ARGS: Argumente të Nisjes Neutrino
+  HINT_NEUTRINO_ARGS: Flamurë shtesë Neutrino, të ndarë me hapësira (p.sh. -mt=dvd). Globale zbatohet për të gjitha lojërat; për-lojë shtohet sipër. Parashtro një flamur me $ për ta çaktivizuar pa fshirë.
+  NEUTRINO_VIDEO: Video Neutrino
+  HINT_NEUTRINO_VIDEO: Detyro modalitetin e videos GS të Neutrino (-gsm). Joaktive mban parazgjedhjen e lojës.
+  NEUTRINO_PATH: Shtegu ELF i Neutrino
+  HINT_NEUTRINO_PATH: Shtegu i plotë drejt neutrino.elf (p.sh. mc0:NEUTRINO/neutrino.elf). Bosh = zbulim automatik në mc0/mc1.
+  POPSTARTER_PATH: Shtegu POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Shtegu i personalizuar POPSTARTER.ELF; kthehet pa zhurmë te dosja POPS e pajisjes nëse është bosh/mungon. Tastiera kufizohet në 31 karaktere; shtegje më të gjata nëpërmjet settings_riptopl.cfg.
+  BDMA_SOURCE: Burimi BDMA
+  HINT_BDMA_SOURCE: Pajisja dosja POPS e së cilës mban skedarët e drejtuesit BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Modaliteti BDMA
+  HINT_BDMA_MODE: Drejtuesi i pajisjes bllok exFAT që ngarkon POPSTARTER. Ndryshimi i tij kopjon modulet në kartë; FAT32 = asnjë (drejtues i integruar).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD i brendshëm
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Skedarët e modulit BDMA nuk u gjetën në pajisjen burimore.
+  BDMA_ERR_SPACE: Hapësirë e pamjaftueshme në kartën e memories për modulet BDMA.
+  BDMA_ERR_IO: Gabim gjatë shkrimit të moduleve BDMA në kartën e memories.
+  COVERFLOW_SETTINGS: Cilësimet Coverflow
+  COVERFLOW_COUNT: Numri i Kopertinave
+  COVERFLOW_SCALE: Shkalla Qendrore
+  COVERFLOW_ANIM: Shpejtësia e Animacionit
+  COVERFLOW_DIM: Errëso Kopertinат Anësore
+  NONE: Asnjë
+  SMALL: I vogël
+  LARGE: I madh
+  NORMAL: Normal
+  FAV: Të Preferuarat
+  FAVMODE: Modaliteti i Nisjes së Të Preferuarave
+  FAV_HINT: E preferuar
+  FAV_MSG: '%s nuk lejohet nëpërmjet Menysë së Të Preferuarave.'
+  FAV_PERSISTENCE_MSG: '%s nuk lejohet ndërkohë që elementi është shënuar si i preferuar.'
+  NEUTRINO_DEVICE: Pajisja Neutrino
+  HINT_NEUTRINO_DEVICE: Pajisja që mban neutrino.elf (në një dosje NEUTRINO/ ose neutrino/). Zbulimi automatik skanon mc0 dhe pastaj mc1.
+  NARGS_QB: Nisje e Shpejtë (-qb)
+  NARGS_CWD: Drejtoria e Punës (-cwd)
+  NARGS_CFG: Konfigurimi (-cfg)
+  NARGS_ELF: ELF i Nisjes (-elf)
+  NARGS_ATA0: Imazhi ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Imazhi ATA1 (-ata1)
+  NARGS_EXTRA: Argumente Shtesë
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Arkiv .tar i kopertinave
+  DISABLE_ALL: Çaktivizo të gjitha
+  BOOT_LOADING_CONFIG: Po ngarkohen cilësimet...
+  BOOT_SCANNING_BDM: Po skanohen disqet USB / kartë / rrjet...
+  BOOT_SCANNING_NET: Po niset rrjeti...
+  BOOT_SCANNING_HDD: Po skanohet HDD...
+  BOOT_READY: Gati.
+  UDPFS_GAMES: "Lojëra UDPFS"
+  UDPFSBD_GAMES: "Lojëra UDPFSBD"
+  NET_PROTOCOL: "Protokolli i rrjetit"
+  NET_NEEDS_NEUTRINO: "Lojërat e rrjetit (UDP) nisen vetëm përmes bërthamës Neutrino. Sigurohu që neutrino.elf ekziston dhe formati mbështetet."
+  VCD_NOT_ON_NET: "Lojërat PS1 (.VCD) nuk mund të nisen përmes pajisjes së rrjetit."
+  MX4SIO_PADEMU_WARN: "MX4SIO dhe emulimi i kontrollerit ndajnë të njëjtën bus SIO2 dhe loja mund të mos niset."
+  HINT_OSD_SETTINGS_LNG: "Detyro një konfigurim gjuhe të personalizuar"
+  OSD_SETTINGS_TVASPECT: "Madhësia e ekranit"
+  FULL_SCREEN: "Ekran i plotë"
+  OSD_SETTINGS_VMODE: "Modaliteti i videos"
+  SYSTEM_DEFAULT: "Parazgjedhja e sistemit"
+  HIGH: "E lartë"
+  LOW: "E ulët"
+  XSENSITIVITY: "Ndjeshmëria e boshtit X analog"
+  YSENSITIVITY: "Ndjeshmëria e boshtit Y analog"
+  FILE_COUNT: "Skedarë të gjetur: %i"
+  CHEAT_SELECTION: "Zgjedhja e mashtrimeve"
+  HDD_HINT: "Lejohet vetëm një HDD; aktivizimi kyç APA ose GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID nuk u zbatua -- neutrino.elf ndodhet në këtë kartë (ndërrimi i saj do ta shkarkonte Neutrino)."
+  POPSTARTER_DEVICE: "Pajisja POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Pajisja që mban POPS/POPSTARTER.ELF për nisjet PS1 VCD. Parazgjedhja = pajisja e nisjes (cwd) pastaj vetë pajisja e VCD-së. E personalizuara shfaq një shteg teksti të lirë."
+  BDMA_APPLY: "Zbato VCD BDMA gjatë nisjes"
+  HINT_BDMA_APPLY: "Aktiv: pajis automatikisht kartën e memories me drejtuesin përkatës exFAT të VCD-së së nisur para nisjes (rekomandohet). Joaktiv: menaxhoje vetë me zgjedhësit Source/Mode të BDMA më poshtë."
+  NETBOOT_RESTART: "Rinis OPL-në për të zbatuar ndryshimin e protokollit të nisjes në rrjet."
+  UDPFS_MODE: "Qasja UDPFS"
+  "MENU": "Menyja"
+  "APPS": "Aplikacione"
+  "DEBUG": "Ngjyra Debug"
+  "COVERART": "Kopertina"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operacione Shkrimi"
+  "MODE1": "Modaliteti 1"
+  "MODE2": "Modaliteti 2"
+  "MODE3": "Modaliteti 3"
+  "MODE4": "Modaliteti 4"
+  "MODE5": "Modaliteti 5"
+  "MODE6": "Modaliteti 6"
+  "ENABLEGSM": "Zgjedhësi GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Motori i Kodeve PS2RD"
+  "PADEMU_ENABLE": "Emulator Kontrolluesi"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulimi"
+  "PADEMU_VIB": "Dridhja"
+  "PADEMU_WORKAROUND": "Zgjidhje për DS3 të Rremë"
+  "SFX": "Efekte Zanore"
+  "BOOT_SND": "Tingulli i Nisjes"
+  "ENABLE_NOTIFICATIONS": "Njoftime"
+  "OPTIONS": "Opsione"
+  "GLOBAL_SETTINGS": "Globale"
+  "INFO_GENRE": "Zhanri"
+  "INFO_RELEASE": "Publikimi"
+  "INFO_DESCRIPTION": "Përshkrimi"
+  "BLOCKDEVICE_SETTINGS": "Pajisje Bllok"
+  "CONTROLLER_SETTINGS": "Cilësimet e Kontrolluesit"
+  "HINT_BDM_START": "Ndiz/fik Menaxherin e Pajisjeve Bllok."
+  "HINT_BLOCK_DEVICES": "Ndiz/fik Pajisjet Bllok (p.sh. USB)."
+  "USB_GAMES": "Lojëra USB"
+  "ILINK_GAMES": "Lojëra iLink"
+  "MX4SIO_GAMES": "Lojëra MX4SIO"
+  "PADMACROCONFIG": "Konfiguro PADMACRO"
+  "PADMACRO_SETTINGS": "Cilësimet e Pad macro"
+  "PADMACRO_ENABLE": "Pad macros"
+  "PADMACRO_SLOWDOWN": "Ngadalësim analog:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Zvogëlon rrezen e levës analoge kur shtypet butoni"
+  "LEFT_ANALOG": "Leva majtas"
+  "RIGHT_ANALOG": "Leva djathtas"
+  "PADMACRO_INVERT_AXIS": "Përmbys boshtin analog:"
+  "HINT_PADMACRO_INVERT_AXIS": "Përmbys boshtin e levës analoge"
+  "TURBO_SPEED": "Shpejtësia e butonit turbo"
+  "HINT_TURBO_SPEED": "Sa shpejt të shtypet butoni kur turbo është aktiv"
+  "ACT_WHILE_PRESSED": "Ndërsa butoni është shtypur"
+  "ACT_TOGGLED": "Ndërruar nga butoni"
+  "LANGUAGE_JAPANESE": "JAPONISHT"
+  "LANGUAGE_ENGLISH": "ANGLISHT"
+  "LANGUAGE_FRENCH": "FRËNGJISHT"
+  "LANGUAGE_SPANISH": "SPANJISHT"
+  "LANGUAGE_GERMAN": "GJERMANISHT"
+  "LANGUAGE_ITALIAN": "ITALISHT"
+  "LANGUAGE_DUTCH": "HOLANDISHT"
+  "LANGUAGE_PORTUGUESE": "PORTUGALISHT"
+  "LANGUAGE_RUSSIAN": "RUSISHT"
+  "LANGUAGE_KOREAN": "KOREANISHT"
+  "LANGUAGE_TRAD_CHINESE": "KINEZISHT TRADICIONALE"
+  "LANGUAGE_SIMPL_CHINESE": "KINEZISHT E THJESHTUAR"
+  "OSD_SETTINGS": "Cilësimet OSD"
+  "OSD_SETTINGS_LNG": "Gjuha OSD"
+  "ENABLE_LNG": "Ndrysho gjuhën"
+  "BGM": "Muzikë Sfondi"
+  "BGM_VOLUME": "Volumi i Muzikës së Sfondit"
+  "DEF_BGM_PATH": "Muzika e Parazgjedhur e Temës"
+  "DEF_BGM_PATH_HINT": "Cakto shtegun për të transmetuar muzikë për temën e brendshme."
+  "BOOT_SCANNING_MC": "Duke skanuar kartat e kujtesës..."
+  "BOOT_LOADING_DRIVERS": "Duke ngarkuar drejtuesit e ruajtjes..."
+  "BOOT_LOADING_USB": "Duke ngarkuar drejtuesin USB..."
+  "BOOT_ARMING_MMCE": "Duke armatosur ID-në e lojës MMCE..."
+  "BOOT_LOADING_SOUNDS": "Duke ngarkuar tingujt e temës..."
+  "BOOT_BUILDING_MENU": "Duke ndërtuar menynë..."
+  "NET_UDPFS_TAB_HINT": "UDPFS është aktive -- hap skedën e re UDPFS dhe shtyp Konfirmo për t'u lidhur. Ana e PC-së ekzekuton udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Pajisja bllok e rrjetit është aktive -- skeda e saj shfaqet sapo serveri i PC-së përgjigjet (udpfsd -bdpath për UDPFS Image, udpbd-server për UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Skedari VMC për këtë lojë nuk u gjet -- po niset pa të (loja përdor kartën e saj reale)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino nuk mund të nisë nga kjo pajisje -- nisja u ndërpre."
+  "NEUTRINO_TOML_SYNC_FAILED": "Konfigurimi i rrjetit të Neutrino (bsd toml) mungon ose nuk mund të shkruhet -- nisja u ndërpre, kontrollo dosjen neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Tepër i fragmentuar për Neutrino (%d fragmente, kufiri %d përfshirë VMC-të) -- po provohet bërthama OPL në vend të tij."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Tepër i fragmentuar për Neutrino (%d fragmente, kufiri %d përfshirë VMC-të) -- defragmento në PC; nisja u ndërpre."
+  "NEUTRINO_GSM_COMP": "Përputhshmëria GSM e Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Rregullim me ndërrim fushash për lojërat që dridhen ose grisen nën një mënyrë Video të detyruar të Neutrino. Kërkon një mënyrë Video të Neutrino të vendosur."
+  "NARGS_DBC": "Ngjyra Debug (-dbc)"
+  "NARGS_LOGO": "Logoja PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Çaktivizo VMC 1 (mbaj kartën)"
+  "VMC_SLOT2_DISABLE": "Çaktivizo VMC 2 (mbaj kartën)"
+  "HINT_VMC_SLOT_DISABLE": "Nis pa VMC-në e kësaj foleje ndërsa mban kartën e saj të konfiguruar. Vetëm nisjet me Neutrino; loja më pas përdor kartën reale në atë fole."
+  "NEUTRINO_BSDFS": "Sistemi i Skedarëve Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Detyro sistemin e skedarëve të pajisjes bllok të Neutrino (-bsdfs). Auto = paracaktimi për çdo pajisje. hdl/bd janë opsione për ekspertë; çiftojini me një -dvd= përkatës në argumentet e nisjes nëse forma e rrugës automatike nuk përshtatet."
+  "PLASCOLOR": "Ngjyra e Përzierjes Plasma"
+  "VCD_HIDE_GAMEID": "Fshih ID-në e Lojës PS1 (lista VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Vetëm kozmetike -- fsheh një prefiks ID-je loje në krye (p.sh. SLUS_005.51.) nga emrat e listës PS1/VCD. Emrat pa ID shfaqen ashtu siç janë. Nuk ndryshon nisjen, artin e kopertinës apo të preferuarat."
+  "VCD_FIRST_DISC": "Vetëm disku i parë (PS1 me shumë disqe)"
+  "HINT_VCD_FIRST_DISC": "Shfaq vetëm Diskun 1 të një loje PS1 me disqe të shumtë në listat e pajisjeve (stili POPSLoader). Fsheh skedarët e emërtuar (Disc 2), (CD 2), etj. Të gjithë disqet mbeten në kartë për ndërrim gjatë lojës; Të preferuarat nuk filtrohen."
+  "GAMES_DEVICE": "Pajisja e Lojës"
+  "DEFAULT_CORE": "Bërthama e Parazgjedhur e Ngarkuesit"
+  "HINT_DEFAULT_CORE": "Bërthama globale e paracaktuar për lojërat, bërthama e ngarkuesit e të cilave për çdo lojë është vendosur në Default. <OPL> është bërthama vendase; Neutrino zinxhiron neutrino.elf të jashtëm. Një zgjedhje për çdo lojë e mbivendos gjithmonë këtë."
+  "VCD_SETTINGS": "Cilësimet VCD"
+  "FINANCIAL_SUPPORT": "Mbështetje Financiare"

--- a/lng_fork/Arabic.yml
+++ b/lng_fork/Arabic.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: ترتيب الألعاب أبجدياً
+  RUMBLE: اهتزاز وحدة التحكم في القوائم
+  HINT_RUMBLE: اهتزاز قصير عند تحريك المؤشر أو التأكيد أو الرجوع -- يتطلب ذراع DualShock في الوضع التناظري
+  FOLDER_NAV: تصفح المجلدات في قائمة الألعاب
+  HINT_FOLDER_NAV: عرض المجلدات الفرعية لأقراص CD/DVD كعناصر قابلة للتصفح؛ اختر للفتح، وألغِ للرجوع
+  SETTINGS_NO_HOME: لم يُعثر على بطاقة ذاكرة -- تعذّر حفظ الإعدادات. تم تشغيل OPL من جهاز شبكي، ويجب أن تُحفظ إعداداته على بطاقة محلية.
+  ERROR_SAVING_SETTINGS_TO: تعذّر كتابة الإعدادات إلى %s (خطأ %d)
+  GENERAL_SETTINGS: الإعدادات العامة
+  DEVICE_SETTINGS: إعدادات الجهاز
+  LAUNCH_PS2_DISC: تشغيل قرص PS2
+  DISC_LAUNCH_ERR: لا يوجد قرص PS2 في المحرك.
+  DEFAULT: افتراضي
+  HINT_MODE7: Neutrino فقط -- إصلاح الألعاب التي تتجاوز مخزن IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: صورة غش PS2RD
+  HINT_ENABLEIMAGE: تطبيق تصحيح PS2RD .img مسبق البناء على لعبتك.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: وضع بدء MMCE
+  MMCE_PREFIX: مسار بادئة MMCE
+  MMCE_SLOT: فتحة MMCE
+  MMCEIGR_SLOT: فتحة (فتحات) بطاقة بدء IGR
+  HINT_MMCEIGR_SLOT: سيتم إرسال أمر التبديل إلى بطاقة البدء للفتحة (الفتحات) المحددة عند IGR
+  MMCE_ADVANCED: متقدم
+  MMCE_SETTINGS: إعدادات MMCE
+  MMCE_SEMA: طريقة قائمة انتظار Lock Sema
+  HINT_MMCE_SEMA: قد يساعد THFIFO في التوافق لكنه قد يضعف الأداء
+  MMCE_WAIT_CYCLES: دورات الانتظار بعد /ACK منخفض
+  HINT_MMCE_WAIT_CYCLES: القيم المنخفضة قد تحسن الأداء لكنها قد تسبب عدم الاستقرار
+  MMCE_USE_ALARMS: استخدام منبهات المهلة
+  HINT_MMCE_USE_ALARMS: قد يساعد الإيقاف على الأداء لكنه قد يتسبب في تجميد MMCE عند انتهاء المهلة
+  CORE_LOADER: نواة المُشغِّل
+  NEUTRINO_BAD_FORMAT: 'Neutrino لا يدعم هذا التنسيق، يتم التشغيل بنواة <OPL>'
+  NEUTRINO_NOT_FOUND: 'لم يُعثر على Neutrino ELF، يتم التشغيل بنواة <OPL>'
+  UDPBD_NEEDS_STATIC_IP: يتطلب UDPBD عنوان IP ثابتاً لـ PS2. عيّنه في إعدادات الشبكة (DHCP مفعّل حالياً).
+  NEUTRINO_SETTING_NA: هذا الإعداد غير مستخدم مع نواة Neutrino.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF مفقود
+  POPSTARTER_SMB_MISSING: متطلبات POPSTARTER SMB مفقودة
+  WRITE_POPSTARTER_NET: كتابة إعدادات شبكة POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: احفظ قيم IP + SMB أيضاً في IPCONFIG.DAT / SMBCONFIG.DAT الخاصة بـ POPSTARTER على بطاقة الذاكرة (لـ VCD عبر SMB).
+  POPSTARTER_NET_ERR: تعذّرت كتابة إعدادات شبكة POPSTARTER على بطاقة الذاكرة.
+  VCD: VCD
+  VCD_ON: عرض ألعاب VCD
+  VCD_OFF: عرض ألعاب الأقراص
+  NEUTRINO_ARGS: وسيطات تشغيل Neutrino
+  HINT_NEUTRINO_ARGS: أعلام Neutrino إضافية مفصولة بمسافة (مثال -mt=dvd). العامة تُطبَّق على جميع الألعاب؛ الخاصة بالعبة تُضاف فوقها. ضع $ قبل العلم لتعطيله دون حذفه.
+  NEUTRINO_VIDEO: فيديو Neutrino
+  HINT_NEUTRINO_VIDEO: 'فرض وضع فيديو GS لـ Neutrino (-gsm). إيقاف يبقي الإعداد الافتراضي للعبة.'
+  NEUTRINO_PATH: مسار Neutrino ELF
+  HINT_NEUTRINO_PATH: 'المسار الكامل لـ neutrino.elf (مثال mc0:NEUTRINO/neutrino.elf). فارغ = اكتشاف تلقائي على mc0/mc1.'
+  POPSTARTER_PATH: 'مسار POPSTARTER.ELF'
+  HINT_POPSTARTER_PATH: مسار POPSTARTER.ELF مخصص؛ يعود تلقائياً إلى مجلد POPS في الجهاز إذا كان فارغاً أو مفقوداً. لوحة المفاتيح محدودة بـ 31 حرفاً؛ المسارات الأطول عبر settings_riptopl.cfg.
+  BDMA_SOURCE: مصدر BDMA
+  HINT_BDMA_SOURCE: الجهاز الذي يحتوي مجلد POPS على ملفات مشغّل BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: وضع BDMA
+  HINT_BDMA_MODE: مشغّل كتلة exFAT الذي يُحمِّله POPSTARTER. تغييره ينسخ الوحدات إلى البطاقة؛ FAT32 = لا شيء (مشغّل مدمج).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: قرص صلب داخلي
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: لم تُوجد ملفات وحدة BDMA على الجهاز المصدر.
+  BDMA_ERR_SPACE: مساحة بطاقة الذاكرة غير كافية لوحدات BDMA.
+  BDMA_ERR_IO: خطأ في كتابة وحدات BDMA على بطاقة الذاكرة.
+  COVERFLOW_SETTINGS: إعدادات Coverflow
+  COVERFLOW_COUNT: عدد الأغلفة
+  COVERFLOW_SCALE: مقياس المركز
+  COVERFLOW_ANIM: سرعة الحركة
+  COVERFLOW_DIM: تعتيم الأغلفة الجانبية
+  NONE: لا شيء
+  SMALL: صغير
+  LARGE: كبير
+  NORMAL: عادي
+  FAV: المفضلة
+  FAVMODE: وضع بدء المفضلة
+  FAV_HINT: مفضلة
+  FAV_MSG: '%s غير مسموح به عبر قائمة المفضلة.'
+  FAV_PERSISTENCE_MSG: '%s غير مسموح به بينما العنصر محدد كمفضلة.'
+  NEUTRINO_DEVICE: جهاز Neutrino
+  HINT_NEUTRINO_DEVICE: الجهاز الذي يحتوي على neutrino.elf (في مجلد NEUTRINO/ أو neutrino/). الاكتشاف التلقائي يفحص mc0 ثم mc1.
+  NARGS_QB: بدء سريع (-qb)
+  NARGS_CWD: المجلد الحالي (-cwd)
+  NARGS_CFG: ملف الإعداد (-cfg)
+  NARGS_ELF: ELF التشغيل (-elf)
+  NARGS_ATA0: صورة ATA0 (-ata0)
+  NARGS_ATA0ID: معرّف ATA0 (-ata0id)
+  NARGS_ATA1: صورة ATA1 (-ata1)
+  NARGS_EXTRA: وسيطات إضافية
+  NARGS_AUTO_NOTE: 'تلقائي: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: أرشيف أغلفة .tar
+  DISABLE_ALL: تعطيل الكل
+  BOOT_LOADING_CONFIG: جارٍ تحميل الإعدادات...
+  BOOT_SCANNING_BDM: جارٍ فحص أقراص USB / البطاقة / الشبكة...
+  BOOT_SCANNING_NET: جارٍ بدء الشبكة...
+  BOOT_SCANNING_HDD: جارٍ فحص HDD...
+  BOOT_READY: جاهز.
+  UDPFS_GAMES: "ألعاب UDPFS"
+  UDPFSBD_GAMES: "ألعاب UDPFSBD"
+  NET_PROTOCOL: "بروتوكول الشبكة"
+  NET_NEEDS_NEUTRINO: "ألعاب الشبكة (UDP) لا تعمل إلا عبر نواة Neutrino. تأكد من وجود neutrino.elf ومن دعم الصيغة."
+  VCD_NOT_ON_NET: "لا يمكن تشغيل ألعاب PS1 (.VCD) عبر جهاز الشبكة."
+  MX4SIO_PADEMU_WARN: "يشترك MX4SIO ومحاكاة اليد في ناقل SIO2 وقد تفشل اللعبة في الإقلاع."
+  HINT_OSD_SETTINGS_LNG: "فرض إعداد لغة مخصص"
+  OSD_SETTINGS_TVASPECT: "حجم الشاشة"
+  FULL_SCREEN: "ملء الشاشة"
+  OSD_SETTINGS_VMODE: "وضع الفيديو"
+  SYSTEM_DEFAULT: "الإعداد الافتراضي للنظام"
+  HIGH: "مرتفع"
+  LOW: "منخفض"
+  XSENSITIVITY: "حساسية المحور X التناظري"
+  YSENSITIVITY: "حساسية المحور Y التناظري"
+  FILE_COUNT: "الملفات الموجودة: %i"
+  CHEAT_SELECTION: "اختيار الغش"
+  HDD_HINT: "يُسمح بقرص صلب HDD واحد فقط، وتفعيله يقفل APA أو GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "لم يُطبَّق MMCE GameID -- ملف neutrino.elf موجود على هذه البطاقة (تبديلها سيُلغي تحميل Neutrino)."
+  POPSTARTER_DEVICE: "جهاز POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "الجهاز الذي يحتوي على POPS/POPSTARTER.ELF لتشغيل PS1 VCD. الافتراضي = جهاز الإقلاع (cwd) ثم جهاز VCD نفسه. المخصص يُظهر مسارًا نصيًا حرًا."
+  BDMA_APPLY: "تطبيق VCD BDMA عند التشغيل"
+  HINT_BDMA_APPLY: "تشغيل: تجهيز مشغّل exFAT المطابق لـ VCD المُشغَّل تلقائيًا على بطاقة الذاكرة قبل الإقلاع (مُوصى به). إيقاف: أدِرها بنفسك عبر محدِّدَي المصدر/الوضع لـ BDMA أدناه."
+  NETBOOT_RESTART: "أعد تشغيل OPL لتطبيق تغيير بروتوكول الإقلاع عبر الشبكة."
+  UDPFS_MODE: "وصول UDPFS"
+  "MENU": "القائمة"
+  "APPS": "التطبيقات"
+  "DEBUG": "ألوان التصحيح"
+  "COVERART": "صورة الغلاف"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "عمليات الكتابة"
+  "MODE1": "الوضع 1"
+  "MODE2": "الوضع 2"
+  "MODE3": "الوضع 3"
+  "MODE4": "الوضع 4"
+  "MODE5": "الوضع 5"
+  "MODE6": "الوضع 6"
+  "ENABLEGSM": "محدد GSM"
+  "OVERSCAN": "تجاوز المسح"
+  "ENABLECHEAT": "محرك الغش PS2RD"
+  "PADEMU_ENABLE": "محاكي وحدة التحكم"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "المحاكاة"
+  "PADEMU_VIB": "الاهتزاز"
+  "PADEMU_WORKAROUND": "حل بديل لـ DS3 المزيف"
+  "SFX": "المؤثرات الصوتية"
+  "BOOT_SND": "صوت الإقلاع"
+  "ENABLE_NOTIFICATIONS": "الإشعارات"
+  "OPTIONS": "الخيارات"
+  "GLOBAL_SETTINGS": "عام"
+  "INFO_GENRE": "النوع"
+  "INFO_RELEASE": "الإصدار"
+  "INFO_DESCRIPTION": "الوصف"
+  "BLOCKDEVICE_SETTINGS": "أجهزة التخزين الكتلية"
+  "CONTROLLER_SETTINGS": "إعدادات وحدة التحكم"
+  "HINT_BDM_START": "تشغيل/إيقاف مدير الأجهزة الكتلية (BDM)."
+  "HINT_BLOCK_DEVICES": "تشغيل/إيقاف الأجهزة الكتلية (مثل USB)."
+  "USB_GAMES": "ألعاب USB"
+  "ILINK_GAMES": "ألعاب iLink"
+  "MX4SIO_GAMES": "ألعاب MX4SIO"
+  "PADMACROCONFIG": "إعداد PADMACRO"
+  "PADMACRO_SETTINGS": "إعدادات ماكرو وحدة التحكم"
+  "PADMACRO_ENABLE": "ماكرو وحدة التحكم"
+  "PADMACRO_SLOWDOWN": "إبطاء الأنالوج:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "تقليل مدى العصا الأنالوج عند الضغط على الزر"
+  "LEFT_ANALOG": "العصا اليسرى"
+  "RIGHT_ANALOG": "العصا اليمنى"
+  "PADMACRO_INVERT_AXIS": "عكس محور الأنالوج:"
+  "HINT_PADMACRO_INVERT_AXIS": "عكس محور العصا الأنالوج"
+  "TURBO_SPEED": "سرعة زر التيربو"
+  "HINT_TURBO_SPEED": "مدى سرعة الضغط على الزر عند تفعيل التيربو"
+  "ACT_WHILE_PRESSED": "أثناء الضغط على الزر"
+  "ACT_TOGGLED": "يُبدَّل بالزر"
+  "LANGUAGE_JAPANESE": "اليابانية"
+  "LANGUAGE_ENGLISH": "الإنجليزية"
+  "LANGUAGE_FRENCH": "الفرنسية"
+  "LANGUAGE_SPANISH": "الإسبانية"
+  "LANGUAGE_GERMAN": "الألمانية"
+  "LANGUAGE_ITALIAN": "الإيطالية"
+  "LANGUAGE_DUTCH": "الهولندية"
+  "LANGUAGE_PORTUGUESE": "البرتغالية"
+  "LANGUAGE_RUSSIAN": "الروسية"
+  "LANGUAGE_KOREAN": "الكورية"
+  "LANGUAGE_TRAD_CHINESE": "الصينية التقليدية"
+  "LANGUAGE_SIMPL_CHINESE": "الصينية المبسطة"
+  "OSD_SETTINGS": "إعدادات OSD"
+  "OSD_SETTINGS_LNG": "لغة OSD"
+  "ENABLE_LNG": "تغيير اللغة"
+  "BGM": "موسيقى الخلفية"
+  "BGM_VOLUME": "مستوى موسيقى الخلفية"
+  "DEF_BGM_PATH": "موسيقى السمة الافتراضية"
+  "DEF_BGM_PATH_HINT": "تحديد مسار بث الموسيقى للسمة الداخلية."
+  "BOOT_SCANNING_MC": "جارٍ فحص بطاقات الذاكرة..."
+  "BOOT_LOADING_DRIVERS": "جارٍ تحميل مشغلات التخزين..."
+  "BOOT_LOADING_USB": "جارٍ تحميل مشغل تخزين USB..."
+  "BOOT_ARMING_MMCE": "جارٍ تجهيز معرّف لعبة MMCE..."
+  "BOOT_LOADING_SOUNDS": "جارٍ تحميل أصوات السمة..."
+  "BOOT_BUILDING_MENU": "جارٍ بناء القائمة..."
+  "NET_UDPFS_TAB_HINT": "UDPFS مُفعَّل -- افتح علامة تبويب UDPFS الجديدة واضغط تأكيد للاتصال. يقوم جانب الكمبيوتر بتشغيل udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "جهاز الكتل الشبكي مُفعَّل -- تظهر علامة تبويبه بمجرد أن يستجيب خادم الكمبيوتر (udpfsd -bdpath لصورة UDPFS، وudpbd-server لـ UDPBD)."
+  "NEUTRINO_VMC_MISSING": "لم يُعثر على ملف VMC الخاص باللعبة -- يتم التشغيل بدونه (تستخدم اللعبة بطاقتها الحقيقية)."
+  "NEUTRINO_DEV_UNSUPPORTED": "لا يمكن لـ Neutrino الإطلاق من هذا الجهاز -- تم إلغاء الإطلاق."
+  "NEUTRINO_TOML_SYNC_FAILED": "إعداد شبكة Neutrino (bsd toml) مفقود أو غير قابل للكتابة -- أُلغي التشغيل، تحقق من مجلد neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "مُجزَّأ أكثر من اللازم لـ Neutrino (%d من الأجزاء، الحد %d بما في ذلك VMCs) -- تتم تجربة نواة OPL بدلاً من ذلك."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "مُجزَّأ أكثر من اللازم لـ Neutrino (%d من الأجزاء، الحد %d بما في ذلك VMCs) -- قم بإلغاء التجزئة على الكمبيوتر؛ أُلغي التشغيل."
+  "NEUTRINO_GSM_COMP": "توافق GSM مع Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "إصلاح بقلب الحقول للألعاب التي تهتز أو تتمزق تحت وضع فيديو Neutrino مفروض. يتطلب ضبط وضع فيديو Neutrino."
+  "NARGS_DBC": "ألوان التصحيح (-dbc)"
+  "NARGS_LOGO": "شعار PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "تعطيل VMC 1 (مع الإبقاء على البطاقة)"
+  "VMC_SLOT2_DISABLE": "تعطيل VMC 2 (مع الإبقاء على البطاقة)"
+  "HINT_VMC_SLOT_DISABLE": "التشغيل دون VMC الخاص بهذه الفتحة مع الإبقاء على بطاقتها مُهيَّأة. يخص تشغيل Neutrino فقط؛ عندها تستخدم اللعبة البطاقة الحقيقية في تلك الفتحة."
+  "NEUTRINO_BSDFS": "نظام ملفات Neutrino"
+  "HINT_NEUTRINO_BSDFS": "فرض نظام ملفات جهاز الكتل الخاص بـ Neutrino (-bsdfs). تلقائي = الافتراضي لكل جهاز. الخياران hdl/bd خياران للخبراء؛ اقرنهما بخيار -dvd= مطابق في وسائط التشغيل إذا كان شكل المسار التلقائي غير مناسب."
+  "PLASCOLOR": "لون مزج البلازما"
+  "VCD_HIDE_GAMEID": "إخفاء معرّف لعبة PS1 (قائمة VCD)"
+  "HINT_VCD_HIDE_GAMEID": "تجميلي فقط -- إخفاء بادئة مُعرِّف اللعبة (مثل SLUS_005.51.) من أسماء قوائم PS1/VCD. تُعرض الأسماء التي لا تحتوي على مُعرِّف كما هي. لا يُغيِّر التشغيل أو صورة الغلاف أو المفضلة."
+  "VCD_FIRST_DISC": "القرص الأول فقط (PS1 متعدد الأقراص)"
+  "HINT_VCD_FIRST_DISC": "إظهار القرص 1 فقط من لعبة PS1 متعددة الأقراص في قوائم الأجهزة (بأسلوب POPSLoader). يخفي الملفات المسماة (Disc 2) و(CD 2) وما إلى ذلك. تبقى كل الأقراص على البطاقة للتبديل أثناء اللعب؛ ولا تتم تصفية المفضلة."
+  "GAMES_DEVICE": "جهاز اللعبة"
+  "DEFAULT_CORE": "نواة التحميل الافتراضية"
+  "HINT_DEFAULT_CORE": "النواة الافتراضية العامة للألعاب التي تكون فيها نواة المُحمِّل (Loader Core) لكل لعبة مضبوطة على الافتراضي. <OPL> هي النواة الأصلية؛ وتقوم Neutrino بتسلسل neutrino.elf الخارجي. يتجاوز اختيار كل لعبة هذا الخيار دائماً."
+  "VCD_SETTINGS": "إعدادات VCD"
+  "FINANCIAL_SUPPORT": "الدعم المالي"

--- a/lng_fork/Bulgarian.yml
+++ b/lng_fork/Bulgarian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Подреди игрите по азбучен ред
+  RUMBLE: Вибрация на контролера в менютата
+  HINT_RUMBLE: Кратка вибрация при движение на курсора, потвърждаване или връщане -- изисква DualShock в аналогов режим
+  FOLDER_NAV: Разглеждай папки в списъка с игри
+  HINT_FOLDER_NAV: Показва подпапките на CD/DVD като записи за разглеждане; избери за отваряне, откажи за връщане
+  SETTINGS_NO_HOME: Няма намерена карта памет -- настройките не могат да се запазят. OPL е стартиран от мрежово устройство, чиито настройки трябва да са на локална карта.
+  ERROR_SAVING_SETTINGS_TO: Настройките не можаха да се запишат в %s (грешка %d)
+  GENERAL_SETTINGS: Общи настройки
+  DEVICE_SETTINGS: Настройки на устройство
+  LAUNCH_PS2_DISC: Стартиране на PS2 диск
+  DISC_LAUNCH_ERR: Няма PS2 диск в устройството.
+  DEFAULT: По подразбиране
+  HINT_MODE7: Само за Neutrino -- поправя игри, препълващи IOP буфер (-gc=7)
+  MODE7: Режим 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Прилага предварително изграден PS2RD .img пач към играта.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Режим на стартиране на MMCE
+  MMCE_PREFIX: Префикс на пътя за MMCE
+  MMCE_SLOT: MMCE слот
+  MMCEIGR_SLOT: IGR слот(ове) за зареждане
+  HINT_MMCEIGR_SLOT: Командата за превключване към зареждащата карта ще бъде изпратена до избрания(те) слот(ове) при IGR
+  MMCE_ADVANCED: Разширени
+  MMCE_SETTINGS: Настройки на MMCE
+  MMCE_SEMA: Метод на заключване на семафорната опашка
+  HINT_MMCE_SEMA: THFIFO може да подобри съвместимостта, но да влоши производителността
+  MMCE_WAIT_CYCLES: Изчакващи цикли след /ACK ниско
+  HINT_MMCE_WAIT_CYCLES: По-ниските стойности могат да подобрят производителността, но да причинят нестабилност
+  MMCE_USE_ALARMS: Използване на аварийни таймери
+  HINT_MMCE_USE_ALARMS: ИЗКЛ може да подобри производителността, но може да причини замразяване при MMCE таймаут
+  CORE_LOADER: Ядро на зареждача
+  NEUTRINO_BAD_FORMAT: Neutrino не поддържа този файлов формат, стартиране с ядро <OPL>
+  NEUTRINO_NOT_FOUND: Neutrino ELF не е намерен, стартиране с ядро <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD изисква статично PS2 IP. Задайте го в Мрежова конфигурация (DHCP е включен).
+  NEUTRINO_SETTING_NA: Тази настройка не се използва с ядрото Neutrino.
+  POPSTARTER_NOT_FOUND: Липсва POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Липсват изисквания на POPSTARTER за SMB
+  WRITE_POPSTARTER_NET: Запис на мрежова конфигурация на POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Записва стойностите на IP + SMB споделяне в собствените IPCONFIG.DAT / SMBCONFIG.DAT на POPSTARTER на картата с памет (за VCD по SMB).
+  POPSTARTER_NET_ERR: Неуспешен запис на мрежовата конфигурация на POPSTARTER в картата с памет.
+  VCD: VCD
+  VCD_ON: Показване на VCD игри
+  VCD_OFF: Показване на дискови игри
+  NEUTRINO_ARGS: Аргументи за стартиране на Neutrino
+  HINT_NEUTRINO_ARGS: Допълнителни флагове на Neutrino, разделени с интервал (напр. -mt=dvd). Глобалните се прилагат за всички игри; за отделна игра се добавят отгоре. Поставете $ пред флаг, за да го деактивирате без изтриване.
+  NEUTRINO_VIDEO: Neutrino видео
+  HINT_NEUTRINO_VIDEO: Принудителен видео режим на GS изхода на Neutrino (-gsm). Изкл запазва настройката на играта.
+  NEUTRINO_PATH: Път до Neutrino ELF
+  HINT_NEUTRINO_PATH: Пълен път до neutrino.elf (напр. mc0:NEUTRINO/neutrino.elf). Празно = автоматично намиране на mc0/mc1.
+  POPSTARTER_PATH: Път до POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Потребителски път до POPSTARTER.ELF; при празно/липсващо тихо се връща към папката POPS на устройството. Клавиатурата е ограничена до 31 знака; по-дълги пътища чрез settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA Източник
+  HINT_BDMA_SOURCE: Устройство, чиято папка POPS съдържа файловете на драйвера BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Режим
+  HINT_BDMA_MODE: exFAT блок-устройство драйвер, зареждан от POPSTARTER. Промяната копира модулите в картата; FAT32 = без (вграден драйвер).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Вътрешен HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: BDMA модулните файлове не са намерени на изходното устройство.
+  BDMA_ERR_SPACE: Недостатъчно място на картата с памет за BDMA модулите.
+  BDMA_ERR_IO: Грешка при запис на BDMA модулите в картата с памет.
+  COVERFLOW_SETTINGS: Настройки на Coverflow
+  COVERFLOW_COUNT: Брой корици
+  COVERFLOW_SCALE: Мащаб на центъра
+  COVERFLOW_ANIM: Скорост на анимацията
+  COVERFLOW_DIM: Затъмняване на страничните корици
+  NONE: Никой
+  SMALL: Малък
+  LARGE: Голям
+  NORMAL: Нормален
+  FAV: Любими
+  FAVMODE: Режим на стартиране на любими
+  FAV_HINT: Любима
+  FAV_MSG: '%s не е разрешено в менюто с любими.'
+  FAV_PERSISTENCE_MSG: '%s не е разрешено, докато елементът е маркиран като любим.'
+  NEUTRINO_DEVICE: Neutrino устройство
+  HINT_NEUTRINO_DEVICE: Устройство, съдържащо neutrino.elf (в папка NEUTRINO/ или neutrino/). Автоматично сканира mc0, след това mc1.
+  NARGS_QB: Бързо стартиране (-qb)
+  NARGS_CWD: Работна директория (-cwd)
+  NARGS_CFG: Конфигурация (-cfg)
+  NARGS_ELF: Стартиращ ELF (-elf)
+  NARGS_ATA0: ATA0 образ (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 образ (-ata1)
+  NARGS_EXTRA: Допълнителни аргументи
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar архив с обложки
+  DISABLE_ALL: Изключи всички
+  BOOT_LOADING_CONFIG: Зареждане на настройките...
+  BOOT_SCANNING_BDM: Сканиране на USB / карта / мрежови устройства...
+  BOOT_SCANNING_NET: Стартиране на мрежата...
+  BOOT_SCANNING_HDD: Сканиране на HDD...
+  BOOT_READY: Готово.
+  UDPFS_GAMES: "UDPFS игри"
+  UDPFSBD_GAMES: "UDPFSBD игри"
+  NET_PROTOCOL: "Мрежов протокол"
+  NET_NEEDS_NEUTRINO: "Мрежовите (UDP) игри се стартират само чрез ядрото Neutrino. Проверете дали neutrino.elf е наличен и форматът се поддържа."
+  VCD_NOT_ON_NET: "PS1 (.VCD) игри не могат да се стартират от мрежово устройство."
+  MX4SIO_PADEMU_WARN: "MX4SIO и емулацията на контролер споделят шината SIO2 и играта може да не се стартира."
+  HINT_OSD_SETTINGS_LNG: "Наложи персонализиран език"
+  OSD_SETTINGS_TVASPECT: "Размер на екрана"
+  FULL_SCREEN: "Цял екран"
+  OSD_SETTINGS_VMODE: "Видео режим"
+  SYSTEM_DEFAULT: "По подразбиране"
+  HIGH: "Висока"
+  LOW: "Ниска"
+  XSENSITIVITY: "Чувствителност на аналог по X"
+  YSENSITIVITY: "Чувствителност на аналог по Y"
+  FILE_COUNT: "Намерени файлове: %i"
+  CHEAT_SELECTION: "Избор на чийтове"
+  HDD_HINT: "Разрешен е само един HDD; включването заключва APA или GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID не е приложен -- neutrino.elf е на тази карта (смяната би разтоварила Neutrino)."
+  POPSTARTER_DEVICE: "Устройство за POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Устройство с POPS/POPSTARTER.ELF за стартиране на PS1 VCD. По подразбиране = зареждащото устройство (cwd), после устройството на самия VCD. Custom показва поле за свободен път."
+  BDMA_APPLY: "Прилагане на VCD BDMA при стартиране"
+  HINT_BDMA_APPLY: "Вкл.: автоматично поставя на картата памет съответния exFAT драйвер на стартирания VCD преди зареждане (препоръчва се). Изкл.: управлявайте ръчно чрез изборите BDMA Source/Mode по-долу."
+  NETBOOT_RESTART: "Рестартирайте OPL, за да приложите промяната на мрежовия протокол за стартиране."
+  UDPFS_MODE: "Достъп до UDPFS"
+  "MENU": "Меню"
+  "APPS": "Приложения"
+  "DEBUG": "Цветове за дебъг"
+  "COVERART": "Обложки"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Операции за запис"
+  "MODE1": "Режим 1"
+  "MODE2": "Режим 2"
+  "MODE3": "Режим 3"
+  "MODE4": "Режим 4"
+  "MODE5": "Режим 5"
+  "MODE6": "Режим 6"
+  "ENABLEGSM": "GSM селектор"
+  "OVERSCAN": "Оверскан"
+  "ENABLECHEAT": "PS2RD чийт енджин"
+  "PADEMU_ENABLE": "Емулатор на контролер"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Емулация"
+  "PADEMU_VIB": "Вибрация"
+  "PADEMU_WORKAROUND": "Обходно решение за фалшив DS3"
+  "SFX": "Звукови ефекти"
+  "BOOT_SND": "Звук при стартиране"
+  "ENABLE_NOTIFICATIONS": "Известия"
+  "OPTIONS": "Опции"
+  "GLOBAL_SETTINGS": "Глобални"
+  "INFO_GENRE": "Жанр"
+  "INFO_RELEASE": "Издаване"
+  "INFO_DESCRIPTION": "Описание"
+  "BLOCKDEVICE_SETTINGS": "Блокови устройства"
+  "CONTROLLER_SETTINGS": "Настройки на контролера"
+  "HINT_BDM_START": "Включване/изключване на мениджъра на блокови устройства (BDM)."
+  "HINT_BLOCK_DEVICES": "Включване/изключване на блокови устройства (напр. USB)."
+  "USB_GAMES": "USB игри"
+  "ILINK_GAMES": "iLink игри"
+  "MX4SIO_GAMES": "MX4SIO игри"
+  "PADMACROCONFIG": "Конфигуриране на PADMACRO"
+  "PADMACRO_SETTINGS": "Настройки на пад макроси"
+  "PADMACRO_ENABLE": "Пад макроси"
+  "PADMACRO_SLOWDOWN": "Аналогово забавяне:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Намалява обхвата на аналоговия стик, когато е натиснат бутон"
+  "LEFT_ANALOG": "Ляв стик"
+  "RIGHT_ANALOG": "Десен стик"
+  "PADMACRO_INVERT_AXIS": "Обръщане на аналогова ос:"
+  "HINT_PADMACRO_INVERT_AXIS": "Обръща оста на аналоговия стик"
+  "TURBO_SPEED": "Скорост на турбо бутона"
+  "HINT_TURBO_SPEED": "Колко бързо да се натиска бутонът, когато турбо е активно"
+  "ACT_WHILE_PRESSED": "Докато бутонът е натиснат"
+  "ACT_TOGGLED": "Превключване с бутон"
+  "LANGUAGE_JAPANESE": "ЯПОНСКИ"
+  "LANGUAGE_ENGLISH": "АНГЛИЙСКИ"
+  "LANGUAGE_FRENCH": "ФРЕНСКИ"
+  "LANGUAGE_SPANISH": "ИСПАНСКИ"
+  "LANGUAGE_GERMAN": "НЕМСКИ"
+  "LANGUAGE_ITALIAN": "ИТАЛИАНСКИ"
+  "LANGUAGE_DUTCH": "НИДЕРЛАНДСКИ"
+  "LANGUAGE_PORTUGUESE": "ПОРТУГАЛСКИ"
+  "LANGUAGE_RUSSIAN": "РУСКИ"
+  "LANGUAGE_KOREAN": "КОРЕЙСКИ"
+  "LANGUAGE_TRAD_CHINESE": "ТРАДИЦИОНЕН КИТАЙСКИ"
+  "LANGUAGE_SIMPL_CHINESE": "ОПРОСТЕН КИТАЙСКИ"
+  "OSD_SETTINGS": "OSD настройки"
+  "OSD_SETTINGS_LNG": "OSD език"
+  "ENABLE_LNG": "Смяна на езика"
+  "BGM": "Фонова музика"
+  "BGM_VOLUME": "Сила на фоновата музика"
+  "DEF_BGM_PATH": "Музика по подразбиране за темата"
+  "DEF_BGM_PATH_HINT": "Задайте път за стрийминг на музика за вградената тема."
+  "BOOT_SCANNING_MC": "Сканиране на карти памет..."
+  "BOOT_LOADING_DRIVERS": "Зареждане на драйвери за съхранение..."
+  "BOOT_LOADING_USB": "Зареждане на USB драйвер за съхранение..."
+  "BOOT_ARMING_MMCE": "Активиране на MMCE game-ID..."
+  "BOOT_LOADING_SOUNDS": "Зареждане на звуци на темата..."
+  "BOOT_BUILDING_MENU": "Изграждане на менюто..."
+  "NET_UDPFS_TAB_HINT": "UDPFS е включено -- отворете новия раздел UDPFS и натиснете Confirm за свързване. На страната на компютъра се изпълнява udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Мрежово блоково устройство е включено -- разделът му се появява, щом сървърът на компютъра отговори (udpfsd -bdpath за UDPFS Image, udpbd-server за UDPBD)."
+  "NEUTRINO_VMC_MISSING": "VMC файлът за отделната игра не е намерен -- стартиране без него (играта използва реалната си карта)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino не може да стартира от това устройство -- стартирането е прекратено."
+  "NEUTRINO_TOML_SYNC_FAILED": "Мрежовата конфигурация на Neutrino (bsd toml) липсва или не може да бъде записана -- стартирането е прекратено, проверете папката neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Твърде фрагментирано за Neutrino (%d фрагмента, лимит %d вкл. VMC) -- вместо това се опитва ядрото OPL."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Твърде фрагментирано за Neutrino (%d фрагмента, лимит %d вкл. VMC) -- дефрагментирайте на компютъра; стартирането е прекратено."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM съвместимост"
+  "HINT_NEUTRINO_GSM_COMP": "Корекция чрез размяна на полета за игри, които трептят или се разкъсват при принуден видео режим на Neutrino. Изисква зададен видео режим на Neutrino."
+  "NARGS_DBC": "Цветове за дебъг (-dbc)"
+  "NARGS_LOGO": "PS2 лого (-logo)"
+  "VMC_SLOT1_DISABLE": "Изключи VMC 1 (запази картата)"
+  "VMC_SLOT2_DISABLE": "Изключи VMC 2 (запази картата)"
+  "HINT_VMC_SLOT_DISABLE": "Стартира без VMC за този слот, като запазва картата му конфигурирана. Само при стартиране с Neutrino; тогава играта използва реалната карта в този слот."
+  "NEUTRINO_BSDFS": "Neutrino файлова система"
+  "HINT_NEUTRINO_BSDFS": "Принуждава файловата система на блоковото устройство на Neutrino (-bsdfs). Auto = стойност по подразбиране за устройството. hdl/bd са опции за напреднали; съчетавайте ги със съответстващ -dvd= в аргументите за стартиране, ако автоматичната форма на пътя не пасва."
+  "PLASCOLOR": "Цвят на плазмения градиент"
+  "VCD_HIDE_GAMEID": "Скрий PS1 Game ID (VCD списък)"
+  "HINT_VCD_HIDE_GAMEID": "Само козметично -- скрива водещ префикс с ID на играта (напр. SLUS_005.51.) от имената в списъците PS1/VCD. Имена без ID се показват както са. Не променя стартирането, обложките или любимите."
+  "VCD_FIRST_DISC": "Само първи диск (многодискови PS1)"
+  "HINT_VCD_FIRST_DISC": "Показва само Диск 1 на PS1 игра с няколко диска в списъците с устройства (в стил POPSLoader). Скрива файлове с имена (Disc 2), (CD 2) и т.н. Всички дискове остават на картата за смяна по време на игра; Любимите не се филтрират."
+  "GAMES_DEVICE": "Устройство на играта"
+  "DEFAULT_CORE": "Ядро на зареждача по подразбиране"
+  "HINT_DEFAULT_CORE": "Глобално ядро по подразбиране за игри, чието ядро на зареждащия модул (Loader Core) за отделната игра е зададено на Default. <OPL> е нативното ядро; Neutrino верижно зарежда външния neutrino.elf. Изборът за отделна игра винаги има превес над това."
+  "VCD_SETTINGS": "VCD настройки"
+  "FINANCIAL_SUPPORT": "Финансова подкрепа"

--- a/lng_fork/Cebuano.yml
+++ b/lng_fork/Cebuano.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Ihan-ay ang mga dula sa alpabeto
+  RUMBLE: Pag-uyog sa controller sa mga menu
+  HINT_RUMBLE: Mubo nga pag-uyog kon molihok ang cursor, mokumpirma o mobalik -- kinahanglan og DualShock sa analog mode
+  FOLDER_NAV: Pagbrowse sa mga folder sa lista sa dula
+  HINT_FOLDER_NAV: Ipakita ang mga subfolder sa CD/DVD isip mabrowse nga entry; pilia aron ablihan, kanselaha aron mobalik
+  SETTINGS_NO_HOME: Walay nakit-ang memory card -- dili matipigan ang mga setting. Gi-boot ang OPL gikan sa network device, kansang mga setting kinahanglang anaa sa lokal nga card.
+  ERROR_SAVING_SETTINGS_TO: Dili masulat ang mga setting ngadto sa %s (sayop %d)
+  GENERAL_SETTINGS: Kinatibuk-ang mga Setting
+  DEVICE_SETTINGS: mga Setting sa Device
+  LAUNCH_PS2_DISC: I-launch ang PS2 Disc
+  DISC_LAUNCH_ERR: Walay PS2 disc sa drive.
+  DEFAULT: Default
+  HINT_MODE7: Neutrino ra -- ayohon ang mga laro nga misobra sa IOP buffer (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Mag-apply og prebuilt nga PS2RD .img patch sa imong laro.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE Start Mode
+  MMCE_PREFIX: MMCE Prefix Path
+  MMCE_SLOT: MMCE Slot
+  MMCEIGR_SLOT: IGR Bootcard Slot(s)
+  HINT_MMCEIGR_SLOT: Ang switch to bootcard cmd ipadala sa piniling slot(s) sa IGR
+  MMCE_ADVANCED: Advanced
+  MMCE_SETTINGS: MMCE Settings
+  MMCE_SEMA: Lock Sema Enqueuing Method
+  HINT_MMCE_SEMA: Ang THFIFO mahimong makatulong sa compatibility apan makahubad sa performance
+  MMCE_WAIT_CYCLES: Wait cycles human sa /ACK low
+  HINT_MMCE_WAIT_CYCLES: Ang mas ubos nga kantidad mahimong makapabilis apan makaingon og kawalay-lig-on
+  MMCE_USE_ALARMS: Gamiton ang timeout alarms
+  HINT_MMCE_USE_ALARMS: Ang OFF mahimong makatulong sa performance apan ang MMCE timeouts mahimong mag-freeze
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Dili suportahan sa Neutrino kining file format, i-launch gamit ang <OPL> core
+  NEUTRINO_NOT_FOUND: Wala makita ang Neutrino ELF, i-launch gamit ang <OPL> core
+  UDPBD_NEEDS_STATIC_IP: Kinahanglan og static nga PS2 IP ang UDPBD. I-set sa Network Config (naka-on ang DHCP karon).
+  NEUTRINO_SETTING_NA: Kining setting dili gigamit sa Neutrino core.
+  POPSTARTER_NOT_FOUND: Nawala ang POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Kulang ang mga POPSTARTER SMB nga kinahanglanon
+  WRITE_POPSTARTER_NET: I-sulat ang POPSTARTER Network Config
+  HINT_WRITE_POPSTARTER_NET: I-save usab kining IP + SMB share nga mga kantidad sa kaugalingon nga IPCONFIG.DAT / SMBCONFIG.DAT sa POPSTARTER sa memory card (para sa VCD-over-SMB).
+  POPSTARTER_NET_ERR: Dili ma-sulat ang POPSTARTER network config sa memory card.
+  VCD: VCD
+  VCD_ON: Gipakita ang VCD games
+  VCD_OFF: Gipakita ang disc games
+  NEUTRINO_ARGS: Neutrino Launch Args
+  HINT_NEUTRINO_ARGS: Dugang Neutrino flags, gibulag og espasyo (hal. -mt=dvd). Global alang sa tanan nga laro; per-game dugang pa. Ibutang ang $ sa unahan sa flag aron ma-disable nga dili pa ma-delete.
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: Puwersahon ang GS output video mode sa Neutrino (-gsm). Ang Off magpadayon sa default sa laro.
+  NEUTRINO_PATH: Neutrino ELF Path
+  HINT_NEUTRINO_PATH: Buong path ngadto sa neutrino.elf (hal. mc0:NEUTRINO/neutrino.elf). Blangko = auto-detect sa mc0/mc1.
+  POPSTARTER_PATH: POPSTARTER.ELF Path
+  HINT_POPSTARTER_PATH: Custom nga POPSTARTER.ELF path; mobalik sa POPS folder sa device kung blangko/wala. Ang keyboard limitado sa 31 chars; mas taas nga paths pinaagi sa settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA Source
+  HINT_BDMA_SOURCE: Device nga ang POPS folder nagdala sa imong BDMAssault driver files (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Mode
+  HINT_BDMA_MODE: exFAT block-device driver nga i-load sa POPSTARTER. Ang pagbag-o nag-kopya sa mga module sa card; FAT32 = wala (built-in driver).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Internal HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Wala makita ang BDMA module files sa source device.
+  BDMA_ERR_SPACE: Dili igo ang espasyo sa memory card para sa BDMA modules.
+  BDMA_ERR_IO: Error sa pagsulat sa BDMA modules sa memory card.
+  COVERFLOW_SETTINGS: Coverflow Settings
+  COVERFLOW_COUNT: Ihap sa Cover
+  COVERFLOW_SCALE: Sentro nga Scale
+  COVERFLOW_ANIM: Tulin sa Animation
+  COVERFLOW_DIM: I-dim ang mga Palibot nga Cover
+  NONE: Wala
+  SMALL: Gamay
+  LARGE: Dako
+  NORMAL: Normal
+  FAV: Mga Paborito
+  FAVMODE: Favourites Start Mode
+  FAV_HINT: Paborito
+  FAV_MSG: '%s dili pwede sa Favourites Menu.'
+  FAV_PERSISTENCE_MSG: '%s dili pwede samtang ang item gimarkahan nga paborito.'
+  NEUTRINO_DEVICE: Neutrino Device
+  HINT_NEUTRINO_DEVICE: Device nga nagdala sa neutrino.elf (sa NEUTRINO/ o neutrino/ folder). Ang Auto mag-scan sa mc0 dayon mc1.
+  NARGS_QB: Quick Boot (-qb)
+  NARGS_CWD: Working Dir (-cwd)
+  NARGS_CFG: Config (-cfg)
+  NARGS_ELF: Boot ELF (-elf)
+  NARGS_ATA0: ATA0 Image (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 Image (-ata1)
+  NARGS_EXTRA: Extra Args
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar nga arkibo sa hapin
+  DISABLE_ALL: I-disable Tanan
+  BOOT_LOADING_CONFIG: Gikarga ang mga setting...
+  BOOT_SCANNING_BDM: Nag-scan sa USB / card / network drives...
+  BOOT_SCANNING_NET: Gisugdan ang network...
+  BOOT_SCANNING_HDD: Nag-scan sa HDD...
+  BOOT_READY: Andam na.
+  UDPFS_GAMES: "Mga Dula sa UDPFS"
+  UDPFSBD_GAMES: "Mga Dula sa UDPFSBD"
+  NET_PROTOCOL: "Protocol sa Network"
+  NET_NEEDS_NEUTRINO: "Ang mga dula sa network (UDP) mahimo lang mag-boot pinaagi sa Neutrino core. Siguroha nga anaa ang neutrino.elf ug suportado ang format."
+  VCD_NOT_ON_NET: "Ang mga dula sa PS1 (.VCD) dili malunsad pinaagi sa network device."
+  MX4SIO_PADEMU_WARN: "Ang MX4SIO ug pad emulation nagbahin sa SIO2 bus ug mahimong mapakyas ang dula sa pag-boot."
+  HINT_OSD_SETTINGS_LNG: "Pugsa ang custom nga configuration sa pinulongan"
+  OSD_SETTINGS_TVASPECT: "Gidak-on sa Screen"
+  FULL_SCREEN: "Tibuok Screen"
+  OSD_SETTINGS_VMODE: "Video Mode"
+  SYSTEM_DEFAULT: "Default sa Sistema"
+  HIGH: "Taas"
+  LOW: "Ubos"
+  XSENSITIVITY: "Sensitivity sa Analog X-Axis"
+  YSENSITIVITY: "Sensitivity sa Analog Y-Axis"
+  FILE_COUNT: "Nakita nga mga file: %i"
+  CHEAT_SELECTION: "Pagpili sa Cheat"
+  HDD_HINT: "Usa ra ka HDD ang gitugotan, kung ma-enable ma-lock ang APA o GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "Wala gigamit ang MMCE GameID -- ang neutrino.elf anaa niini nga card (kung usbon kini, ma-unload ang Neutrino)."
+  POPSTARTER_DEVICE: "Device sa POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Device nga naghupot sa POPS/POPSTARTER.ELF para sa mga paglunsad sa PS1 VCD. Default = boot device (cwd) unya ang kaugalingong device sa VCD. Ang Custom magpakita og free-text nga path."
+  BDMA_APPLY: "Ipatuman ang VCD BDMA sa Paglunsad"
+  HINT_BDMA_APPLY: "Naka-on: awtomatikong ibutang ang katugbang nga exFAT driver sa gilunsad nga VCD sa memory card sa dili pa mag-boot (girekomenda). Naka-off: dumalaha kini sa imong kaugalingon gamit ang mga pili nga Source/Mode sa BDMA sa ubos."
+  NETBOOT_RESTART: "I-restart ang OPL aron ipatuman ang kausaban sa network boot protocol."
+  UDPFS_MODE: "Pag-access sa UDPFS"
+  "MENU": "Menu"
+  "APPS": "Mga App"
+  "DEBUG": "Mga Kolor sa Debug"
+  "COVERART": "Cover Art"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Mga Operasyon sa Pagsulat"
+  "MODE1": "Mode 1"
+  "MODE2": "Mode 2"
+  "MODE3": "Mode 3"
+  "MODE4": "Mode 4"
+  "MODE5": "Mode 5"
+  "MODE6": "Mode 6"
+  "ENABLEGSM": "GSM Selector"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD Cheat Engine"
+  "PADEMU_ENABLE": "Pad Emulator"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulasyon"
+  "PADEMU_VIB": "Pagkurog"
+  "PADEMU_WORKAROUND": "Fake DS3 Workaround"
+  "SFX": "Mga Sound Effect"
+  "BOOT_SND": "Tingog sa Pag-boot"
+  "ENABLE_NOTIFICATIONS": "Mga Notification"
+  "OPTIONS": "Mga Opsyon"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Gipagawas"
+  "INFO_DESCRIPTION": "Deskripsyon"
+  "BLOCKDEVICE_SETTINGS": "Mga Block Device"
+  "CONTROLLER_SETTINGS": "Mga Setting sa Controller"
+  "HINT_BDM_START": "I-on/i-off ang Block Device Manager."
+  "HINT_BLOCK_DEVICES": "I-on/i-off ang Block Devices (pananglitan USB)."
+  "USB_GAMES": "Mga Dula sa USB"
+  "ILINK_GAMES": "Mga Dula sa iLink"
+  "MX4SIO_GAMES": "Mga Dula sa MX4SIO"
+  "PADMACROCONFIG": "I-configure ang PADMACRO"
+  "PADMACRO_SETTINGS": "Mga Setting sa Pad macro"
+  "PADMACRO_ENABLE": "Mga Pad macro"
+  "PADMACRO_SLOWDOWN": "Analog slow-down:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Pakunhora ang range sa analog stick kung gipislit ang button"
+  "LEFT_ANALOG": "Wala nga stick"
+  "RIGHT_ANALOG": "Tuo nga stick"
+  "PADMACRO_INVERT_AXIS": "Analog axis invert:"
+  "HINT_PADMACRO_INVERT_AXIS": "I-invert ang axis sa analog stick"
+  "TURBO_SPEED": "Katulin sa turbo button"
+  "HINT_TURBO_SPEED": "Unsa ka paspas ipislit ang button kung aktibo ang turbo"
+  "ACT_WHILE_PRESSED": "Samtang gipislit ang button"
+  "ACT_TOGGLED": "Gi-toggle sa button"
+  "LANGUAGE_JAPANESE": "HINAPON"
+  "LANGUAGE_ENGLISH": "ININGLES"
+  "LANGUAGE_FRENCH": "PRINSES"
+  "LANGUAGE_SPANISH": "INESPANYOL"
+  "LANGUAGE_GERMAN": "ALEMAN"
+  "LANGUAGE_ITALIAN": "ITALYANO"
+  "LANGUAGE_DUTCH": "OLANDES"
+  "LANGUAGE_PORTUGUESE": "PORTUGES"
+  "LANGUAGE_RUSSIAN": "RUSO"
+  "LANGUAGE_KOREAN": "KOREANO"
+  "LANGUAGE_TRAD_CHINESE": "TRADISYUNAL NGA INSIK"
+  "LANGUAGE_SIMPL_CHINESE": "GIPASAYON NGA INSIK"
+  "OSD_SETTINGS": "Mga setting sa OSD"
+  "OSD_SETTINGS_LNG": "Pinulongan sa OSD"
+  "ENABLE_LNG": "Usba ang pinulongan"
+  "BGM": "Musika sa Background"
+  "BGM_VOLUME": "Volume sa Musika sa Background"
+  "DEF_BGM_PATH": "Default nga Musika sa Tema"
+  "DEF_BGM_PATH_HINT": "Itakda ang path aron mag-stream og musika para sa internal nga tema."
+  "BOOT_SCANNING_MC": "Nag-scan sa mga memory card..."
+  "BOOT_LOADING_DRIVERS": "Nagkarga sa mga storage driver..."
+  "BOOT_LOADING_USB": "Nagkarga sa USB storage driver..."
+  "BOOT_ARMING_MMCE": "Gi-arma ang MMCE game-ID..."
+  "BOOT_LOADING_SOUNDS": "Nagkarga sa mga tingog sa tema..."
+  "BOOT_BUILDING_MENU": "Gitukod ang menu..."
+  "NET_UDPFS_TAB_HINT": "Naka-on ang UDPFS -- ablihi ang bag-ong UDPFS tab ug pindota ang Confirm aron makonektar. Sa PC nga bahin nagdagan ang udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Naka-on ang network block device -- motungha ang tab niini kung motubag na ang PC server (udpfsd -bdpath para sa UDPFS Image, udpbd-server para sa UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Wala makit-i ang per-game nga VMC file -- gilunsad nga wala kini (ang dula mogamit sa tinuod niini nga card)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Dili makalunsad ang Neutrino gikan niini nga device -- gi-abort ang paglunsad."
+  "NEUTRINO_TOML_SYNC_FAILED": "Nawala o dili masulatan ang Neutrino network config (bsd toml) -- giabort ang launch, susiha ang neutrino folder."
+  "NEUTRINO_TOO_FRAGMENTED": "Sobra ka fragmented para sa Neutrino (%d fragments, limit %d apil ang VMCs) -- gisulayan hinuon ang OPL core."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Sobra ka fragmented para sa Neutrino (%d fragments, limit %d apil ang VMCs) -- i-defragment sa PC; giabort ang launch."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM Compatibility"
+  "HINT_NEUTRINO_GSM_COMP": "Field-flipping nga ayo para sa mga dula nga nag-uyog o nag-gisi ubos sa usa ka pinugos nga Neutrino Video mode. Nagkinahanglan og gi-set nga Neutrino Video mode."
+  "NARGS_DBC": "Mga Kolor sa Debug (-dbc)"
+  "NARGS_LOGO": "PS2 Logo (-logo)"
+  "VMC_SLOT1_DISABLE": "I-disable ang VMC 1 (ibilin ang card)"
+  "VMC_SLOT2_DISABLE": "I-disable ang VMC 2 (ibilin ang card)"
+  "HINT_VMC_SLOT_DISABLE": "Ilunsad nga walay VMC niini nga slot samtang gipabilin ang pagka-configure sa card niini. Neutrino nga mga launch lamang; ang dula unya mogamit sa tinuod nga card niana nga slot."
+  "NEUTRINO_BSDFS": "Neutrino Filesystem"
+  "HINT_NEUTRINO_BSDFS": "Pugsa ang block-device filesystem sa Neutrino (-bsdfs). Ang Auto = default kada-device. Ang hdl/bd mga expert nga opsyon; ipares kini sa usa ka nahaom nga -dvd= sa launch args kung ang porma sa auto nga dalan dili mohaom."
+  "PLASCOLOR": "Plasma Blend Color"
+  "VCD_HIDE_GAMEID": "Itago ang PS1 Game ID (VCD list)"
+  "HINT_VCD_HIDE_GAMEID": "Cosmetic lamang -- itago ang nag-una nga game-ID prefix (pananglitan SLUS_005.51.) gikan sa mga ngalan sa listahan sa PS1/VCD. Ang mga ngalan nga walay ID ipakita nga sama sa naa. Wala kini mag-usab sa launch, cover art, o favourites."
+  "VCD_FIRST_DISC": "Unang disc lang (multi-disc PS1)"
+  "HINT_VCD_FIRST_DISC": "Ipakita lamang ang Disc 1 sa usa ka daghang-disc nga PS1 nga dula sa mga listahan sa device (POPSLoader style). Itago ang mga file nga ginganlan og (Disc 2), (CD 2), ug uban pa. Ang tanang disc magpabilin sa card para sa pag-ilis samtang nagdula; ang mga Favourites dili sala-on."
+  "GAMES_DEVICE": "Device sa Dula"
+  "DEFAULT_CORE": "Default nga Loader Core"
+  "HINT_DEFAULT_CORE": "Global nga default nga core para sa mga dula kansang per-game Loader Core gi-set sa Default. Ang <OPL> mao ang lumad nga core; ang Neutrino nag-chain sa gawas nga neutrino.elf. Ang per-game nga pagpili kanunay mo-override niini."
+  "VCD_SETTINGS": "Mga Setting sa VCD"
+  "FINANCIAL_SUPPORT": "Suporta sa Panalapi"

--- a/lng_fork/Croatian.yml
+++ b/lng_fork/Croatian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Poredaj igre abecedno
+  RUMBLE: Vibracija kontrolera u izbornicima
+  HINT_RUMBLE: Kratka vibracija pri pomicanju pokazivača, potvrdi ili povratku -- treba DualShock u analognom načinu
+  FOLDER_NAV: Pregledavaj mape u popisu igara
+  HINT_FOLDER_NAV: Prikaži podmape CD/DVD-a kao stavke za pregled -- odaberi za otvaranje, odustani za povratak
+  SETTINGS_NO_HOME: Memorijska kartica nije pronađena -- postavke se ne mogu spremiti. OPL je pokrenut s mrežnog uređaja, čije postavke moraju biti na lokalnoj kartici.
+  ERROR_SAVING_SETTINGS_TO: Nije moguće zapisati postavke na %s (pogreška %d)
+  GENERAL_SETTINGS: Opće postavke
+  DEVICE_SETTINGS: Postavke uređaja
+  LAUNCH_PS2_DISC: Pokretanje PS2 diska
+  DISC_LAUNCH_ERR: Nema PS2 diska u pogonu.
+  DEFAULT: Zadano
+  HINT_MODE7: Samo Neutrino -- popravak igara koje prekoračuju IOP međuspremnik (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Primijeni gotovu PS2RD .img zakrpu na svoju igru.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE Način pokretanja
+  MMCE_PREFIX: MMCE Predputanja
+  MMCE_SLOT: MMCE Utor
+  MMCEIGR_SLOT: IGR Utor kartice za pokretanje
+  HINT_MMCEIGR_SLOT: Naredba za prelaz na bootcard šalje se odabranom utoru/utorima pri IGR
+  MMCE_ADVANCED: Napredno
+  MMCE_SETTINGS: MMCE Postavke
+  MMCE_SEMA: Metoda zaključavanja Sema reda
+  HINT_MMCE_SEMA: THFIFO može poboljšati kompatibilnost ali narušiti performanse
+  MMCE_WAIT_CYCLES: Ciklusi čekanja nakon /ACK low
+  HINT_MMCE_WAIT_CYCLES: Niže vrijednosti mogu poboljšati performanse ali uzrokovati nestabilnosti
+  MMCE_USE_ALARMS: Koristi alarme vremenskog ograničenja
+  HINT_MMCE_USE_ALARMS: ISKLJ. može pomoći performansama ali može uzrokovati zamrzavanje pri MMCE timeoutu
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino ne podržava ovaj format datoteke, pokretanje s jezgrom <OPL>
+  NEUTRINO_NOT_FOUND: Neutrino ELF nije pronađen, pokretanje s jezgrom <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD zahtijeva statičku PS2 IP adresu. Postavite je u mrežnoj konfiguraciji (DHCP je trenutno uključen).
+  NEUTRINO_SETTING_NA: Ova postavka se ne koristi s Neutrino jezgrom.
+  POPSTARTER_NOT_FOUND: Nedostaje POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Nedostaju POPSTARTER SMB preduvjeti
+  WRITE_POPSTARTER_NET: Spremi POPSTARTER mrežnu konfiguraciju
+  HINT_WRITE_POPSTARTER_NET: Spremi ove IP + SMB vrijednosti i u POPSTARTER-ove IPCONFIG.DAT / SMBCONFIG.DAT na memorijskoj kartici (za VCD-over-SMB).
+  POPSTARTER_NET_ERR: Nije moguće zapisati POPSTARTER mrežnu konfiguraciju na memorijsku karticu.
+  VCD: VCD
+  VCD_ON: Prikazuju se VCD igre
+  VCD_OFF: Prikazuju se disk igre
+  NEUTRINO_ARGS: Neutrino Argumenti pokretanja
+  HINT_NEUTRINO_ARGS: Dodatne Neutrino zastavice, odvojene razmacima (npr. -mt=dvd). Globalno vrijedi za sve igre; po igri dodaje na vrh. Prefiks zastavice s $ onemogućuje je bez brisanja.
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: Prisili Neutrino GS izlazni video način (-gsm). Isklj. zadržava zadano igre.
+  NEUTRINO_PATH: Neutrino ELF Putanja
+  HINT_NEUTRINO_PATH: Puna putanja do neutrino.elf (npr. mc0:NEUTRINO/neutrino.elf). Prazno = automatsko otkrivanje na mc0/mc1.
+  POPSTARTER_PATH: POPSTARTER.ELF Putanja
+  HINT_POPSTARTER_PATH: Prilagođena POPSTARTER.ELF putanja; tiho se vraća na POPS mapu uređaja ako je prazna/nedostaje. Tipkovnica ograničena na 31 znak; dulje putanje putem settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA Izvor
+  HINT_BDMA_SOURCE: Uređaj čija POPS mapa sadrži vaše BDMAssault upravljačke datoteke (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Način
+  HINT_BDMA_MODE: exFAT upravljački program blok-uređaja koji POPSTARTER učitava. Promjenom se moduli kopiraju na karticu; FAT32 = nije potrebno (ugrađeni upravljački program).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Interni HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: BDMA datoteke modula nisu pronađene na izvornom uređaju.
+  BDMA_ERR_SPACE: Nema dovoljno prostora na memorijskoj kartici za BDMA module.
+  BDMA_ERR_IO: Greška pri zapisivanju BDMA modula na memorijsku karticu.
+  COVERFLOW_SETTINGS: Coverflow Postavke
+  COVERFLOW_COUNT: Broj naslovnica
+  COVERFLOW_SCALE: Razmjer središta
+  COVERFLOW_ANIM: Brzina animacije
+  COVERFLOW_DIM: Zatamni bočne naslovnice
+  NONE: Nijedno
+  SMALL: Malo
+  LARGE: Veliko
+  NORMAL: Normalno
+  FAV: Favoriti
+  FAVMODE: Favoriti Način pokretanja
+  FAV_HINT: Favorit
+  FAV_MSG: '%s nije dopušteno kroz izbornik Favorita.'
+  FAV_PERSISTENCE_MSG: '%s nije dopušteno dok je stavka označena kao favorit.'
+  NEUTRINO_DEVICE: Neutrino Uređaj
+  HINT_NEUTRINO_DEVICE: Uređaj koji sadrži neutrino.elf (u mapi NEUTRINO/ ili neutrino/). Auto pretražuje mc0 pa mc1.
+  NARGS_QB: Brzo pokretanje (-qb)
+  NARGS_CWD: Radni direktorij (-cwd)
+  NARGS_CFG: Konfiguracija (-cfg)
+  NARGS_ELF: Pokretački ELF (-elf)
+  NARGS_ATA0: ATA0 Slika (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 Slika (-ata1)
+  NARGS_EXTRA: Dodatni argumenti
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar arhiva omota
+  DISABLE_ALL: Onemogući sve
+  BOOT_LOADING_CONFIG: Učitavanje postavki...
+  BOOT_SCANNING_BDM: Pretraživanje USB / kartice / mrežnih pogona...
+  BOOT_SCANNING_NET: Pokretanje mreže...
+  BOOT_SCANNING_HDD: Pretraživanje HDD-a...
+  BOOT_READY: Spremno.
+  UDPFS_GAMES: "UDPFS igre"
+  UDPFSBD_GAMES: "UDPFSBD igre"
+  NET_PROTOCOL: "Mrežni protokol"
+  NET_NEEDS_NEUTRINO: "Mrežne (UDP) igre mogu se pokrenuti samo putem jezgre Neutrino. Provjerite je li neutrino.elf prisutan i podržava li se format."
+  VCD_NOT_ON_NET: "PS1 (.VCD) igre ne mogu se pokrenuti s mrežnog uređaja."
+  MX4SIO_PADEMU_WARN: "MX4SIO i emulacija kontrolera dijele sabirnicu SIO2 pa se igra možda neće pokrenuti."
+  HINT_OSD_SETTINGS_LNG: "Nametni prilagođeni jezik"
+  OSD_SETTINGS_TVASPECT: "Veličina slike"
+  FULL_SCREEN: "Cijeli zaslon"
+  OSD_SETTINGS_VMODE: "Videonačin"
+  SYSTEM_DEFAULT: "Zadano sustava"
+  HIGH: "Visoka"
+  LOW: "Niska"
+  XSENSITIVITY: "Osjetljivost analoga po osi X"
+  YSENSITIVITY: "Osjetljivost analoga po osi Y"
+  FILE_COUNT: "Pronađeno datoteka: %i"
+  CHEAT_SELECTION: "Odabir cheatova"
+  HDD_HINT: "Dopušten je samo jedan HDD; uključivanje zaključava APA ili GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID nije primijenjen -- neutrino.elf je na ovoj kartici (promjena bi izbacila Neutrino)."
+  POPSTARTER_DEVICE: "Uređaj za POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Uređaj s POPS/POPSTARTER.ELF za pokretanje PS1 VCD-a. Zadano = uređaj za pokretanje (cwd), zatim vlastiti uređaj VCD-a. Custom otkriva polje za slobodan unos putanje."
+  BDMA_APPLY: "Primijeni VCD BDMA pri pokretanju"
+  HINT_BDMA_APPLY: "Uklj.: prije pokretanja automatski postavlja na memorijsku karticu odgovarajući exFAT upravljački program pokrenutog VCD-a (preporučeno). Isklj.: upravljajte ručno pomoću izbornika BDMA Source/Mode ispod."
+  NETBOOT_RESTART: "Ponovno pokrenite OPL da biste primijenili promjenu protokola mrežnog pokretanja."
+  UDPFS_MODE: "UDPFS pristup"
+  "MENU": "Izbornik"
+  "APPS": "Aplikacije"
+  "DEBUG": "Boje za otklanjanje pogrešaka"
+  "COVERART": "Naslovnica"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operacije pisanja"
+  "MODE1": "Način 1"
+  "MODE2": "Način 2"
+  "MODE3": "Način 3"
+  "MODE4": "Način 4"
+  "MODE5": "Način 5"
+  "MODE6": "Način 6"
+  "ENABLEGSM": "GSM birač"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD engine za varanje"
+  "PADEMU_ENABLE": "Emulator kontrolera"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulacija"
+  "PADEMU_VIB": "Vibracija"
+  "PADEMU_WORKAROUND": "Lažni DS3 zaobilazni način"
+  "SFX": "Zvučni efekti"
+  "BOOT_SND": "Zvuk pri pokretanju"
+  "ENABLE_NOTIFICATIONS": "Obavijesti"
+  "OPTIONS": "Opcije"
+  "GLOBAL_SETTINGS": "Globalno"
+  "INFO_GENRE": "Žanr"
+  "INFO_RELEASE": "Izdanje"
+  "INFO_DESCRIPTION": "Opis"
+  "BLOCKDEVICE_SETTINGS": "Blok uređaji"
+  "CONTROLLER_SETTINGS": "Postavke kontrolera"
+  "HINT_BDM_START": "Uključi/isključi upravitelj blok uređaja."
+  "HINT_BLOCK_DEVICES": "Uključi/isključi blok uređaje (npr. USB)."
+  "USB_GAMES": "USB igre"
+  "ILINK_GAMES": "iLink igre"
+  "MX4SIO_GAMES": "MX4SIO igre"
+  "PADMACROCONFIG": "Konfiguriraj PADMACRO"
+  "PADMACRO_SETTINGS": "Postavke makronaredbi kontrolera"
+  "PADMACRO_ENABLE": "Makronaredbe kontrolera"
+  "PADMACRO_SLOWDOWN": "Usporavanje analoga:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Smanji domet analogne palice kad je tipka pritisnuta"
+  "LEFT_ANALOG": "Lijeva palica"
+  "RIGHT_ANALOG": "Desna palica"
+  "PADMACRO_INVERT_AXIS": "Obrni os analoga:"
+  "HINT_PADMACRO_INVERT_AXIS": "Obrni os analogne palice"
+  "TURBO_SPEED": "Brzina turbo tipke"
+  "HINT_TURBO_SPEED": "Koliko brzo pritiskati tipku dok je turbo aktivan"
+  "ACT_WHILE_PRESSED": "Dok je tipka pritisnuta"
+  "ACT_TOGGLED": "Uključi/isključi tipkom"
+  "LANGUAGE_JAPANESE": "JAPANSKI"
+  "LANGUAGE_ENGLISH": "ENGLESKI"
+  "LANGUAGE_FRENCH": "FRANCUSKI"
+  "LANGUAGE_SPANISH": "ŠPANJOLSKI"
+  "LANGUAGE_GERMAN": "NJEMAČKI"
+  "LANGUAGE_ITALIAN": "TALIJANSKI"
+  "LANGUAGE_DUTCH": "NIZOZEMSKI"
+  "LANGUAGE_PORTUGUESE": "PORTUGALSKI"
+  "LANGUAGE_RUSSIAN": "RUSKI"
+  "LANGUAGE_KOREAN": "KOREJSKI"
+  "LANGUAGE_TRAD_CHINESE": "TRADICIONALNI KINESKI"
+  "LANGUAGE_SIMPL_CHINESE": "POJEDNOSTAVLJENI KINESKI"
+  "OSD_SETTINGS": "OSD postavke"
+  "OSD_SETTINGS_LNG": "OSD jezik"
+  "ENABLE_LNG": "Promijeni jezik"
+  "BGM": "Pozadinska glazba"
+  "BGM_VOLUME": "Glasnoća pozadinske glazbe"
+  "DEF_BGM_PATH": "Zadana glazba teme"
+  "DEF_BGM_PATH_HINT": "Postavi putanju za reprodukciju glazbe interne teme."
+  "BOOT_SCANNING_MC": "Pretraživanje memorijskih kartica..."
+  "BOOT_LOADING_DRIVERS": "Učitavanje upravljačkih programa pohrane..."
+  "BOOT_LOADING_USB": "Učitavanje USB upravljačkog programa pohrane..."
+  "BOOT_ARMING_MMCE": "Priprema MMCE ID-a igre..."
+  "BOOT_LOADING_SOUNDS": "Učitavanje zvukova teme..."
+  "BOOT_BUILDING_MENU": "Izrada izbornika..."
+  "NET_UDPFS_TAB_HINT": "UDPFS uključen -- otvori novu UDPFS karticu i pritisni Potvrdi za spajanje. PC strana pokreće udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Mrežni blok-uređaj uključen -- njegova kartica pojavljuje se kad PC poslužitelj odgovori (udpfsd -bdpath za UDPFS Image, udpbd-server za UDPBD)."
+  "NEUTRINO_VMC_MISSING": "VMC datoteka za igru nije pronađena -- pokrećem bez nje (igra koristi svoju stvarnu karticu)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino ne može pokrenuti s ovog uređaja -- pokretanje prekinuto."
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino mrežna konfiguracija (bsd toml) nedostaje ili se ne može zapisati -- pokretanje prekinuto, provjeri neutrino mapu."
+  "NEUTRINO_TOO_FRAGMENTED": "Previše fragmentirano za Neutrino (%d fragmenata, ograničenje %d uklj. VMC-e) -- umjesto toga pokušavam s OPL jezgrom."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Previše fragmentirano za Neutrino (%d fragmenata, ograničenje %d uklj. VMC-e) -- defragmentiraj na PC-u; pokretanje prekinuto."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM kompatibilnost"
+  "HINT_NEUTRINO_GSM_COMP": "Ispravak zamjene polja za igre koje se tresu ili trgaju pod prisilnim Neutrino Video načinom. Potreban je postavljen Neutrino Video način."
+  "NARGS_DBC": "Boje za otklanjanje pogrešaka (-dbc)"
+  "NARGS_LOGO": "PS2 logo (-logo)"
+  "VMC_SLOT1_DISABLE": "Onemogući VMC 1 (zadrži karticu)"
+  "VMC_SLOT2_DISABLE": "Onemogući VMC 2 (zadrži karticu)"
+  "HINT_VMC_SLOT_DISABLE": "Pokreni bez VMC-a ovog utora, a da mu kartica ostane konfigurirana. Samo Neutrino pokretanja; igra tada koristi stvarnu karticu u tom utoru."
+  "NEUTRINO_BSDFS": "Neutrino datotečni sustav"
+  "HINT_NEUTRINO_BSDFS": "Prisili Neutrinov datotečni sustav blok-uređaja (-bsdfs). Auto = zadano po uređaju. hdl/bd su stručne opcije; upari ih s odgovarajućim -dvd= u argumentima pokretanja ako oblik automatske putanje ne odgovara."
+  "PLASCOLOR": "Boja miješanja plazme"
+  "VCD_HIDE_GAMEID": "Sakrij PS1 ID igre (VCD popis)"
+  "HINT_VCD_HIDE_GAMEID": "Samo kozmetički -- sakrij vodeći prefiks ID-a igre (npr. SLUS_005.51.) iz naziva u PS1/VCD popisima. Nazivi bez ID-a prikazuju se kakvi jesu. Ne mijenja pokretanje, naslovnicu ni favorite."
+  "VCD_FIRST_DISC": "Samo prvi disk (višediskovni PS1)"
+  "HINT_VCD_FIRST_DISC": "Prikaži samo disk 1 PS1 igre s više diskova u popisima uređaja (POPSLoader stil). Skriva datoteke nazvane (Disc 2), (CD 2) itd. Svi diskovi ostaju na kartici za zamjenu tijekom igre; Favoriti se ne filtriraju."
+  "GAMES_DEVICE": "Uređaj igre"
+  "DEFAULT_CORE": "Zadana jezgra učitavača"
+  "HINT_DEFAULT_CORE": "Globalno zadano jezgro za igre čije je pojedinačno Loader Core postavljeno na Default. <OPL> je izvorno jezgro; Neutrino povezuje vanjski neutrino.elf. Odabir po igri uvijek nadjačava ovo."
+  "VCD_SETTINGS": "VCD postavke"
+  "FINANCIAL_SUPPORT": "Financijska podrška"

--- a/lng_fork/Czech.yml
+++ b/lng_fork/Czech.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Řadit hry podle abecedy
+  RUMBLE: Vibrace ovladače v nabídkách
+  HINT_RUMBLE: Krátká vibrace při pohybu kurzoru, potvrzení nebo návratu -- vyžaduje DualShock v analogovém režimu
+  FOLDER_NAV: Procházet složky v seznamu her
+  HINT_FOLDER_NAV: Zobrazit podsložky CD/DVD jako procházené položky -- vyber pro otevření, zruš pro návrat
+  SETTINGS_NO_HOME: Paměťová karta nenalezena -- nastavení nelze uložit. OPL byl spuštěn ze síťového zařízení, jehož nastavení musí být na místní kartě.
+  ERROR_SAVING_SETTINGS_TO: Nelze zapsat nastavení na %s (chyba %d)
+  GENERAL_SETTINGS: Obecná nastavení
+  DEVICE_SETTINGS: Nastavení zařízení
+  LAUNCH_PS2_DISC: Spustit PS2 disk
+  DISC_LAUNCH_ERR: V mechanice není žádný PS2 disk.
+  DEFAULT: Výchozí
+  HINT_MODE7: Pouze Neutrino -- oprava her přetékajících IOP buffer (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Aplikovat předpřipravený PS2RD .img patch na vaši hru.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE Startovní režim
+  MMCE_PREFIX: MMCE Předpona cesty
+  MMCE_SLOT: MMCE Slot
+  MMCEIGR_SLOT: IGR Bootcard Slot(y)
+  HINT_MMCEIGR_SLOT: Příkaz přepnutí na bootcard bude odeslán do vybraného slotu při IGR
+  MMCE_ADVANCED: Pokročilé
+  MMCE_SETTINGS: MMCE Nastavení
+  MMCE_SEMA: Metoda zámku Sema fronty
+  HINT_MMCE_SEMA: THFIFO může pomoci s kompatibilitou, ale zhoršit výkon
+  MMCE_WAIT_CYCLES: Čekací cykly po /ACK low
+  HINT_MMCE_WAIT_CYCLES: Nižší hodnoty mohou zlepšit výkon, ale způsobit nestabilitu
+  MMCE_USE_ALARMS: Použít časové limity alarmů
+  HINT_MMCE_USE_ALARMS: OFF může zlepšit výkon, ale MMCE timeouty mohou způsobit zamrznutí
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino nepodporuje tento formát souboru, spouštím s jádrem <OPL>
+  NEUTRINO_NOT_FOUND: Neutrino ELF nenalezeno, spouštím s jádrem <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD vyžaduje statickou IP PS2. Nastavte ji v Síťové konfiguraci (DHCP je zapnuto).
+  NEUTRINO_SETTING_NA: Toto nastavení se s jádrem Neutrino nepoužívá.
+  POPSTARTER_NOT_FOUND: Chybí POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Chybí požadavky POPSTARTER SMB
+  WRITE_POPSTARTER_NET: Zapsat síťovou konfiguraci POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Uložit také tyto hodnoty IP + SMB sdílení do vlastních souborů POPSTARTER IPCONFIG.DAT / SMBCONFIG.DAT na paměťové kartě (pro VCD přes SMB).
+  POPSTARTER_NET_ERR: Nepodařilo se zapsat síťovou konfiguraci POPSTARTER na paměťovou kartu.
+  VCD: VCD
+  VCD_ON: Zobrazuji VCD hry
+  VCD_OFF: Zobrazuji diskové hry
+  NEUTRINO_ARGS: Neutrino Spouštěcí Args
+  HINT_NEUTRINO_ARGS: 'Extra příznaky Neutrino, oddělené mezerami (např. -mt=dvd). Globální platí pro všechny hry; na hru se přidá navíc. Prefix příznaku $ ho zakáže bez smazání.'
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: 'Vynutit výstupní video režim GS Neutrino (-gsm). Vypnuto ponechá výchozí nastavení hry.'
+  NEUTRINO_PATH: Neutrino ELF Cesta
+  HINT_NEUTRINO_PATH: Úplná cesta k neutrino.elf (např. mc0:NEUTRINO/neutrino.elf). Prázdné = automatická detekce na mc0/mc1.
+  POPSTARTER_PATH: POPSTARTER.ELF Cesta
+  HINT_POPSTARTER_PATH: Vlastní cesta k POPSTARTER.ELF; pokud je prázdná/chybí, použije složku POPS na zařízení. Klávesnice max. 31 znaků; delší cesty přes settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA Zdroj
+  HINT_BDMA_SOURCE: Zařízení, jehož složka POPS obsahuje soubory ovladače BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Režim
+  HINT_BDMA_MODE: Ovladač blokového zařízení exFAT, který POPSTARTER načte. Změna zkopíruje moduly na kartu; FAT32 = žádný (vestavěný ovladač).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Interní HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Soubory modulu BDMA nenalezeny na zdrojovém zařízení.
+  BDMA_ERR_SPACE: Na paměťové kartě není dostatek místa pro moduly BDMA.
+  BDMA_ERR_IO: Chyba při zápisu modulů BDMA na paměťovou kartu.
+  COVERFLOW_SETTINGS: Nastavení Coverflow
+  COVERFLOW_COUNT: Počet obalů
+  COVERFLOW_SCALE: Měřítko středu
+  COVERFLOW_ANIM: Rychlost animace
+  COVERFLOW_DIM: Ztmavit boční obaly
+  NONE: Žádný
+  SMALL: Malý
+  LARGE: Velký
+  NORMAL: Normální
+  FAV: Oblíbené
+  FAVMODE: Oblíbené Startovní režim
+  FAV_HINT: Oblíbená
+  FAV_MSG: '%s není povolen v nabídce Oblíbených.'
+  FAV_PERSISTENCE_MSG: '%s není povoleno, dokud je položka označena jako oblíbená.'
+  NEUTRINO_DEVICE: Neutrino Zařízení
+  HINT_NEUTRINO_DEVICE: Zařízení obsahující neutrino.elf (ve složce NEUTRINO/ nebo neutrino/). Auto prohledá nejprve mc0, poté mc1.
+  NARGS_QB: Rychlý start (-qb)
+  NARGS_CWD: Pracovní adresář (-cwd)
+  NARGS_CFG: Konfigurace (-cfg)
+  NARGS_ELF: Spouštěcí ELF (-elf)
+  NARGS_ATA0: Obraz ATA0 (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: Obraz ATA1 (-ata1)
+  NARGS_EXTRA: Extra Args
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Archiv obalů .tar
+  DISABLE_ALL: Vypnout vše
+  BOOT_LOADING_CONFIG: Načítání nastavení...
+  BOOT_SCANNING_BDM: Prohledávání USB / karty / síťových disků...
+  BOOT_SCANNING_NET: Spouštění sítě...
+  BOOT_SCANNING_HDD: Prohledávání HDD...
+  BOOT_READY: Hotovo.
+  UDPFS_GAMES: "Hry UDPFS"
+  UDPFSBD_GAMES: "Hry UDPFSBD"
+  NET_PROTOCOL: "Síťový protokol"
+  NET_NEEDS_NEUTRINO: "Síťové (UDP) hry lze spustit pouze přes jádro Neutrino. Ověřte, že je neutrino.elf přítomen a formát je podporován."
+  VCD_NOT_ON_NET: "Hry PS1 (.VCD) nelze spustit ze síťového zařízení."
+  MX4SIO_PADEMU_WARN: "MX4SIO a emulace ovladače sdílejí sběrnici SIO2 a hra se nemusí spustit."
+  HINT_OSD_SETTINGS_LNG: "Vynutit vlastní jazyk"
+  OSD_SETTINGS_TVASPECT: "Velikost obrazu"
+  FULL_SCREEN: "Celá obrazovka"
+  OSD_SETTINGS_VMODE: "Režim videa"
+  SYSTEM_DEFAULT: "Výchozí systému"
+  HIGH: "Vysoká"
+  LOW: "Nízká"
+  XSENSITIVITY: "Citlivost analogu, osa X"
+  YSENSITIVITY: "Citlivost analogu, osa Y"
+  FILE_COUNT: "Nalezené soubory: %i"
+  CHEAT_SELECTION: "Výběr cheatů"
+  HDD_HINT: "Povolen je jen jeden HDD; zapnutí uzamkne APA nebo GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID nepoužito -- neutrino.elf je na této kartě (přepnutí by vyložilo Neutrino)."
+  POPSTARTER_DEVICE: "Zařízení POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Zařízení s POPS/POPSTARTER.ELF pro spouštění PS1 VCD. Výchozí = zaváděcí zařízení (cwd), poté vlastní zařízení VCD. Custom zobrazí volné pole pro cestu."
+  BDMA_APPLY: "Použít VCD BDMA při spuštění"
+  HINT_BDMA_APPLY: "Zap.: před spuštěním automaticky nasadí na paměťovou kartu odpovídající ovladač exFAT spouštěného VCD (doporučeno). Vyp.: spravujte ručně pomocí voleb BDMA Source/Mode níže."
+  NETBOOT_RESTART: "Restartujte OPL pro použití změny protokolu síťového spouštění."
+  UDPFS_MODE: "Přístup UDPFS"
+  "MENU": "Menu"
+  "APPS": "Aplikace"
+  "DEBUG": "Ladicí barvy"
+  "COVERART": "Obal hry"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operace zápisu"
+  "MODE1": "Režim 1"
+  "MODE2": "Režim 2"
+  "MODE3": "Režim 3"
+  "MODE4": "Režim 4"
+  "MODE5": "Režim 5"
+  "MODE6": "Režim 6"
+  "ENABLEGSM": "Výběr GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Cheat engine PS2RD"
+  "PADEMU_ENABLE": "Emulátor ovladače"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulace"
+  "PADEMU_VIB": "Vibrace"
+  "PADEMU_WORKAROUND": "Náhrada za falešný DS3"
+  "SFX": "Zvukové efekty"
+  "BOOT_SND": "Zvuk při spuštění"
+  "ENABLE_NOTIFICATIONS": "Oznámení"
+  "OPTIONS": "Možnosti"
+  "GLOBAL_SETTINGS": "Obecné"
+  "INFO_GENRE": "Žánr"
+  "INFO_RELEASE": "Vydání"
+  "INFO_DESCRIPTION": "Popis"
+  "BLOCKDEVICE_SETTINGS": "Bloková zařízení"
+  "CONTROLLER_SETTINGS": "Nastavení ovladače"
+  "HINT_BDM_START": "Zapne/vypne správce blokových zařízení (BDM)."
+  "HINT_BLOCK_DEVICES": "Zapne/vypne bloková zařízení (např. USB)."
+  "USB_GAMES": "Hry USB"
+  "ILINK_GAMES": "Hry iLink"
+  "MX4SIO_GAMES": "Hry MX4SIO"
+  "PADMACROCONFIG": "Nastavit PADMACRO"
+  "PADMACRO_SETTINGS": "Nastavení maker ovladače"
+  "PADMACRO_ENABLE": "Makra ovladače"
+  "PADMACRO_SLOWDOWN": "Zpomalení analogu:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Sníží rozsah analogové páčky při stisknutí tlačítka"
+  "LEFT_ANALOG": "Levá páčka"
+  "RIGHT_ANALOG": "Pravá páčka"
+  "PADMACRO_INVERT_AXIS": "Invertovat osu analogu:"
+  "HINT_PADMACRO_INVERT_AXIS": "Invertuje osu analogové páčky"
+  "TURBO_SPEED": "Rychlost turbo tlačítka"
+  "HINT_TURBO_SPEED": "Jak rychle tisknout tlačítko, když je turbo aktivní"
+  "ACT_WHILE_PRESSED": "Při stisknutém tlačítku"
+  "ACT_TOGGLED": "Přepínáno tlačítkem"
+  "LANGUAGE_JAPANESE": "JAPONŠTINA"
+  "LANGUAGE_ENGLISH": "ANGLIČTINA"
+  "LANGUAGE_FRENCH": "FRANCOUZŠTINA"
+  "LANGUAGE_SPANISH": "ŠPANĚLŠTINA"
+  "LANGUAGE_GERMAN": "NĚMČINA"
+  "LANGUAGE_ITALIAN": "ITALŠTINA"
+  "LANGUAGE_DUTCH": "NIZOZEMŠTINA"
+  "LANGUAGE_PORTUGUESE": "PORTUGALŠTINA"
+  "LANGUAGE_RUSSIAN": "RUŠTINA"
+  "LANGUAGE_KOREAN": "KOREJŠTINA"
+  "LANGUAGE_TRAD_CHINESE": "TRADIČNÍ ČÍNŠTINA"
+  "LANGUAGE_SIMPL_CHINESE": "ZJEDNODUŠENÁ ČÍNŠTINA"
+  "OSD_SETTINGS": "Nastavení OSD"
+  "OSD_SETTINGS_LNG": "Jazyk OSD"
+  "ENABLE_LNG": "Změnit jazyk"
+  "BGM": "Hudba na pozadí"
+  "BGM_VOLUME": "Hlasitost hudby na pozadí"
+  "DEF_BGM_PATH": "Výchozí hudba motivu"
+  "DEF_BGM_PATH_HINT": "Nastaví cestu k přehrávané hudbě pro interní motiv."
+  "BOOT_SCANNING_MC": "Prohledávání paměťových karet..."
+  "BOOT_LOADING_DRIVERS": "Načítání ovladačů úložišť..."
+  "BOOT_LOADING_USB": "Načítání ovladače úložiště USB..."
+  "BOOT_ARMING_MMCE": "Aktivace herního ID MMCE..."
+  "BOOT_LOADING_SOUNDS": "Načítání zvuků motivu..."
+  "BOOT_BUILDING_MENU": "Sestavování menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS zapnuto -- otevřete novou kartu UDPFS a stiskněte Potvrdit pro připojení. Na straně PC běží udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Síťové blokové zařízení zapnuto -- jeho karta se objeví, jakmile odpoví PC server (udpfsd -bdpath pro UDPFS Image, udpbd-server pro UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Soubor VMC pro danou hru nenalezen -- spouštím bez něj (hra použije svou skutečnou kartu)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino nelze spustit z tohoto zařízení -- spuštění přerušeno."
+  "NEUTRINO_TOML_SYNC_FAILED": "Síťová konfigurace Neutrina (bsd toml) chybí nebo do ní nelze zapisovat -- spuštění přerušeno, zkontrolujte složku neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Příliš fragmentované pro Neutrino (%d fragmentů, limit %d včetně VMC) -- zkouším místo toho jádro OPL."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Příliš fragmentované pro Neutrino (%d fragmentů, limit %d včetně VMC) -- defragmentujte na PC; spuštění přerušeno."
+  "NEUTRINO_GSM_COMP": "Kompatibilita Neutrino GSM"
+  "HINT_NEUTRINO_GSM_COMP": "Oprava přepínáním polí pro hry, které se třesou nebo trhají při vynuceném Neutrino Video režimu. Vyžaduje nastavený Neutrino Video režim."
+  "NARGS_DBC": "Ladicí barvy (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Vypnout VMC 1 (ponechat kartu)"
+  "VMC_SLOT2_DISABLE": "Vypnout VMC 2 (ponechat kartu)"
+  "HINT_VMC_SLOT_DISABLE": "Spustí bez VMC tohoto slotu, přičemž jeho kartu ponechá nakonfigurovanou. Pouze spuštění přes Neutrino; hra pak použije skutečnou kartu v tomto slotu."
+  "NEUTRINO_BSDFS": "Souborový systém Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Vynutí souborový systém blokového zařízení Neutrina (-bsdfs). Auto = výchozí pro dané zařízení. hdl/bd jsou expertní volby; zkombinujte je s odpovídajícím -dvd= v argumentech spuštění, pokud automatický tvar cesty nevyhovuje."
+  "PLASCOLOR": "Barva prolnutí plazmy"
+  "VCD_HIDE_GAMEID": "Skrýt herní ID PS1 (seznam VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Pouze kosmetické -- skryje úvodní prefix s ID hry (např. SLUS_005.51.) z názvů v seznamu PS1/VCD. Názvy bez ID se zobrazují tak, jak jsou. Nemění spuštění, obal ani oblíbené."
+  "VCD_FIRST_DISC": "Pouze první disk (vícediskové PS1)"
+  "HINT_VCD_FIRST_DISC": "Zobrazí v seznamech zařízení pouze Disc 1 vícediskové hry PS1 (styl POPSLoader). Skryje soubory pojmenované (Disc 2), (CD 2) atd. Všechny disky zůstávají na kartě pro přepínání během hry; Oblíbené se nefiltrují."
+  "GAMES_DEVICE": "Zařízení hry"
+  "DEFAULT_CORE": "Výchozí jádro loaderu"
+  "HINT_DEFAULT_CORE": "Globální výchozí jádro pro hry, jejichž Loader Core pro danou hru je nastaven na Default. <OPL> je nativní jádro; Neutrino řetězí externí neutrino.elf. Volba u konkrétní hry toto vždy přepíše."
+  "VCD_SETTINGS": "Nastavení VCD"
+  "FINANCIAL_SUPPORT": "Finanční podpora"

--- a/lng_fork/Danish.yml
+++ b/lng_fork/Danish.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Sortér spil alfabetisk
+  RUMBLE: Controllervibration i menuer
+  HINT_RUMBLE: Kort vibration ved flytning af markøren, bekræftelse eller tilbage -- kræver en DualShock i analog tilstand
+  FOLDER_NAV: Gennemse mapper i spillisten
+  HINT_FOLDER_NAV: Vis undermapper på CD/DVD som mapper til gennemsyn -- vælg for at åbne, annuller for at gå tilbage
+  SETTINGS_NO_HOME: Intet hukommelseskort fundet -- indstillinger kan ikke gemmes. OPL blev startet fra en netværksenhed, hvis indstillinger skal ligge på et lokalt kort.
+  ERROR_SAVING_SETTINGS_TO: Kunne ikke skrive indstillinger til %s (fejl %d)
+  GENERAL_SETTINGS: Generelle indstillinger
+  DEVICE_SETTINGS: Enhedsindstillinger
+  LAUNCH_PS2_DISC: Start PS2-disk
+  DISC_LAUNCH_ERR: Ingen PS2-disk i drevet.
+  DEFAULT: Standard
+  HINT_MODE7: Kun Neutrino -- ret spil der overskrider en IOP-buffer (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat-billede
+  HINT_ENABLEIMAGE: Anvend et færdigbygget PS2RD .img-patch på dit spil.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE-spil
+  MMCEMODE: MMCE-starttilstand
+  MMCE_PREFIX: MMCE-præfiksti
+  MMCE_SLOT: MMCE-slot
+  MMCEIGR_SLOT: IGR-opstartskortstik(s)
+  HINT_MMCEIGR_SLOT: Skift til bootcard-kommando sendes til det/de valgte slot(s) ved IGR
+  MMCE_ADVANCED: Avanceret
+  MMCE_SETTINGS: MMCE-indstillinger
+  MMCE_SEMA: Lås sema-kømetode
+  HINT_MMCE_SEMA: THFIFO kan hjælpe kompatibilitet, men forringe ydeevne
+  MMCE_WAIT_CYCLES: Ventetakter efter /ACK lav
+  HINT_MMCE_WAIT_CYCLES: Lavere værdier kan forbedre ydeevne, men medføre ustabilitet
+  MMCE_USE_ALARMS: Brug timeout-alarmer
+  HINT_MMCE_USE_ALARMS: FRA kan hjælpe ydeevne, men MMCE-timeouts kan medføre frysninger
+  CORE_LOADER: Loader-kerne
+  NEUTRINO_BAD_FORMAT: Neutrino understøtter ikke dette filformat, starter med <OPL>-kernen
+  NEUTRINO_NOT_FOUND: Neutrino ELF ikke fundet, starter med <OPL>-kernen
+  UDPBD_NEEDS_STATIC_IP: UDPBD kræver en statisk PS2 IP. Indstil én i Netværkskonfiguration (DHCP er aktivt).
+  NEUTRINO_SETTING_NA: Denne indstilling bruges ikke med Neutrino-kernen.
+  POPSTARTER_NOT_FOUND: Mangler POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Mangler POPSTARTER SMB-forudsætninger
+  WRITE_POPSTARTER_NET: Skriv POPSTARTER-netværkskonfig
+  HINT_WRITE_POPSTARTER_NET: Gem også disse IP + SMB-delingsværdier til POPSTARTERs egne IPCONFIG.DAT / SMBCONFIG.DAT på hukommelseskortet (til VCD over SMB).
+  POPSTARTER_NET_ERR: Kunne ikke skrive POPSTARTER-netværkskonfig til hukommelseskortet.
+  VCD: VCD
+  VCD_ON: Viser VCD-spil
+  VCD_OFF: Viser diskspil
+  NEUTRINO_ARGS: Neutrino-startargumenter
+  HINT_NEUTRINO_ARGS: 'Ekstra Neutrino-flag, mellemrumsadskilt (f.eks. -mt=dvd). Global gælder alle spil; per spil tilføjes ovenpå. Præfiks et flag med $ for at deaktivere det uden at slette det.'
+  NEUTRINO_VIDEO: Neutrino-video
+  HINT_NEUTRINO_VIDEO: Tving Neutrinos GS-outputvideotilstand (-gsm). Fra bevarer spillets standard.
+  NEUTRINO_PATH: Neutrino ELF-sti
+  HINT_NEUTRINO_PATH: Fuld sti til neutrino.elf (f.eks. mc0:NEUTRINO/neutrino.elf). Tom = auto-søg på mc0/mc1.
+  POPSTARTER_PATH: POPSTARTER.ELF-sti
+  HINT_POPSTARTER_PATH: Brugerdefineret POPSTARTER.ELF-sti; falder stille tilbage til enhedens POPS-mappe hvis tom/manglende. Tastatur begrænset til 31 tegn; længere stier via settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA-kilde
+  HINT_BDMA_SOURCE: Enhed hvis POPS-mappe indeholder dine BDMAssault-driverfiler (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA-tilstand
+  HINT_BDMA_MODE: exFAT-blokenhedsdriveren POPSTARTER indlæser. Ændring kopierer modulerne til kortet; FAT32 = ingen (indbygget driver).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Intern HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: BDMA-modulfiler ikke fundet på kildeenheden.
+  BDMA_ERR_SPACE: Ikke nok hukommelseskortplads til BDMA-modulerne.
+  BDMA_ERR_IO: Fejl ved skrivning af BDMA-moduler til hukommelseskortet.
+  COVERFLOW_SETTINGS: Coverflow-indstillinger
+  COVERFLOW_COUNT: Coverantal
+  COVERFLOW_SCALE: Centersskala
+  COVERFLOW_ANIM: Animationshastighed
+  COVERFLOW_DIM: Dæmp sidecovers
+  NONE: Ingen
+  SMALL: Lille
+  LARGE: Stor
+  NORMAL: Normal
+  FAV: Favoritter
+  FAVMODE: Favorit-starttilstand
+  FAV_HINT: Favorit
+  FAV_MSG: '%s er ikke tilladt via Favoritmenuen.'
+  FAV_PERSISTENCE_MSG: '%s er ikke tilladt, mens elementet er markeret som favorit.'
+  NEUTRINO_DEVICE: Neutrino-enhed
+  HINT_NEUTRINO_DEVICE: Enhed med neutrino.elf (i en NEUTRINO/ eller neutrino/ mappe). Auto søger mc0 og derefter mc1.
+  NARGS_QB: Hurtig start (-qb)
+  NARGS_CWD: Arbejdsmappe (-cwd)
+  NARGS_CFG: Konfig (-cfg)
+  NARGS_ELF: Start-ELF (-elf)
+  NARGS_ATA0: ATA0-billede (-ata0)
+  NARGS_ATA0ID: ATA0-id (-ata0id)
+  NARGS_ATA1: ATA1-billede (-ata1)
+  NARGS_EXTRA: Ekstra argumenter
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar-arkiv med omslag
+  DISABLE_ALL: Deaktiver alle
+  BOOT_LOADING_CONFIG: Indlæser indstillinger...
+  BOOT_SCANNING_BDM: Scanner USB / kort / netværksdrev...
+  BOOT_SCANNING_NET: Starter netværk...
+  BOOT_SCANNING_HDD: Scanner HDD...
+  BOOT_READY: Klar.
+  UDPFS_GAMES: "UDPFS-spil"
+  UDPFSBD_GAMES: "UDPFSBD-spil"
+  NET_PROTOCOL: "Netværksprotokol"
+  NET_NEEDS_NEUTRINO: "Netværksspil (UDP) kan kun starte via Neutrino-kernen. Kontrollér, at neutrino.elf findes, og at formatet understøttes."
+  VCD_NOT_ON_NET: "PS1-spil (.VCD) kan ikke startes via netværksenheden."
+  MX4SIO_PADEMU_WARN: "MX4SIO og controller-emulering deler SIO2-bussen, og spillet starter måske ikke."
+  HINT_OSD_SETTINGS_LNG: "Gennemtving en tilpasset sprogindstilling"
+  OSD_SETTINGS_TVASPECT: "Skærmstørrelse"
+  FULL_SCREEN: "Fuld skærm"
+  OSD_SETTINGS_VMODE: "Videotilstand"
+  SYSTEM_DEFAULT: "Systemstandard"
+  HIGH: "Høj"
+  LOW: "Lav"
+  XSENSITIVITY: "Følsomhed analog X-akse"
+  YSENSITIVITY: "Følsomhed analog Y-akse"
+  FILE_COUNT: "Filer fundet: %i"
+  CHEAT_SELECTION: "Snydevalg"
+  HDD_HINT: "Kun én HDD tilladt; aktivering låser APA eller GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID ikke anvendt -- neutrino.elf er på dette kort (skift ville udlæse Neutrino)."
+  POPSTARTER_DEVICE: "POPSTARTER.ELF-enhed"
+  HINT_POPSTARTER_DEVICE: "Enhed med POPS/POPSTARTER.ELF til start af PS1-VCD'er. Standard = startenhed (cwd) derefter VCD'ens egen enhed. Tilpasset viser et frit stifelt."
+  BDMA_APPLY: "Anvend VCD BDMA ved start"
+  HINT_BDMA_APPLY: "Til: udstyrer automatisk den startede VCD's matchende exFAT-driver på hukommelseskortet før start (anbefales). Fra: håndtér det selv med BDMA-kilde/tilstand-vælgerne nedenfor."
+  NETBOOT_RESTART: "Genstart OPL for at anvende ændringen af netværksstartprotokollen."
+  UDPFS_MODE: "UDPFS-adgang"
+  "MENU": "Menu"
+  "APPS": "Apps"
+  "DEBUG": "Fejlfindingsfarver"
+  "COVERART": "Coveromslag"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Skrivehandlinger"
+  "MODE1": "Tilstand 1"
+  "MODE2": "Tilstand 2"
+  "MODE3": "Tilstand 3"
+  "MODE4": "Tilstand 4"
+  "MODE5": "Tilstand 5"
+  "MODE6": "Tilstand 6"
+  "ENABLEGSM": "GSM-vælger"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD-snydemotor"
+  "PADEMU_ENABLE": "Controlleremulator"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulering"
+  "PADEMU_VIB": "Vibration"
+  "PADEMU_WORKAROUND": "Falsk DS3-løsning"
+  "SFX": "Lydeffekter"
+  "BOOT_SND": "Opstartslyd"
+  "ENABLE_NOTIFICATIONS": "Notifikationer"
+  "OPTIONS": "Indstillinger"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Udgivelse"
+  "INFO_DESCRIPTION": "Beskrivelse"
+  "BLOCKDEVICE_SETTINGS": "Blokenheder"
+  "CONTROLLER_SETTINGS": "Controllerindstillinger"
+  "HINT_BDM_START": "Slå Block Device Manager til/fra."
+  "HINT_BLOCK_DEVICES": "Slå blokenheder til/fra (f.eks. USB)."
+  "USB_GAMES": "USB-spil"
+  "ILINK_GAMES": "iLink-spil"
+  "MX4SIO_GAMES": "MX4SIO-spil"
+  "PADMACROCONFIG": "Konfigurer PADMACRO"
+  "PADMACRO_SETTINGS": "Pad-makroindstillinger"
+  "PADMACRO_ENABLE": "Pad-makroer"
+  "PADMACRO_SLOWDOWN": "Analog nedbremsning:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Reducer det analoge stiks rækkevidde, når knappen trykkes ned"
+  "LEFT_ANALOG": "Venstre stik"
+  "RIGHT_ANALOG": "Højre stik"
+  "PADMACRO_INVERT_AXIS": "Analog akse-invertering:"
+  "HINT_PADMACRO_INVERT_AXIS": "Inverter det analoge stiks akse"
+  "TURBO_SPEED": "Turboknaphastighed"
+  "HINT_TURBO_SPEED": "Hvor hurtigt knappen trykkes, når turbo er aktiv"
+  "ACT_WHILE_PRESSED": "Mens knappen holdes nede"
+  "ACT_TOGGLED": "Skiftes med knappen"
+  "LANGUAGE_JAPANESE": "JAPANSK"
+  "LANGUAGE_ENGLISH": "ENGELSK"
+  "LANGUAGE_FRENCH": "FRANSK"
+  "LANGUAGE_SPANISH": "SPANSK"
+  "LANGUAGE_GERMAN": "TYSK"
+  "LANGUAGE_ITALIAN": "ITALIENSK"
+  "LANGUAGE_DUTCH": "HOLLANDSK"
+  "LANGUAGE_PORTUGUESE": "PORTUGISISK"
+  "LANGUAGE_RUSSIAN": "RUSSISK"
+  "LANGUAGE_KOREAN": "KOREANSK"
+  "LANGUAGE_TRAD_CHINESE": "TRADITIONELT KINESISK"
+  "LANGUAGE_SIMPL_CHINESE": "FORENKLET KINESISK"
+  "OSD_SETTINGS": "OSD-indstillinger"
+  "OSD_SETTINGS_LNG": "OSD-sprog"
+  "ENABLE_LNG": "Skift sprog"
+  "BGM": "Baggrundsmusik"
+  "BGM_VOLUME": "Baggrundsmusikkens lydstyrke"
+  "DEF_BGM_PATH": "Standard temamusik"
+  "DEF_BGM_PATH_HINT": "Angiv sti til streaming af musik til internt tema."
+  "BOOT_SCANNING_MC": "Scanner hukommelseskort..."
+  "BOOT_LOADING_DRIVERS": "Indlæser lagerdrivere..."
+  "BOOT_LOADING_USB": "Indlæser USB-lagerdriver..."
+  "BOOT_ARMING_MMCE": "Aktiverer MMCE-spil-ID..."
+  "BOOT_LOADING_SOUNDS": "Indlæser temalyde..."
+  "BOOT_BUILDING_MENU": "Bygger menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS til -- åbn den nye UDPFS-fane og tryk på Bekræft for at forbinde. På PC-siden køres udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Netværksblokenhed til -- dens fane vises, når PC-serveren svarer (udpfsd -bdpath for UDPFS Image, udpbd-server for UDPBD)."
+  "NEUTRINO_VMC_MISSING": "VMC-fil pr. spil blev ikke fundet -- starter uden den (spillet bruger sit rigtige kort)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino kan ikke starte fra denne enhed -- start afbrudt."
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino-netværkskonfiguration (bsd toml) mangler eller kan ikke skrives -- start afbrudt, tjek neutrino-mappen."
+  "NEUTRINO_TOO_FRAGMENTED": "For fragmenteret til Neutrino (%d fragmenter, grænse %d inkl. VMC'er) -- prøver OPL-kernen i stedet."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "For fragmenteret til Neutrino (%d fragmenter, grænse %d inkl. VMC'er) -- defragmentér på pc'en; start afbrudt."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM-kompatibilitet"
+  "HINT_NEUTRINO_GSM_COMP": "Field-flipping-rettelse for spil, der ryster eller flænser under en fremtvunget Neutrino Video-tilstand. Kræver en Neutrino Video-tilstand indstillet."
+  "NARGS_DBC": "Fejlfindingsfarver (-dbc)"
+  "NARGS_LOGO": "PS2-logo (-logo)"
+  "VMC_SLOT1_DISABLE": "Deaktiver VMC 1 (behold kort)"
+  "VMC_SLOT2_DISABLE": "Deaktiver VMC 2 (behold kort)"
+  "HINT_VMC_SLOT_DISABLE": "Start uden denne plads' VMC, mens dens kort forbliver konfigureret. Kun Neutrino-start; spillet bruger derefter det rigtige kort i den plads."
+  "NEUTRINO_BSDFS": "Neutrino-filsystem"
+  "HINT_NEUTRINO_BSDFS": "Fremtving Neutrinos blokenheds-filsystem (-bsdfs). Auto = standard pr. enhed. hdl/bd er ekspertindstillinger; kombinér dem med et matchende -dvd= i startargumenterne, hvis den automatiske stiform ikke passer."
+  "PLASCOLOR": "Plasma-blandingsfarve"
+  "VCD_HIDE_GAMEID": "Skjul PS1-spil-ID (VCD-liste)"
+  "HINT_VCD_HIDE_GAMEID": "Kun kosmetisk -- skjul et indledende spil-ID-præfiks (f.eks. SLUS_005.51.) fra navne i PS1/VCD-listen. Navne uden et ID vises som de er. Ændrer ikke start, cover-art eller favoritter."
+  "VCD_FIRST_DISC": "Kun første disk (fler-disk PS1)"
+  "HINT_VCD_FIRST_DISC": "Vis kun disk 1 af et PS1-spil med flere diske i enhedslisterne (POPSLoader-stil). Skjuler filer med navne som (Disc 2), (CD 2) osv. Alle diske forbliver på kortet til skift under spil; Favoritter filtreres ikke."
+  "GAMES_DEVICE": "Spillets enhed"
+  "DEFAULT_CORE": "Standard Loader Core"
+  "HINT_DEFAULT_CORE": "Global standardkerne for spil, hvis Loader Core pr. spil er sat til Default. <OPL> er den native kerne; Neutrino kæder den eksterne neutrino.elf. Et valg pr. spil tilsidesætter altid dette."
+  "VCD_SETTINGS": "VCD-indstillinger"
+  "FINANCIAL_SUPPORT": "Økonomisk støtte"

--- a/lng_fork/Dutch.yml
+++ b/lng_fork/Dutch.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Games alfabetisch sorteren
+  RUMBLE: Controllertrilling in menu's
+  HINT_RUMBLE: Korte trilling bij verplaatsen van de cursor, bevestigen of teruggaan -- vereist een DualShock in analoge modus
+  FOLDER_NAV: Mappen doorbladeren in gamelijst
+  HINT_FOLDER_NAV: Toon submappen van cd/dvd als doorbladerbare items -- selecteer om te openen, annuleer om terug te gaan
+  SETTINGS_NO_HOME: Geen geheugenkaart gevonden -- instellingen kunnen niet worden opgeslagen. OPL is opgestart vanaf een netwerkapparaat, waarvan de instellingen op een lokale kaart moeten staan.
+  ERROR_SAVING_SETTINGS_TO: Kan instellingen niet naar %s schrijven (fout %d)
+  GENERAL_SETTINGS: Algemene instellingen
+  DEVICE_SETTINGS: Apparaatinstellingen
+  LAUNCH_PS2_DISC: PS2-schijf starten
+  DISC_LAUNCH_ERR: Geen PS2-schijf in het station.
+  DEFAULT: Standaard
+  HINT_MODE7: Alleen Neutrino -- herstel spellen die een IOP-buffer overschrijden (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat-image
+  HINT_ENABLEIMAGE: Pas een voorgebouwde PS2RD .img-patch toe op je spel.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE startmodus
+  MMCE_PREFIX: MMCE voorvoegselpad
+  MMCE_SLOT: MMCE-slot
+  MMCEIGR_SLOT: IGR-opstartkaartslot(s)
+  HINT_MMCEIGR_SLOT: Bij IGR wordt de schakelaarcommand naar het/de geselecteerde slot(s) gestuurd
+  MMCE_ADVANCED: Geavanceerd
+  MMCE_SETTINGS: MMCE-instellingen
+  MMCE_SEMA: Vergrendeling Sema-wachtrijmethode
+  HINT_MMCE_SEMA: THFIFO kan de compatibiliteit verbeteren maar de prestaties verslechteren
+  MMCE_WAIT_CYCLES: Wachtcycli na /ACK laag
+  HINT_MMCE_WAIT_CYCLES: Lagere waarden kunnen de prestaties verbeteren maar instabiliteit veroorzaken
+  MMCE_USE_ALARMS: Gebruik time-outalarms
+  HINT_MMCE_USE_ALARMS: UIT kan prestaties verbeteren maar MMCE-time-outs kunnen bevriezingen veroorzaken
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino ondersteunt dit bestandsformaat niet; gestart met <OPL>-kern
+  NEUTRINO_NOT_FOUND: Neutrino ELF niet gevonden; gestart met <OPL>-kern
+  UDPBD_NEEDS_STATIC_IP: UDPBD vereist een statisch PS2-IP. Stel dit in bij Netwerkconfiguratie (DHCP is momenteel ingeschakeld).
+  NEUTRINO_SETTING_NA: Deze instelling wordt niet gebruikt met de Neutrino-kern.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF ontbreekt
+  POPSTARTER_SMB_MISSING: POPSTARTER SMB-vereisten ontbreken
+  WRITE_POPSTARTER_NET: POPSTARTER-netwerkconfiguratie schrijven
+  HINT_WRITE_POPSTARTER_NET: Sla ook deze IP- en SMB-sharewaarden op in POPSTARTER's eigen IPCONFIG.DAT / SMBCONFIG.DAT op de geheugenkaart (voor VCD via SMB).
+  POPSTARTER_NET_ERR: Kan POPSTARTER-netwerkconfiguratie niet naar de geheugenkaart schrijven.
+  VCD: VCD
+  VCD_ON: VCD-spellen worden getoond
+  VCD_OFF: Schijfspellen worden getoond
+  NEUTRINO_ARGS: Neutrino opstartargumenten
+  HINT_NEUTRINO_ARGS: Extra Neutrino-vlaggen, spatie-gescheiden (bijv. -mt=dvd). Globaal geldt voor alle spellen; per spel wordt bovenop toegevoegd. Prefix een vlag met $ om hem te deactiveren zonder te verwijderen.
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: Forceer Neutrino's GS-uitvoervideomodus (-gsm). Uit behoudt de standaard van het spel.
+  NEUTRINO_PATH: Neutrino ELF-pad
+  HINT_NEUTRINO_PATH: Volledig pad naar neutrino.elf (bijv. mc0:NEUTRINO/neutrino.elf). Leeg = automatisch zoeken op mc0/mc1.
+  POPSTARTER_PATH: POPSTARTER.ELF-pad
+  HINT_POPSTARTER_PATH: Aangepast POPSTARTER.ELF-pad; valt stil terug op de POPS-map van het apparaat indien leeg/ontbrekend. Toetsenbord beperkt tot 31 tekens; langere paden via settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA-bron
+  HINT_BDMA_SOURCE: Apparaat waarvan de POPS-map de BDMAssault-stuurprogrammabestanden bevat (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA-modus
+  HINT_BDMA_MODE: exFAT-blokapparaatstuurprogramma dat POPSTARTER laadt. Wijzigen kopieert de modules naar de kaart; FAT32 = geen (ingebouwd stuurprogramma).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Interne HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: BDMA-modulebestanden niet gevonden op het bronapparaat.
+  BDMA_ERR_SPACE: Onvoldoende geheugenkaartruimte voor de BDMA-modules.
+  BDMA_ERR_IO: Fout bij schrijven van de BDMA-modules naar de geheugenkaart.
+  COVERFLOW_SETTINGS: Coverflow-instellingen
+  COVERFLOW_COUNT: Aantal hoezen
+  COVERFLOW_SCALE: Middenschaal
+  COVERFLOW_ANIM: Animatiesnelheid
+  COVERFLOW_DIM: Zijhoezen dimmen
+  NONE: Geen
+  SMALL: Klein
+  LARGE: Groot
+  NORMAL: Normaal
+  FAV: Favorieten
+  FAVMODE: Favorieten startmodus
+  FAV_HINT: Favoriet
+  FAV_MSG: '%s is niet toegestaan via het favorietenmenu.'
+  FAV_PERSISTENCE_MSG: '%s is niet toegestaan terwijl het item als favoriet is gemarkeerd.'
+  NEUTRINO_DEVICE: Neutrino-apparaat
+  HINT_NEUTRINO_DEVICE: Apparaat met neutrino.elf (in een NEUTRINO/- of neutrino/-map). Auto scant eerst mc0, dan mc1.
+  NARGS_QB: Snel opstarten (-qb)
+  NARGS_CWD: Werkmap (-cwd)
+  NARGS_CFG: Configuratie (-cfg)
+  NARGS_ELF: Opstart-ELF (-elf)
+  NARGS_ATA0: ATA0-image (-ata0)
+  NARGS_ATA0ID: ATA0-ID (-ata0id)
+  NARGS_ATA1: ATA1-image (-ata1)
+  NARGS_EXTRA: Extra argumenten
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar-archief met hoezen
+  DISABLE_ALL: Alles uitschakelen
+  BOOT_LOADING_CONFIG: Instellingen laden...
+  BOOT_SCANNING_BDM: USB / kaart / netwerkschijven scannen...
+  BOOT_SCANNING_NET: Netwerk starten...
+  BOOT_SCANNING_HDD: HDD scannen...
+  BOOT_READY: Klaar.
+  UDPFS_GAMES: "UDPFS-spellen"
+  UDPFSBD_GAMES: "UDPFSBD-spellen"
+  NET_PROTOCOL: "Netwerkprotocol"
+  NET_NEEDS_NEUTRINO: "Netwerkspellen (UDP) kunnen alleen starten via de Neutrino-core. Controleer of neutrino.elf aanwezig is en het formaat wordt ondersteund."
+  VCD_NOT_ON_NET: "PS1-spellen (.VCD) kunnen niet via het netwerkapparaat worden gestart."
+  MX4SIO_PADEMU_WARN: "MX4SIO en pad-emulatie delen de SIO2-bus en het spel start mogelijk niet."
+  HINT_OSD_SETTINGS_LNG: "Een aangepaste taalinstelling afdwingen"
+  OSD_SETTINGS_TVASPECT: "Schermgrootte"
+  FULL_SCREEN: "Volledig scherm"
+  OSD_SETTINGS_VMODE: "Videomodus"
+  SYSTEM_DEFAULT: "Systeemstandaard"
+  HIGH: "Hoog"
+  LOW: "Laag"
+  XSENSITIVITY: "Gevoeligheid analoge X-as"
+  YSENSITIVITY: "Gevoeligheid analoge Y-as"
+  FILE_COUNT: "Bestanden gevonden: %i"
+  CHEAT_SELECTION: "Cheatselectie"
+  HDD_HINT: "Slechts één HDD toegestaan; inschakelen vergrendelt APA of GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID niet toegepast -- neutrino.elf staat op deze kaart (wisselen zou Neutrino ontladen)."
+  POPSTARTER_DEVICE: "POPSTARTER.ELF-apparaat"
+  HINT_POPSTARTER_DEVICE: "Apparaat met POPS/POPSTARTER.ELF voor het starten van PS1-VCD's. Standaard = bootapparaat (cwd) daarna het eigen apparaat van de VCD. Aangepast toont een vrij pad-veld."
+  BDMA_APPLY: "VCD BDMA toepassen bij starten"
+  HINT_BDMA_APPLY: "Aan: rust automatisch de bijpassende exFAT-driver van de gestarte VCD uit op de geheugenkaart vóór het booten (aanbevolen). Uit: beheer dit zelf met de BDMA-bron/modus-kiezers hieronder."
+  NETBOOT_RESTART: "Herstart OPL om de wijziging van het netwerk-bootprotocol toe te passen."
+  UDPFS_MODE: "UDPFS-toegang"
+  "MENU": "Menu"
+  "APPS": "Apps"
+  "DEBUG": "Debugkleuren"
+  "COVERART": "Omslagafbeelding"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Schrijfbewerkingen"
+  "MODE1": "Modus 1"
+  "MODE2": "Modus 2"
+  "MODE3": "Modus 3"
+  "MODE4": "Modus 4"
+  "MODE5": "Modus 5"
+  "MODE6": "Modus 6"
+  "ENABLEGSM": "GSM-selector"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD-cheatengine"
+  "PADEMU_ENABLE": "Pad-emulator"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulatie"
+  "PADEMU_VIB": "Trilling"
+  "PADEMU_WORKAROUND": "Nep-DS3-oplossing"
+  "SFX": "Geluidseffecten"
+  "BOOT_SND": "Opstartgeluid"
+  "ENABLE_NOTIFICATIONS": "Meldingen"
+  "OPTIONS": "Opties"
+  "GLOBAL_SETTINGS": "Globaal"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Uitgave"
+  "INFO_DESCRIPTION": "Beschrijving"
+  "BLOCKDEVICE_SETTINGS": "Blokapparaten"
+  "CONTROLLER_SETTINGS": "Controllerinstellingen"
+  "HINT_BDM_START": "Block Device Manager in-/uitschakelen."
+  "HINT_BLOCK_DEVICES": "Blokapparaten in-/uitschakelen (bijv. USB)."
+  "USB_GAMES": "USB-games"
+  "ILINK_GAMES": "iLink-games"
+  "MX4SIO_GAMES": "MX4SIO-games"
+  "PADMACROCONFIG": "PADMACRO configureren"
+  "PADMACRO_SETTINGS": "Padmacro-instellingen"
+  "PADMACRO_ENABLE": "Padmacro's"
+  "PADMACRO_SLOWDOWN": "Analoge vertraging:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Bereik van de analoge stick verkleinen wanneer een knop wordt ingedrukt"
+  "LEFT_ANALOG": "Linkerstick"
+  "RIGHT_ANALOG": "Rechterstick"
+  "PADMACRO_INVERT_AXIS": "Analoge as omkeren:"
+  "HINT_PADMACRO_INVERT_AXIS": "As van de analoge stick omkeren"
+  "TURBO_SPEED": "Turboknopsnelheid"
+  "HINT_TURBO_SPEED": "Hoe snel de knop wordt ingedrukt wanneer turbo actief is"
+  "ACT_WHILE_PRESSED": "Terwijl knop ingedrukt"
+  "ACT_TOGGLED": "In-/uitgeschakeld met knop"
+  "LANGUAGE_JAPANESE": "JAPANS"
+  "LANGUAGE_ENGLISH": "ENGELS"
+  "LANGUAGE_FRENCH": "FRANS"
+  "LANGUAGE_SPANISH": "SPAANS"
+  "LANGUAGE_GERMAN": "DUITS"
+  "LANGUAGE_ITALIAN": "ITALIAANS"
+  "LANGUAGE_DUTCH": "NEDERLANDS"
+  "LANGUAGE_PORTUGUESE": "PORTUGEES"
+  "LANGUAGE_RUSSIAN": "RUSSISCH"
+  "LANGUAGE_KOREAN": "KOREAANS"
+  "LANGUAGE_TRAD_CHINESE": "TRADITIONEEL CHINEES"
+  "LANGUAGE_SIMPL_CHINESE": "VEREENVOUDIGD CHINEES"
+  "OSD_SETTINGS": "OSD-instellingen"
+  "OSD_SETTINGS_LNG": "OSD-taal"
+  "ENABLE_LNG": "Taal wijzigen"
+  "BGM": "Achtergrondmuziek"
+  "BGM_VOLUME": "Volume achtergrondmuziek"
+  "DEF_BGM_PATH": "Standaard themamuziek"
+  "DEF_BGM_PATH_HINT": "Stel het pad in voor het streamen van muziek voor het interne thema."
+  "BOOT_SCANNING_MC": "Geheugenkaarten scannen..."
+  "BOOT_LOADING_DRIVERS": "Opslagstuurprogramma's laden..."
+  "BOOT_LOADING_USB": "USB-opslagstuurprogramma laden..."
+  "BOOT_ARMING_MMCE": "MMCE game-ID activeren..."
+  "BOOT_LOADING_SOUNDS": "Themageluiden laden..."
+  "BOOT_BUILDING_MENU": "Menu opbouwen..."
+  "NET_UDPFS_TAB_HINT": "UDPFS aan -- open het nieuwe UDPFS-tabblad en druk op Bevestigen om te verbinden. Aan de pc-kant draait udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Netwerk-block-device aan -- het tabblad verschijnt zodra de pc-server antwoordt (udpfsd -bdpath voor UDPFS Image, udpbd-server voor UDPBD)."
+  "NEUTRINO_VMC_MISSING": "VMC-bestand per spel niet gevonden -- start zonder dit (het spel gebruikt zijn echte kaart)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino kan niet vanaf dit apparaat starten -- starten afgebroken."
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino-netwerkconfiguratie (bsd toml) ontbreekt of is niet schrijfbaar -- starten afgebroken, controleer de neutrino-map."
+  "NEUTRINO_TOO_FRAGMENTED": "Te gefragmenteerd voor Neutrino (%d fragmenten, limiet %d incl. VMC's) -- de OPL-core wordt in plaats daarvan geprobeerd."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Te gefragmenteerd voor Neutrino (%d fragmenten, limiet %d incl. VMC's) -- defragmenteer op de pc; starten afgebroken."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM-compatibiliteit"
+  "HINT_NEUTRINO_GSM_COMP": "Field-flipping-oplossing voor spellen die schudden of scheuren onder een geforceerde Neutrino-videomodus. Vereist een ingestelde Neutrino-videomodus."
+  "NARGS_DBC": "Debugkleuren (-dbc)"
+  "NARGS_LOGO": "PS2-logo (-logo)"
+  "VMC_SLOT1_DISABLE": "VMC 1 uitschakelen (kaart behouden)"
+  "VMC_SLOT2_DISABLE": "VMC 2 uitschakelen (kaart behouden)"
+  "HINT_VMC_SLOT_DISABLE": "Start zonder de VMC van dit slot terwijl de kaart geconfigureerd blijft. Alleen bij het starten van Neutrino; het spel gebruikt dan de echte kaart in dat slot."
+  "NEUTRINO_BSDFS": "Neutrino-bestandssysteem"
+  "HINT_NEUTRINO_BSDFS": "Forceer Neutrino's block-device-bestandssysteem (-bsdfs). Auto = standaard per apparaat. hdl/bd zijn opties voor experts; combineer ze met een bijpassende -dvd= in de opstartargumenten als de vorm van het auto-pad niet past."
+  "PLASCOLOR": "Plasma-mengkleur"
+  "VCD_HIDE_GAMEID": "PS1 game-ID verbergen (VCD-lijst)"
+  "HINT_VCD_HIDE_GAMEID": "Alleen cosmetisch -- verberg een voorloopprefix met spel-ID (bijv. SLUS_005.51.) in de namen van de PS1/VCD-lijst. Namen zonder ID worden ongewijzigd getoond. Verandert niets aan opstarten, hoesillustratie of favorieten."
+  "VCD_FIRST_DISC": "Alleen eerste disc (multi-disc PS1)"
+  "HINT_VCD_FIRST_DISC": "Toon alleen Disc 1 van een PS1-spel met meerdere discs in de apparaatlijsten (POPSLoader-stijl). Verbergt bestanden met de naam (Disc 2), (CD 2), enz. Alle discs blijven op de kaart staan om tijdens het spel te wisselen; Favorieten worden niet gefilterd."
+  "GAMES_DEVICE": "Apparaat van game"
+  "DEFAULT_CORE": "Standaard Loader Core"
+  "HINT_DEFAULT_CORE": "Globale standaardcore voor spellen waarvan de Loader Core per spel op Default is ingesteld. <OPL> is de native core; Neutrino koppelt de externe neutrino.elf. Een keuze per spel overschrijft dit altijd."
+  "VCD_SETTINGS": "VCD-instellingen"
+  "FINANCIAL_SUPPORT": "Financiële steun"

--- a/lng_fork/Filipino.yml
+++ b/lng_fork/Filipino.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Isaayos ang Laro Ayon sa Alpabeto
+  RUMBLE: Pag-vibrate ng Kontroler sa Menu
+  HINT_RUMBLE: Maikling vibration kapag ginagalaw ang cursor, kinukumpirma o bumabalik -- kailangan ng DualShock na naka-analog mode
+  FOLDER_NAV: Mag-browse ng Folder sa Listahan ng Laro
+  HINT_FOLDER_NAV: Ipakita ang mga subfolder ng CD/DVD bilang mabu-browse na entry; piliin para buksan, kanselahin para bumalik
+  SETTINGS_NO_HOME: Walang nakitang memory card -- hindi ma-save ang mga setting. Naka-boot ang OPL mula sa network device, na ang mga setting ay dapat nasa lokal na card.
+  ERROR_SAVING_SETTINGS_TO: Hindi maisulat ang mga setting sa %s (error %d)
+  GENERAL_SETTINGS: Pangkalahatang Mga Setting
+  DEVICE_SETTINGS: Mga Setting ng Device
+  LAUNCH_PS2_DISC: I-launch ang PS2 Disc
+  DISC_LAUNCH_ERR: Walang PS2 disc sa drive.
+  DEFAULT: Default
+  HINT_MODE7: Neutrino lamang -- ayusin ang mga laro na lumagpas sa IOP buffer (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Mag-apply ng prebuilt na PS2RD .img patch sa iyong laro.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE Start Mode
+  MMCE_PREFIX: MMCE Prefix Path
+  MMCE_SLOT: MMCE Slot
+  MMCEIGR_SLOT: IGR Bootcard Slot(s)
+  HINT_MMCEIGR_SLOT: Ang utos na lumipat sa bootcard ay ipapadala sa napiling slot(s) sa IGR
+  MMCE_ADVANCED: Advanced
+  MMCE_SETTINGS: MMCE Settings
+  MMCE_SEMA: Lock Sema Enqueuing Method
+  HINT_MMCE_SEMA: Maaaring makatulong ang THFIFO sa compatibility ngunit makakapagpabagal ng performance
+  MMCE_WAIT_CYCLES: Maghintay ng cycles pagkatapos ng /ACK low
+  HINT_MMCE_WAIT_CYCLES: Ang mas mababang halaga ay maaaring mapabuti ang performance ngunit maaaring magdulot ng kawalang-tatag
+  MMCE_USE_ALARMS: Gumamit ng timeout alarms
+  HINT_MMCE_USE_ALARMS: Ang OFF ay maaaring makatulong sa performance ngunit maaaring maging sanhi ng MMCE timeout na mag-freeze
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Hindi sinusuportahan ng Neutrino ang format na ito, inilulunsad gamit ang <OPL> core
+  NEUTRINO_NOT_FOUND: Hindi nahanap ang Neutrino ELF, inilulunsad gamit ang <OPL> core
+  UDPBD_NEEDS_STATIC_IP: Kailangan ng UDPBD ng static na PS2 IP. Itakda sa Network Config (naka-on ang DHCP ngayon).
+  NEUTRINO_SETTING_NA: Hindi ginagamit ang setting na ito sa Neutrino core.
+  POPSTARTER_NOT_FOUND: Nawawala ang POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Nawawala ang mga kinakailangan ng POPSTARTER para sa SMB
+  WRITE_POPSTARTER_NET: I-save ang POPSTARTER Network Config
+  HINT_WRITE_POPSTARTER_NET: I-save din ang mga IP + SMB share na ito sa sariling IPCONFIG.DAT / SMBCONFIG.DAT ng POPSTARTER sa memory card (para sa VCD-over-SMB).
+  POPSTARTER_NET_ERR: Hindi nasulat ang POPSTARTER network config sa memory card.
+  VCD: VCD
+  VCD_ON: Ipinapakita ang mga VCD game
+  VCD_OFF: Ipinapakita ang mga disc game
+  NEUTRINO_ARGS: Neutrino Launch Args
+  HINT_NEUTRINO_ARGS: Karagdagang Neutrino flags, pinaghiwalay ng espasyo (hal. -mt=dvd). Ang Global ay naaangkop sa lahat ng laro; ang per-game ay nadaragdag pa. Lagyan ng $ prefix ang isang flag para i-disable nang hindi binubura.
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: Pilitin ang GS output video mode ng Neutrino (-gsm). Ang Off ay pinapanatili ang default ng laro.
+  NEUTRINO_PATH: Neutrino ELF Path
+  HINT_NEUTRINO_PATH: 'Buong path patungo sa neutrino.elf (hal. mc0:NEUTRINO/neutrino.elf). Blangko = auto-detect sa mc0/mc1.'
+  POPSTARTER_PATH: POPSTARTER.ELF Path
+  HINT_POPSTARTER_PATH: Custom na POPSTARTER.ELF path; bumabalik sa POPS folder ng device kung blangko/nawawala. Ang keyboard ay limitado sa 31 chars; mas mahabang paths sa pamamagitan ng settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA Source
+  HINT_BDMA_SOURCE: Device na ang POPS folder ay naglalaman ng iyong BDMAssault driver files (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Mode
+  HINT_BDMA_MODE: exFAT block-device driver na inilulunsad ng POPSTARTER. Ang pagbabago nito ay nagkokopya ng mga module sa card; FAT32 = wala (built-in driver).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Internal HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Hindi nahanap ang mga BDMA module file sa source device.
+  BDMA_ERR_SPACE: Hindi sapat ang espasyo ng memory card para sa mga BDMA module.
+  BDMA_ERR_IO: Error sa pagsulat ng mga BDMA module sa memory card.
+  COVERFLOW_SETTINGS: Coverflow Settings
+  COVERFLOW_COUNT: Bilang ng Cover
+  COVERFLOW_SCALE: Center Scale
+  COVERFLOW_ANIM: Bilis ng Animation
+  COVERFLOW_DIM: Dimimin ang Mga Side Cover
+  NONE: Wala
+  SMALL: Maliit
+  LARGE: Malaki
+  NORMAL: Normal
+  FAV: Mga Paborito
+  FAVMODE: Favourites Start Mode
+  FAV_HINT: Paborito
+  FAV_MSG: '%s ay hindi pinapayagan sa Favourites Menu.'
+  FAV_PERSISTENCE_MSG: '%s ay hindi pinapayagan habang naka-marka ang item bilang paborito.'
+  NEUTRINO_DEVICE: Neutrino Device
+  HINT_NEUTRINO_DEVICE: Device na naglalaman ng neutrino.elf (sa loob ng NEUTRINO/ o neutrino/ folder). Ang Auto ay nagsa-scan muna sa mc0 pagkatapos mc1.
+  NARGS_QB: Quick Boot (-qb)
+  NARGS_CWD: Working Dir (-cwd)
+  NARGS_CFG: Config (-cfg)
+  NARGS_ELF: Boot ELF (-elf)
+  NARGS_ATA0: ATA0 Image (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 Image (-ata1)
+  NARGS_EXTRA: Karagdagang Args
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar archive ng pabalat
+  DISABLE_ALL: I-disable Lahat
+  BOOT_LOADING_CONFIG: Naglo-load ng mga setting...
+  BOOT_SCANNING_BDM: Sina-scan ang USB / card / network drives...
+  BOOT_SCANNING_NET: Sinisimulan ang network...
+  BOOT_SCANNING_HDD: Sina-scan ang HDD...
+  BOOT_READY: Handa na.
+  UDPFS_GAMES: "Mga Laro sa UDPFS"
+  UDPFSBD_GAMES: "Mga Laro sa UDPFSBD"
+  NET_PROTOCOL: "Protocol ng Network"
+  NET_NEEDS_NEUTRINO: "Ang mga larong network (UDP) ay maaari lamang mag-boot sa pamamagitan ng Neutrino core. Tiyaking naroon ang neutrino.elf at suportado ang format."
+  VCD_NOT_ON_NET: "Hindi mailulunsad ang mga larong PS1 (.VCD) sa pamamagitan ng network device."
+  MX4SIO_PADEMU_WARN: "Ang MX4SIO at pad emulation ay nagbabahagi ng SIO2 bus at maaaring mabigo ang laro sa pag-boot."
+  HINT_OSD_SETTINGS_LNG: "Piliting gumamit ng custom na configuration ng wika"
+  OSD_SETTINGS_TVASPECT: "Laki ng Screen"
+  FULL_SCREEN: "Buong Screen"
+  OSD_SETTINGS_VMODE: "Video Mode"
+  SYSTEM_DEFAULT: "Default ng System"
+  HIGH: "Mataas"
+  LOW: "Mababa"
+  XSENSITIVITY: "Sensitivity ng Analog X-Axis"
+  YSENSITIVITY: "Sensitivity ng Analog Y-Axis"
+  FILE_COUNT: "Mga file na natagpuan: %i"
+  CHEAT_SELECTION: "Pagpili ng Cheat"
+  HDD_HINT: "Isang HDD lang ang pinapayagan, kapag inilagay ay ni-lock ang APA o GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "Hindi inilapat ang MMCE GameID -- naroon ang neutrino.elf sa card na ito (kapag pinalitan ito ay mai-uload ang Neutrino)."
+  POPSTARTER_DEVICE: "Device ng POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Device na naglalaman ng POPS/POPSTARTER.ELF para sa mga paglulunsad ng PS1 VCD. Default = boot device (cwd) tapos ang sariling device ng VCD. Ang Custom ay nagpapakita ng free-text na path."
+  BDMA_APPLY: "Ilapat ang VCD BDMA sa Paglulunsad"
+  HINT_BDMA_APPLY: "Naka-on: awtomatikong ikabit ang tugmang exFAT driver ng inilunsad na VCD sa memory card bago mag-boot (inirerekomenda). Naka-off: pamahalaan ito nang mag-isa gamit ang mga pantukoy na Source/Mode ng BDMA sa ibaba."
+  NETBOOT_RESTART: "I-restart ang OPL para ilapat ang pagbabago sa network boot protocol."
+  UDPFS_MODE: "Pag-access ng UDPFS"
+  "MENU": "Menu"
+  "APPS": "Apps"
+  "DEBUG": "Mga Kulay ng Debug"
+  "COVERART": "Cover Art"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Mga Write Operation"
+  "MODE1": "Mode 1"
+  "MODE2": "Mode 2"
+  "MODE3": "Mode 3"
+  "MODE4": "Mode 4"
+  "MODE5": "Mode 5"
+  "MODE6": "Mode 6"
+  "ENABLEGSM": "GSM Selector"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD Cheat Engine"
+  "PADEMU_ENABLE": "Pad Emulator"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulation"
+  "PADEMU_VIB": "Vibration"
+  "PADEMU_WORKAROUND": "Fake DS3 Workaround"
+  "SFX": "Mga Sound Effect"
+  "BOOT_SND": "Boot Sound"
+  "ENABLE_NOTIFICATIONS": "Mga Notification"
+  "OPTIONS": "Mga Opsyon"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Release"
+  "INFO_DESCRIPTION": "Deskripsyon"
+  "BLOCKDEVICE_SETTINGS": "Mga Block Device"
+  "CONTROLLER_SETTINGS": "Mga Setting ng Controller"
+  "HINT_BDM_START": "I-on/off ang Block Device Manager."
+  "HINT_BLOCK_DEVICES": "I-on/off ang Mga Block Device (hal. USB)."
+  "USB_GAMES": "Mga USB Game"
+  "ILINK_GAMES": "Mga iLink Game"
+  "MX4SIO_GAMES": "Mga MX4SIO Game"
+  "PADMACROCONFIG": "I-configure ang PADMACRO"
+  "PADMACRO_SETTINGS": "Mga Setting ng Pad macro"
+  "PADMACRO_ENABLE": "Mga Pad macro"
+  "PADMACRO_SLOWDOWN": "Pagbagal ng analog:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Bawasan ang saklaw ng analog stick kapag pinindot ang button"
+  "LEFT_ANALOG": "Kaliwang stick"
+  "RIGHT_ANALOG": "Kanang stick"
+  "PADMACRO_INVERT_AXIS": "Pag-invert ng analog axis:"
+  "HINT_PADMACRO_INVERT_AXIS": "I-invert ang axis ng analog stick"
+  "TURBO_SPEED": "Bilis ng turbo button"
+  "HINT_TURBO_SPEED": "Gaano kabilis pindutin ang button kapag aktibo ang turbo"
+  "ACT_WHILE_PRESSED": "Habang pinindot ang button"
+  "ACT_TOGGLED": "I-toggle sa pamamagitan ng button"
+  "LANGUAGE_JAPANESE": "HAPON"
+  "LANGUAGE_ENGLISH": "INGLES"
+  "LANGUAGE_FRENCH": "PRANSES"
+  "LANGUAGE_SPANISH": "KASTILA"
+  "LANGUAGE_GERMAN": "ALEMAN"
+  "LANGUAGE_ITALIAN": "ITALYANO"
+  "LANGUAGE_DUTCH": "OLANDES"
+  "LANGUAGE_PORTUGUESE": "PORTUGES"
+  "LANGUAGE_RUSSIAN": "RUSO"
+  "LANGUAGE_KOREAN": "KOREANO"
+  "LANGUAGE_TRAD_CHINESE": "TRADISYONAL NA INTSIK"
+  "LANGUAGE_SIMPL_CHINESE": "PINASIMPLENG INTSIK"
+  "OSD_SETTINGS": "Mga setting ng OSD"
+  "OSD_SETTINGS_LNG": "Wika ng OSD"
+  "ENABLE_LNG": "Palitan ang wika"
+  "BGM": "Background Music"
+  "BGM_VOLUME": "Volume ng Background Music"
+  "DEF_BGM_PATH": "Default na Theme Music"
+  "DEF_BGM_PATH_HINT": "Itakda ang path para i-stream ang musika ng internal na theme."
+  "BOOT_SCANNING_MC": "Ini-scan ang mga memory card..."
+  "BOOT_LOADING_DRIVERS": "Nilo-load ang mga storage driver..."
+  "BOOT_LOADING_USB": "Nilo-load ang USB storage driver..."
+  "BOOT_ARMING_MMCE": "Inihahanda ang MMCE game-ID..."
+  "BOOT_LOADING_SOUNDS": "Nilo-load ang mga tunog ng theme..."
+  "BOOT_BUILDING_MENU": "Binubuo ang menu..."
+  "NET_UDPFS_TAB_HINT": "Naka-on ang UDPFS -- buksan ang bagong UDPFS tab at pindutin ang Confirm para kumonekta. Sa panig ng PC ay tumatakbo ang udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Naka-on ang network block device -- lumalabas ang tab nito kapag sumagot na ang PC server (udpfsd -bdpath para sa UDPFS Image, udpbd-server para sa UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Hindi natagpuan ang per-game na VMC file -- inilulunsad nang wala ito (gagamitin ng laro ang tunay nitong card)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Hindi makakapaglunsad ang Neutrino mula sa device na ito -- itinigil ang paglunsad."
+  "NEUTRINO_TOML_SYNC_FAILED": "Nawawala o hindi masulatan ang network config ng Neutrino (bsd toml) -- ikinansela ang paglulunsad, tingnan ang neutrino folder."
+  "NEUTRINO_TOO_FRAGMENTED": "Masyadong fragmented para sa Neutrino (%d fragments, limitasyon %d kasama ang mga VMC) -- sinusubukan na lang ang OPL core."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Masyadong fragmented para sa Neutrino (%d fragments, limitasyon %d kasama ang mga VMC) -- i-defragment sa PC; ikinansela ang paglulunsad."
+  "NEUTRINO_GSM_COMP": "Compatibility ng Neutrino GSM"
+  "HINT_NEUTRINO_GSM_COMP": "Ayos na nagpapalit ng field para sa mga laro na nanginginig o napupunit sa ilalim ng sapilitang Neutrino Video mode. Kailangang may nakatakdang Neutrino Video mode."
+  "NARGS_DBC": "Mga Kulay ng Debug (-dbc)"
+  "NARGS_LOGO": "PS2 Logo (-logo)"
+  "VMC_SLOT1_DISABLE": "I-disable ang VMC 1 (panatilihin ang card)"
+  "VMC_SLOT2_DISABLE": "I-disable ang VMC 2 (panatilihin ang card)"
+  "HINT_VMC_SLOT_DISABLE": "Maglunsad nang walang VMC ng slot na ito habang nananatiling naka-configure ang card nito. Mga paglulunsad ng Neutrino lamang; gagamitin ng laro ang tunay na card sa slot na iyon."
+  "NEUTRINO_BSDFS": "Neutrino Filesystem"
+  "HINT_NEUTRINO_BSDFS": "Piliting gamitin ang block-device filesystem ng Neutrino (-bsdfs). Auto = default kada device. Ang hdl/bd ay mga expert na opsyon; ipares ang mga ito sa katugmang -dvd= sa launch args kung hindi bagay ang hugis ng auto na path."
+  "PLASCOLOR": "Kulay ng Plasma Blend"
+  "VCD_HIDE_GAMEID": "Itago ang PS1 Game ID (VCD list)"
+  "HINT_VCD_HIDE_GAMEID": "Pangkosmetiko lamang -- itago ang nauunang game-ID prefix (hal. SLUS_005.51.) sa mga pangalan ng PS1/VCD list. Ang mga pangalang walang ID ay ipinapakita nang buo. Hindi binabago ang paglulunsad, cover art, o mga favourites."
+  "VCD_FIRST_DISC": "Unang disc lang (multi-disc PS1)"
+  "HINT_VCD_FIRST_DISC": "Ipakita lamang ang Disc 1 ng isang multi-disc na PS1 game sa mga listahan ng device (istilong POPSLoader). Itinatago ang mga file na pinangalanang (Disc 2), (CD 2), atbp. Nananatili ang lahat ng disc sa card para sa in-game na pagpapalit; hindi sinasala ang mga Favourites."
+  "GAMES_DEVICE": "Device ng Laro"
+  "DEFAULT_CORE": "Default na Loader Core"
+  "HINT_DEFAULT_CORE": "Global na default na core para sa mga laro na naka-set sa Default ang per-game na Loader Core. Ang <OPL> ang native na core; ikinakadena ng Neutrino ang panlabas na neutrino.elf. Palaging pinapangibabawan ito ng per-game na pagpili."
+  "VCD_SETTINGS": "Mga Setting ng VCD"
+  "FINANCIAL_SUPPORT": "Suportang Pinansyal"

--- a/lng_fork/French.yml
+++ b/lng_fork/French.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Trier les jeux par ordre alphabétique
+  RUMBLE: Vibration de la manette dans les menus
+  HINT_RUMBLE: Courte vibration en déplaçant le curseur, en confirmant ou en revenant -- nécessite une DualShock en mode analogique
+  FOLDER_NAV: Parcourir les dossiers dans la liste des jeux
+  HINT_FOLDER_NAV: Affiche les sous-dossiers du CD/DVD comme entrées navigables ; valider pour ouvrir, annuler pour revenir
+  SETTINGS_NO_HOME: Aucune carte mémoire trouvée -- impossible d'enregistrer les réglages. OPL a démarré depuis un périphérique réseau, dont les réglages doivent résider sur une carte locale.
+  ERROR_SAVING_SETTINGS_TO: Impossible d'écrire les réglages sur %s (erreur %d)
+  GENERAL_SETTINGS: Paramètres généraux
+  DEVICE_SETTINGS: Paramètres des périphériques
+  LAUNCH_PS2_DISC: Lancer un disque PS2
+  DISC_LAUNCH_ERR: Aucun disque PS2 dans le lecteur.
+  DEFAULT: Défaut
+  HINT_MODE7: Neutrino uniquement -- corrige les jeux qui débordent un tampon IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: Image de triche PS2RD
+  HINT_ENABLEIMAGE: Applique un patch PS2RD .img précompilé à votre jeu.
+  UDPBD_GAMES: Jeux UDPBD
+  MMCE: MMCE
+  MMCE_GAMES: Jeux MMCE
+  MMCEMODE: Mode de démarrage MMCE
+  MMCE_PREFIX: Chemin préfixe MMCE
+  MMCE_SLOT: Slot MMCE
+  MMCEIGR_SLOT: Slot(s) IGR Bootcard
+  HINT_MMCEIGR_SLOT: La commande de basculement vers la bootcard sera envoyée au(x) slot(s) sélectionné(s) lors d'un IGR
+  MMCE_ADVANCED: Avancé
+  MMCE_SETTINGS: Paramètres MMCE
+  MMCE_SEMA: Méthode de file d'attente du sémaphore
+  HINT_MMCE_SEMA: THFIFO peut améliorer la compatibilité mais dégrader les performances
+  MMCE_WAIT_CYCLES: Cycles d'attente après /ACK bas
+  HINT_MMCE_WAIT_CYCLES: Des valeurs plus faibles peuvent améliorer les performances mais provoquer des instabilités
+  MMCE_USE_ALARMS: Utiliser les alarmes de délai
+  HINT_MMCE_USE_ALARMS: 'OFF peut améliorer les performances mais provoquer des blocages en cas de timeout MMCE'
+  CORE_LOADER: Noyau de chargement
+  NEUTRINO_BAD_FORMAT: Neutrino ne supporte pas ce format de fichier, lancement avec le noyau <OPL>
+  NEUTRINO_NOT_FOUND: ELF Neutrino introuvable, lancement avec le noyau <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD nécessite une IP PS2 statique. Configurez-en une dans la Config réseau (DHCP est actuellement activé).
+  NEUTRINO_SETTING_NA: Ce paramètre n'est pas utilisé avec le noyau Neutrino.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF manquant
+  POPSTARTER_SMB_MISSING: Prérequis SMB de POPSTARTER manquants
+  WRITE_POPSTARTER_NET: Écrire la config réseau POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Enregistre également les valeurs IP + partage SMB dans IPCONFIG.DAT / SMBCONFIG.DAT de POPSTARTER sur la carte mémoire (pour VCD via SMB).
+  POPSTARTER_NET_ERR: Impossible d'écrire la config réseau POPSTARTER sur la carte mémoire.
+  VCD: VCD
+  VCD_ON: Affichage des jeux VCD
+  VCD_OFF: Affichage des jeux disque
+  NEUTRINO_ARGS: Arguments de lancement Neutrino
+  HINT_NEUTRINO_ARGS: Options Neutrino supplémentaires, séparées par des espaces (ex. -mt=dvd). Global s'applique à tous les jeux ; par jeu s'ajoute en plus. Préfixez un paramètre avec $ pour le désactiver sans le supprimer.
+  NEUTRINO_VIDEO: Vidéo Neutrino
+  HINT_NEUTRINO_VIDEO: Force le mode vidéo GS de Neutrino (-gsm). Désactivé conserve le mode par défaut du jeu.
+  NEUTRINO_PATH: Chemin ELF Neutrino
+  HINT_NEUTRINO_PATH: Chemin complet vers neutrino.elf (ex. mc0:NEUTRINO/neutrino.elf). Vide = détection automatique sur mc0/mc1.
+  POPSTARTER_PATH: Chemin POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Chemin personnalisé pour POPSTARTER.ELF ; utilise le dossier POPS du périphérique si vide/absent. Le clavier est limité à 31 caractères ; chemins plus longs via settings_riptopl.cfg.
+  BDMA_SOURCE: Source BDMA
+  HINT_BDMA_SOURCE: Périphérique dont le dossier POPS contient les fichiers pilotes BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Mode BDMA
+  HINT_BDMA_MODE: Pilote de bloc exFAT chargé par POPSTARTER. Le modifier copie les modules sur la carte ; FAT32 = aucun (pilote intégré).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD interne
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Fichiers modules BDMA introuvables sur le périphérique source.
+  BDMA_ERR_SPACE: Espace insuffisant sur la carte mémoire pour les modules BDMA.
+  BDMA_ERR_IO: Erreur lors de l'écriture des modules BDMA sur la carte mémoire.
+  COVERFLOW_SETTINGS: Paramètres Coverflow
+  COVERFLOW_COUNT: Nombre de jaquettes
+  COVERFLOW_SCALE: Échelle centrale
+  COVERFLOW_ANIM: Vitesse d'animation
+  COVERFLOW_DIM: Assombrir les jaquettes latérales
+  NONE: Aucun
+  SMALL: Petit
+  LARGE: Grand
+  NORMAL: Normal
+  FAV: Favoris
+  FAVMODE: Mode de démarrage des favoris
+  FAV_HINT: Favori
+  FAV_MSG: '%s n''est pas accessible depuis le menu Favoris.'
+  FAV_PERSISTENCE_MSG: '%s n''est pas autorisé lorsque l''élément est marqué comme favori.'
+  NEUTRINO_DEVICE: Périphérique Neutrino
+  HINT_NEUTRINO_DEVICE: Périphérique contenant neutrino.elf (dans un dossier NEUTRINO/ ou neutrino/). Auto scanne mc0 puis mc1.
+  NARGS_QB: Démarrage rapide (-qb)
+  NARGS_CWD: Répertoire de travail (-cwd)
+  NARGS_CFG: Config (-cfg)
+  NARGS_ELF: ELF de démarrage (-elf)
+  NARGS_ATA0: Image ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Image ATA1 (-ata1)
+  NARGS_EXTRA: Arguments supplémentaires
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Archive .tar des jaquettes
+  DISABLE_ALL: Tout désactiver
+  BOOT_LOADING_CONFIG: Chargement des paramètres...
+  BOOT_SCANNING_BDM: Analyse des lecteurs USB / carte / réseau...
+  BOOT_SCANNING_NET: Démarrage du réseau...
+  BOOT_SCANNING_HDD: Analyse du HDD...
+  BOOT_READY: Prêt.
+  UDPFS_GAMES: "Jeux UDPFS"
+  UDPFSBD_GAMES: "Jeux UDPFSBD"
+  NET_PROTOCOL: "Protocole réseau"
+  NET_NEEDS_NEUTRINO: "Les jeux réseau (UDP) ne peuvent démarrer que via le cœur Neutrino. Vérifiez que neutrino.elf est présent et que le format est pris en charge."
+  VCD_NOT_ON_NET: "Les jeux PS1 (.VCD) ne peuvent pas être lancés via le périphérique réseau."
+  MX4SIO_PADEMU_WARN: "MX4SIO et l'émulation de manette partagent le bus SIO2 et le jeu peut ne pas démarrer."
+  HINT_OSD_SETTINGS_LNG: "Forcer une configuration de langue personnalisée"
+  OSD_SETTINGS_TVASPECT: "Taille de l'écran"
+  FULL_SCREEN: "Plein écran"
+  OSD_SETTINGS_VMODE: "Mode vidéo"
+  SYSTEM_DEFAULT: "Défaut système"
+  HIGH: "Haute"
+  LOW: "Basse"
+  XSENSITIVITY: "Sensibilité analogique axe X"
+  YSENSITIVITY: "Sensibilité analogique axe Y"
+  FILE_COUNT: "Fichiers trouvés : %i"
+  CHEAT_SELECTION: "Sélection des codes"
+  HDD_HINT: "Un seul HDD autorisé ; l'activer verrouille APA ou GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "GameID MMCE non appliqué -- neutrino.elf est sur cette carte (le changer déchargerait Neutrino)."
+  POPSTARTER_DEVICE: "Périphérique POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Périphérique contenant POPS/POPSTARTER.ELF pour les lancements VCD PS1. Défaut = périphérique de démarrage (cwd) puis le périphérique propre au VCD. Personnalisé affiche un chemin libre."
+  BDMA_APPLY: "Appliquer VCD BDMA au lancement"
+  HINT_BDMA_APPLY: "Activé : équipe automatiquement le pilote exFAT correspondant au VCD lancé sur la carte mémoire avant le démarrage (recommandé). Désactivé : gérez-le vous-même avec les sélecteurs Source/Mode BDMA ci-dessous."
+  NETBOOT_RESTART: "Redémarrez OPL pour appliquer le changement de protocole de démarrage réseau."
+  UDPFS_MODE: "Accès UDPFS"
+  "MENU": "Menu"
+  "APPS": "Applications"
+  "DEBUG": "Couleurs de débogage"
+  "COVERART": "Jaquettes"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Opérations d'écriture"
+  "MODE1": "Mode 1"
+  "MODE2": "Mode 2"
+  "MODE3": "Mode 3"
+  "MODE4": "Mode 4"
+  "MODE5": "Mode 5"
+  "MODE6": "Mode 6"
+  "ENABLEGSM": "Sélecteur GSM"
+  "OVERSCAN": "Surbalayage"
+  "ENABLECHEAT": "Moteur de triche PS2RD"
+  "PADEMU_ENABLE": "Émulateur de manette"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Émulation"
+  "PADEMU_VIB": "Vibration"
+  "PADEMU_WORKAROUND": "Contournement faux DS3"
+  "SFX": "Effets sonores"
+  "BOOT_SND": "Son de démarrage"
+  "ENABLE_NOTIFICATIONS": "Notifications"
+  "OPTIONS": "Options"
+  "GLOBAL_SETTINGS": "Général"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Sortie"
+  "INFO_DESCRIPTION": "Description"
+  "BLOCKDEVICE_SETTINGS": "Périphériques bloc"
+  "CONTROLLER_SETTINGS": "Réglages de la manette"
+  "HINT_BDM_START": "Activer/désactiver le gestionnaire de périphériques bloc (BDM)."
+  "HINT_BLOCK_DEVICES": "Activer/désactiver les périphériques bloc (p. ex. USB)."
+  "USB_GAMES": "Jeux USB"
+  "ILINK_GAMES": "Jeux iLink"
+  "MX4SIO_GAMES": "Jeux MX4SIO"
+  "PADMACROCONFIG": "Configurer PADMACRO"
+  "PADMACRO_SETTINGS": "Réglages des macros de manette"
+  "PADMACRO_ENABLE": "Macros de manette"
+  "PADMACRO_SLOWDOWN": "Ralenti analogique :"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Réduire l'amplitude du stick analogique lorsque le bouton est enfoncé"
+  "LEFT_ANALOG": "Stick gauche"
+  "RIGHT_ANALOG": "Stick droit"
+  "PADMACRO_INVERT_AXIS": "Inversion de l'axe analogique :"
+  "HINT_PADMACRO_INVERT_AXIS": "Inverser l'axe du stick analogique"
+  "TURBO_SPEED": "Vitesse du bouton turbo"
+  "HINT_TURBO_SPEED": "Vitesse d'appui sur le bouton lorsque le turbo est actif"
+  "ACT_WHILE_PRESSED": "Tant que le bouton est enfoncé"
+  "ACT_TOGGLED": "Basculé par le bouton"
+  "LANGUAGE_JAPANESE": "JAPONAIS"
+  "LANGUAGE_ENGLISH": "ANGLAIS"
+  "LANGUAGE_FRENCH": "FRANÇAIS"
+  "LANGUAGE_SPANISH": "ESPAGNOL"
+  "LANGUAGE_GERMAN": "ALLEMAND"
+  "LANGUAGE_ITALIAN": "ITALIEN"
+  "LANGUAGE_DUTCH": "NÉERLANDAIS"
+  "LANGUAGE_PORTUGUESE": "PORTUGAIS"
+  "LANGUAGE_RUSSIAN": "RUSSE"
+  "LANGUAGE_KOREAN": "CORÉEN"
+  "LANGUAGE_TRAD_CHINESE": "CHINOIS TRADITIONNEL"
+  "LANGUAGE_SIMPL_CHINESE": "CHINOIS SIMPLIFIÉ"
+  "OSD_SETTINGS": "Réglages OSD"
+  "OSD_SETTINGS_LNG": "Langue de l'OSD"
+  "ENABLE_LNG": "Changer de langue"
+  "BGM": "Musique de fond"
+  "BGM_VOLUME": "Volume de la musique de fond"
+  "DEF_BGM_PATH": "Musique du thème par défaut"
+  "DEF_BGM_PATH_HINT": "Définir le chemin de la musique à diffuser pour le thème interne."
+  "BOOT_SCANNING_MC": "Analyse des cartes mémoire..."
+  "BOOT_LOADING_DRIVERS": "Chargement des pilotes de stockage..."
+  "BOOT_LOADING_USB": "Chargement du pilote de stockage USB..."
+  "BOOT_ARMING_MMCE": "Activation de l'ID de jeu MMCE..."
+  "BOOT_LOADING_SOUNDS": "Chargement des sons du thème..."
+  "BOOT_BUILDING_MENU": "Construction du menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS activé -- ouvrez le nouvel onglet UDPFS et appuyez sur Confirmer pour vous connecter. Côté PC, exécutez udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Périphérique de bloc réseau activé -- son onglet apparaît dès que le serveur PC répond (udpfsd -bdpath pour l'image UDPFS, udpbd-server pour UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Fichier VMC par jeu introuvable -- lancement sans celui-ci (le jeu utilise sa vraie carte)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino ne peut pas se lancer depuis ce périphérique -- lancement annulé."
+  "NEUTRINO_TOML_SYNC_FAILED": "Configuration réseau de Neutrino (bsd toml) manquante ou non inscriptible -- lancement annulé, vérifiez le dossier neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Trop fragmenté pour Neutrino (%d fragments, limite %d y compris les VMC) -- essai du cœur OPL à la place."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Trop fragmenté pour Neutrino (%d fragments, limite %d y compris les VMC) -- défragmentez sur le PC ; lancement annulé."
+  "NEUTRINO_GSM_COMP": "Compatibilité GSM Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Correctif d'inversion de trame pour les jeux qui tremblent ou déchirent sous un mode Vidéo Neutrino forcé. Nécessite un mode Vidéo Neutrino défini."
+  "NARGS_DBC": "Couleurs de débogage (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Désactiver le VMC 1 (garder la carte)"
+  "VMC_SLOT2_DISABLE": "Désactiver le VMC 2 (garder la carte)"
+  "HINT_VMC_SLOT_DISABLE": "Lancer sans la VMC de cet emplacement tout en gardant sa carte configurée. Lancements Neutrino uniquement ; le jeu utilise alors la vraie carte de cet emplacement."
+  "NEUTRINO_BSDFS": "Système de fichiers Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Forcer le système de fichiers du périphérique de bloc de Neutrino (-bsdfs). Auto = valeur par défaut selon le périphérique. hdl/bd sont des options avancées ; associez-les à un -dvd= correspondant dans les arguments de lancement si la forme du chemin automatique ne convient pas."
+  "PLASCOLOR": "Couleur de fusion plasma"
+  "VCD_HIDE_GAMEID": "Masquer l'ID de jeu PS1 (liste VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Cosmétique uniquement -- masque un préfixe d'ID de jeu en tête (par ex. SLUS_005.51.) dans les noms des listes PS1/VCD. Les noms sans ID sont affichés tels quels. Ne modifie ni le lancement, ni la jaquette, ni les favoris."
+  "VCD_FIRST_DISC": "Premier disque seulement (PS1 multi-disques)"
+  "HINT_VCD_FIRST_DISC": "Afficher uniquement le Disc 1 d'un jeu PS1 multidisque dans les listes de périphériques (style POPSLoader). Masque les fichiers nommés (Disc 2), (CD 2), etc. Tous les disques restent sur la carte pour l'échange en cours de jeu ; les Favoris ne sont pas filtrés."
+  "GAMES_DEVICE": "Périphérique du jeu"
+  "DEFAULT_CORE": "Cœur de chargement par défaut"
+  "HINT_DEFAULT_CORE": "Cœur par défaut global pour les jeux dont le Cœur de chargement par jeu est réglé sur Défaut. <OPL> est le cœur natif ; Neutrino enchaîne le neutrino.elf externe. Un choix par jeu remplace toujours ce réglage."
+  "VCD_SETTINGS": "Réglages VCD"
+  "FINANCIAL_SUPPORT": "Soutien financier"

--- a/lng_fork/German.yml
+++ b/lng_fork/German.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Spiele alphabetisch sortieren
+  RUMBLE: Controller-Vibration in den Menüs
+  HINT_RUMBLE: Kurze Vibration beim Bewegen des Cursors, Bestätigen oder Zurückgehen -- erfordert einen DualShock im Analogmodus
+  FOLDER_NAV: Ordner in der Spieleliste durchsuchen
+  HINT_FOLDER_NAV: Unterordner der CD/DVD als durchsuchbare Einträge anzeigen; zum Öffnen bestätigen, zum Zurückgehen abbrechen
+  SETTINGS_NO_HOME: Keine Memory Card gefunden -- Einstellungen können nicht gespeichert werden. OPL wurde von einem Netzwerkgerät gestartet, dessen Einstellungen auf einer lokalen Karte liegen müssen.
+  ERROR_SAVING_SETTINGS_TO: Einstellungen konnten nicht auf %s geschrieben werden (Fehler %d)
+  GENERAL_SETTINGS: Allgemeine Einstellungen
+  DEVICE_SETTINGS: Geräteeinstellungen
+  LAUNCH_PS2_DISC: PS2 Disc starten
+  DISC_LAUNCH_ERR: Keine PS2 Disc im Laufwerk.
+  DEFAULT: Standard
+  HINT_MODE7: Nur Neutrino -- behebt Spiele, die einen IOP-Puffer überschreiben (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Einen vorgefertigten PS2RD .img Patch auf das Spiel anwenden.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE Startmodus
+  MMCE_PREFIX: MMCE Pfadpräfix
+  MMCE_SLOT: MMCE Slot
+  MMCEIGR_SLOT: IGR Bootcard Slot(s)
+  HINT_MMCEIGR_SLOT: Der Befehl zum Wechsel zur Bootcard wird beim IGR an die gewählten Slot(s) gesendet
+  MMCE_ADVANCED: Erweitert
+  MMCE_SETTINGS: MMCE Einstellungen
+  MMCE_SEMA: Sema-Einreihungsmethode sperren
+  HINT_MMCE_SEMA: THFIFO kann die Kompatibilität verbessern, aber die Leistung verringern
+  MMCE_WAIT_CYCLES: Wartezyklen nach /ACK low
+  HINT_MMCE_WAIT_CYCLES: Niedrigere Werte können die Leistung verbessern, aber Instabilitäten verursachen
+  MMCE_USE_ALARMS: Timeout-Alarme verwenden
+  HINT_MMCE_USE_ALARMS: AUS kann die Leistung verbessern, aber MMCE-Timeouts können zu Einfrieren führen
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino unterstützt dieses Dateiformat nicht, Start mit <OPL> Core
+  NEUTRINO_NOT_FOUND: Neutrino ELF nicht gefunden, Start mit <OPL> Core
+  UDPBD_NEEDS_STATIC_IP: UDPBD benötigt eine statische PS2 IP. In der Netzwerkkonfiguration festlegen (DHCP ist aktiv).
+  NEUTRINO_SETTING_NA: Diese Einstellung wird mit dem Neutrino Core nicht verwendet.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF fehlt
+  POPSTARTER_SMB_MISSING: POPSTARTER SMB-Voraussetzungen fehlen
+  WRITE_POPSTARTER_NET: POPSTARTER Netzwerkkonfiguration schreiben
+  HINT_WRITE_POPSTARTER_NET: Diese IP- und SMB-Freigabewerte auch in POPSTARTER's eigene IPCONFIG.DAT / SMBCONFIG.DAT auf der Speicherkarte schreiben (für VCD über SMB).
+  POPSTARTER_NET_ERR: POPSTARTER-Netzwerkkonfiguration konnte nicht auf die Speicherkarte geschrieben werden.
+  VCD: VCD
+  VCD_ON: VCD-Spiele werden angezeigt
+  VCD_OFF: Disc-Spiele werden angezeigt
+  NEUTRINO_ARGS: Neutrino Startargumente
+  HINT_NEUTRINO_ARGS: 'Zusätzliche Neutrino-Flags, durch Leerzeichen getrennt (z.B. -mt=dvd). Global gilt für alle Spiele; pro Spiel wird obendrauf addiert. Flag mit $ präfixieren, um es ohne Löschen zu deaktivieren.'
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: Neutrinos GS-Ausgabe-Videomodus erzwingen (-gsm). Aus behält den Standard des Spiels.
+  NEUTRINO_PATH: Neutrino ELF Pfad
+  HINT_NEUTRINO_PATH: Vollständiger Pfad zu neutrino.elf (z.B. mc0:NEUTRINO/neutrino.elf). Leer = automatische Erkennung auf mc0/mc1.
+  POPSTARTER_PATH: POPSTARTER.ELF Pfad
+  HINT_POPSTARTER_PATH: Benutzerdefinierter POPSTARTER.ELF Pfad; fällt auf den POPS-Ordner des Geräts zurück, wenn leer/fehlend. Tastatur auf 31 Zeichen begrenzt; längere Pfade über settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA Quelle
+  HINT_BDMA_SOURCE: Gerät, dessen POPS-Ordner die BDMAssault-Treiberdateien enthält (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Modus
+  HINT_BDMA_MODE: exFAT Block-Gerätetreiber, den POPSTARTER lädt. Bei Änderung werden die Module auf die Karte kopiert; FAT32 = keiner (integrierter Treiber).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Interne HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: BDMA-Moduldateien nicht auf dem Quellgerät gefunden.
+  BDMA_ERR_SPACE: Nicht genügend Speicherplatz auf der Speicherkarte für die BDMA-Module.
+  BDMA_ERR_IO: Fehler beim Schreiben der BDMA-Module auf die Speicherkarte.
+  COVERFLOW_SETTINGS: Coverflow Einstellungen
+  COVERFLOW_COUNT: Cover-Anzahl
+  COVERFLOW_SCALE: Mittlere Skalierung
+  COVERFLOW_ANIM: Animationsgeschwindigkeit
+  COVERFLOW_DIM: Seitliche Cover abdunkeln
+  NONE: Keine
+  SMALL: Klein
+  LARGE: Groß
+  NORMAL: Normal
+  FAV: Favoriten
+  FAVMODE: Favoriten-Startmodus
+  FAV_HINT: Favorit
+  FAV_MSG: '%s ist über das Favoritenmenü nicht erlaubt.'
+  FAV_PERSISTENCE_MSG: '%s ist nicht erlaubt, solange das Element als Favorit markiert ist.'
+  NEUTRINO_DEVICE: Neutrino Gerät
+  HINT_NEUTRINO_DEVICE: Gerät, das neutrino.elf enthält (in einem NEUTRINO/- oder neutrino/-Ordner). Auto durchsucht zuerst mc0, dann mc1.
+  NARGS_QB: Schnellstart (-qb)
+  NARGS_CWD: Arbeitsverzeichnis (-cwd)
+  NARGS_CFG: Konfiguration (-cfg)
+  NARGS_ELF: Start-ELF (-elf)
+  NARGS_ATA0: ATA0 Image (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 Image (-ata1)
+  NARGS_EXTRA: Weitere Argumente
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Cover-Art-.tar-Archiv
+  DISABLE_ALL: Alle deaktivieren
+  BOOT_LOADING_CONFIG: Einstellungen werden geladen...
+  BOOT_SCANNING_BDM: USB- / Karten- / Netzlaufwerke werden durchsucht...
+  BOOT_SCANNING_NET: Netzwerk wird gestartet...
+  BOOT_SCANNING_HDD: HDD wird durchsucht...
+  BOOT_READY: Bereit.
+  UDPFS_GAMES: "UDPFS-Spiele"
+  UDPFSBD_GAMES: "UDPFSBD-Spiele"
+  NET_PROTOCOL: "Netzwerkprotokoll"
+  NET_NEEDS_NEUTRINO: "Netzwerkspiele (UDP) können nur über den Neutrino-Core starten. Prüfe, ob neutrino.elf vorhanden ist und das Format unterstützt wird."
+  VCD_NOT_ON_NET: "PS1-Spiele (.VCD) können nicht über das Netzwerkgerät gestartet werden."
+  MX4SIO_PADEMU_WARN: "MX4SIO und Pad-Emulation teilen sich den SIO2-Bus, das Spiel startet möglicherweise nicht."
+  HINT_OSD_SETTINGS_LNG: "Eigene Sprachkonfiguration erzwingen"
+  OSD_SETTINGS_TVASPECT: "Bildschirmgröße"
+  FULL_SCREEN: "Vollbild"
+  OSD_SETTINGS_VMODE: "Videomodus"
+  SYSTEM_DEFAULT: "Systemstandard"
+  HIGH: "Hoch"
+  LOW: "Niedrig"
+  XSENSITIVITY: "Analog-Empfindlichkeit X-Achse"
+  YSENSITIVITY: "Analog-Empfindlichkeit Y-Achse"
+  FILE_COUNT: "Gefundene Dateien: %i"
+  CHEAT_SELECTION: "Cheat-Auswahl"
+  HDD_HINT: "Nur eine HDD erlaubt; Aktivieren sperrt APA oder GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE-GameID nicht angewendet -- neutrino.elf liegt auf dieser Karte (ein Wechsel würde Neutrino entladen)."
+  POPSTARTER_DEVICE: "POPSTARTER.ELF-Gerät"
+  HINT_POPSTARTER_DEVICE: "Gerät mit POPS/POPSTARTER.ELF für PS1-VCD-Starts. Standard = Boot-Gerät (cwd), dann das eigene Gerät des VCD. Benutzerdefiniert zeigt einen freien Pfad an."
+  BDMA_APPLY: "VCD BDMA beim Start anwenden"
+  HINT_BDMA_APPLY: "Ein: rüstet vor dem Start automatisch den passenden exFAT-Treiber des gestarteten VCD auf die Memory Card (empfohlen). Aus: manuell über die BDMA-Quelle/Modus-Auswahl unten verwalten."
+  NETBOOT_RESTART: "OPL neu starten, um die Änderung des Netzwerk-Boot-Protokolls anzuwenden."
+  UDPFS_MODE: "UDPFS-Zugriff"
+  "MENU": "Menü"
+  "APPS": "Apps"
+  "DEBUG": "Debug-Farben"
+  "COVERART": "Cover-Art"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Schreibvorgänge"
+  "MODE1": "Modus 1"
+  "MODE2": "Modus 2"
+  "MODE3": "Modus 3"
+  "MODE4": "Modus 4"
+  "MODE5": "Modus 5"
+  "MODE6": "Modus 6"
+  "ENABLEGSM": "GSM-Auswahl"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD-Cheat-Engine"
+  "PADEMU_ENABLE": "Pad-Emulator"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulation"
+  "PADEMU_VIB": "Vibration"
+  "PADEMU_WORKAROUND": "Fake-DS3-Workaround"
+  "SFX": "Soundeffekte"
+  "BOOT_SND": "Startton"
+  "ENABLE_NOTIFICATIONS": "Benachrichtigungen"
+  "OPTIONS": "Optionen"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Veröffentlichung"
+  "INFO_DESCRIPTION": "Beschreibung"
+  "BLOCKDEVICE_SETTINGS": "Blockgeräte"
+  "CONTROLLER_SETTINGS": "Controller-Einstellungen"
+  "HINT_BDM_START": "Block Device Manager ein-/ausschalten."
+  "HINT_BLOCK_DEVICES": "Blockgeräte ein-/ausschalten (z. B. USB)."
+  "USB_GAMES": "USB-Spiele"
+  "ILINK_GAMES": "iLink-Spiele"
+  "MX4SIO_GAMES": "MX4SIO-Spiele"
+  "PADMACROCONFIG": "PADMACRO konfigurieren"
+  "PADMACRO_SETTINGS": "Pad-Makro-Einstellungen"
+  "PADMACRO_ENABLE": "Pad-Makros"
+  "PADMACRO_SLOWDOWN": "Analog-Verlangsamung:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Bereich des Analogsticks reduzieren, wenn Taste gedrückt wird"
+  "LEFT_ANALOG": "Linker Stick"
+  "RIGHT_ANALOG": "Rechter Stick"
+  "PADMACRO_INVERT_AXIS": "Analogachse invertieren:"
+  "HINT_PADMACRO_INVERT_AXIS": "Analogstick-Achse invertieren"
+  "TURBO_SPEED": "Turbo-Tastengeschwindigkeit"
+  "HINT_TURBO_SPEED": "Wie schnell die Taste bei aktivem Turbo gedrückt wird"
+  "ACT_WHILE_PRESSED": "Während Taste gedrückt"
+  "ACT_TOGGLED": "Per Taste umschalten"
+  "LANGUAGE_JAPANESE": "JAPANISCH"
+  "LANGUAGE_ENGLISH": "ENGLISCH"
+  "LANGUAGE_FRENCH": "FRANZÖSISCH"
+  "LANGUAGE_SPANISH": "SPANISCH"
+  "LANGUAGE_GERMAN": "DEUTSCH"
+  "LANGUAGE_ITALIAN": "ITALIENISCH"
+  "LANGUAGE_DUTCH": "NIEDERLÄNDISCH"
+  "LANGUAGE_PORTUGUESE": "PORTUGIESISCH"
+  "LANGUAGE_RUSSIAN": "RUSSISCH"
+  "LANGUAGE_KOREAN": "KOREANISCH"
+  "LANGUAGE_TRAD_CHINESE": "TRADITIONELLES CHINESISCH"
+  "LANGUAGE_SIMPL_CHINESE": "VEREINFACHTES CHINESISCH"
+  "OSD_SETTINGS": "OSD-Einstellungen"
+  "OSD_SETTINGS_LNG": "OSD-Sprache"
+  "ENABLE_LNG": "Sprache ändern"
+  "BGM": "Hintergrundmusik"
+  "BGM_VOLUME": "Hintergrundmusik-Lautstärke"
+  "DEF_BGM_PATH": "Standard-Themenmusik"
+  "DEF_BGM_PATH_HINT": "Pfad zum Streamen der Musik für das interne Theme festlegen."
+  "BOOT_SCANNING_MC": "Speicherkarten werden durchsucht..."
+  "BOOT_LOADING_DRIVERS": "Speichertreiber werden geladen..."
+  "BOOT_LOADING_USB": "USB-Speichertreiber wird geladen..."
+  "BOOT_ARMING_MMCE": "MMCE-Spiel-ID wird aktiviert..."
+  "BOOT_LOADING_SOUNDS": "Theme-Sounds werden geladen..."
+  "BOOT_BUILDING_MENU": "Menü wird erstellt..."
+  "NET_UDPFS_TAB_HINT": "UDPFS aktiv -- öffne den neuen UDPFS-Tab und drücke Bestätigen, um zu verbinden. Auf PC-Seite läuft udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Netzwerk-Blockgerät aktiv -- sein Tab erscheint, sobald der PC-Server antwortet (udpfsd -bdpath für UDPFS-Image, udpbd-server für UDPBD)."
+  "NEUTRINO_VMC_MISSING": "VMC-Datei pro Spiel nicht gefunden -- Start ohne sie (Spiel verwendet seine echte Karte)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino kann von diesem Gerät nicht starten -- Start abgebrochen."
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino-Netzwerkkonfiguration (bsd toml) fehlt oder ist nicht beschreibbar -- Start abgebrochen, prüfe den neutrino-Ordner."
+  "NEUTRINO_TOO_FRAGMENTED": "Zu fragmentiert für Neutrino (%d Fragmente, Limit %d inkl. VMCs) -- versuche stattdessen den OPL-Core."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Zu fragmentiert für Neutrino (%d Fragmente, Limit %d inkl. VMCs) -- defragmentiere auf dem PC; Start abgebrochen."
+  "NEUTRINO_GSM_COMP": "Neutrino-GSM-Kompatibilität"
+  "HINT_NEUTRINO_GSM_COMP": "Field-Flipping-Fix für Spiele, die unter einem erzwungenen Neutrino-Videomodus zittern oder reißen. Erfordert einen gesetzten Neutrino-Videomodus."
+  "NARGS_DBC": "Debug-Farben (-dbc)"
+  "NARGS_LOGO": "PS2-Logo (-logo)"
+  "VMC_SLOT1_DISABLE": "VMC 1 deaktivieren (Karte behalten)"
+  "VMC_SLOT2_DISABLE": "VMC 2 deaktivieren (Karte behalten)"
+  "HINT_VMC_SLOT_DISABLE": "Startet ohne die VMC dieses Slots, behält dessen Karte aber konfiguriert. Nur Neutrino-Starts; das Spiel verwendet dann die echte Karte in diesem Slot."
+  "NEUTRINO_BSDFS": "Neutrino-Dateisystem"
+  "HINT_NEUTRINO_BSDFS": "Erzwingt das Blockgerät-Dateisystem von Neutrino (-bsdfs). Auto = Standard je nach Gerät. hdl/bd sind Expertenoptionen; kombiniere sie mit einem passenden -dvd= in den Startargumenten, falls die automatische Pfadform nicht passt."
+  "PLASCOLOR": "Plasma-Mischfarbe"
+  "VCD_HIDE_GAMEID": "PS1-Spiel-ID ausblenden (VCD-Liste)"
+  "HINT_VCD_HIDE_GAMEID": "Nur kosmetisch -- blendet einen führenden Spiel-ID-Präfix (z. B. SLUS_005.51.) aus den PS1/VCD-Listennamen aus. Namen ohne ID werden unverändert angezeigt. Ändert weder Start, Cover-Art noch Favoriten."
+  "VCD_FIRST_DISC": "Nur erste Disc (Multi-Disc-PS1)"
+  "HINT_VCD_FIRST_DISC": "Zeigt in den Gerätelisten nur Disc 1 eines PS1-Spiels mit mehreren Discs an (POPSLoader-Stil). Blendet Dateien mit Namen wie (Disc 2), (CD 2) usw. aus. Alle Discs bleiben zum Wechseln im Spiel auf der Karte; Favoriten werden nicht gefiltert."
+  "GAMES_DEVICE": "Spielgerät"
+  "DEFAULT_CORE": "Standard-Loader-Core"
+  "HINT_DEFAULT_CORE": "Globaler Standard-Core für Spiele, deren Loader-Core pro Spiel auf Default gesetzt ist. <OPL> ist der native Core; Neutrino verkettet die externe neutrino.elf. Eine Auswahl pro Spiel überschreibt dies immer."
+  "VCD_SETTINGS": "VCD-Einstellungen"
+  "FINANCIAL_SUPPORT": "Finanzielle Unterstützung"

--- a/lng_fork/Greek.yml
+++ b/lng_fork/Greek.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Ταξινόμηση παιχνιδιών αλφαβητικά
+  RUMBLE: Δόνηση χειριστηρίου στα μενού
+  HINT_RUMBLE: Σύντομη δόνηση κατά τη μετακίνηση του δρομέα, την επιβεβαίωση ή την επιστροφή -- απαιτεί DualShock σε αναλογική λειτουργία
+  FOLDER_NAV: Περιήγηση φακέλων στη λίστα παιχνιδιών
+  HINT_FOLDER_NAV: Εμφάνιση υποφακέλων του CD/DVD ως στοιχεία περιήγησης· επιλέξτε για άνοιγμα, ακυρώστε για επιστροφή
+  SETTINGS_NO_HOME: Δεν βρέθηκε κάρτα μνήμης -- οι ρυθμίσεις δεν μπορούν να αποθηκευτούν. Το OPL εκκίνησε από συσκευή δικτύου, της οποίας οι ρυθμίσεις πρέπει να βρίσκονται σε τοπική κάρτα.
+  ERROR_SAVING_SETTINGS_TO: Δεν ήταν δυνατή η εγγραφή ρυθμίσεων στο %s (σφάλμα %d)
+  GENERAL_SETTINGS: Γενικές Ρυθμίσεις
+  DEVICE_SETTINGS: Ρυθμίσεις Συσκευής
+  LAUNCH_PS2_DISC: Εκκίνηση Δίσκου PS2
+  DISC_LAUNCH_ERR: Δεν υπάρχει δίσκος PS2 στη μονάδα.
+  DEFAULT: Προεπιλογή
+  HINT_MODE7: Μόνο για Neutrino -- διορθώνει παιχνίδια που υπερχειλίζουν buffer IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Εφαρμογή έτοιμου patch PS2RD .img στο παιχνίδι σας.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Λειτουργία Εκκίνησης MMCE
+  MMCE_PREFIX: Διαδρομή Προθέματος MMCE
+  MMCE_SLOT: Υποδοχή MMCE
+  MMCEIGR_SLOT: Υποδοχή(ές) Bootcard IGR
+  HINT_MMCEIGR_SLOT: Η εντολή εναλλαγής σε bootcard θα αποσταλεί στις επιλεγμένες υποδοχές κατά το IGR
+  MMCE_ADVANCED: Για Προχωρημένους
+  MMCE_SETTINGS: Ρυθμίσεις MMCE
+  MMCE_SEMA: Μέθοδος Ουράς Κλειδώματος Sema
+  HINT_MMCE_SEMA: Το THFIFO μπορεί να βοηθήσει τη συμβατότητα αλλά να μειώσει την απόδοση
+  MMCE_WAIT_CYCLES: Κύκλοι αναμονής μετά το /ACK low
+  HINT_MMCE_WAIT_CYCLES: Χαμηλότερες τιμές μπορεί να βελτιώσουν την απόδοση αλλά να προκαλέσουν αστάθειες
+  MMCE_USE_ALARMS: Χρήση χρονοορίων
+  HINT_MMCE_USE_ALARMS: Το OFF μπορεί να βελτιώσει την απόδοση αλλά τα χρονόρια MMCE μπορεί να προκαλέσουν παγώματα
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Το Neutrino δεν υποστηρίζει αυτή τη μορφή αρχείου, εκκίνηση με πυρήνα <OPL>
+  NEUTRINO_NOT_FOUND: Δεν βρέθηκε το Neutrino ELF, εκκίνηση με πυρήνα <OPL>
+  UDPBD_NEEDS_STATIC_IP: Το UDPBD απαιτεί στατική IP για PS2. Ορίστε μία στις Ρυθμίσεις Δικτύου (το DHCP είναι ενεργό).
+  NEUTRINO_SETTING_NA: Αυτή η ρύθμιση δεν χρησιμοποιείται με τον πυρήνα Neutrino.
+  POPSTARTER_NOT_FOUND: Λείπει το POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Λείπουν οι απαιτήσεις SMB για το POPSTARTER
+  WRITE_POPSTARTER_NET: Εγγραφή Ρύθμισης Δικτύου POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Αποθήκευση τιμών IP + SMB και στα IPCONFIG.DAT / SMBCONFIG.DAT του POPSTARTER στην κάρτα μνήμης (για VCD μέσω SMB).
+  POPSTARTER_NET_ERR: Αποτυχία εγγραφής ρύθμισης δικτύου POPSTARTER στην κάρτα μνήμης.
+  VCD: VCD
+  VCD_ON: Εμφάνιση VCD παιχνιδιών
+  VCD_OFF: Εμφάνιση παιχνιδιών δίσκου
+  NEUTRINO_ARGS: Ορίσματα Εκκίνησης Neutrino
+  HINT_NEUTRINO_ARGS: 'Επιπλέον σημαίες Neutrino, διαχωρισμένες με κενό (π.χ. -mt=dvd). Το καθολικό ισχύει για όλα τα παιχνίδια· ανά παιχνίδι προστίθεται επιπλέον. Προσθέστε $ πριν μια σημαία για απενεργοποίηση χωρίς διαγραφή.'
+  NEUTRINO_VIDEO: Βίντεο Neutrino
+  HINT_NEUTRINO_VIDEO: Εξαναγκασμός λειτουργίας βίντεο GS εξόδου Neutrino (-gsm). Ανενεργό διατηρεί την προεπιλογή του παιχνιδιού.
+  NEUTRINO_PATH: Διαδρομή Neutrino ELF
+  HINT_NEUTRINO_PATH: Πλήρης διαδρομή προς neutrino.elf (π.χ. mc0:NEUTRINO/neutrino.elf). Κενό = αυτόματη ανίχνευση σε mc0/mc1.
+  POPSTARTER_PATH: Διαδρομή POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Προσαρμοσμένη διαδρομή POPSTARTER.ELF· αν είναι κενή/ανύπαρκτη χρησιμοποιείται ο φάκελος POPS της συσκευής. Πληκτρολόγιο έως 31 χαρακτήρες· μεγαλύτερες διαδρομές μέσω settings_riptopl.cfg.
+  BDMA_SOURCE: Πηγή BDMA
+  HINT_BDMA_SOURCE: Συσκευή της οποίας ο φάκελος POPS περιέχει τα αρχεία οδηγού BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Λειτουργία BDMA
+  HINT_BDMA_MODE: Οδηγός μπλοκ συσκευής exFAT που φορτώνει το POPSTARTER. Η αλλαγή αντιγράφει τα modules στην κάρτα· FAT32 = κανένας (ενσωματωμένος οδηγός).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Εσωτερικός HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Τα αρχεία module BDMA δεν βρέθηκαν στη συσκευή πηγής.
+  BDMA_ERR_SPACE: Δεν υπάρχει αρκετός χώρος στην κάρτα μνήμης για τα modules BDMA.
+  BDMA_ERR_IO: Σφάλμα εγγραφής modules BDMA στην κάρτα μνήμης.
+  COVERFLOW_SETTINGS: Ρυθμίσεις Coverflow
+  COVERFLOW_COUNT: Πλήθος Εξωφύλλων
+  COVERFLOW_SCALE: Κλίμακα Κέντρου
+  COVERFLOW_ANIM: Ταχύτητα Κινούμενης Εικόνας
+  COVERFLOW_DIM: Σκίαση Πλευρικών Εξωφύλλων
+  NONE: Κανένα
+  SMALL: Μικρό
+  LARGE: Μεγάλο
+  NORMAL: Κανονικό
+  FAV: Αγαπημένα
+  FAVMODE: Λειτουργία Εκκίνησης Αγαπημένων
+  FAV_HINT: Αγαπημένο
+  FAV_MSG: '%s δεν επιτρέπεται μέσω Μενού Αγαπημένων.'
+  FAV_PERSISTENCE_MSG: '%s δεν επιτρέπεται ενώ το στοιχείο είναι σημειωμένο ως αγαπημένο.'
+  NEUTRINO_DEVICE: Συσκευή Neutrino
+  HINT_NEUTRINO_DEVICE: Συσκευή που περιέχει το neutrino.elf (στον φάκελο NEUTRINO/ ή neutrino/). Αυτόματη σάρωση σε mc0 και μετά mc1.
+  NARGS_QB: Γρήγορη Εκκίνηση (-qb)
+  NARGS_CWD: Φάκελος Εργασίας (-cwd)
+  NARGS_CFG: Ρύθμιση (-cfg)
+  NARGS_ELF: ELF Εκκίνησης (-elf)
+  NARGS_ATA0: Εικόνα ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Εικόνα ATA1 (-ata1)
+  NARGS_EXTRA: Επιπλέον Ορίσματα
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Αρχείο .tar εξωφύλλων
+  DISABLE_ALL: Απενεργοποίηση όλων
+  BOOT_LOADING_CONFIG: Φόρτωση ρυθμίσεων...
+  BOOT_SCANNING_BDM: Σάρωση μονάδων USB / κάρτας / δικτύου...
+  BOOT_SCANNING_NET: Εκκίνηση δικτύου...
+  BOOT_SCANNING_HDD: Σάρωση HDD...
+  BOOT_READY: Έτοιμο.
+  UDPFS_GAMES: "Παιχνίδια UDPFS"
+  UDPFSBD_GAMES: "Παιχνίδια UDPFSBD"
+  NET_PROTOCOL: "Πρωτόκολλο δικτύου"
+  NET_NEEDS_NEUTRINO: "Τα παιχνίδια δικτύου (UDP) εκκινούν μόνο μέσω του πυρήνα Neutrino. Βεβαιωθείτε ότι το neutrino.elf υπάρχει και ότι η μορφή υποστηρίζεται."
+  VCD_NOT_ON_NET: "Τα παιχνίδια PS1 (.VCD) δεν εκκινούν μέσω της συσκευής δικτύου."
+  MX4SIO_PADEMU_WARN: "Το MX4SIO και η προσομοίωση χειριστηρίου μοιράζονται τον δίαυλο SIO2 και το παιχνίδι ίσως δεν εκκινήσει."
+  HINT_OSD_SETTINGS_LNG: "Επιβολή προσαρμοσμένης ρύθμισης γλώσσας"
+  OSD_SETTINGS_TVASPECT: "Μέγεθος οθόνης"
+  FULL_SCREEN: "Πλήρης οθόνη"
+  OSD_SETTINGS_VMODE: "Λειτουργία βίντεο"
+  SYSTEM_DEFAULT: "Προεπιλογή συστήματος"
+  HIGH: "Υψηλή"
+  LOW: "Χαμηλή"
+  XSENSITIVITY: "Ευαισθησία αναλογικού άξονα X"
+  YSENSITIVITY: "Ευαισθησία αναλογικού άξονα Y"
+  FILE_COUNT: "Αρχεία που βρέθηκαν: %i"
+  CHEAT_SELECTION: "Επιλογή cheat"
+  HDD_HINT: "Επιτρέπεται μόνο ένας HDD· η ενεργοποίηση κλειδώνει APA ή GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "Το MMCE GameID δεν εφαρμόστηκε -- το neutrino.elf βρίσκεται σε αυτήν την κάρτα (η αλλαγή της θα αφαιρούσε το Neutrino)."
+  POPSTARTER_DEVICE: "Συσκευή POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Συσκευή με POPS/POPSTARTER.ELF για εκκινήσεις PS1 VCD. Προεπιλογή = συσκευή εκκίνησης (cwd) και μετά η ίδια η συσκευή του VCD. Η προσαρμοσμένη εμφανίζει διαδρομή ελεύθερου κειμένου."
+  BDMA_APPLY: "Εφαρμογή VCD BDMA κατά την εκκίνηση"
+  HINT_BDMA_APPLY: "Ενεργό: αυτόματη τοποθέτηση του αντίστοιχου οδηγού exFAT του VCD στην κάρτα μνήμης πριν την εκκίνηση (συνιστάται). Ανενεργό: διαχειριστείτε το μόνοι σας με τους επιλογείς Source/Mode του BDMA παρακάτω."
+  NETBOOT_RESTART: "Επανεκκινήστε το OPL για να εφαρμοστεί η αλλαγή του πρωτοκόλλου εκκίνησης δικτύου."
+  UDPFS_MODE: "Πρόσβαση UDPFS"
+  "MENU": "Μενού"
+  "APPS": "Εφαρμογές"
+  "DEBUG": "Χρώματα Debug"
+  "COVERART": "Εξώφυλλο"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Λειτουργίες Εγγραφής"
+  "MODE1": "Λειτουργία 1"
+  "MODE2": "Λειτουργία 2"
+  "MODE3": "Λειτουργία 3"
+  "MODE4": "Λειτουργία 4"
+  "MODE5": "Λειτουργία 5"
+  "MODE6": "Λειτουργία 6"
+  "ENABLEGSM": "Επιλογέας GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Μηχανή Cheat PS2RD"
+  "PADEMU_ENABLE": "Εξομοιωτής Χειριστηρίου"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Εξομοίωση"
+  "PADEMU_VIB": "Δόνηση"
+  "PADEMU_WORKAROUND": "Λύση Ψεύτικου DS3"
+  "SFX": "Ηχητικά Εφέ"
+  "BOOT_SND": "Ήχος Εκκίνησης"
+  "ENABLE_NOTIFICATIONS": "Ειδοποιήσεις"
+  "OPTIONS": "Επιλογές"
+  "GLOBAL_SETTINGS": "Γενικά"
+  "INFO_GENRE": "Είδος"
+  "INFO_RELEASE": "Κυκλοφορία"
+  "INFO_DESCRIPTION": "Περιγραφή"
+  "BLOCKDEVICE_SETTINGS": "Συσκευές Μπλοκ"
+  "CONTROLLER_SETTINGS": "Ρυθμίσεις Χειριστηρίου"
+  "HINT_BDM_START": "Ενεργοποίηση/απενεργοποίηση του Block Device Manager."
+  "HINT_BLOCK_DEVICES": "Ενεργοποίηση/απενεργοποίηση συσκευών μπλοκ (π.χ. USB)."
+  "USB_GAMES": "Παιχνίδια USB"
+  "ILINK_GAMES": "Παιχνίδια iLink"
+  "MX4SIO_GAMES": "Παιχνίδια MX4SIO"
+  "PADMACROCONFIG": "Ρύθμιση PADMACRO"
+  "PADMACRO_SETTINGS": "Ρυθμίσεις Pad macro"
+  "PADMACRO_ENABLE": "Pad macros"
+  "PADMACRO_SLOWDOWN": "Επιβράδυνση αναλογικού:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Μείωση εύρους του αναλογικού μοχλού όταν πατιέται το κουμπί"
+  "LEFT_ANALOG": "Αριστερός μοχλός"
+  "RIGHT_ANALOG": "Δεξιός μοχλός"
+  "PADMACRO_INVERT_AXIS": "Αντιστροφή άξονα αναλογικού:"
+  "HINT_PADMACRO_INVERT_AXIS": "Αντιστροφή άξονα αναλογικού μοχλού"
+  "TURBO_SPEED": "Ταχύτητα κουμπιού turbo"
+  "HINT_TURBO_SPEED": "Πόσο γρήγορα πατιέται το κουμπί όταν το turbo είναι ενεργό"
+  "ACT_WHILE_PRESSED": "Όσο πατιέται το κουμπί"
+  "ACT_TOGGLED": "Εναλλαγή με το κουμπί"
+  "LANGUAGE_JAPANESE": "ΙΑΠΩΝΙΚΑ"
+  "LANGUAGE_ENGLISH": "ΑΓΓΛΙΚΑ"
+  "LANGUAGE_FRENCH": "ΓΑΛΛΙΚΑ"
+  "LANGUAGE_SPANISH": "ΙΣΠΑΝΙΚΑ"
+  "LANGUAGE_GERMAN": "ΓΕΡΜΑΝΙΚΑ"
+  "LANGUAGE_ITALIAN": "ΙΤΑΛΙΚΑ"
+  "LANGUAGE_DUTCH": "ΟΛΛΑΝΔΙΚΑ"
+  "LANGUAGE_PORTUGUESE": "ΠΟΡΤΟΓΑΛΙΚΑ"
+  "LANGUAGE_RUSSIAN": "ΡΩΣΙΚΑ"
+  "LANGUAGE_KOREAN": "ΚΟΡΕΑΤΙΚΑ"
+  "LANGUAGE_TRAD_CHINESE": "ΠΑΡΑΔΟΣΙΑΚΑ ΚΙΝΕΖΙΚΑ"
+  "LANGUAGE_SIMPL_CHINESE": "ΑΠΛΟΠΟΙΗΜΕΝΑ ΚΙΝΕΖΙΚΑ"
+  "OSD_SETTINGS": "Ρυθμίσεις OSD"
+  "OSD_SETTINGS_LNG": "Γλώσσα OSD"
+  "ENABLE_LNG": "Αλλαγή γλώσσας"
+  "BGM": "Μουσική Υπόβαθρου"
+  "BGM_VOLUME": "Ένταση Μουσικής Υπόβαθρου"
+  "DEF_BGM_PATH": "Προεπιλεγμένη Μουσική Θέματος"
+  "DEF_BGM_PATH_HINT": "Ορισμός διαδρομής για ροή μουσικής του εσωτερικού θέματος."
+  "BOOT_SCANNING_MC": "Σάρωση καρτών μνήμης..."
+  "BOOT_LOADING_DRIVERS": "Φόρτωση οδηγών αποθήκευσης..."
+  "BOOT_LOADING_USB": "Φόρτωση οδηγού αποθήκευσης USB..."
+  "BOOT_ARMING_MMCE": "Ενεργοποίηση game-ID MMCE..."
+  "BOOT_LOADING_SOUNDS": "Φόρτωση ήχων θέματος..."
+  "BOOT_BUILDING_MENU": "Δημιουργία μενού..."
+  "NET_UDPFS_TAB_HINT": "UDPFS ενεργό -- ανοίξτε τη νέα καρτέλα UDPFS και πατήστε Confirm για σύνδεση. Η πλευρά PC εκτελεί udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Συσκευή μπλοκ δικτύου ενεργή -- η καρτέλα της εμφανίζεται μόλις απαντήσει ο διακομιστής PC (udpfsd -bdpath για UDPFS Image, udpbd-server για UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Το ανά παιχνίδι αρχείο VMC δεν βρέθηκε -- εκκίνηση χωρίς αυτό (το παιχνίδι χρησιμοποιεί την πραγματική του κάρτα)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Το Neutrino δεν μπορεί να εκκινήσει από αυτή τη συσκευή -- η εκκίνηση ματαιώθηκε."
+  "NEUTRINO_TOML_SYNC_FAILED": "Η διαμόρφωση δικτύου του Neutrino (bsd toml) λείπει ή δεν είναι εγγράψιμη -- η εκκίνηση ματαιώθηκε, ελέγξτε τον φάκελο neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Πολύ κατακερματισμένο για το Neutrino (%d θραύσματα, όριο %d συμπ. VMC) -- δοκιμή του πυρήνα OPL αντ' αυτού."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Πολύ κατακερματισμένο για το Neutrino (%d θραύσματα, όριο %d συμπ. VMC) -- κάντε ανασυγκρότηση στο PC· η εκκίνηση ματαιώθηκε."
+  "NEUTRINO_GSM_COMP": "Συμβατότητα GSM Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Διόρθωση αναστροφής πεδίων για παιχνίδια που τρέμουν ή σκίζονται υπό μια επιβεβλημένη λειτουργία Neutrino Video. Απαιτείται ορισμένη λειτουργία Neutrino Video."
+  "NARGS_DBC": "Χρώματα Debug (-dbc)"
+  "NARGS_LOGO": "Λογότυπο PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Απενεργοποίηση VMC 1 (διατήρηση κάρτας)"
+  "VMC_SLOT2_DISABLE": "Απενεργοποίηση VMC 2 (διατήρηση κάρτας)"
+  "HINT_VMC_SLOT_DISABLE": "Εκκίνηση χωρίς το VMC αυτής της υποδοχής διατηρώντας παράλληλα ρυθμισμένη την κάρτα της. Μόνο για εκκινήσεις Neutrino· το παιχνίδι στη συνέχεια χρησιμοποιεί την πραγματική κάρτα σε εκείνη την υποδοχή."
+  "NEUTRINO_BSDFS": "Σύστημα Αρχείων Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Επιβολή του συστήματος αρχείων συσκευής μπλοκ του Neutrino (-bsdfs). Auto = προεπιλογή ανά συσκευή. Τα hdl/bd είναι επιλογές για ειδικούς· συνδυάστε τα με ένα αντίστοιχο -dvd= στα ορίσματα εκκίνησης αν η αυτόματη μορφή διαδρομής δεν ταιριάζει."
+  "PLASCOLOR": "Χρώμα Ανάμειξης Plasma"
+  "VCD_HIDE_GAMEID": "Απόκρυψη Game ID PS1 (λίστα VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Μόνο αισθητικό -- απόκρυψη ενός αρχικού προθέματος game-ID (π.χ. SLUS_005.51.) από τα ονόματα λιστών PS1/VCD. Τα ονόματα χωρίς ID εμφανίζονται ως έχουν. Δεν αλλάζει την εκκίνηση, το εξώφυλλο ή τα αγαπημένα."
+  "VCD_FIRST_DISC": "Μόνο ο πρώτος δίσκος (πολυδισκικό PS1)"
+  "HINT_VCD_FIRST_DISC": "Εμφάνιση μόνο του Disc 1 ενός PS1 παιχνιδιού πολλαπλών δίσκων στις λίστες συσκευών (στυλ POPSLoader). Αποκρύπτει αρχεία με ονόματα (Disc 2), (CD 2), κ.λπ. Όλοι οι δίσκοι παραμένουν στην κάρτα για εναλλαγή εντός παιχνιδιού· τα Αγαπημένα δεν φιλτράρονται."
+  "GAMES_DEVICE": "Συσκευή Παιχνιδιού"
+  "DEFAULT_CORE": "Προεπιλεγμένος Πυρήνας Loader"
+  "HINT_DEFAULT_CORE": "Καθολικός προεπιλεγμένος πυρήνας για παιχνίδια των οποίων ο ανά παιχνίδι Loader Core έχει οριστεί σε Default. Το <OPL> είναι ο εγγενής πυρήνας· το Neutrino αλυσιδώνει το εξωτερικό neutrino.elf. Μια ανά παιχνίδι επιλογή υπερισχύει πάντα αυτού."
+  "VCD_SETTINGS": "Ρυθμίσεις VCD"
+  "FINANCIAL_SUPPORT": "Οικονομική Υποστήριξη"

--- a/lng_fork/Hungarian.yml
+++ b/lng_fork/Hungarian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Játékok rendezése ábécésorrendben
+  RUMBLE: Kontroller rezgése a menükben
+  HINT_RUMBLE: Rövid rezgés a kurzor mozgatásakor, megerősítéskor vagy visszalépéskor - DualShock szükséges analóg módban
+  FOLDER_NAV: Mappák böngészése a játéklistában
+  HINT_FOLDER_NAV: A CD/DVD almappáit böngészhető elemekként mutatja; kiválasztás megnyit, mégse visszalép
+  SETTINGS_NO_HOME: Nincs memóriakártya - a beállítások nem menthetők. Az OPL hálózati eszközről indult, amelynek beállításait helyi kártyán kell tárolni.
+  ERROR_SAVING_SETTINGS_TO: A beállítások mentése a(z) %s helyre sikertelen (hiba %d)
+  GENERAL_SETTINGS: Általános beállítások
+  DEVICE_SETTINGS: Eszközbeállítások
+  LAUNCH_PS2_DISC: PS2 lemez indítása
+  DISC_LAUNCH_ERR: Nincs PS2 lemez a meghajtóban.
+  DEFAULT: Alapértelmezett
+  HINT_MODE7: Csak Neutrino -- javítja az IOP puffertúlcsordulást okozó játékokat (-gc=7)
+  MODE7: 7. mód
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Előre elkészített PS2RD .img javítás alkalmazása a játékra.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE indítási mód
+  MMCE_PREFIX: MMCE előtag elérési út
+  MMCE_SLOT: MMCE foglalat
+  MMCEIGR_SLOT: IGR rendszerkártya foglalat(ok)
+  HINT_MMCEIGR_SLOT: A rendszerkártya-váltás parancs a kiválasztott foglalat(ok)ra kerül elküldésre IGR-kor
+  MMCE_ADVANCED: Speciális
+  MMCE_SETTINGS: MMCE beállítások
+  MMCE_SEMA: Szemafor sorba állítási módszer zárolása
+  HINT_MMCE_SEMA: A THFIFO javíthatja a kompatibilitást, de ronthatja a teljesítményt
+  MMCE_WAIT_CYCLES: Várakozási ciklusok /ACK alacsony után
+  HINT_MMCE_WAIT_CYCLES: Az alacsonyabb értékek javíthatják a teljesítményt, de instabilitást okozhatnak
+  MMCE_USE_ALARMS: Időtúllépési riasztások használata
+  HINT_MMCE_USE_ALARMS: A KI beállítás javíthatja a teljesítményt, de MMCE időtúllépés esetén lefagyást okozhat
+  CORE_LOADER: Betöltő mag
+  NEUTRINO_BAD_FORMAT: A Neutrino nem támogatja ezt a fájlformátumot, indítás <OPL> maggal
+  NEUTRINO_NOT_FOUND: A Neutrino ELF nem található, indítás <OPL> maggal
+  UDPBD_NEEDS_STATIC_IP: Az UDPBD statikus PS2 IP-t igényel. Állítsd be a Hálózati konfigurációban (a DHCP jelenleg be van kapcsolva).
+  NEUTRINO_SETTING_NA: Ez a beállítás nem használható a Neutrino maggal.
+  POPSTARTER_NOT_FOUND: Hiányzó POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Hiányzó POPSTARTER SMB követelmények
+  WRITE_POPSTARTER_NET: POPSTARTER hálózati konfiguráció írása
+  HINT_WRITE_POPSTARTER_NET: Az IP + SMB megosztási értékek mentése a POPSTARTER saját IPCONFIG.DAT / SMBCONFIG.DAT fájljaiba a memóriakártyán (SMB-n keresztüli VCD-hez).
+  POPSTARTER_NET_ERR: Nem sikerült a POPSTARTER hálózati konfigurációt a memóriakártyára írni.
+  VCD: VCD
+  VCD_ON: VCD játékok megjelenítése
+  VCD_OFF: Lemezes játékok megjelenítése
+  NEUTRINO_ARGS: Neutrino indítási argumentumok
+  HINT_NEUTRINO_ARGS: 'Extra Neutrino jelzők, szóközzel elválasztva (pl. -mt=dvd). A globális minden játékra vonatkozik; a játékonkénti hozzáadódik. Egy jelző elé írj $ jelet a letiltásához törlés nélkül.'
+  NEUTRINO_VIDEO: Neutrino videó
+  HINT_NEUTRINO_VIDEO: A Neutrino GS kimeneti videómódjának kényszerítése (-gsm). Ki = a játék alapértelmezettje marad.
+  NEUTRINO_PATH: Neutrino ELF elérési út
+  HINT_NEUTRINO_PATH: 'Teljes elérési út a neutrino.elf fájlhoz (pl. mc0:NEUTRINO/neutrino.elf). Üresen = automatikus keresés mc0/mc1-en.'
+  POPSTARTER_PATH: POPSTARTER.ELF elérési út
+  HINT_POPSTARTER_PATH: Egyéni POPSTARTER.ELF elérési út; üresen/hiányzóan az eszköz POPS mappájára vált vissza. A billentyűzet 31 karakterre korlátoz; hosszabb elérési utak a settings_riptopl.cfg-n keresztül adhatók meg.
+  BDMA_SOURCE: BDMA forrás
+  HINT_BDMA_SOURCE: Az az eszköz, amelynek POPS mappájában találhatók a BDMAssault illesztőprogram fájlok (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA mód
+  HINT_BDMA_MODE: exFAT blokkeszköz-illesztőprogram, amelyet a POPSTARTER betölt. A módosítás a modulokat a kártyára másolja; FAT32 = nincs (beépített illesztőprogram).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Belső HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: A BDMA modulfájlok nem találhatók a forráseszközön.
+  BDMA_ERR_SPACE: Nincs elegendő hely a memóriakártyán a BDMA modulokhoz.
+  BDMA_ERR_IO: Hiba a BDMA modulok memóriakártyára írása közben.
+  COVERFLOW_SETTINGS: Coverflow beállítások
+  COVERFLOW_COUNT: Borítók száma
+  COVERFLOW_SCALE: Középső méretezés
+  COVERFLOW_ANIM: Animáció sebessége
+  COVERFLOW_DIM: Oldalsó borítók halványítása
+  NONE: Egyik sem
+  SMALL: Kicsi
+  LARGE: Nagy
+  NORMAL: Normál
+  FAV: Kedvencek
+  FAVMODE: Kedvencek indítási mód
+  FAV_HINT: Kedvenc
+  FAV_MSG: '%s nem érhető el a Kedvencek menün keresztül.'
+  FAV_PERSISTENCE_MSG: '%s nem engedélyezett, amíg az elem kedvencként van jelölve.'
+  NEUTRINO_DEVICE: Neutrino eszköz
+  HINT_NEUTRINO_DEVICE: A neutrino.elf fájlt tartalmazó eszköz (NEUTRINO/ vagy neutrino/ mappában). Az Auto először mc0-t, majd mc1-et keres.
+  NARGS_QB: Gyors indítás (-qb)
+  NARGS_CWD: Munkakönyvtár (-cwd)
+  NARGS_CFG: Konfiguráció (-cfg)
+  NARGS_ELF: Rendszertöltő ELF (-elf)
+  NARGS_ATA0: ATA0 kép (-ata0)
+  NARGS_ATA0ID: ATA0 azonosító (-ata0id)
+  NARGS_ATA1: ATA1 kép (-ata1)
+  NARGS_EXTRA: Extra argumentumok
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Borító .tar archívum
+  DISABLE_ALL: Összes letiltása
+  BOOT_LOADING_CONFIG: Beállítások betöltése...
+  BOOT_SCANNING_BDM: USB / kártya / hálózati meghajtók keresése...
+  BOOT_SCANNING_NET: Hálózat indítása...
+  BOOT_SCANNING_HDD: HDD keresése...
+  BOOT_READY: Kész.
+  UDPFS_GAMES: "UDPFS játékok"
+  UDPFSBD_GAMES: "UDPFSBD játékok"
+  NET_PROTOCOL: "Hálózati protokoll"
+  NET_NEEDS_NEUTRINO: "A hálózati (UDP) játékok csak a Neutrino magon keresztül indíthatók. Ellenőrizze, hogy a neutrino.elf megvan-e és a formátum támogatott-e."
+  VCD_NOT_ON_NET: "A PS1 (.VCD) játékok nem indíthatók hálózati eszközről."
+  MX4SIO_PADEMU_WARN: "Az MX4SIO és a kontroller-emuláció közös SIO2 buszt használ, így a játék nem biztos, hogy elindul."
+  HINT_OSD_SETTINGS_LNG: "Egyéni nyelv kényszerítése"
+  OSD_SETTINGS_TVASPECT: "Képméret"
+  FULL_SCREEN: "Teljes képernyő"
+  OSD_SETTINGS_VMODE: "Videómód"
+  SYSTEM_DEFAULT: "Rendszer alapértelmezés"
+  HIGH: "Magas"
+  LOW: "Alacsony"
+  XSENSITIVITY: "Analóg X-tengely érzékenysége"
+  YSENSITIVITY: "Analóg Y-tengely érzékenysége"
+  FILE_COUNT: "Talált fájlok: %i"
+  CHEAT_SELECTION: "Csalások kiválasztása"
+  HDD_HINT: "Csak egy HDD engedélyezett; a bekapcsolás rögzíti az APA-t vagy a GPT-t."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID nem alkalmazva -- a neutrino.elf ezen a kártyán van (a váltás kikapcsolná a Neutrinót)."
+  POPSTARTER_DEVICE: "POPSTARTER.ELF eszköz"
+  HINT_POPSTARTER_DEVICE: "A POPS/POPSTARTER.ELF fájlt tároló eszköz PS1 VCD indításához. Alapértelmezett = indító eszköz (cwd), majd a VCD saját eszköze. A Custom szabad szövegű útvonalmezőt jelenít meg."
+  BDMA_APPLY: "VCD BDMA alkalmazása indításkor"
+  HINT_BDMA_APPLY: "Be: indítás előtt automatikusan felteszi a memóriakártyára az elindított VCD megfelelő exFAT illesztőprogramját (ajánlott). Ki: kezelje kézzel az alábbi BDMA Source/Mode választókkal."
+  NETBOOT_RESTART: "Indítsa újra az OPL-t a hálózati indítási protokoll módosításának alkalmazásához."
+  UDPFS_MODE: "UDPFS-hozzáférés"
+  "MENU": "Menü"
+  "APPS": "Alkalmazások"
+  "DEBUG": "Hibakereső színek"
+  "COVERART": "Borítókép"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Írási műveletek"
+  "MODE1": "1. mód"
+  "MODE2": "2. mód"
+  "MODE3": "3. mód"
+  "MODE4": "4. mód"
+  "MODE5": "5. mód"
+  "MODE6": "6. mód"
+  "ENABLEGSM": "GSM választó"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD csalómotor"
+  "PADEMU_ENABLE": "Kontroller emulátor"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emuláció"
+  "PADEMU_VIB": "Rezgés"
+  "PADEMU_WORKAROUND": "Hamis DS3 megoldás"
+  "SFX": "Hangeffektek"
+  "BOOT_SND": "Indítási hang"
+  "ENABLE_NOTIFICATIONS": "Értesítések"
+  "OPTIONS": "Beállítások"
+  "GLOBAL_SETTINGS": "Globális"
+  "INFO_GENRE": "Műfaj"
+  "INFO_RELEASE": "Megjelenés"
+  "INFO_DESCRIPTION": "Leírás"
+  "BLOCKDEVICE_SETTINGS": "Blokkeszközök"
+  "CONTROLLER_SETTINGS": "Kontroller beállítások"
+  "HINT_BDM_START": "A Block Device Manager be- és kikapcsolása."
+  "HINT_BLOCK_DEVICES": "Blokkeszközök be- és kikapcsolása (pl. USB)."
+  "USB_GAMES": "USB játékok"
+  "ILINK_GAMES": "iLink játékok"
+  "MX4SIO_GAMES": "MX4SIO játékok"
+  "PADMACROCONFIG": "PADMACRO beállítása"
+  "PADMACRO_SETTINGS": "Pad makró beállítások"
+  "PADMACRO_ENABLE": "Pad makrók"
+  "PADMACRO_SLOWDOWN": "Analóg lassítás:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Az analóg kar tartományának csökkentése gombnyomásra"
+  "LEFT_ANALOG": "Bal kar"
+  "RIGHT_ANALOG": "Jobb kar"
+  "PADMACRO_INVERT_AXIS": "Analóg tengely fordítása:"
+  "HINT_PADMACRO_INVERT_AXIS": "Analóg kar tengelyének fordítása"
+  "TURBO_SPEED": "Turbógomb sebessége"
+  "HINT_TURBO_SPEED": "Milyen gyorsan nyomja a gombot, ha a turbó aktív"
+  "ACT_WHILE_PRESSED": "Gomb lenyomva tartva"
+  "ACT_TOGGLED": "Gombbal kapcsolva"
+  "LANGUAGE_JAPANESE": "JAPÁN"
+  "LANGUAGE_ENGLISH": "ANGOL"
+  "LANGUAGE_FRENCH": "FRANCIA"
+  "LANGUAGE_SPANISH": "SPANYOL"
+  "LANGUAGE_GERMAN": "NÉMET"
+  "LANGUAGE_ITALIAN": "OLASZ"
+  "LANGUAGE_DUTCH": "HOLLAND"
+  "LANGUAGE_PORTUGUESE": "PORTUGÁL"
+  "LANGUAGE_RUSSIAN": "OROSZ"
+  "LANGUAGE_KOREAN": "KOREAI"
+  "LANGUAGE_TRAD_CHINESE": "HAGYOMÁNYOS KÍNAI"
+  "LANGUAGE_SIMPL_CHINESE": "EGYSZERŰSÍTETT KÍNAI"
+  "OSD_SETTINGS": "OSD beállítások"
+  "OSD_SETTINGS_LNG": "OSD nyelve"
+  "ENABLE_LNG": "Nyelv megváltoztatása"
+  "BGM": "Háttérzene"
+  "BGM_VOLUME": "Háttérzene hangereje"
+  "DEF_BGM_PATH": "Alapértelmezett témazene"
+  "DEF_BGM_PATH_HINT": "Adja meg a belső témához streamelt zene elérési útját."
+  "BOOT_SCANNING_MC": "Memóriakártyák vizsgálata..."
+  "BOOT_LOADING_DRIVERS": "Tárolóillesztők betöltése..."
+  "BOOT_LOADING_USB": "USB tárolóillesztő betöltése..."
+  "BOOT_ARMING_MMCE": "MMCE játék-azonosító élesítése..."
+  "BOOT_LOADING_SOUNDS": "Témahangok betöltése..."
+  "BOOT_BUILDING_MENU": "Menü felépítése..."
+  "NET_UDPFS_TAB_HINT": "UDPFS bekapcsolva -- nyisd meg az új UDPFS fület, és nyomd meg a Megerősítést a csatlakozáshoz. A PC oldalon az udpfsd -fsroot <games folder> fut."
+  "NET_UDPBD_TAB_HINT": "A hálózati blokkeszköz bekapcsolva -- a füle megjelenik, amint a PC-szerver válaszol (udpfsd -bdpath az UDPFS Image-hez, udpbd-server az UDPBD-hez)."
+  "NEUTRINO_VMC_MISSING": "A játékonkénti VMC fájl nem található -- indítás nélküle (a játék a valódi kártyáját használja)."
+  "NEUTRINO_DEV_UNSUPPORTED": "A Neutrino nem tud indulni erről az eszközről -- indítás megszakítva."
+  "NEUTRINO_TOML_SYNC_FAILED": "A Neutrino hálózati konfigurációja (bsd toml) hiányzik vagy nem írható -- az indítás megszakítva, ellenőrizd a neutrino mappát."
+  "NEUTRINO_TOO_FRAGMENTED": "Túl töredezett a Neutrinóhoz (%d töredék, korlát %d a VMC-kkel együtt) -- helyette az OPL mag megpróbálása."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Túl töredezett a Neutrinóhoz (%d töredék, korlát %d a VMC-kkel együtt) -- töredezettségmentesítsd a PC-n; az indítás megszakítva."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM kompatibilitás"
+  "HINT_NEUTRINO_GSM_COMP": "Mezőváltó javítás azokhoz a játékokhoz, amelyek remegnek vagy szakadoznak egy kényszerített Neutrino Videó mód alatt. Beállított Neutrino Videó módot igényel."
+  "NARGS_DBC": "Hibakereső színek (-dbc)"
+  "NARGS_LOGO": "PS2 logó (-logo)"
+  "VMC_SLOT1_DISABLE": "VMC 1 letiltása (kártya megtartása)"
+  "VMC_SLOT2_DISABLE": "VMC 2 letiltása (kártya megtartása)"
+  "HINT_VMC_SLOT_DISABLE": "Indítás e nyílás VMC-je nélkül, miközben a kártyája konfigurálva marad. Csak Neutrino indításnál; a játék ekkor az adott nyílásban lévő valódi kártyát használja."
+  "NEUTRINO_BSDFS": "Neutrino fájlrendszer"
+  "HINT_NEUTRINO_BSDFS": "A Neutrino blokkeszköz-fájlrendszerének kényszerítése (-bsdfs). Auto = eszközönkénti alapértelmezés. A hdl/bd szakértői beállítások; párosítsd őket egy megfelelő -dvd= értékkel az indítási argumentumokban, ha az automatikus útvonal alakja nem illik."
+  "PLASCOLOR": "Plazma keverési szín"
+  "VCD_HIDE_GAMEID": "PS1 játék-azonosító elrejtése (VCD lista)"
+  "HINT_VCD_HIDE_GAMEID": "Csak kozmetikai -- elrejti a bevezető játék-azonosító előtagot (pl. SLUS_005.51.) a PS1/VCD listanevekből. Az azonosító nélküli nevek változatlanul jelennek meg. Nem változtatja meg az indítást, a borítót vagy a kedvenceket."
+  "VCD_FIRST_DISC": "Csak első lemez (több lemezes PS1)"
+  "HINT_VCD_FIRST_DISC": "Az eszközlistákban csak egy több lemezes PS1 játék 1. lemezét mutatja (POPSLoader stílus). Elrejti a (Disc 2), (CD 2) stb. nevű fájlokat. Minden lemez a kártyán marad a játékon belüli cseréhez; a Kedvencek nincsenek szűrve."
+  "GAMES_DEVICE": "Játék eszköze"
+  "DEFAULT_CORE": "Alapértelmezett betöltő mag"
+  "HINT_DEFAULT_CORE": "Globális alapértelmezett mag azokhoz a játékokhoz, amelyeknél a játékonkénti Betöltő Mag Alapértelmezettre van állítva. Az <OPL> a natív mag; a Neutrino a külső neutrino.elf fájlt láncolja. A játékonkénti választás mindig felülírja ezt."
+  "VCD_SETTINGS": "VCD beállítások"
+  "FINANCIAL_SUPPORT": "Anyagi támogatás"

--- a/lng_fork/Indonesian.yml
+++ b/lng_fork/Indonesian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Urutkan Game Menurut Abjad
+  RUMBLE: Getaran Kontroler di Menu
+  HINT_RUMBLE: Getaran singkat saat menggerakkan kursor, mengonfirmasi, atau kembali - perlu DualShock dalam mode analog
+  FOLDER_NAV: Jelajahi Folder di Daftar Game
+  HINT_FOLDER_NAV: Tampilkan subfolder CD/DVD sebagai entri yang dapat dijelajahi; pilih untuk membuka, batal untuk kembali
+  SETTINGS_NO_HOME: Kartu memori tidak ditemukan - pengaturan tidak dapat disimpan. OPL di-boot dari perangkat jaringan, yang pengaturannya harus tersimpan di kartu lokal.
+  ERROR_SAVING_SETTINGS_TO: Gagal menulis pengaturan ke %s (kesalahan %d)
+  GENERAL_SETTINGS: Pengaturan Umum
+  DEVICE_SETTINGS: Pengaturan Perangkat
+  LAUNCH_PS2_DISC: Jalankan Disc PS2
+  DISC_LAUNCH_ERR: Tidak ada disc PS2 di drive.
+  DEFAULT: Default
+  HINT_MODE7: Hanya Neutrino -- perbaiki game yang melampaui buffer IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Terapkan patch PS2RD .img yang sudah dibuat ke game Anda.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Mode Mulai MMCE
+  MMCE_PREFIX: Path Prefix MMCE
+  MMCE_SLOT: Slot MMCE
+  MMCEIGR_SLOT: Slot Bootcard IGR
+  HINT_MMCEIGR_SLOT: Perintah beralih ke bootcard akan dikirim ke slot yang dipilih saat IGR
+  MMCE_ADVANCED: Lanjutan
+  MMCE_SETTINGS: Pengaturan MMCE
+  MMCE_SEMA: Metode Antrian Kunci Sema
+  HINT_MMCE_SEMA: THFIFO dapat membantu kompatibilitas tetapi menurunkan performa
+  MMCE_WAIT_CYCLES: Siklus tunggu setelah /ACK rendah
+  HINT_MMCE_WAIT_CYCLES: Nilai lebih rendah dapat meningkatkan performa tetapi menyebabkan ketidakstabilan
+  MMCE_USE_ALARMS: Gunakan alarm timeout
+  HINT_MMCE_USE_ALARMS: OFF dapat membantu performa tetapi dapat menyebabkan timeout MMCE berujung freeze
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino tidak mendukung format file ini, menjalankan dengan core <OPL>
+  NEUTRINO_NOT_FOUND: ELF Neutrino tidak ditemukan, menjalankan dengan core <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD membutuhkan IP PS2 statis. Atur di Konfigurasi Jaringan (DHCP sedang aktif).
+  NEUTRINO_SETTING_NA: Pengaturan ini tidak digunakan dengan core Neutrino.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF tidak ditemukan
+  POPSTARTER_SMB_MISSING: Persyaratan SMB POPSTARTER tidak terpenuhi
+  WRITE_POPSTARTER_NET: Tulis Konfigurasi Jaringan POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Simpan juga nilai IP + SMB share ini ke IPCONFIG.DAT / SMBCONFIG.DAT milik POPSTARTER di kartu memori (untuk VCD lewat SMB).
+  POPSTARTER_NET_ERR: Gagal menulis konfigurasi jaringan POPSTARTER ke kartu memori.
+  VCD: VCD
+  VCD_ON: Menampilkan game VCD
+  VCD_OFF: Menampilkan game disc
+  NEUTRINO_ARGS: Argumen Launch Neutrino
+  HINT_NEUTRINO_ARGS: 'Flag Neutrino tambahan, dipisah spasi (misal -mt=dvd). Global berlaku untuk semua game; per-game ditambahkan di atasnya. Awali flag dengan $ untuk menonaktifkan tanpa menghapus.'
+  NEUTRINO_VIDEO: Video Neutrino
+  HINT_NEUTRINO_VIDEO: Paksa mode video output GS Neutrino (-gsm). Off mempertahankan default game.
+  NEUTRINO_PATH: Path ELF Neutrino
+  HINT_NEUTRINO_PATH: Path lengkap ke neutrino.elf (misal mc0:NEUTRINO/neutrino.elf). Kosong = deteksi otomatis di mc0/mc1.
+  POPSTARTER_PATH: Path POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Path POPSTARTER.ELF kustom; otomatis kembali ke folder POPS perangkat jika kosong/tidak ada. Keyboard maks 31 karakter; path lebih panjang via settings_riptopl.cfg.
+  BDMA_SOURCE: Sumber BDMA
+  HINT_BDMA_SOURCE: Perangkat yang folder POPS-nya menyimpan file driver BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Mode BDMA
+  HINT_BDMA_MODE: Driver blok-perangkat exFAT yang dimuat POPSTARTER. Mengubahnya menyalin modul ke kartu; FAT32 = tidak ada (driver bawaan).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD Internal
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: File modul BDMA tidak ditemukan di perangkat sumber.
+  BDMA_ERR_SPACE: Ruang kartu memori tidak cukup untuk modul BDMA.
+  BDMA_ERR_IO: Kesalahan saat menulis modul BDMA ke kartu memori.
+  COVERFLOW_SETTINGS: Pengaturan Coverflow
+  COVERFLOW_COUNT: Jumlah Cover
+  COVERFLOW_SCALE: Skala Tengah
+  COVERFLOW_ANIM: Kecepatan Animasi
+  COVERFLOW_DIM: Redupkan Cover Samping
+  NONE: Tidak Ada
+  SMALL: Kecil
+  LARGE: Besar
+  NORMAL: Normal
+  FAV: Favorit
+  FAVMODE: Mode Mulai Favorit
+  FAV_HINT: Favorit
+  FAV_MSG: '%s tidak diizinkan melalui Menu Favorit.'
+  FAV_PERSISTENCE_MSG: '%s tidak diizinkan selama item ditandai sebagai favorit.'
+  NEUTRINO_DEVICE: Perangkat Neutrino
+  HINT_NEUTRINO_DEVICE: Perangkat yang menyimpan neutrino.elf (di folder NEUTRINO/ atau neutrino/). Auto memindai mc0 lalu mc1.
+  NARGS_QB: Quick Boot (-qb)
+  NARGS_CWD: Direktori Kerja (-cwd)
+  NARGS_CFG: Config (-cfg)
+  NARGS_ELF: Boot ELF (-elf)
+  NARGS_ATA0: Image ATA0 (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: Image ATA1 (-ata1)
+  NARGS_EXTRA: Argumen Tambahan
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Arsip .tar sampul
+  DISABLE_ALL: Nonaktifkan Semua
+  BOOT_LOADING_CONFIG: Memuat pengaturan...
+  BOOT_SCANNING_BDM: Memindai drive USB / kartu / jaringan...
+  BOOT_SCANNING_NET: Memulai jaringan...
+  BOOT_SCANNING_HDD: Memindai HDD...
+  BOOT_READY: Siap.
+  UDPFS_GAMES: "Game UDPFS"
+  UDPFSBD_GAMES: "Game UDPFSBD"
+  NET_PROTOCOL: "Protokol Jaringan"
+  NET_NEEDS_NEUTRINO: "Game jaringan (UDP) hanya bisa di-boot lewat core Neutrino. Pastikan neutrino.elf tersedia dan formatnya didukung."
+  VCD_NOT_ON_NET: "Game PS1 (.VCD) tidak bisa dijalankan lewat perangkat jaringan."
+  MX4SIO_PADEMU_WARN: "MX4SIO dan emulasi pad berbagi bus SIO2 dan game mungkin gagal di-boot."
+  HINT_OSD_SETTINGS_LNG: "Paksa konfigurasi bahasa kustom"
+  OSD_SETTINGS_TVASPECT: "Ukuran Layar"
+  FULL_SCREEN: "Layar Penuh"
+  OSD_SETTINGS_VMODE: "Mode Video"
+  SYSTEM_DEFAULT: "Bawaan Sistem"
+  HIGH: "Tinggi"
+  LOW: "Rendah"
+  XSENSITIVITY: "Sensitivitas Sumbu-X Analog"
+  YSENSITIVITY: "Sensitivitas Sumbu-Y Analog"
+  FILE_COUNT: "File ditemukan: %i"
+  CHEAT_SELECTION: "Pilihan Cheat"
+  HDD_HINT: "Hanya satu HDD yang diizinkan, mengaktifkan akan mengunci APA atau GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID tidak diterapkan -- neutrino.elf ada di kartu ini (menggantinya akan membongkar Neutrino)."
+  POPSTARTER_DEVICE: "Perangkat POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Perangkat yang menyimpan POPS/POPSTARTER.ELF untuk peluncuran VCD PS1. Default = perangkat boot (cwd) lalu perangkat VCD itu sendiri. Kustom menampilkan jalur teks bebas."
+  BDMA_APPLY: "Terapkan VCD BDMA saat Peluncuran"
+  HINT_BDMA_APPLY: "Aktif: otomatis pasang driver exFAT yang cocok dengan VCD yang diluncurkan ke kartu memori sebelum boot (disarankan). Nonaktif: kelola sendiri dengan pemilih Sumber/Mode BDMA di bawah."
+  NETBOOT_RESTART: "Mulai ulang OPL untuk menerapkan perubahan protokol boot jaringan."
+  UDPFS_MODE: "Akses UDPFS"
+  "MENU": "Menu"
+  "APPS": "Aplikasi"
+  "DEBUG": "Warna Debug"
+  "COVERART": "Gambar Sampul"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operasi Tulis"
+  "MODE1": "Mode 1"
+  "MODE2": "Mode 2"
+  "MODE3": "Mode 3"
+  "MODE4": "Mode 4"
+  "MODE5": "Mode 5"
+  "MODE6": "Mode 6"
+  "ENABLEGSM": "Pemilih GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Mesin Cheat PS2RD"
+  "PADEMU_ENABLE": "Emulator Pad"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulasi"
+  "PADEMU_VIB": "Getaran"
+  "PADEMU_WORKAROUND": "Solusi Palsu DS3"
+  "SFX": "Efek Suara"
+  "BOOT_SND": "Suara Boot"
+  "ENABLE_NOTIFICATIONS": "Notifikasi"
+  "OPTIONS": "Opsi"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Rilis"
+  "INFO_DESCRIPTION": "Deskripsi"
+  "BLOCKDEVICE_SETTINGS": "Perangkat Blok"
+  "CONTROLLER_SETTINGS": "Pengaturan Kontroler"
+  "HINT_BDM_START": "Aktif/nonaktifkan Block Device Manager."
+  "HINT_BLOCK_DEVICES": "Aktif/nonaktifkan Perangkat Blok (mis. USB)."
+  "USB_GAMES": "Game USB"
+  "ILINK_GAMES": "Game iLink"
+  "MX4SIO_GAMES": "Game MX4SIO"
+  "PADMACROCONFIG": "Konfigurasi PADMACRO"
+  "PADMACRO_SETTINGS": "Pengaturan Makro Pad"
+  "PADMACRO_ENABLE": "Makro pad"
+  "PADMACRO_SLOWDOWN": "Perlambatan analog:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Kurangi jangkauan stik analog saat tombol ditekan"
+  "LEFT_ANALOG": "Stik kiri"
+  "RIGHT_ANALOG": "Stik kanan"
+  "PADMACRO_INVERT_AXIS": "Balik sumbu analog:"
+  "HINT_PADMACRO_INVERT_AXIS": "Balik sumbu stik analog"
+  "TURBO_SPEED": "Kecepatan tombol turbo"
+  "HINT_TURBO_SPEED": "Seberapa cepat menekan tombol saat turbo aktif"
+  "ACT_WHILE_PRESSED": "Saat tombol ditekan"
+  "ACT_TOGGLED": "Diaktifkan oleh tombol"
+  "LANGUAGE_JAPANESE": "JEPANG"
+  "LANGUAGE_ENGLISH": "INGGRIS"
+  "LANGUAGE_FRENCH": "PRANCIS"
+  "LANGUAGE_SPANISH": "SPANYOL"
+  "LANGUAGE_GERMAN": "JERMAN"
+  "LANGUAGE_ITALIAN": "ITALIA"
+  "LANGUAGE_DUTCH": "BELANDA"
+  "LANGUAGE_PORTUGUESE": "PORTUGIS"
+  "LANGUAGE_RUSSIAN": "RUSIA"
+  "LANGUAGE_KOREAN": "KOREA"
+  "LANGUAGE_TRAD_CHINESE": "TIONGHOA TRADISIONAL"
+  "LANGUAGE_SIMPL_CHINESE": "TIONGHOA SEDERHANA"
+  "OSD_SETTINGS": "Pengaturan OSD"
+  "OSD_SETTINGS_LNG": "Bahasa OSD"
+  "ENABLE_LNG": "Ubah bahasa"
+  "BGM": "Musik Latar"
+  "BGM_VOLUME": "Volume Musik Latar"
+  "DEF_BGM_PATH": "Musik Tema Bawaan"
+  "DEF_BGM_PATH_HINT": "Tetapkan jalur untuk memutar musik tema internal."
+  "BOOT_SCANNING_MC": "Memindai memory card..."
+  "BOOT_LOADING_DRIVERS": "Memuat driver penyimpanan..."
+  "BOOT_LOADING_USB": "Memuat driver penyimpanan USB..."
+  "BOOT_ARMING_MMCE": "Menyiapkan game-ID MMCE..."
+  "BOOT_LOADING_SOUNDS": "Memuat suara tema..."
+  "BOOT_BUILDING_MENU": "Membangun menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS aktif -- buka tab UDPFS baru dan tekan Confirm untuk terhubung. Sisi PC menjalankan udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Network block device aktif -- tab-nya muncul begitu server PC merespons (udpfsd -bdpath untuk UDPFS Image, udpbd-server untuk UDPBD)."
+  "NEUTRINO_VMC_MISSING": "File VMC per-game tidak ditemukan -- meluncurkan tanpanya (game menggunakan kartu aslinya)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino tidak dapat meluncur dari perangkat ini -- peluncuran dibatalkan."
+  "NEUTRINO_TOML_SYNC_FAILED": "Konfigurasi jaringan Neutrino (bsd toml) hilang atau tidak dapat ditulis -- peluncuran dibatalkan, periksa folder neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Terlalu terfragmentasi untuk Neutrino (%d fragmen, batas %d termasuk VMC) -- mencoba core OPL sebagai gantinya."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Terlalu terfragmentasi untuk Neutrino (%d fragmen, batas %d termasuk VMC) -- defragmentasi di PC; peluncuran dibatalkan."
+  "NEUTRINO_GSM_COMP": "Kompatibilitas GSM Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Perbaikan field-flipping untuk game yang bergetar atau robek di bawah mode Neutrino Video yang dipaksakan. Membutuhkan mode Neutrino Video yang diatur."
+  "NARGS_DBC": "Warna Debug (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Nonaktifkan VMC 1 (simpan kartu)"
+  "VMC_SLOT2_DISABLE": "Nonaktifkan VMC 2 (simpan kartu)"
+  "HINT_VMC_SLOT_DISABLE": "Luncurkan tanpa VMC slot ini sambil tetap mempertahankan konfigurasi kartunya. Hanya untuk peluncuran Neutrino; game kemudian menggunakan kartu asli di slot itu."
+  "NEUTRINO_BSDFS": "Sistem File Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Paksa filesystem block-device milik Neutrino (-bsdfs). Auto = default per perangkat. hdl/bd adalah opsi lanjutan; pasangkan dengan -dvd= yang cocok di argumen peluncuran jika bentuk jalur auto tidak sesuai."
+  "PLASCOLOR": "Warna Campuran Plasma"
+  "VCD_HIDE_GAMEID": "Sembunyikan Game ID PS1 (daftar VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Kosmetik saja -- sembunyikan prefiks game-ID di depan (mis. SLUS_005.51.) dari nama daftar PS1/VCD. Nama tanpa ID ditampilkan apa adanya. Tidak mengubah peluncuran, cover art, atau favourites."
+  "VCD_FIRST_DISC": "Hanya disc pertama (PS1 multi-disc)"
+  "HINT_VCD_FIRST_DISC": "Tampilkan hanya Disc 1 dari game PS1 multi-disc di daftar perangkat (gaya POPSLoader). Menyembunyikan file bernama (Disc 2), (CD 2), dll. Semua disc tetap ada di kartu untuk pergantian dalam game; Favourites tidak difilter."
+  "GAMES_DEVICE": "Perangkat Game"
+  "DEFAULT_CORE": "Loader Core Bawaan"
+  "HINT_DEFAULT_CORE": "Core default global untuk game yang Loader Core per-game-nya diatur ke Default. <OPL> adalah core native; Neutrino merantai neutrino.elf eksternal. Pilihan per-game selalu menimpa pengaturan ini."
+  "VCD_SETTINGS": "Pengaturan VCD"
+  "FINANCIAL_SUPPORT": "Dukungan Finansial"

--- a/lng_fork/Italian.yml
+++ b/lng_fork/Italian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Ordina i giochi in ordine alfabetico
+  RUMBLE: Vibrazione del controller nei menu
+  HINT_RUMBLE: Breve vibrazione muovendo il cursore, confermando o tornando indietro - richiede un DualShock in modalità analogica
+  FOLDER_NAV: Sfoglia le cartelle nella lista giochi
+  HINT_FOLDER_NAV: Mostra le sottocartelle di CD/DVD come voci sfogliabili; seleziona per aprire, annulla per tornare
+  SETTINGS_NO_HOME: Nessuna memory card trovata - impossibile salvare le impostazioni. OPL è stato avviato da un dispositivo di rete, le cui impostazioni devono risiedere su una card locale.
+  ERROR_SAVING_SETTINGS_TO: Impossibile scrivere le impostazioni su %s (errore %d)
+  GENERAL_SETTINGS: Impostazioni Generali
+  DEVICE_SETTINGS: Impostazioni Dispositivo
+  LAUNCH_PS2_DISC: Avvia Disco PS2
+  DISC_LAUNCH_ERR: Nessun disco PS2 nel lettore.
+  DEFAULT: Default
+  HINT_MODE7: Solo Neutrino -- corregge giochi che superano un buffer IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: Immagine Cheat PS2RD
+  HINT_ENABLEIMAGE: Applica una patch PS2RD .img precompilata al tuo gioco.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Modalità Avvio MMCE
+  MMCE_PREFIX: Percorso Prefisso MMCE
+  MMCE_SLOT: Slot MMCE
+  MMCEIGR_SLOT: Slot Bootcard IGR
+  HINT_MMCEIGR_SLOT: Il comando di cambio bootcard verrà inviato agli slot selezionati all'IGR
+  MMCE_ADVANCED: Avanzate
+  MMCE_SETTINGS: Impostazioni MMCE
+  MMCE_SEMA: Metodo di Accodamento Lock Sema
+  HINT_MMCE_SEMA: THFIFO può migliorare la compatibilità ma ridurre le prestazioni
+  MMCE_WAIT_CYCLES: Cicli di attesa dopo /ACK basso
+  HINT_MMCE_WAIT_CYCLES: Valori più bassi possono migliorare le prestazioni ma causare instabilità
+  MMCE_USE_ALARMS: Usa allarmi di timeout
+  HINT_MMCE_USE_ALARMS: OFF può migliorare le prestazioni ma i timeout MMCE possono causare blocchi
+  CORE_LOADER: Core Loader
+  NEUTRINO_BAD_FORMAT: Neutrino non supporta questo formato, avvio con core <OPL>
+  NEUTRINO_NOT_FOUND: ELF Neutrino non trovato, avvio con core <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD richiede un IP statico PS2. Impostalo nella Config di Rete (DHCP attualmente attivo).
+  NEUTRINO_SETTING_NA: Questa impostazione non è usata con il core Neutrino.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF mancante
+  POPSTARTER_SMB_MISSING: Requisiti SMB per POPSTARTER mancanti
+  WRITE_POPSTARTER_NET: Scrivi Config di Rete POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Salva anche i valori IP + condivisione SMB nei file IPCONFIG.DAT / SMBCONFIG.DAT di POPSTARTER sulla memory card (per VCD via SMB).
+  POPSTARTER_NET_ERR: Impossibile scrivere la config di rete POPSTARTER sulla memory card.
+  VCD: VCD
+  VCD_ON: Mostra giochi VCD
+  VCD_OFF: Mostra giochi da disco
+  NEUTRINO_ARGS: Argomenti Avvio Neutrino
+  HINT_NEUTRINO_ARGS: Flag extra Neutrino, separati da spazio (es. -mt=dvd). Globale si applica a tutti i giochi; per-gioco si aggiunge. Anteponi $ a un flag per disabilitarlo senza eliminarlo.
+  NEUTRINO_VIDEO: Video Neutrino
+  HINT_NEUTRINO_VIDEO: Forza la modalità video GS di Neutrino (-gsm). Off mantiene il default del gioco.
+  NEUTRINO_PATH: Percorso ELF Neutrino
+  HINT_NEUTRINO_PATH: Percorso completo di neutrino.elf (es. mc0:NEUTRINO/neutrino.elf). Vuoto = rilevamento automatico su mc0/mc1.
+  POPSTARTER_PATH: Percorso POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Percorso personalizzato POPSTARTER.ELF; usa la cartella POPS del dispositivo se vuoto/mancante. La tastiera accetta max 31 caratteri; percorsi più lunghi via settings_riptopl.cfg.
+  BDMA_SOURCE: Sorgente BDMA
+  HINT_BDMA_SOURCE: Dispositivo la cui cartella POPS contiene i file driver BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Modalità BDMA
+  HINT_BDMA_MODE: Driver block-device exFAT caricato da POPSTARTER. Cambiarlo copia i moduli sulla card; FAT32 = nessuno (driver integrato).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD interno
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: File modulo BDMA non trovati sul dispositivo sorgente.
+  BDMA_ERR_SPACE: Spazio insufficiente sulla memory card per i moduli BDMA.
+  BDMA_ERR_IO: Errore durante la scrittura dei moduli BDMA sulla memory card.
+  COVERFLOW_SETTINGS: Impostazioni Coverflow
+  COVERFLOW_COUNT: Numero Cover
+  COVERFLOW_SCALE: Scala Centrale
+  COVERFLOW_ANIM: Velocità Animazione
+  COVERFLOW_DIM: Oscura Cover Laterali
+  NONE: Nessuno
+  SMALL: Piccolo
+  LARGE: Grande
+  NORMAL: Normale
+  FAV: Preferiti
+  FAVMODE: Modalità Avvio Preferiti
+  FAV_HINT: Preferito
+  FAV_MSG: '%s non consentito nel Menu Preferiti.'
+  FAV_PERSISTENCE_MSG: '%s non è consentito mentre l''elemento è contrassegnato come preferito.'
+  NEUTRINO_DEVICE: Dispositivo Neutrino
+  HINT_NEUTRINO_DEVICE: Dispositivo contenente neutrino.elf (in una cartella NEUTRINO/ o neutrino/). Auto scansiona mc0 poi mc1.
+  NARGS_QB: Avvio Rapido (-qb)
+  NARGS_CWD: Directory di Lavoro (-cwd)
+  NARGS_CFG: Config (-cfg)
+  NARGS_ELF: ELF di Avvio (-elf)
+  NARGS_ATA0: Immagine ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Immagine ATA1 (-ata1)
+  NARGS_EXTRA: Argomenti Extra
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Archivio .tar copertine
+  DISABLE_ALL: Disabilita tutto
+  BOOT_LOADING_CONFIG: Caricamento impostazioni...
+  BOOT_SCANNING_BDM: Scansione unità USB / scheda / rete...
+  BOOT_SCANNING_NET: Avvio della rete...
+  BOOT_SCANNING_HDD: Scansione HDD...
+  BOOT_READY: Pronto.
+  UDPFS_GAMES: "Giochi UDPFS"
+  UDPFSBD_GAMES: "Giochi UDPFSBD"
+  NET_PROTOCOL: "Protocollo di rete"
+  NET_NEEDS_NEUTRINO: "I giochi di rete (UDP) possono avviarsi solo tramite il core Neutrino. Verifica che neutrino.elf sia presente e che il formato sia supportato."
+  VCD_NOT_ON_NET: "I giochi PS1 (.VCD) non possono essere avviati tramite il dispositivo di rete."
+  MX4SIO_PADEMU_WARN: "MX4SIO e l'emulazione del pad condividono il bus SIO2 e il gioco potrebbe non avviarsi."
+  HINT_OSD_SETTINGS_LNG: "Forza una configurazione lingua personalizzata"
+  OSD_SETTINGS_TVASPECT: "Dimensione schermo"
+  FULL_SCREEN: "Schermo intero"
+  OSD_SETTINGS_VMODE: "Modalità video"
+  SYSTEM_DEFAULT: "Predefinito sistema"
+  HIGH: "Alta"
+  LOW: "Bassa"
+  XSENSITIVITY: "Sensibilità analogica asse X"
+  YSENSITIVITY: "Sensibilità analogica asse Y"
+  FILE_COUNT: "File trovati: %i"
+  CHEAT_SELECTION: "Selezione trucchi"
+  HDD_HINT: "Consentito un solo HDD; attivarlo blocca APA o GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "GameID MMCE non applicato -- neutrino.elf è su questa scheda (cambiarlo scaricherebbe Neutrino)."
+  POPSTARTER_DEVICE: "Dispositivo POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Dispositivo che contiene POPS/POPSTARTER.ELF per gli avvii VCD PS1. Predefinito = dispositivo di avvio (cwd) poi il dispositivo del VCD stesso. Personalizzato mostra un percorso libero."
+  BDMA_APPLY: "Applica VCD BDMA all'avvio"
+  HINT_BDMA_APPLY: "On: equipaggia automaticamente il driver exFAT corrispondente del VCD avviato sulla memory card prima dell'avvio (consigliato). Off: gestiscilo manualmente con i selettori Sorgente/Modalità BDMA sotto."
+  NETBOOT_RESTART: "Riavvia OPL per applicare la modifica del protocollo di avvio di rete."
+  UDPFS_MODE: "Accesso UDPFS"
+  "MENU": "Menu"
+  "APPS": "App"
+  "DEBUG": "Colori di debug"
+  "COVERART": "Copertine"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operazioni di scrittura"
+  "MODE1": "Mode 1"
+  "MODE2": "Mode 2"
+  "MODE3": "Mode 3"
+  "MODE4": "Mode 4"
+  "MODE5": "Mode 5"
+  "MODE6": "Mode 6"
+  "ENABLEGSM": "Selettore GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Motore trucchi PS2RD"
+  "PADEMU_ENABLE": "Emulatore pad"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulazione"
+  "PADEMU_VIB": "Vibrazione"
+  "PADEMU_WORKAROUND": "Soluzione DS3 fittizio"
+  "SFX": "Effetti sonori"
+  "BOOT_SND": "Suono di avvio"
+  "ENABLE_NOTIFICATIONS": "Notifiche"
+  "OPTIONS": "Opzioni"
+  "GLOBAL_SETTINGS": "Globali"
+  "INFO_GENRE": "Genere"
+  "INFO_RELEASE": "Uscita"
+  "INFO_DESCRIPTION": "Descrizione"
+  "BLOCKDEVICE_SETTINGS": "Dispositivi a blocchi"
+  "CONTROLLER_SETTINGS": "Impostazioni controller"
+  "HINT_BDM_START": "Attiva/disattiva il Block Device Manager."
+  "HINT_BLOCK_DEVICES": "Attiva/disattiva i dispositivi a blocchi (es. USB)."
+  "USB_GAMES": "Giochi USB"
+  "ILINK_GAMES": "Giochi iLink"
+  "MX4SIO_GAMES": "Giochi MX4SIO"
+  "PADMACROCONFIG": "Configura PADMACRO"
+  "PADMACRO_SETTINGS": "Impostazioni macro pad"
+  "PADMACRO_ENABLE": "Macro pad"
+  "PADMACRO_SLOWDOWN": "Rallentamento analogico:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Riduce l'escursione dello stick analogico quando il tasto è premuto"
+  "LEFT_ANALOG": "Stick sinistro"
+  "RIGHT_ANALOG": "Stick destro"
+  "PADMACRO_INVERT_AXIS": "Inversione asse analogico:"
+  "HINT_PADMACRO_INVERT_AXIS": "Inverte l'asse dello stick analogico"
+  "TURBO_SPEED": "Velocità tasto turbo"
+  "HINT_TURBO_SPEED": "Quanto velocemente premere il tasto quando il turbo è attivo"
+  "ACT_WHILE_PRESSED": "Mentre il tasto è premuto"
+  "ACT_TOGGLED": "Commutato dal tasto"
+  "LANGUAGE_JAPANESE": "GIAPPONESE"
+  "LANGUAGE_ENGLISH": "INGLESE"
+  "LANGUAGE_FRENCH": "FRANCESE"
+  "LANGUAGE_SPANISH": "SPAGNOLO"
+  "LANGUAGE_GERMAN": "TEDESCO"
+  "LANGUAGE_ITALIAN": "ITALIANO"
+  "LANGUAGE_DUTCH": "OLANDESE"
+  "LANGUAGE_PORTUGUESE": "PORTOGHESE"
+  "LANGUAGE_RUSSIAN": "RUSSO"
+  "LANGUAGE_KOREAN": "COREANO"
+  "LANGUAGE_TRAD_CHINESE": "CINESE TRADIZIONALE"
+  "LANGUAGE_SIMPL_CHINESE": "CINESE SEMPLIFICATO"
+  "OSD_SETTINGS": "Impostazioni OSD"
+  "OSD_SETTINGS_LNG": "Lingua OSD"
+  "ENABLE_LNG": "Cambia lingua"
+  "BGM": "Musica di sottofondo"
+  "BGM_VOLUME": "Volume musica di sottofondo"
+  "DEF_BGM_PATH": "Musica tema predefinita"
+  "DEF_BGM_PATH_HINT": "Imposta il percorso per riprodurre la musica del tema interno."
+  "BOOT_SCANNING_MC": "Scansione memory card..."
+  "BOOT_LOADING_DRIVERS": "Caricamento driver di archiviazione..."
+  "BOOT_LOADING_USB": "Caricamento driver di archiviazione USB..."
+  "BOOT_ARMING_MMCE": "Attivazione game-ID MMCE..."
+  "BOOT_LOADING_SOUNDS": "Caricamento suoni del tema..."
+  "BOOT_BUILDING_MENU": "Creazione menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS attivo -- apri la nuova scheda UDPFS e premi Conferma per connetterti. Sul lato PC gira udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Dispositivo a blocchi di rete attivo -- la sua scheda compare quando il server PC risponde (udpfsd -bdpath per Immagine UDPFS, udpbd-server per UDPBD)."
+  "NEUTRINO_VMC_MISSING": "File VMC per gioco non trovato -- avvio senza di esso (il gioco usa la sua scheda reale)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino non può avviarsi da questo dispositivo -- avvio annullato."
+  "NEUTRINO_TOML_SYNC_FAILED": "Configurazione di rete di Neutrino (bsd toml) mancante o non scrivibile -- avvio annullato, controlla la cartella neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Troppo frammentato per Neutrino (%d frammenti, limite %d incl. VMC) -- si tenta invece il core OPL."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Troppo frammentato per Neutrino (%d frammenti, limite %d incl. VMC) -- deframmenta sul PC; avvio annullato."
+  "NEUTRINO_GSM_COMP": "Compatibilità GSM Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Correzione con inversione dei campi per i giochi che tremano o mostrano tearing in una modalità Video di Neutrino forzata. Richiede l'impostazione di una modalità Video di Neutrino."
+  "NARGS_DBC": "Colori di debug (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Disattiva VMC 1 (mantieni card)"
+  "VMC_SLOT2_DISABLE": "Disattiva VMC 2 (mantieni card)"
+  "HINT_VMC_SLOT_DISABLE": "Avvia senza la VMC di questo slot mantenendo la sua scheda configurata. Solo avvii Neutrino; il gioco usa quindi la scheda reale in quello slot."
+  "NEUTRINO_BSDFS": "Filesystem Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Forza il filesystem del dispositivo a blocchi di Neutrino (-bsdfs). Auto = predefinito per dispositivo. hdl/bd sono opzioni per esperti; abbinali a un -dvd= corrispondente negli argomenti di avvio se la forma del percorso automatico non è adatta."
+  "PLASCOLOR": "Colore fusione plasma"
+  "VCD_HIDE_GAMEID": "Nascondi ID gioco PS1 (lista VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Solo estetico -- nasconde un prefisso di ID gioco iniziale (es. SLUS_005.51.) dai nomi negli elenchi PS1/VCD. I nomi senza ID vengono mostrati così come sono. Non modifica l'avvio, le copertine o i preferiti."
+  "VCD_FIRST_DISC": "Solo primo disco (PS1 multi-disco)"
+  "HINT_VCD_FIRST_DISC": "Mostra solo il Disco 1 di un gioco PS1 multi-disco negli elenchi dei dispositivi (stile POPSLoader). Nasconde i file denominati (Disc 2), (CD 2), ecc. Tutti i dischi restano sulla scheda per lo scambio durante il gioco; i Preferiti non vengono filtrati."
+  "GAMES_DEVICE": "Dispositivo del gioco"
+  "DEFAULT_CORE": "Core Loader predefinito"
+  "HINT_DEFAULT_CORE": "Core predefinito globale per i giochi il cui Loader Core per gioco è impostato su Default. <OPL> è il core nativo; Neutrino concatena il neutrino.elf esterno. Una scelta per gioco ha sempre la precedenza su questa."
+  "VCD_SETTINGS": "Impostazioni VCD"
+  "FINANCIAL_SUPPORT": "Supporto finanziario"

--- a/lng_fork/Japanese.yml
+++ b/lng_fork/Japanese.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: ゲームをアルファベット順に並べ替え
+  RUMBLE: メニューでのコントローラー振動
+  HINT_RUMBLE: カーソル移動、決定、戻る操作時の短い振動 - アナログモードのDualShockが必要
+  FOLDER_NAV: ゲームリストでフォルダを閲覧
+  HINT_FOLDER_NAV: CD/DVDのサブフォルダを閲覧可能な項目として表示。決定で開き、キャンセルで戻る
+  SETTINGS_NO_HOME: メモリーカードが見つかりません - 設定を保存できません。OPLはネットワーク機器から起動したため、設定はローカルカードに保存する必要があります。
+  ERROR_SAVING_SETTINGS_TO: "%s に設定を書き込めませんでした (エラー %d)"
+  GENERAL_SETTINGS: 全般設定
+  DEVICE_SETTINGS: デバイス設定
+  LAUNCH_PS2_DISC: PS2 ディスクを起動
+  DISC_LAUNCH_ERR: ドライブに PS2 ディスクがありません。
+  DEFAULT: デフォルト
+  HINT_MODE7: Neutrino 専用 -- IOP バッファをオーバーランするゲームを修正 (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD チートイメージ
+  HINT_ENABLEIMAGE: ビルド済み PS2RD .img パッチをゲームに適用します。
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE ゲーム
+  MMCEMODE: MMCE 起動モード
+  MMCE_PREFIX: MMCE プレフィックスパス
+  MMCE_SLOT: MMCE スロット
+  MMCEIGR_SLOT: IGR ブートカードスロット
+  HINT_MMCEIGR_SLOT: IGR 時、選択したスロットにブートカードコマンドが送信されます
+  MMCE_ADVANCED: 詳細
+  MMCE_SETTINGS: MMCE 設定
+  MMCE_SEMA: ロックセマフォのエンキューメソッド
+  HINT_MMCE_SEMA: THFIFO は互換性向上に役立つ場合がありますが、パフォーマンスが低下することがあります
+  MMCE_WAIT_CYCLES: /ACK ロー後の待機サイクル
+  HINT_MMCE_WAIT_CYCLES: 値を低くするとパフォーマンスが向上しますが、不安定になる場合があります
+  MMCE_USE_ALARMS: タイムアウトアラームを使用
+  HINT_MMCE_USE_ALARMS: OFF にするとパフォーマンスが向上しますが、MMCE タイムアウト時にフリーズする場合があります
+  CORE_LOADER: ローダーコア
+  NEUTRINO_BAD_FORMAT: Neutrino はこのファイル形式をサポートしていません。<OPL> コアで起動します
+  NEUTRINO_NOT_FOUND: Neutrino ELF が見つかりません。<OPL> コアで起動します
+  UDPBD_NEEDS_STATIC_IP: UDPBD には PS2 の固定 IP が必要です。ネットワーク設定で設定してください（現在 DHCP が有効です）。
+  NEUTRINO_SETTING_NA: この設定は Neutrino コアでは使用されません。
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF が見つかりません
+  POPSTARTER_SMB_MISSING: POPSTARTER の SMB 要件が不足しています
+  WRITE_POPSTARTER_NET: POPSTARTER ネットワーク設定を書き込む
+  HINT_WRITE_POPSTARTER_NET: IP と SMB 共有の値をメモリーカード上の POPSTARTER 専用 IPCONFIG.DAT / SMBCONFIG.DAT にも保存します（SMB 経由の VCD 用）。
+  POPSTARTER_NET_ERR: メモリーカードへの POPSTARTER ネットワーク設定の書き込みに失敗しました。
+  VCD: VCD
+  VCD_ON: VCD ゲームを表示中
+  VCD_OFF: ディスクゲームを表示中
+  NEUTRINO_ARGS: Neutrino 起動引数
+  HINT_NEUTRINO_ARGS: 追加の Neutrino フラグをスペース区切りで指定（例 -mt=dvd）。グローバルは全ゲームに適用、ゲーム個別はその上に追加。フラグの先頭に $ を付けると削除せずに無効化できます。
+  NEUTRINO_VIDEO: Neutrino ビデオ
+  HINT_NEUTRINO_VIDEO: Neutrino の GS 出力ビデオモードを強制します（-gsm）。オフでゲームのデフォルトを使用。
+  NEUTRINO_PATH: Neutrino ELF パス
+  HINT_NEUTRINO_PATH: neutrino.elf へのフルパス（例 mc0:NEUTRINO/neutrino.elf）。空白時は mc0/mc1 を自動検索。
+  POPSTARTER_PATH: POPSTARTER.ELF パス
+  HINT_POPSTARTER_PATH: カスタム POPSTARTER.ELF パス。空白または未検出時はデバイスの POPS フォルダにフォールバック。キーボード入力は 31 文字まで。より長いパスは settings_riptopl.cfg で設定。
+  BDMA_SOURCE: BDMA ソース
+  HINT_BDMA_SOURCE: BDMAssault ドライバーファイル（usbd.irx.* / usbhdfsd.irx.*）の POPS フォルダを持つデバイス。
+  BDMA_MODE: BDMA モード
+  HINT_BDMA_MODE: POPSTARTER が読み込む exFAT ブロックデバイスドライバー。変更するとモジュールがカードにコピーされます。FAT32 = なし（内蔵ドライバー）。
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: 内蔵HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: ソースデバイスに BDMA モジュールファイルが見つかりません。
+  BDMA_ERR_SPACE: BDMA モジュールを保存するメモリーカードの空き容量が不足しています。
+  BDMA_ERR_IO: メモリーカードへの BDMA モジュールの書き込みに失敗しました。
+  COVERFLOW_SETTINGS: Coverflow 設定
+  COVERFLOW_COUNT: カバー表示数
+  COVERFLOW_SCALE: 中央スケール
+  COVERFLOW_ANIM: アニメーション速度
+  COVERFLOW_DIM: サイドカバーを暗くする
+  NONE: なし
+  SMALL: 小
+  LARGE: 大
+  NORMAL: 標準
+  FAV: お気に入り
+  FAVMODE: お気に入り起動モード
+  FAV_HINT: お気に入り
+  FAV_MSG: '%s はお気に入りメニューから使用できません。'
+  FAV_PERSISTENCE_MSG: '%s はお気に入りに登録されているアイテムでは使用できません。'
+  NEUTRINO_DEVICE: Neutrino デバイス
+  HINT_NEUTRINO_DEVICE: neutrino.elf を保持するデバイス（NEUTRINO/ または neutrino/ フォルダ内）。自動スキャンは mc0 → mc1 の順で検索。
+  NARGS_QB: クイック起動 (-qb)
+  NARGS_CWD: 作業ディレクトリ (-cwd)
+  NARGS_CFG: 設定ファイル (-cfg)
+  NARGS_ELF: 起動 ELF (-elf)
+  NARGS_ATA0: ATA0 イメージ (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 イメージ (-ata1)
+  NARGS_EXTRA: 追加引数
+  NARGS_AUTO_NOTE: '自動: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: カバーアートの.tarアーカイブ
+  DISABLE_ALL: すべて無効化
+  BOOT_LOADING_CONFIG: 設定を読み込み中...
+  BOOT_SCANNING_BDM: USB / カード / ネットワークドライブをスキャン中...
+  BOOT_SCANNING_NET: ネットワークを開始中...
+  BOOT_SCANNING_HDD: HDD をスキャン中...
+  BOOT_READY: 準備完了。
+  UDPFS_GAMES: "UDPFS ゲーム"
+  UDPFSBD_GAMES: "UDPFSBD ゲーム"
+  NET_PROTOCOL: "ネットワークプロトコル"
+  NET_NEEDS_NEUTRINO: "ネットワーク（UDP）ゲームは Neutrino コアでのみ起動できます。neutrino.elf があり、形式が対応しているか確認してください。"
+  VCD_NOT_ON_NET: "PS1（.VCD）ゲームはネットワークデバイスから起動できません。"
+  MX4SIO_PADEMU_WARN: "MX4SIO とパッドエミュレーションは SIO2 バスを共有するため、ゲームが起動しない場合があります。"
+  HINT_OSD_SETTINGS_LNG: "言語設定を強制的に変更します"
+  OSD_SETTINGS_TVASPECT: "画面サイズ"
+  FULL_SCREEN: "フルスクリーン"
+  OSD_SETTINGS_VMODE: "ビデオモード"
+  SYSTEM_DEFAULT: "システム標準"
+  HIGH: "高"
+  LOW: "低"
+  XSENSITIVITY: "アナログX軸感度"
+  YSENSITIVITY: "アナログY軸感度"
+  FILE_COUNT: "検出ファイル数: %i"
+  CHEAT_SELECTION: "チート選択"
+  HDD_HINT: "HDD は1台のみ有効。有効化すると APA か GPT に固定されます。"
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID は未適用 -- このカードに neutrino.elf があります（切り替えると Neutrino がアンロードされます）。"
+  POPSTARTER_DEVICE: "POPSTARTER.ELF デバイス"
+  HINT_POPSTARTER_DEVICE: "PS1 VCD 起動用の POPS/POPSTARTER.ELF を保持するデバイス。標準 = 起動デバイス（cwd）、次に VCD 自身のデバイス。カスタムで自由入力パスを表示します。"
+  BDMA_APPLY: "起動時に VCD BDMA を適用"
+  HINT_BDMA_APPLY: "オン: 起動する VCD に対応する exFAT ドライバを起動前にメモリーカードへ自動装備します（推奨）。オフ: 下の BDMA ソース/モード選択で手動管理します。"
+  NETBOOT_RESTART: "ネットワーク起動プロトコルの変更を適用するには OPL を再起動してください。"
+  UDPFS_MODE: "UDPFS アクセス"
+  "MENU": "メニュー"
+  "APPS": "アプリ"
+  "DEBUG": "デバッグカラー"
+  "COVERART": "カバーアート"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "書き込み操作"
+  "MODE1": "モード 1"
+  "MODE2": "モード 2"
+  "MODE3": "モード 3"
+  "MODE4": "モード 4"
+  "MODE5": "モード 5"
+  "MODE6": "モード 6"
+  "ENABLEGSM": "GSM セレクター"
+  "OVERSCAN": "オーバースキャン"
+  "ENABLECHEAT": "PS2RD チートエンジン"
+  "PADEMU_ENABLE": "パッドエミュレーター"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "エミュレーション"
+  "PADEMU_VIB": "振動"
+  "PADEMU_WORKAROUND": "擬似 DS3 対応"
+  "SFX": "効果音"
+  "BOOT_SND": "起動音"
+  "ENABLE_NOTIFICATIONS": "通知"
+  "OPTIONS": "オプション"
+  "GLOBAL_SETTINGS": "全体"
+  "INFO_GENRE": "ジャンル"
+  "INFO_RELEASE": "発売日"
+  "INFO_DESCRIPTION": "説明"
+  "BLOCKDEVICE_SETTINGS": "ブロックデバイス"
+  "CONTROLLER_SETTINGS": "コントローラー設定"
+  "HINT_BDM_START": "ブロックデバイスマネージャーのオン/オフを切り替えます。"
+  "HINT_BLOCK_DEVICES": "ブロックデバイス（例：USB）のオン/オフを切り替えます。"
+  "USB_GAMES": "USB ゲーム"
+  "ILINK_GAMES": "iLink ゲーム"
+  "MX4SIO_GAMES": "MX4SIO ゲーム"
+  "PADMACROCONFIG": "PADMACRO を設定"
+  "PADMACRO_SETTINGS": "パッドマクロ設定"
+  "PADMACRO_ENABLE": "パッドマクロ"
+  "PADMACRO_SLOWDOWN": "アナログ減速："
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "ボタンを押している間、アナログスティックの範囲を狭めます"
+  "LEFT_ANALOG": "左スティック"
+  "RIGHT_ANALOG": "右スティック"
+  "PADMACRO_INVERT_AXIS": "アナログ軸反転："
+  "HINT_PADMACRO_INVERT_AXIS": "アナログスティックの軸を反転します"
+  "TURBO_SPEED": "連射速度"
+  "HINT_TURBO_SPEED": "連射が有効な時にボタンを押す速さ"
+  "ACT_WHILE_PRESSED": "ボタンを押している間"
+  "ACT_TOGGLED": "ボタンで切り替え"
+  "LANGUAGE_JAPANESE": "日本語"
+  "LANGUAGE_ENGLISH": "英語"
+  "LANGUAGE_FRENCH": "フランス語"
+  "LANGUAGE_SPANISH": "スペイン語"
+  "LANGUAGE_GERMAN": "ドイツ語"
+  "LANGUAGE_ITALIAN": "イタリア語"
+  "LANGUAGE_DUTCH": "オランダ語"
+  "LANGUAGE_PORTUGUESE": "ポルトガル語"
+  "LANGUAGE_RUSSIAN": "ロシア語"
+  "LANGUAGE_KOREAN": "韓国語"
+  "LANGUAGE_TRAD_CHINESE": "繁体字中国語"
+  "LANGUAGE_SIMPL_CHINESE": "簡体字中国語"
+  "OSD_SETTINGS": "OSD 設定"
+  "OSD_SETTINGS_LNG": "OSD 言語"
+  "ENABLE_LNG": "言語を変更"
+  "BGM": "BGM"
+  "BGM_VOLUME": "BGM 音量"
+  "DEF_BGM_PATH": "デフォルトテーマ曲"
+  "DEF_BGM_PATH_HINT": "内部テーマ用にストリーミングする音楽のパスを設定します。"
+  "BOOT_SCANNING_MC": "メモリーカードをスキャン中..."
+  "BOOT_LOADING_DRIVERS": "ストレージドライバーを読み込み中..."
+  "BOOT_LOADING_USB": "USB ストレージドライバーを読み込み中..."
+  "BOOT_ARMING_MMCE": "MMCE ゲーム ID を準備中..."
+  "BOOT_LOADING_SOUNDS": "テーマサウンドを読み込み中..."
+  "BOOT_BUILDING_MENU": "メニューを構築中..."
+  "NET_UDPFS_TAB_HINT": "UDPFSがオンです -- 新しいUDPFSタブを開き、Confirmを押して接続します。PC側では udpfsd -fsroot <games folder> を実行します。"
+  "NET_UDPBD_TAB_HINT": "ネットワークブロックデバイスがオンです -- PCサーバーが応答すると、そのタブが表示されます（UDPFSイメージ用は udpfsd -bdpath、UDPBD用は udpbd-server）。"
+  "NEUTRINO_VMC_MISSING": "ゲームごとのVMCファイルが見つかりません -- なしで起動します（ゲームは実際のカードを使用します）。"
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino はこのデバイスから起動できません -- 起動を中止しました。"
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrinoのネットワーク設定（bsd toml）が見つからないか書き込めません -- 起動を中止しました。neutrinoフォルダを確認してください。"
+  "NEUTRINO_TOO_FRAGMENTED": "Neutrinoには断片化しすぎています（%d 個の断片、上限 %d 個、VMC含む）-- 代わりにOPLコアを試します。"
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Neutrinoには断片化しすぎています（%d 個の断片、上限 %d 個、VMC含む）-- PCでデフラグしてください。起動を中止しました。"
+  "NEUTRINO_GSM_COMP": "Neutrino GSM 互換性"
+  "HINT_NEUTRINO_GSM_COMP": "強制されたNeutrino Videoモードでちらつきやティアリングが起きるゲーム向けの、フィールド反転による修正です。Neutrino Videoモードの設定が必要です。"
+  "NARGS_DBC": "デバッグカラー (-dbc)"
+  "NARGS_LOGO": "PS2 ロゴ (-logo)"
+  "VMC_SLOT1_DISABLE": "VMC 1 を無効化（カードは保持）"
+  "VMC_SLOT2_DISABLE": "VMC 2 を無効化（カードは保持）"
+  "HINT_VMC_SLOT_DISABLE": "このスロットのカードを設定したまま、そのVMCなしで起動します。Neutrino起動のみ対応。ゲームはそのスロットの実際のカードを使用します。"
+  "NEUTRINO_BSDFS": "Neutrino ファイルシステム"
+  "HINT_NEUTRINO_BSDFS": "Neutrinoのブロックデバイスファイルシステムを強制します（-bsdfs）。Auto = デバイスごとの既定値。hdl/bd は上級者向けのオプションです。自動のパス形状が合わない場合は、起動引数の -dvd= を一致させて組み合わせてください。"
+  "PLASCOLOR": "プラズマブレンドカラー"
+  "VCD_HIDE_GAMEID": "PS1 ゲーム ID を隠す（VCD リスト）"
+  "HINT_VCD_HIDE_GAMEID": "見た目だけの設定です -- PS1/VCD一覧の名前から先頭のゲームIDプレフィックス（例: SLUS_005.51.）を非表示にします。IDのない名前はそのまま表示されます。起動、カバーアート、お気に入りには影響しません。"
+  "VCD_FIRST_DISC": "最初のディスクのみ（マルチディスク PS1）"
+  "HINT_VCD_FIRST_DISC": "デバイス一覧にマルチディスクのPS1ゲームのDisc 1だけを表示します（POPSLoaderスタイル）。(Disc 2)、(CD 2)などの名前のファイルを非表示にします。すべてのディスクはゲーム中のディスク交換のためにカードに残ります。お気に入りはフィルターされません。"
+  "GAMES_DEVICE": "ゲームのデバイス"
+  "DEFAULT_CORE": "デフォルトローダーコア"
+  "HINT_DEFAULT_CORE": "ゲームごとのLoader CoreがDefaultに設定されているゲームに使う、グローバルの既定コアです。<OPL> はネイティブコアで、Neutrinoは外部の neutrino.elf をチェーンします。ゲームごとの選択が常にこれを上書きします。"
+  "VCD_SETTINGS": "VCD 設定"
+  "FINANCIAL_SUPPORT": "資金援助"

--- a/lng_fork/Korean.yml
+++ b/lng_fork/Korean.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: 게임 가나다순 정렬
+  RUMBLE: 메뉴에서 컨트롤러 진동
+  HINT_RUMBLE: 커서 이동, 확인 또는 취소 시 짧게 진동 -- 아날로그 모드의 듀얼쇼크 필요
+  FOLDER_NAV: 게임 목록에서 폴더 탐색
+  HINT_FOLDER_NAV: CD/DVD의 하위 폴더를 탐색 가능한 항목으로 표시, 선택하면 열고 취소하면 뒤로
+  SETTINGS_NO_HOME: 메모리 카드가 없어 설정을 저장할 수 없습니다. OPL이 네트워크 장치에서 부팅되었으며, 설정은 로컬 카드에 저장되어야 합니다.
+  ERROR_SAVING_SETTINGS_TO: "%s에 설정을 저장할 수 없습니다 (오류 %d)"
+  GENERAL_SETTINGS: 일반 설정
+  DEVICE_SETTINGS: 장치 설정
+  LAUNCH_PS2_DISC: PS2 디스크 실행
+  DISC_LAUNCH_ERR: 드라이브에 PS2 디스크가 없습니다.
+  DEFAULT: 기본값
+  HINT_MODE7: Neutrino 전용 -- IOP 버퍼 오버런 게임 수정 (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD 치트 이미지
+  HINT_ENABLEIMAGE: 게임에 미리 빌드된 PS2RD .img 패치를 적용합니다.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE 게임
+  MMCEMODE: MMCE 시작 모드
+  MMCE_PREFIX: MMCE 접두 경로
+  MMCE_SLOT: MMCE 슬롯
+  MMCEIGR_SLOT: IGR 부트카드 슬롯
+  HINT_MMCEIGR_SLOT: IGR 시 선택된 슬롯으로 부트카드 전환 명령이 전송됩니다
+  MMCE_ADVANCED: 고급
+  MMCE_SETTINGS: MMCE 설정
+  MMCE_SEMA: 잠금 세마 큐잉 방식
+  HINT_MMCE_SEMA: THFIFO는 호환성에 도움이 될 수 있지만 성능이 저하될 수 있습니다
+  MMCE_WAIT_CYCLES: /ACK 로우 후 대기 사이클
+  HINT_MMCE_WAIT_CYCLES: 낮은 값은 성능을 향상시킬 수 있지만 불안정을 초래할 수 있습니다
+  MMCE_USE_ALARMS: 타임아웃 알람 사용
+  HINT_MMCE_USE_ALARMS: OFF는 성능에 도움이 될 수 있지만 MMCE 타임아웃 시 프리즈를 유발할 수 있습니다
+  CORE_LOADER: 로더 코어
+  NEUTRINO_BAD_FORMAT: Neutrino는 이 파일 형식을 지원하지 않아 <OPL> 코어로 실행합니다
+  NEUTRINO_NOT_FOUND: Neutrino ELF를 찾을 수 없어 <OPL> 코어로 실행합니다
+  UDPBD_NEEDS_STATIC_IP: UDPBD는 고정 PS2 IP가 필요합니다. 네트워크 설정에서 지정하세요 (현재 DHCP 사용 중).
+  NEUTRINO_SETTING_NA: 이 설정은 Neutrino 코어에서 사용되지 않습니다.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF 파일이 없습니다
+  POPSTARTER_SMB_MISSING: POPSTARTER SMB 요구 파일이 없습니다
+  WRITE_POPSTARTER_NET: POPSTARTER 네트워크 설정 저장
+  HINT_WRITE_POPSTARTER_NET: IP + SMB 공유 값을 메모리 카드의 POPSTARTER용 IPCONFIG.DAT / SMBCONFIG.DAT에도 저장합니다 (SMB 경유 VCD용).
+  POPSTARTER_NET_ERR: 메모리 카드에 POPSTARTER 네트워크 설정을 쓸 수 없습니다.
+  VCD: VCD
+  VCD_ON: VCD 게임 표시 중
+  VCD_OFF: 디스크 게임 표시 중
+  NEUTRINO_ARGS: Neutrino 실행 인수
+  HINT_NEUTRINO_ARGS: '추가 Neutrino 플래그, 공백으로 구분 (예: -mt=dvd). 전역은 모든 게임에 적용; 게임별은 추가됩니다. 플래그 앞에 $를 붙이면 삭제 없이 비활성화됩니다.'
+  NEUTRINO_VIDEO: Neutrino 비디오
+  HINT_NEUTRINO_VIDEO: Neutrino의 GS 출력 비디오 모드를 강제 설정합니다 (-gsm). Off는 게임 기본값을 유지합니다.
+  NEUTRINO_PATH: Neutrino ELF 경로
+  HINT_NEUTRINO_PATH: 'neutrino.elf의 전체 경로 (예: mc0:NEUTRINO/neutrino.elf). 비워두면 mc0/mc1에서 자동 감지합니다.'
+  POPSTARTER_PATH: POPSTARTER.ELF 경로
+  HINT_POPSTARTER_PATH: 사용자 지정 POPSTARTER.ELF 경로; 비어 있거나 없으면 장치 POPS 폴더로 자동 대체됩니다. 키보드 입력 31자 제한; 긴 경로는 settings_riptopl.cfg를 통해 설정하세요.
+  BDMA_SOURCE: BDMA 소스
+  HINT_BDMA_SOURCE: BDMAssault 드라이버 파일 (usbd.irx.* / usbhdfsd.irx.*)이 있는 POPS 폴더의 장치를 선택합니다.
+  BDMA_MODE: BDMA 모드
+  HINT_BDMA_MODE: POPSTARTER가 로드하는 exFAT 블록 장치 드라이버. 변경 시 모듈이 카드에 복사됩니다; FAT32 = 없음 (내장 드라이버).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: 내장 HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: 소스 장치에서 BDMA 모듈 파일을 찾을 수 없습니다.
+  BDMA_ERR_SPACE: 메모리 카드에 BDMA 모듈을 저장할 공간이 부족합니다.
+  BDMA_ERR_IO: 메모리 카드에 BDMA 모듈을 쓰는 중 오류가 발생했습니다.
+  COVERFLOW_SETTINGS: Coverflow 설정
+  COVERFLOW_COUNT: 커버 개수
+  COVERFLOW_SCALE: 중앙 크기
+  COVERFLOW_ANIM: 애니메이션 속도
+  COVERFLOW_DIM: 측면 커버 어둡게
+  NONE: 없음
+  SMALL: 작게
+  LARGE: 크게
+  NORMAL: 보통
+  FAV: 즐겨찾기
+  FAVMODE: 즐겨찾기 시작 모드
+  FAV_HINT: 즐겨찾기
+  FAV_MSG: '%s은(는) 즐겨찾기 메뉴에서 허용되지 않습니다.'
+  FAV_PERSISTENCE_MSG: '%s은(는) 즐겨찾기로 표시된 항목에서 허용되지 않습니다.'
+  NEUTRINO_DEVICE: Neutrino 장치
+  HINT_NEUTRINO_DEVICE: neutrino.elf이 있는 장치 (NEUTRINO/ 또는 neutrino/ 폴더). 자동은 mc0 후 mc1을 순서대로 검색합니다.
+  NARGS_QB: 빠른 부팅 (-qb)
+  NARGS_CWD: 작업 디렉터리 (-cwd)
+  NARGS_CFG: 설정 파일 (-cfg)
+  NARGS_ELF: 부팅 ELF (-elf)
+  NARGS_ATA0: ATA0 이미지 (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 이미지 (-ata1)
+  NARGS_EXTRA: 추가 인수
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: 커버 아트 .tar 아카이브
+  DISABLE_ALL: 모두 비활성화
+  BOOT_LOADING_CONFIG: 설정 불러오는 중...
+  BOOT_SCANNING_BDM: USB / 카드 / 네트워크 드라이브 검색 중...
+  BOOT_SCANNING_NET: 네트워크 시작 중...
+  BOOT_SCANNING_HDD: HDD 검색 중...
+  BOOT_READY: 준비됨.
+  UDPFS_GAMES: "UDPFS 게임"
+  UDPFSBD_GAMES: "UDPFSBD 게임"
+  NET_PROTOCOL: "네트워크 프로토콜"
+  NET_NEEDS_NEUTRINO: "네트워크(UDP) 게임은 Neutrino 코어로만 부팅할 수 있습니다. neutrino.elf가 있고 형식이 지원되는지 확인하세요."
+  VCD_NOT_ON_NET: "PS1(.VCD) 게임은 네트워크 장치로 실행할 수 없습니다."
+  MX4SIO_PADEMU_WARN: "MX4SIO와 패드 에뮬레이션은 SIO2 버스를 공유하므로 게임이 부팅되지 않을 수 있습니다."
+  HINT_OSD_SETTINGS_LNG: "사용자 지정 언어 설정을 강제 적용"
+  OSD_SETTINGS_TVASPECT: "화면 크기"
+  FULL_SCREEN: "전체 화면"
+  OSD_SETTINGS_VMODE: "비디오 모드"
+  SYSTEM_DEFAULT: "시스템 기본값"
+  HIGH: "높음"
+  LOW: "낮음"
+  XSENSITIVITY: "아날로그 X축 감도"
+  YSENSITIVITY: "아날로그 Y축 감도"
+  FILE_COUNT: "찾은 파일: %i"
+  CHEAT_SELECTION: "치트 선택"
+  HDD_HINT: "HDD는 하나만 허용됩니다. 활성화하면 APA 또는 GPT로 고정됩니다."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID 적용 안 됨 -- 이 카드에 neutrino.elf가 있습니다(전환하면 Neutrino가 언로드됨)."
+  POPSTARTER_DEVICE: "POPSTARTER.ELF 장치"
+  HINT_POPSTARTER_DEVICE: "PS1 VCD 실행을 위해 POPS/POPSTARTER.ELF를 담고 있는 장치. 기본값 = 부팅 장치(cwd) 다음 VCD 자체 장치. 사용자 지정을 선택하면 자유 입력 경로가 표시됩니다."
+  BDMA_APPLY: "실행 시 VCD BDMA 적용"
+  HINT_BDMA_APPLY: "켜기: 부팅 전에 실행하는 VCD에 맞는 exFAT 드라이버를 메모리 카드에 자동 장착합니다(권장). 끄기: 아래 BDMA 소스/모드 선택기로 직접 관리합니다."
+  NETBOOT_RESTART: "네트워크 부팅 프로토콜 변경을 적용하려면 OPL을 다시 시작하세요."
+  UDPFS_MODE: "UDPFS 액세스"
+  "MENU": "메뉴"
+  "APPS": "앱"
+  "DEBUG": "디버그 색상"
+  "COVERART": "커버 아트"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "쓰기 작업"
+  "MODE1": "모드 1"
+  "MODE2": "모드 2"
+  "MODE3": "모드 3"
+  "MODE4": "모드 4"
+  "MODE5": "모드 5"
+  "MODE6": "모드 6"
+  "ENABLEGSM": "GSM 선택기"
+  "OVERSCAN": "오버스캔"
+  "ENABLECHEAT": "PS2RD 치트 엔진"
+  "PADEMU_ENABLE": "패드 에뮬레이터"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "에뮬레이션"
+  "PADEMU_VIB": "진동"
+  "PADEMU_WORKAROUND": "가짜 DS3 우회"
+  "SFX": "음향 효과"
+  "BOOT_SND": "부팅 사운드"
+  "ENABLE_NOTIFICATIONS": "알림"
+  "OPTIONS": "옵션"
+  "GLOBAL_SETTINGS": "전체"
+  "INFO_GENRE": "장르"
+  "INFO_RELEASE": "출시"
+  "INFO_DESCRIPTION": "설명"
+  "BLOCKDEVICE_SETTINGS": "블록 장치"
+  "CONTROLLER_SETTINGS": "컨트롤러 설정"
+  "HINT_BDM_START": "블록 장치 관리자를 켜거나 끕니다."
+  "HINT_BLOCK_DEVICES": "블록 장치(예: USB)를 켜거나 끕니다."
+  "USB_GAMES": "USB 게임"
+  "ILINK_GAMES": "iLink 게임"
+  "MX4SIO_GAMES": "MX4SIO 게임"
+  "PADMACROCONFIG": "PADMACRO 구성"
+  "PADMACRO_SETTINGS": "패드 매크로 설정"
+  "PADMACRO_ENABLE": "패드 매크로"
+  "PADMACRO_SLOWDOWN": "아날로그 감속:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "버튼을 누르면 아날로그 스틱의 범위를 줄입니다"
+  "LEFT_ANALOG": "왼쪽 스틱"
+  "RIGHT_ANALOG": "오른쪽 스틱"
+  "PADMACRO_INVERT_AXIS": "아날로그 축 반전:"
+  "HINT_PADMACRO_INVERT_AXIS": "아날로그 스틱 축을 반전합니다"
+  "TURBO_SPEED": "터보 버튼 속도"
+  "HINT_TURBO_SPEED": "터보가 활성화된 동안 버튼을 누르는 속도"
+  "ACT_WHILE_PRESSED": "버튼을 누르는 동안"
+  "ACT_TOGGLED": "버튼으로 전환"
+  "LANGUAGE_JAPANESE": "일본어"
+  "LANGUAGE_ENGLISH": "영어"
+  "LANGUAGE_FRENCH": "프랑스어"
+  "LANGUAGE_SPANISH": "스페인어"
+  "LANGUAGE_GERMAN": "독일어"
+  "LANGUAGE_ITALIAN": "이탈리아어"
+  "LANGUAGE_DUTCH": "네덜란드어"
+  "LANGUAGE_PORTUGUESE": "포르투갈어"
+  "LANGUAGE_RUSSIAN": "러시아어"
+  "LANGUAGE_KOREAN": "한국어"
+  "LANGUAGE_TRAD_CHINESE": "번체 중국어"
+  "LANGUAGE_SIMPL_CHINESE": "간체 중국어"
+  "OSD_SETTINGS": "OSD 설정"
+  "OSD_SETTINGS_LNG": "OSD 언어"
+  "ENABLE_LNG": "언어 변경"
+  "BGM": "배경 음악"
+  "BGM_VOLUME": "배경 음악 볼륨"
+  "DEF_BGM_PATH": "기본 테마 음악"
+  "DEF_BGM_PATH_HINT": "내부 테마의 스트리밍 음악 경로를 설정합니다."
+  "BOOT_SCANNING_MC": "메모리 카드 검색 중..."
+  "BOOT_LOADING_DRIVERS": "저장 장치 드라이버 로드 중..."
+  "BOOT_LOADING_USB": "USB 저장 장치 드라이버 로드 중..."
+  "BOOT_ARMING_MMCE": "MMCE 게임 ID 준비 중..."
+  "BOOT_LOADING_SOUNDS": "테마 사운드 로드 중..."
+  "BOOT_BUILDING_MENU": "메뉴 구성 중..."
+  "NET_UDPFS_TAB_HINT": "UDPFS 켜짐 -- 새 UDPFS 탭을 열고 확인을 눌러 연결하세요. PC 측에서는 udpfsd -fsroot <games folder> 를 실행합니다."
+  "NET_UDPBD_TAB_HINT": "네트워크 블록 기기 켜짐 -- PC 서버가 응답하면 해당 탭이 나타납니다(UDPFS Image의 경우 udpfsd -bdpath, UDPBD의 경우 udpbd-server)."
+  "NEUTRINO_VMC_MISSING": "게임별 VMC 파일을 찾을 수 없습니다 -- 이를 사용하지 않고 실행합니다(게임은 실제 카드를 사용)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino는 이 장치에서 실행할 수 없습니다 -- 실행이 중단되었습니다."
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino 네트워크 구성(bsd toml)이 없거나 쓸 수 없습니다 -- 실행이 중단되었습니다. neutrino 폴더를 확인하세요."
+  "NEUTRINO_TOO_FRAGMENTED": "Neutrino에 사용하기에 조각이 너무 많습니다(조각 %d개, VMC 포함 한도 %d개) -- 대신 OPL 코어를 시도합니다."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Neutrino에 사용하기에 조각이 너무 많습니다(조각 %d개, VMC 포함 한도 %d개) -- PC에서 조각 모음을 하세요. 실행이 중단되었습니다."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM 호환성"
+  "HINT_NEUTRINO_GSM_COMP": "강제된 Neutrino 비디오 모드에서 흔들리거나 찢어지는 게임을 위한 필드 반전 수정입니다. Neutrino 비디오 모드가 설정되어 있어야 합니다."
+  "NARGS_DBC": "디버그 색상 (-dbc)"
+  "NARGS_LOGO": "PS2 로고 (-logo)"
+  "VMC_SLOT1_DISABLE": "VMC 1 비활성화 (카드 유지)"
+  "VMC_SLOT2_DISABLE": "VMC 2 비활성화 (카드 유지)"
+  "HINT_VMC_SLOT_DISABLE": "이 슬롯의 카드를 구성해 둔 채로 해당 슬롯의 VMC 없이 실행합니다. Neutrino 실행에만 해당되며, 게임은 해당 슬롯의 실제 카드를 사용합니다."
+  "NEUTRINO_BSDFS": "Neutrino 파일 시스템"
+  "HINT_NEUTRINO_BSDFS": "Neutrino의 블록 기기 파일 시스템(-bsdfs)을 강제합니다. Auto = 기기별 기본값. hdl/bd는 전문가용 옵션이며, 자동 경로 형태가 맞지 않으면 실행 인수에 일치하는 -dvd= 와 함께 사용하세요."
+  "PLASCOLOR": "플라즈마 혼합 색상"
+  "VCD_HIDE_GAMEID": "PS1 게임 ID 숨기기 (VCD 목록)"
+  "HINT_VCD_HIDE_GAMEID": "외형상 효과만 있음 -- PS1/VCD 목록 이름에서 앞부분의 게임 ID 접두사(예: SLUS_005.51.)를 숨깁니다. ID가 없는 이름은 그대로 표시됩니다. 실행, 커버 아트, 즐겨찾기는 변경되지 않습니다."
+  "VCD_FIRST_DISC": "첫 번째 디스크만 (멀티 디스크 PS1)"
+  "HINT_VCD_FIRST_DISC": "기기 목록에 멀티 디스크 PS1 게임의 Disc 1만 표시합니다(POPSLoader 방식). (Disc 2), (CD 2) 등으로 명명된 파일을 숨깁니다. 모든 디스크는 인게임 교체를 위해 카드에 그대로 유지되며, 즐겨찾기는 필터링되지 않습니다."
+  "GAMES_DEVICE": "게임 장치"
+  "DEFAULT_CORE": "기본 로더 코어"
+  "HINT_DEFAULT_CORE": "게임별 로더 코어가 Default로 설정된 게임에 사용할 전역 기본 코어입니다. <OPL>은 네이티브 코어이고, Neutrino는 외부 neutrino.elf 를 체인합니다. 게임별 선택은 항상 이 설정을 재정의합니다."
+  "VCD_SETTINGS": "VCD 설정"
+  "FINANCIAL_SUPPORT": "재정 지원"

--- a/lng_fork/Laotian.yml
+++ b/lng_fork/Laotian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: ຈັດຮຽງເກມຕາມຕົວອັກສອນ
+  RUMBLE: ການສັ່ນຂອງຕົວຄວບຄຸມໃນເມນູ
+  HINT_RUMBLE: ສັ່ນສັ້ນໆເມື່ອຍ້າຍຕົວກະພິບ, ຢືນຢັນ ຫຼື ຍ້ອນກັບ -- ຕ້ອງໃຊ້ DualShock ໃນໂໝດອະນາລັອກ
+  FOLDER_NAV: ເປີດເບິ່ງໂຟນເດີໃນລາຍການເກມ
+  HINT_FOLDER_NAV: ສະແດງໂຟນເດີຍ່ອຍຂອງ CD/DVD ເປັນລາຍການທີ່ເປີດເບິ່ງໄດ້, ເລືອກເພື່ອເປີດ, ຍົກເລີກເພື່ອຍ້ອນກັບ
+  SETTINGS_NO_HOME: ບໍ່ພົບ memory card -- ບໍ່ສາມາດບັນທຶກການຕັ້ງຄ່າໄດ້. OPL ຖືກ boot ຈາກອຸປະກອນເຄືອຂ່າຍ, ຊຶ່ງການຕັ້ງຄ່າຂອງມັນຕ້ອງຢູ່ໃນ card ໃນເຄື່ອງ.
+  ERROR_SAVING_SETTINGS_TO: ບໍ່ສາມາດຂຽນການຕັ້ງຄ່າໃສ່ %s ໄດ້ (ຂໍ້ຜິດພາດ %d)
+  GENERAL_SETTINGS: ການຕັ້ງຄ່າທົ່ວໄປ
+  DEVICE_SETTINGS: ການຕັ້ງຄ່າອຸປະກອນ
+  LAUNCH_PS2_DISC: ເປີດແຜ່ນ PS2
+  DISC_LAUNCH_ERR: ບໍ່ມີແຜ່ນ PS2 ໃນໄດ.
+  DEFAULT: ຄ່າເລີ່ມຕົ້ນ
+  HINT_MODE7: Neutrino ເທົ່ານັ້ນ -- ແກ້ໄຂເກມທີ່ overrun IOP buffer (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: ນຳໃຊ້ patch PS2RD .img ທີ່ສ້າງໄວ້ລ່ວງໜ້າກັບເກມຂອງທ່ານ.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: ໂໝດເລີ່ມຕົ້ນ MMCE
+  MMCE_PREFIX: ເສັ້ນທາງ MMCE Prefix
+  MMCE_SLOT: ຊ່ອງ MMCE
+  MMCEIGR_SLOT: ຊ່ອງ IGR Bootcard
+  HINT_MMCEIGR_SLOT: ຄຳສັ່ງສະລັບ bootcard ຈະຖືກສົ່ງໄປຍັງຊ່ອງທີ່ເລືອກເມື່ອ IGR
+  MMCE_ADVANCED: ຂັ້ນສູງ
+  MMCE_SETTINGS: ການຕັ້ງຄ່າ MMCE
+  MMCE_SEMA: ວິທີ Lock Sema Enqueuing
+  HINT_MMCE_SEMA: THFIFO ອາດຊ່ວຍຄວາມເຂົ້າກັນໄດ້ແຕ່ຫຼຸດປະສິດທິພາບ
+  MMCE_WAIT_CYCLES: Wait cycles ຫຼັງ /ACK ຕ່ຳ
+  HINT_MMCE_WAIT_CYCLES: ຄ່າຕ່ຳອາດປັບປຸງປະສິດທິພາບແຕ່ເກີດຄວາມບໍ່ໝັ້ນຄົງໄດ້
+  MMCE_USE_ALARMS: ໃຊ້ timeout alarms
+  HINT_MMCE_USE_ALARMS: ປິດອາດຊ່ວຍປະສິດທິພາບແຕ່ອາດເຮັດໃຫ້ MMCE timeout ຄ້າງ
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino ບໍ່ຮອງຮັບຮູບແບບໄຟລ໌ນີ້, ເປີດດ້ວຍ <OPL> core
+  NEUTRINO_NOT_FOUND: ບໍ່ພົບ Neutrino ELF, ເປີດດ້ວຍ <OPL> core
+  UDPBD_NEEDS_STATIC_IP: UDPBD ຕ້ອງການ IP ຄົງທີ່ຂອງ PS2. ຕັ້ງໃນ Network Config (DHCP ເປີດຢູ່ຕອນນີ້).
+  NEUTRINO_SETTING_NA: ການຕັ້ງຄ່ານີ້ບໍ່ໃຊ້ກັບ Neutrino core.
+  POPSTARTER_NOT_FOUND: ບໍ່ພົບ POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: ຂາດຄວາມຕ້ອງການ SMB ສຳລັບ POPSTARTER
+  WRITE_POPSTARTER_NET: ບັນທຶກ POPSTARTER Network Config
+  HINT_WRITE_POPSTARTER_NET: ບັນທຶກຄ່າ IP + SMB share ນີ້ໄປຍັງ IPCONFIG.DAT / SMBCONFIG.DAT ຂອງ POPSTARTER ໃນ memory card (ສຳລັບ VCD ຜ່ານ SMB).
+  POPSTARTER_NET_ERR: ບໍ່ສາມາດບັນທຶກ network config ຂອງ POPSTARTER ລົງ memory card.
+  VCD: VCD
+  VCD_ON: ກຳລັງສະແດງເກມ VCD
+  VCD_OFF: ກຳລັງສະແດງເກມ disc
+  NEUTRINO_ARGS: Neutrino Launch Args
+  HINT_NEUTRINO_ARGS: "flags Neutrino ເພີ່ມເຕີມ, ຄັ່ນດ້ວຍຍະຫວ່າງ (ເຊັ່ນ -mt=dvd). Global ໃຊ້ກັບທຸກເກມ; ຕໍ່ເກມເພີ່ມໄລຍ. ໃສ່ $ ໜ້າ flag ເພື່ອປິດໂດຍບໍ່ລຶບ."
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: ບັງຄັບໂໝດວີດີໂອ GS output ຂອງ Neutrino (-gsm). ປິດຮັກສາຄ່າເລີ່ມຕົ້ນຂອງເກມ.
+  NEUTRINO_PATH: ເສັ້ນທາງ Neutrino ELF
+  HINT_NEUTRINO_PATH: ເສັ້ນທາງເຕັມໄປຫາ neutrino.elf (ເຊັ່ນ mc0:NEUTRINO/neutrino.elf). ວ່າງ = ຊອກຫາອັດຕະໂນມັດໃນ mc0/mc1.
+  POPSTARTER_PATH: ເສັ້ນທາງ POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: ເສັ້ນທາງ POPSTARTER.ELF ກຳນົດເອງ; ໃຊ້ໂຟລເດີ POPS ຂອງອຸປະກອນໂດຍອັດຕະໂນມັດຖ້າຫາກວ່າງ/ບໍ່ພົບ. Keyboard ຈຳກັດ 31 ຕົວອັກສອນ; ເສັ້ນທາງຍາວກວ່ານັ້ນຜ່ານ settings_riptopl.cfg.
+  BDMA_SOURCE: ແຫຼ່ງ BDMA
+  HINT_BDMA_SOURCE: ອຸປະກອນທີ່ໂຟລເດີ POPS ມີໄຟລ໌ driver BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Mode
+  HINT_BDMA_MODE: driver block-device exFAT ທີ່ POPSTARTER ໂຫຼດ. ການປ່ຽນແປງຈະສຳເນົາ module ໄປຍັງ card; FAT32 = ບໍ່ມີ (driver ໃນຕົວ).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD ພາຍໃນ
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: ບໍ່ພົບໄຟລ໌ BDMA module ໃນອຸປະກອນຕົ້ນທາງ.
+  BDMA_ERR_SPACE: ບໍ່ມີພື້ນທີ່ memory card ພໍສຳລັບ BDMA modules.
+  BDMA_ERR_IO: ເກີດຂໍ້ຜິດພາດໃນການຂຽນ BDMA modules ລົງ memory card.
+  COVERFLOW_SETTINGS: ການຕັ້ງຄ່າ Coverflow
+  COVERFLOW_COUNT: ຈຳນວນ Cover
+  COVERFLOW_SCALE: ຂະໜາດກາງ
+  COVERFLOW_ANIM: ຄວາມໄວ Animation
+  COVERFLOW_DIM: ມືດ Cover ດ້ານຂ້າງ
+  NONE: ບໍ່ມີ
+  SMALL: ນ້ອຍ
+  LARGE: ໃຫຍ່
+  NORMAL: ປົກກະຕິ
+  FAV: ລາຍການໂປດ
+  FAVMODE: ໂໝດເລີ່ມຕົ້ນລາຍການໂປດ
+  FAV_HINT: ລາຍການໂປດ
+  FAV_MSG: '%s ບໍ່ອະນຸຍາດຜ່ານເມນູລາຍການໂປດ.'
+  FAV_PERSISTENCE_MSG: '%s ບໍ່ສາມາດໃຊ້ໄດ້ຂະນະທີ່ລາຍການຖືກໝາຍເປັນລາຍການໂປດ.'
+  NEUTRINO_DEVICE: ອຸປະກອນ Neutrino
+  HINT_NEUTRINO_DEVICE: ອຸປະກອນທີ່ມີ neutrino.elf (ໃນໂຟລເດີ NEUTRINO/ ຫຼື neutrino/). ອັດຕະໂນມັດສະແກນ mc0 ແລ້ວ mc1.
+  NARGS_QB: Quick Boot (-qb)
+  NARGS_CWD: Working Dir (-cwd)
+  NARGS_CFG: Config (-cfg)
+  NARGS_ELF: Boot ELF (-elf)
+  NARGS_ATA0: ATA0 Image (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 Image (-ata1)
+  NARGS_EXTRA: Args ເພີ່ມເຕີມ
+  NARGS_AUTO_NOTE: 'ອັດຕະໂນມັດ: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: ແຟ້ມ .tar ຮູບປົກ
+  DISABLE_ALL: ປິດທັງໝົດ
+  BOOT_LOADING_CONFIG: ກຳລັງໂຫຼດການຕັ້ງຄ່າ...
+  BOOT_SCANNING_BDM: ກຳລັງສະແກນ USB / ກາດ / ເຄືອຂ່າຍ...
+  BOOT_SCANNING_NET: ກຳລັງເລີ່ມເຄືອຂ່າຍ...
+  BOOT_SCANNING_HDD: ກຳລັງສະແກນ HDD...
+  BOOT_READY: ພ້ອມແລ້ວ.
+  UDPFS_GAMES: "ເກມ UDPFS"
+  UDPFSBD_GAMES: "ເກມ UDPFSBD"
+  NET_PROTOCOL: "ໂປຣໂຕຄໍເຄືອຂ່າຍ"
+  NET_NEEDS_NEUTRINO: "ເກມເຄືອຂ່າຍ (UDP) ສາມາດບູດໄດ້ຜ່ານ core Neutrino ເທົ່ານັ້ນ. ກວດເບິ່ງວ່າມີ neutrino.elf ຢູ່ ແລະ ຮອງຮັບຮູບແບບນັ້ນ."
+  VCD_NOT_ON_NET: "ເກມ PS1 (.VCD) ບໍ່ສາມາດເປີດຜ່ານອຸປະກອນເຄືອຂ່າຍໄດ້."
+  MX4SIO_PADEMU_WARN: "MX4SIO ແລະ ການຈຳລອງແພັດໃຊ້ບັສ SIO2 ຮ່ວມກັນ ແລະ ເກມອາດຈະບູດບໍ່ໄດ້."
+  HINT_OSD_SETTINGS_LNG: "ບັງຄັບໃຊ້ການຕັ້ງຄ່າພາສາແບບກຳນົດເອງ"
+  OSD_SETTINGS_TVASPECT: "ຂະໜາດຈໍ"
+  FULL_SCREEN: "ເຕັມຈໍ"
+  OSD_SETTINGS_VMODE: "ໂໝດວິດີໂອ"
+  SYSTEM_DEFAULT: "ຄ່າເລີ່ມຕົ້ນຂອງລະບົບ"
+  HIGH: "ສູງ"
+  LOW: "ຕໍ່າ"
+  XSENSITIVITY: "ຄວາມໄວແກນ X ອະນາລັອກ"
+  YSENSITIVITY: "ຄວາມໄວແກນ Y ອະນາລັອກ"
+  FILE_COUNT: "ພົບໄຟລ໌: %i"
+  CHEAT_SELECTION: "ການເລືອກໂກງ"
+  HDD_HINT: "ອະນຸຍາດພຽງ HDD ດຽວ, ການເປີດໃຊ້ຈະລັອກ APA ຫຼື GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "ບໍ່ໄດ້ນຳໃຊ້ MMCE GameID -- neutrino.elf ຢູ່ໃນກາດນີ້ (ການປ່ຽນມັນຈະຖອນ Neutrino ອອກ)."
+  POPSTARTER_DEVICE: "ອຸປະກອນ POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "ອຸປະກອນທີ່ເກັບ POPS/POPSTARTER.ELF ສຳລັບການເປີດ PS1 VCD. ຄ່າເລີ່ມຕົ້ນ = ອຸປະກອນບູດ (cwd) ຈາກນັ້ນອຸປະກອນຂອງ VCD ເອງ. ແບບກຳນົດເອງຈະສະແດງເສັ້ນທາງແບບພິມເອງ."
+  BDMA_APPLY: "ນຳໃຊ້ VCD BDMA ຕອນເປີດ"
+  HINT_BDMA_APPLY: "ເປີດ: ຕິດຕັ້ງໄດຣເວີ exFAT ທີ່ກົງກັບ VCD ທີ່ເປີດໃສ່ກາດຄວາມຈຳໂດຍອັດຕະໂນມັດກ່ອນບູດ (ແນະນຳ). ປິດ: ຈັດການເອງດ້ວຍຕົວເລືອກ Source/Mode ຂອງ BDMA ຂ້າງລຸ່ມ."
+  NETBOOT_RESTART: "ຣີສະຕາດ OPL ເພື່ອນຳໃຊ້ການປ່ຽນໂປຣໂຕຄໍການບູດເຄືອຂ່າຍ."
+  UDPFS_MODE: "ການເຂົ້າເຖິງ UDPFS"
+  "MENU": "ເມນູ"
+  "APPS": "ແອັບ"
+  "DEBUG": "ສີດີບັກ"
+  "COVERART": "ຮູບໜ້າປົກ"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "ການຂຽນຂໍ້ມູນ"
+  "MODE1": "ໂໝດ 1"
+  "MODE2": "ໂໝດ 2"
+  "MODE3": "ໂໝດ 3"
+  "MODE4": "ໂໝດ 4"
+  "MODE5": "ໂໝດ 5"
+  "MODE6": "ໂໝດ 6"
+  "ENABLEGSM": "ຕົວເລືອກ GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "ເຄື່ອງໂກງ PS2RD"
+  "PADEMU_ENABLE": "ຕົວຈຳລອງແພັດ"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "ການຈຳລອງ"
+  "PADEMU_VIB": "ການສັ່ນ"
+  "PADEMU_WORKAROUND": "ວິທີແກ້ DS3 ປອມ"
+  "SFX": "ສຽງເອັບເຟັກ"
+  "BOOT_SND": "ສຽງເປີດເຄື່ອງ"
+  "ENABLE_NOTIFICATIONS": "ການແຈ້ງເຕືອນ"
+  "OPTIONS": "ຕົວເລືອກ"
+  "GLOBAL_SETTINGS": "ທົ່ວໄປ"
+  "INFO_GENRE": "ປະເພດ"
+  "INFO_RELEASE": "ວັນວາງຈຳໜ່າຍ"
+  "INFO_DESCRIPTION": "ຄຳອະທິບາຍ"
+  "BLOCKDEVICE_SETTINGS": "ອຸປະກອນ Block"
+  "CONTROLLER_SETTINGS": "ຕັ້ງຄ່າຄອນໂທຣນເລີ"
+  "HINT_BDM_START": "ເປີດ/ປິດ Block Device Manager."
+  "HINT_BLOCK_DEVICES": "ເປີດ/ປິດ Block Devices (ເຊັ່ນ USB)."
+  "USB_GAMES": "ເກມ USB"
+  "ILINK_GAMES": "ເກມ iLink"
+  "MX4SIO_GAMES": "ເກມ MX4SIO"
+  "PADMACROCONFIG": "ຕັ້ງຄ່າ PADMACRO"
+  "PADMACRO_SETTINGS": "ຕັ້ງຄ່າ Pad macro"
+  "PADMACRO_ENABLE": "Pad macro"
+  "PADMACRO_SLOWDOWN": "ຫຼຸດຄວາມໄວອານາລັອກ:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "ຫຼຸດໄລຍະຂອງກ້ານອານາລັອກເມື່ອກົດປຸ່ມ"
+  "LEFT_ANALOG": "ກ້ານຊ້າຍ"
+  "RIGHT_ANALOG": "ກ້ານຂວາ"
+  "PADMACRO_INVERT_AXIS": "ກັບແກນອານາລັອກ:"
+  "HINT_PADMACRO_INVERT_AXIS": "ກັບແກນຂອງກ້ານອານາລັອກ"
+  "TURBO_SPEED": "ຄວາມໄວປຸ່ມ Turbo"
+  "HINT_TURBO_SPEED": "ຄວາມໄວໃນການກົດປຸ່ມເມື່ອ turbo ເປີດຢູ່"
+  "ACT_WHILE_PRESSED": "ຂະນະກົດປຸ່ມ"
+  "ACT_TOGGLED": "ສະຫຼັບດ້ວຍປຸ່ມ"
+  "LANGUAGE_JAPANESE": "ຍີ່ປຸ່ນ"
+  "LANGUAGE_ENGLISH": "ອັງກິດ"
+  "LANGUAGE_FRENCH": "ຝຣັ່ງ"
+  "LANGUAGE_SPANISH": "ສະເປນ"
+  "LANGUAGE_GERMAN": "ເຢຍລະມັນ"
+  "LANGUAGE_ITALIAN": "ອິຕາລີ"
+  "LANGUAGE_DUTCH": "ໂຮນລັງ"
+  "LANGUAGE_PORTUGUESE": "ໂປຕຸເກດ"
+  "LANGUAGE_RUSSIAN": "ລັດເຊຍ"
+  "LANGUAGE_KOREAN": "ເກົາຫຼີ"
+  "LANGUAGE_TRAD_CHINESE": "ຈີນດັ້ງເດີມ"
+  "LANGUAGE_SIMPL_CHINESE": "ຈີນຕົວຫຍໍ້"
+  "OSD_SETTINGS": "ຕັ້ງຄ່າ OSD"
+  "OSD_SETTINGS_LNG": "ພາສາ OSD"
+  "ENABLE_LNG": "ປ່ຽນພາສາ"
+  "BGM": "ເພງພື້ນຫຼັງ"
+  "BGM_VOLUME": "ລະດັບສຽງເພງພື້ນຫຼັງ"
+  "DEF_BGM_PATH": "ເພງທີມມາດຕະຖານ"
+  "DEF_BGM_PATH_HINT": "ຕັ້ງເສັ້ນທາງເພື່ອສະຕຣີມເພງສຳລັບທີມພາຍໃນ."
+  "BOOT_SCANNING_MC": "ກຳລັງສະແກນເມມໂມຣີກາດ..."
+  "BOOT_LOADING_DRIVERS": "ກຳລັງໂຫຼດໄດຣເວີບ່ອນເກັບຂໍ້ມູນ..."
+  "BOOT_LOADING_USB": "ກຳລັງໂຫຼດໄດຣເວີບ່ອນເກັບຂໍ້ມູນ USB..."
+  "BOOT_ARMING_MMCE": "ກຳລັງຕຽມ MMCE game-ID..."
+  "BOOT_LOADING_SOUNDS": "ກຳລັງໂຫຼດສຽງທີມ..."
+  "BOOT_BUILDING_MENU": "ກຳລັງສ້າງເມນູ..."
+  "NET_UDPFS_TAB_HINT": "UDPFS ເປີດຢູ່ -- ເປີດແທັບ UDPFS ໃໝ່ ແລ້ວກົດ Confirm ເພື່ອເชื่อมต่อ. ຝั่ง PC ແລ່ນ udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "ອຸປະກອນບລັອກເครือข่ายເປີດຢູ່ -- ແທັບຂອງມັນຈະປາກົດຂຶ້ນເມື່ອເซิร์ฟเวอร์ PC ຕອບກັບ (udpfsd -bdpath ສຳລັບ UDPFS Image, udpbd-server ສຳລັບ UDPBD)."
+  "NEUTRINO_VMC_MISSING": "ບໍ່ພົບໄຟລ໌ VMC ຕໍ່ເກມ -- ກຳລັງເປີດຕົວໂດຍບໍ່ໃຊ້ມັນ (ເກມໃຊ້ກາດຈິງຂອງມັນ)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino ບໍ່ສາມາດເປີດຈາກອຸປະກອນນີ້ໄດ້ -- ຍົກເລີກການເປີດ."
+  "NEUTRINO_TOML_SYNC_FAILED": "ຄ่าตั้งเครือข่ายของ Neutrino (bsd toml) ຫາຍໄປ ຫຼື ຂຽນບໍ່ໄດ້ -- ຍົກເລີກການເປີດຕົວ, ກวดสอบโฟลเดอร์ neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "แตกกระจายเกินไปสำหรับ Neutrino (%d fragments, ຂີດຈຳກັດ %d ລວມ VMCs) -- ກຳລັງລອງໃຊ້ຄอร์ OPL ແທน."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "แตกกระจายเกินไปสำหรับ Neutrino (%d fragments, ຂີດຈຳກັດ %d ລວມ VMCs) -- ຈัดเรียงไฟล์ใหม่ (defragment) ໃນ PC; ຍົກເລີກການເປີດຕົວແລ້ວ."
+  "NEUTRINO_GSM_COMP": "ຄວາມເຂົ້າກັນໄດ້ Neutrino GSM"
+  "HINT_NEUTRINO_GSM_COMP": "ການແກ້ໄຂແບບ field-flipping ສຳລັບເກມທີ່ສັ່ນ ຫຼື ฉีกขาด ພາຍໃຕ້ Neutrino Video mode ທີ່ຖືກບັງຄັບ. ต้องມີການຕັ້ງ Neutrino Video mode."
+  "NARGS_DBC": "ສີດີບັກ (-dbc)"
+  "NARGS_LOGO": "ໂລໂກ້ PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "ປິດ VMC 1 (ຮັກສາກາດ)"
+  "VMC_SLOT2_DISABLE": "ປິດ VMC 2 (ຮັກສາກາດ)"
+  "HINT_VMC_SLOT_DISABLE": "ເປີດຕົວໂດຍບໍ່ໃຊ້ VMC ຂອງຊ່ອງນີ້ ໃນຂณะທີ່ຍັງຕັ້ງຄ່າກາດຂອງມັນໄວ້. ເປີດຕົວດ້ວຍ Neutrino ເທົ່ານັ້ນ; ຈາກນັ້ນເກມຈະໃຊ້ກາດຈິງໃນຊ່ອງນັ້ນ."
+  "NEUTRINO_BSDFS": "ລະບົບໄຟລ໌ Neutrino"
+  "HINT_NEUTRINO_BSDFS": "ບັງຄັບໃຊ້ລະບົບໄຟລ໌ອຸປະກອນແບບບລັອກຂອງ Neutrino (-bsdfs). Auto = ຄ່າເລີ່ມຕົ້ນຕາມແຕ່ລະອຸປະກອນ. hdl/bd ແມ່ນທາງເລືອກສຳລັບຜູ້ຊ່ຽວຊານ; ຈັບຄູ່ພວກມັນກັບ -dvd= ທີ່ກົງກັນໃນ argument ການເປີດຕົວ ຖ້າຮູບຮ່າງເສັ້ນທາງ auto ບໍ່ເໝາະສົມ."
+  "PLASCOLOR": "ສີຜະສົມ Plasma"
+  "VCD_HIDE_GAMEID": "ເຊື່ອງ PS1 Game ID (ລາຍການ VCD)"
+  "HINT_VCD_HIDE_GAMEID": "ເປັນຄวามงามເທົ່ານັ້ນ -- ເຊື່ອງຄຳນຳໜ້າ game-ID (ຕົວຢ່າງ SLUS_005.51.) ອອກຈາກຊື່ໃນລາຍການ PS1/VCD. ຊື່ທີ່ບໍ່ມີ ID ຈະຖືກສະແດງຕາມເດີມ. ບໍ່ປ່ຽນແປງການເປີດຕົວ, ຮູບໜ້າປົກ, ຫຼື ລາຍການທີ່ມັກ."
+  "VCD_FIRST_DISC": "ແຜ່ນທຳອິດເທົ່ານັ້ນ (PS1 ຫຼາຍແຜ່ນ)"
+  "HINT_VCD_FIRST_DISC": "ສະແດງແຕ່ແຜ່ນທີ 1 (Disc 1) ຂອງເກມ PS1 ແບບຫຼາຍແຜ່ນໃນລາຍການອຸປະກອນ (ຮູບແບບ POPSLoader). ເຊື່ອງໄຟລ໌ທີ່ຕັ້ງຊື່ວ່າ (Disc 2), (CD 2), ແລະ ອື່ນໆ. ແຜ່ນທັງໝົດຍັງຄົງຢູ່ໃນກາດເພື່ອສະຫຼັບໃນເກມ; ລາຍການທີ່ມັກ (Favourites) ຈະບໍ່ຖືກກັ່ນຕອງ."
+  "GAMES_DEVICE": "ອຸປະກອນຂອງເກມ"
+  "DEFAULT_CORE": "Loader Core ມາດຕະຖານ"
+  "HINT_DEFAULT_CORE": "ຄอร์เริ່มต้นแบบ global สำหรับเกมที่ Loader Core ຕໍ່ເກມ ຖືກຕັ້ງເປັນ Default. <OPL> ແມ່ນຄอร์ພື້ນເມືອງ; Neutrino ຕໍ່ຫ່ວງໄປຫາ neutrino.elf ພາຍນອກ. ການເລືອກຕໍ່ເກມຈະລົບລ້າງຄ່ານີ້ສະເໝີ."
+  "VCD_SETTINGS": "ຕັ້ງຄ່າ VCD"
+  "FINANCIAL_SUPPORT": "ການສະໜັບສະໜູນທາງການເງິນ"

--- a/lng_fork/Persian.yml
+++ b/lng_fork/Persian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: مرتب‌سازی بازی‌ها به ترتیب الفبا
+  RUMBLE: لرزش دسته در منوها
+  HINT_RUMBLE: لرزش کوتاه هنگام جابه‌جایی مکان‌نما، تأیید یا بازگشت -- به دوال‌شاک در حالت آنالوگ نیاز دارد
+  FOLDER_NAV: مرور پوشه‌ها در فهرست بازی‌ها
+  HINT_FOLDER_NAV: نمایش زیرپوشه‌های CD/DVD به‌صورت ورودی‌های قابل‌مرور، برای باز کردن انتخاب و برای بازگشت لغو کنید
+  SETTINGS_NO_HOME: کارت حافظه‌ای یافت نشد -- تنظیمات قابل ذخیره نیست. OPL از یک دستگاه شبکه بوت شده که تنظیماتش باید روی یک کارت محلی باشد.
+  ERROR_SAVING_SETTINGS_TO: نوشتن تنظیمات در %s ممکن نشد (خطای %d)
+  GENERAL_SETTINGS: تنظیمات کلی
+  DEVICE_SETTINGS: تنظیمات دستگاه
+  LAUNCH_PS2_DISC: اجرای دیسک PS2
+  DISC_LAUNCH_ERR: دیسک PS2 در درایو نیست.
+  DEFAULT: پیش‌فرض
+  HINT_MODE7: فقط Neutrino -- رفع مشکل بازی‌هایی که بافر IOP را پر می‌کنند (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: تصویر چیت PS2RD
+  HINT_ENABLEIMAGE: اعمال پچ پیش‌ساخته PS2RD .img روی بازی.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: حالت شروع MMCE
+  MMCE_PREFIX: مسیر پیشوند MMCE
+  MMCE_SLOT: اسلات MMCE
+  MMCEIGR_SLOT: اسلات(های) کارت بوت IGR
+  HINT_MMCEIGR_SLOT: دستور سوییچ به کارت بوت در IGR به اسلات(های) انتخاب‌شده ارسال می‌شود
+  MMCE_ADVANCED: پیشرفته
+  MMCE_SETTINGS: تنظیمات MMCE
+  MMCE_SEMA: روش صف‌بندی قفل Sema
+  HINT_MMCE_SEMA: THFIFO ممکن است سازگاری را بهبود دهد اما عملکرد را کاهش دهد
+  MMCE_WAIT_CYCLES: چرخه‌های انتظار پس از پایین آمدن /ACK
+  HINT_MMCE_WAIT_CYCLES: مقادیر کمتر ممکن است عملکرد را بهبود دهند اما ناپایداری ایجاد کنند
+  MMCE_USE_ALARMS: استفاده از آلارم‌های تایم‌اوت
+  HINT_MMCE_USE_ALARMS: خاموش ممکن است عملکرد را بهبود دهد اما تایم‌اوت MMCE می‌تواند باعث فریز شود
+  CORE_LOADER: هسته لودر
+  NEUTRINO_BAD_FORMAT: Neutrino از این فرمت فایل پشتیبانی نمی‌کند، اجرا با هسته <OPL>
+  NEUTRINO_NOT_FOUND: Neutrino ELF پیدا نشد، اجرا با هسته <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD نیاز به IP ثابت PS2 دارد. در تنظیمات شبکه تنظیم کنید (DHCP در حال حاضر روشن است).
+  NEUTRINO_SETTING_NA: این تنظیم با هسته Neutrino استفاده نمی‌شود.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF پیدا نشد
+  POPSTARTER_SMB_MISSING: پیش‌نیازهای SMB برای POPSTARTER موجود نیست
+  WRITE_POPSTARTER_NET: نوشتن تنظیمات شبکه POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: 'مقادیر IP + SMB را در IPCONFIG.DAT / SMBCONFIG.DAT مربوط به POPSTARTER روی کارت حافظه ذخیره کنید (برای VCD از طریق SMB).'
+  POPSTARTER_NET_ERR: نوشتن تنظیمات شبکه POPSTARTER روی کارت حافظه ناموفق بود.
+  VCD: VCD
+  VCD_ON: نمایش بازی‌های VCD
+  VCD_OFF: نمایش بازی‌های دیسک
+  NEUTRINO_ARGS: آرگومان‌های اجرای Neutrino
+  HINT_NEUTRINO_ARGS: فلگ‌های اضافی Neutrino، جداشده با فاصله (مثلاً -mt=dvd). کلی روی همه بازی‌ها اعمال می‌شود؛ هر بازی می‌تواند فلگ اضافه کند. پیشوند $ فلگ را بدون حذف غیرفعال می‌کند.
+  NEUTRINO_VIDEO: ویدیوی Neutrino
+  HINT_NEUTRINO_VIDEO: تعیین اجباری حالت ویدیوی خروجی GS در Neutrino (-gsm). خاموش = حالت پیش‌فرض بازی.
+  NEUTRINO_PATH: مسیر Neutrino ELF
+  HINT_NEUTRINO_PATH: مسیر کامل به neutrino.elf (مثلاً mc0:NEUTRINO/neutrino.elf). خالی = تشخیص خودکار روی mc0/mc1.
+  POPSTARTER_PATH: 'مسیر POPSTARTER.ELF'
+  HINT_POPSTARTER_PATH: مسیر سفارشی POPSTARTER.ELF؛ در صورت خالی/نبودن به پوشه POPS دستگاه برمی‌گردد. صفحه‌کلید حداکثر ۳۱ کاراکتر؛ مسیرهای طولانی‌تر از طریق settings_riptopl.cfg.
+  BDMA_SOURCE: منبع BDMA
+  HINT_BDMA_SOURCE: دستگاهی که پوشه POPS آن فایل‌های درایور BDMAssault را دارد (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: حالت BDMA
+  HINT_BDMA_MODE: درایور بلاک‌دیوایس exFAT که POPSTARTER بارگذاری می‌کند. تغییر آن ماژول‌ها را به کارت کپی می‌کند؛ FAT32 = بدون ماژول (درایور داخلی).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: هارد داخلی
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: فایل‌های ماژول BDMA روی دستگاه منبع پیدا نشد.
+  BDMA_ERR_SPACE: فضای کافی روی کارت حافظه برای ماژول‌های BDMA وجود ندارد.
+  BDMA_ERR_IO: خطا در نوشتن ماژول‌های BDMA روی کارت حافظه.
+  COVERFLOW_SETTINGS: تنظیمات Coverflow
+  COVERFLOW_COUNT: تعداد کاور
+  COVERFLOW_SCALE: مقیاس مرکز
+  COVERFLOW_ANIM: سرعت انیمیشن
+  COVERFLOW_DIM: کم‌نور کردن کاورهای کناری
+  NONE: هیچ‌کدام
+  SMALL: کوچک
+  LARGE: بزرگ
+  NORMAL: معمولی
+  FAV: علاقه‌مندی‌ها
+  FAVMODE: حالت شروع علاقه‌مندی‌ها
+  FAV_HINT: علاقه‌مندی
+  FAV_MSG: '%s از طریق منوی علاقه‌مندی‌ها مجاز نیست.'
+  FAV_PERSISTENCE_MSG: '%s در حالی که آیتم به عنوان علاقه‌مندی علامت‌گذاری شده، مجاز نیست.'
+  NEUTRINO_DEVICE: دستگاه Neutrino
+  HINT_NEUTRINO_DEVICE: دستگاهی که neutrino.elf را در پوشه NEUTRINO/ یا neutrino/ نگه می‌دارد. Auto ابتدا mc0 سپس mc1 را اسکن می‌کند.
+  NARGS_QB: راه‌اندازی سریع (-qb)
+  NARGS_CWD: پوشه کاری (-cwd)
+  NARGS_CFG: پیکربندی (-cfg)
+  NARGS_ELF: ELF بوت (-elf)
+  NARGS_ATA0: تصویر ATA0 (-ata0)
+  NARGS_ATA0ID: شناسه ATA0 (-ata0id)
+  NARGS_ATA1: تصویر ATA1 (-ata1)
+  NARGS_EXTRA: آرگومان‌های اضافی
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: آرشیو .tar جلد
+  DISABLE_ALL: غیرفعال کردن همه
+  BOOT_LOADING_CONFIG: در حال بارگذاری تنظیمات...
+  BOOT_SCANNING_BDM: در حال اسکن درایوهای USB / کارت / شبکه...
+  BOOT_SCANNING_NET: در حال راه‌اندازی شبکه...
+  BOOT_SCANNING_HDD: در حال اسکن HDD...
+  BOOT_READY: آماده.
+  UDPFS_GAMES: "بازی‌های UDPFS"
+  UDPFSBD_GAMES: "بازی‌های UDPFSBD"
+  NET_PROTOCOL: "پروتکل شبکه"
+  NET_NEEDS_NEUTRINO: "بازی‌های شبکه (UDP) فقط از طریق هستهٔ Neutrino اجرا می‌شوند. مطمئن شوید neutrino.elf موجود است و قالب پشتیبانی می‌شود."
+  VCD_NOT_ON_NET: "بازی‌های PS1 (.VCD) را نمی‌توان روی دستگاه شبکه اجرا کرد."
+  MX4SIO_PADEMU_WARN: "MX4SIO و شبیه‌سازی دسته از گذرگاه SIO2 مشترک استفاده می‌کنند و ممکن است بازی اجرا نشود."
+  HINT_OSD_SETTINGS_LNG: "اعمال پیکربندی زبان سفارشی"
+  OSD_SETTINGS_TVASPECT: "اندازهٔ صفحه"
+  FULL_SCREEN: "تمام‌صفحه"
+  OSD_SETTINGS_VMODE: "حالت ویدیو"
+  SYSTEM_DEFAULT: "پیش‌فرض سیستم"
+  HIGH: "زیاد"
+  LOW: "کم"
+  XSENSITIVITY: "حساسیت محور X آنالوگ"
+  YSENSITIVITY: "حساسیت محور Y آنالوگ"
+  FILE_COUNT: "فایل‌های یافت‌شده: %i"
+  CHEAT_SELECTION: "انتخاب تقلب"
+  HDD_HINT: "فقط یک HDD مجاز است؛ فعال‌سازی، APA یا GPT را قفل می‌کند."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID اعمال نشد -- فایل neutrino.elf روی این کارت است (تعویض آن Neutrino را از حافظه خارج می‌کند)."
+  POPSTARTER_DEVICE: "دستگاه POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "دستگاه دارای POPS/POPSTARTER.ELF برای اجرای PS1 VCD. پیش‌فرض = دستگاه بوت (cwd) سپس دستگاه خودِ VCD. سفارشی یک مسیر متنی آزاد نمایش می‌دهد."
+  BDMA_APPLY: "اعمال VCD BDMA هنگام اجرا"
+  HINT_BDMA_APPLY: "روشن: تجهیز خودکار درایور exFAT متناظرِ VCD اجراشده روی کارت حافظه پیش از بوت (توصیه‌شده). خاموش: خودتان با انتخابگرهای Source/Mode مربوط به BDMA در زیر آن را مدیریت کنید."
+  NETBOOT_RESTART: "برای اعمال تغییر پروتکل بوت شبکه، OPL را دوباره راه‌اندازی کنید."
+  UDPFS_MODE: "دسترسی UDPFS"
+  "MENU": "منو"
+  "APPS": "برنامه‌ها"
+  "DEBUG": "رنگ‌های اشکال‌زدایی"
+  "COVERART": "تصویر جلد"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "عملیات نوشتن"
+  "MODE1": "حالت ۱"
+  "MODE2": "حالت ۲"
+  "MODE3": "حالت ۳"
+  "MODE4": "حالت ۴"
+  "MODE5": "حالت ۵"
+  "MODE6": "حالت ۶"
+  "ENABLEGSM": "انتخابگر GSM"
+  "OVERSCAN": "اسکن بیش از حد"
+  "ENABLECHEAT": "موتور تقلب PS2RD"
+  "PADEMU_ENABLE": "شبیه‌ساز دسته"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "شبیه‌سازی"
+  "PADEMU_VIB": "لرزش"
+  "PADEMU_WORKAROUND": "راه‌حل جایگزین DS3 جعلی"
+  "SFX": "جلوه‌های صوتی"
+  "BOOT_SND": "صدای راه‌اندازی"
+  "ENABLE_NOTIFICATIONS": "اعلان‌ها"
+  "OPTIONS": "گزینه‌ها"
+  "GLOBAL_SETTINGS": "سراسری"
+  "INFO_GENRE": "ژانر"
+  "INFO_RELEASE": "انتشار"
+  "INFO_DESCRIPTION": "توضیحات"
+  "BLOCKDEVICE_SETTINGS": "دستگاه‌های بلوکی"
+  "CONTROLLER_SETTINGS": "تنظیمات دسته"
+  "HINT_BDM_START": "روشن/خاموش کردن مدیر دستگاه بلوکی (BDM)."
+  "HINT_BLOCK_DEVICES": "روشن/خاموش کردن دستگاه‌های بلوکی (مثلاً USB)."
+  "USB_GAMES": "بازی‌های USB"
+  "ILINK_GAMES": "بازی‌های iLink"
+  "MX4SIO_GAMES": "بازی‌های MX4SIO"
+  "PADMACROCONFIG": "پیکربندی PADMACRO"
+  "PADMACRO_SETTINGS": "تنظیمات ماکروی دسته"
+  "PADMACRO_ENABLE": "ماکروهای دسته"
+  "PADMACRO_SLOWDOWN": "کند کردن آنالوگ:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "کاهش دامنه دسته آنالوگ هنگام فشردن دکمه"
+  "LEFT_ANALOG": "دسته چپ"
+  "RIGHT_ANALOG": "دسته راست"
+  "PADMACRO_INVERT_AXIS": "وارونه‌سازی محور آنالوگ:"
+  "HINT_PADMACRO_INVERT_AXIS": "وارونه‌سازی محور دسته آنالوگ"
+  "TURBO_SPEED": "سرعت دکمه توربو"
+  "HINT_TURBO_SPEED": "سرعت فشردن دکمه هنگام فعال بودن توربو"
+  "ACT_WHILE_PRESSED": "هنگام فشردن دکمه"
+  "ACT_TOGGLED": "با دکمه تغییر وضعیت می‌دهد"
+  "LANGUAGE_JAPANESE": "ژاپنی"
+  "LANGUAGE_ENGLISH": "انگلیسی"
+  "LANGUAGE_FRENCH": "فرانسوی"
+  "LANGUAGE_SPANISH": "اسپانیایی"
+  "LANGUAGE_GERMAN": "آلمانی"
+  "LANGUAGE_ITALIAN": "ایتالیایی"
+  "LANGUAGE_DUTCH": "هلندی"
+  "LANGUAGE_PORTUGUESE": "پرتغالی"
+  "LANGUAGE_RUSSIAN": "روسی"
+  "LANGUAGE_KOREAN": "کره‌ای"
+  "LANGUAGE_TRAD_CHINESE": "چینی سنتی"
+  "LANGUAGE_SIMPL_CHINESE": "چینی ساده‌شده"
+  "OSD_SETTINGS": "تنظیمات OSD"
+  "OSD_SETTINGS_LNG": "زبان OSD"
+  "ENABLE_LNG": "تغییر زبان"
+  "BGM": "موسیقی پس‌زمینه"
+  "BGM_VOLUME": "بلندی موسیقی پس‌زمینه"
+  "DEF_BGM_PATH": "موسیقی پیش‌فرض قالب"
+  "DEF_BGM_PATH_HINT": "تنظیم مسیر پخش موسیقی برای قالب داخلی."
+  "BOOT_SCANNING_MC": "در حال اسکن کارت‌های حافظه..."
+  "BOOT_LOADING_DRIVERS": "در حال بارگذاری درایورهای ذخیره‌سازی..."
+  "BOOT_LOADING_USB": "در حال بارگذاری درایور ذخیره‌سازی USB..."
+  "BOOT_ARMING_MMCE": "در حال آماده‌سازی شناسه بازی MMCE..."
+  "BOOT_LOADING_SOUNDS": "در حال بارگذاری صداهای قالب..."
+  "BOOT_BUILDING_MENU": "در حال ساخت منو..."
+  "NET_UDPFS_TAB_HINT": "UDPFS روشن است -- زبانه جدید UDPFS را باز کن و Confirm را برای اتصال فشار بده. سمت PC، udpfsd -fsroot <games folder> را اجرا می‌کند."
+  "NET_UDPBD_TAB_HINT": "دستگاه بلوکی شبکه روشن است -- زبانه آن پس از پاسخ‌دادن سرور PC ظاهر می‌شود (udpfsd -bdpath برای UDPFS Image، udpbd-server برای UDPBD)."
+  "NEUTRINO_VMC_MISSING": "فایل VMC مخصوص بازی یافت نشد -- بدون آن اجرا می‌شود (بازی از کارت واقعی خود استفاده می‌کند)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino نمی‌تواند از این دستگاه اجرا شود -- اجرا لغو شد."
+  "NEUTRINO_TOML_SYNC_FAILED": "پیکربندی شبکه Neutrino (bsd toml) وجود ندارد یا قابل نوشتن نیست -- اجرا لغو شد، پوشه neutrino را بررسی کن."
+  "NEUTRINO_TOO_FRAGMENTED": "برای Neutrino بیش از حد قطعه‌قطعه است (%d قطعه، محدودیت %d شامل VMCها) -- به جای آن هسته OPL امتحان می‌شود."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "برای Neutrino بیش از حد قطعه‌قطعه است (%d قطعه، محدودیت %d شامل VMCها) -- روی PC یکپارچه‌سازی (defragment) کن؛ اجرا لغو شد."
+  "NEUTRINO_GSM_COMP": "سازگاری GSM با Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "رفع مشکل با جابه‌جایی فیلد (field-flipping) برای بازی‌هایی که زیر یک حالت Neutrino Video اجباری می‌لرزند یا پارگی تصویر دارند. نیازمند تنظیم یک حالت Neutrino Video است."
+  "NARGS_DBC": "رنگ‌های اشکال‌زدایی (-dbc)"
+  "NARGS_LOGO": "لوگوی PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "غیرفعال کردن VMC 1 (حفظ کارت)"
+  "VMC_SLOT2_DISABLE": "غیرفعال کردن VMC 2 (حفظ کارت)"
+  "HINT_VMC_SLOT_DISABLE": "بدون VMC این اسلات اجرا کن در حالی که کارت آن پیکربندی‌شده باقی می‌ماند. فقط برای اجراهای Neutrino؛ سپس بازی از کارت واقعی در آن اسلات استفاده می‌کند."
+  "NEUTRINO_BSDFS": "سیستم‌فایل Neutrino"
+  "HINT_NEUTRINO_BSDFS": "سیستم‌فایل دستگاه بلوکی Neutrino را اجباری کن (-bsdfs). Auto = پیش‌فرض هر دستگاه. hdl/bd گزینه‌های تخصصی هستند؛ اگر شکل مسیر خودکار مناسب نبود، آن‌ها را با یک -dvd= متناظر در آرگومان‌های اجرا همراه کن."
+  "PLASCOLOR": "رنگ ترکیب پلاسما"
+  "VCD_HIDE_GAMEID": "پنهان کردن شناسه بازی PS1 (فهرست VCD)"
+  "HINT_VCD_HIDE_GAMEID": "فقط ظاهری -- پیشوند شناسه بازی ابتدایی (مثلاً SLUS_005.51.) را از نام‌های فهرست PS1/VCD پنهان کن. نام‌های بدون شناسه همان‌طور که هستند نشان داده می‌شوند. اجرا، تصویر جلد یا موارد دلخواه را تغییر نمی‌دهد."
+  "VCD_FIRST_DISC": "فقط دیسک اول (PS1 چنددیسکی)"
+  "HINT_VCD_FIRST_DISC": "فقط دیسک ۱ یک بازی چنددیسکی PS1 را در فهرست دستگاه‌ها نشان بده (به سبک POPSLoader). فایل‌هایی با نام (Disc 2)، (CD 2) و مانند آن را پنهان می‌کند. همه دیسک‌ها برای تعویض درون‌بازی روی کارت باقی می‌مانند؛ موارد دلخواه (Favourites) فیلتر نمی‌شوند."
+  "GAMES_DEVICE": "دستگاه بازی"
+  "DEFAULT_CORE": "هسته لودر پیش‌فرض"
+  "HINT_DEFAULT_CORE": "هسته پیش‌فرض سراسری برای بازی‌هایی که Loader Core مخصوص هر بازی آن‌ها روی Default تنظیم شده است. <OPL> هسته بومی است؛ Neutrino فایل خارجی neutrino.elf را زنجیره می‌کند. انتخاب مخصوص هر بازی همیشه این را بازنویسی می‌کند."
+  "VCD_SETTINGS": "تنظیمات VCD"
+  "FINANCIAL_SUPPORT": "حمایت مالی"

--- a/lng_fork/Polish.yml
+++ b/lng_fork/Polish.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Sortuj gry alfabetycznie
+  RUMBLE: Wibracje kontrolera w menu
+  HINT_RUMBLE: Krótka wibracja przy przesuwaniu kursora, zatwierdzaniu lub cofaniu -- wymaga DualShocka w trybie analogowym
+  FOLDER_NAV: Przeglądaj foldery na liście gier
+  HINT_FOLDER_NAV: Pokazuj podfoldery CD/DVD jako pozycje do przeglądania, wybierz aby otworzyć, anuluj aby cofnąć
+  SETTINGS_NO_HOME: Nie znaleziono karty pamięci -- nie można zapisać ustawień. OPL uruchomiono z urządzenia sieciowego, którego ustawienia muszą być na lokalnej karcie.
+  ERROR_SAVING_SETTINGS_TO: Nie można zapisać ustawień do %s (błąd %d)
+  GENERAL_SETTINGS: Ustawienia ogólne
+  DEVICE_SETTINGS: Ustawienia urządzenia
+  LAUNCH_PS2_DISC: Uruchom dysk PS2
+  DISC_LAUNCH_ERR: Brak dysku PS2 w napędzie.
+  DEFAULT: Domyślny
+  HINT_MODE7: Tylko Neutrino -- naprawia gry powodujące przepełnienie bufora IOP (-gc=7)
+  MODE7: Tryb 7
+  ENABLEIMAGE: Obraz cheatów PS2RD
+  HINT_ENABLEIMAGE: Zastosuj gotową łatkę PS2RD .img do swojej gry.
+  UDPBD_GAMES: Gry UDPBD
+  MMCE: MMCE
+  MMCE_GAMES: Gry MMCE
+  MMCEMODE: Tryb startowy MMCE
+  MMCE_PREFIX: Ścieżka prefiksu MMCE
+  MMCE_SLOT: Gniazdo MMCE
+  MMCEIGR_SLOT: Gniazdo(a) karty startowej IGR
+  HINT_MMCEIGR_SLOT: Polecenie przełączenia na kartę startową zostanie wysłane do wybranych gniazd przy IGR
+  MMCE_ADVANCED: Zaawansowane
+  MMCE_SETTINGS: Ustawienia MMCE
+  MMCE_SEMA: Metoda kolejkowania blokady semaforów
+  HINT_MMCE_SEMA: THFIFO może poprawić zgodność, ale pogorszyć wydajność
+  MMCE_WAIT_CYCLES: Cykle oczekiwania po /ACK niskim
+  HINT_MMCE_WAIT_CYCLES: Niższe wartości mogą poprawić wydajność, ale powodować niestabilność
+  MMCE_USE_ALARMS: Używaj alarmów timeout
+  HINT_MMCE_USE_ALARMS: WYŁ może poprawić wydajność, ale może powodować zamrożenie przy timeoutach MMCE
+  CORE_LOADER: Rdzeń programu ładującego
+  NEUTRINO_BAD_FORMAT: Neutrino nie obsługuje tego formatu pliku, uruchamianie przez rdzeń <OPL>
+  NEUTRINO_NOT_FOUND: Nie znaleziono ELF Neutrino, uruchamianie przez rdzeń <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD wymaga statycznego IP dla PS2. Ustaw je w Konfiguracji sieci (DHCP jest aktualnie włączone).
+  NEUTRINO_SETTING_NA: To ustawienie nie jest używane z rdzeniem Neutrino.
+  POPSTARTER_NOT_FOUND: Brak POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Brak wymagań SMB dla POPSTARTER
+  WRITE_POPSTARTER_NET: Zapisz konfigurację sieciową POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Zapisz również wartości IP + udziału SMB do własnych plików IPCONFIG.DAT / SMBCONFIG.DAT POPSTARTERa na karcie pamięci (dla VCD przez SMB).
+  POPSTARTER_NET_ERR: Nie można zapisać konfiguracji sieciowej POPSTARTER na kartę pamięci.
+  VCD: VCD
+  VCD_ON: Wyświetlanie gier VCD
+  VCD_OFF: Wyświetlanie gier z dysku
+  NEUTRINO_ARGS: Argumenty uruchamiania Neutrino
+  HINT_NEUTRINO_ARGS: Dodatkowe flagi Neutrino, oddzielone spacjami (np. -mt=dvd). Globalne dotyczą wszystkich gier; dla gry dodawane na wierzch. Poprzedź flagę $ aby ją wyłączyć bez usuwania.
+  NEUTRINO_VIDEO: Wideo Neutrino
+  HINT_NEUTRINO_VIDEO: Wymuś tryb wyjścia wideo GS Neutrino (-gsm). Wył. zachowuje domyślny tryb gry.
+  NEUTRINO_PATH: Ścieżka ELF Neutrino
+  HINT_NEUTRINO_PATH: Pełna ścieżka do neutrino.elf (np. mc0:NEUTRINO/neutrino.elf). Puste = automatyczne wykrycie na mc0/mc1.
+  POPSTARTER_PATH: 'Ścieżka POPSTARTER.ELF'
+  HINT_POPSTARTER_PATH: Niestandardowa ścieżka POPSTARTER.ELF; przy pustej/brakującej cofa się do folderu POPS urządzenia. Klawiatura ograniczona do 31 znaków; dłuższe ścieżki przez settings_riptopl.cfg.
+  BDMA_SOURCE: Źródło BDMA
+  HINT_BDMA_SOURCE: Urządzenie, w którego folderze POPS znajdują się pliki sterownika BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Tryb BDMA
+  HINT_BDMA_MODE: Sterownik urządzenia blokowego exFAT ładowany przez POPSTARTER. Zmiana kopiuje moduły na kartę; FAT32 = brak (wbudowany sterownik).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Wewnętrzny HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Nie znaleziono plików modułu BDMA na urządzeniu źródłowym.
+  BDMA_ERR_SPACE: Za mało miejsca na karcie pamięci dla modułów BDMA.
+  BDMA_ERR_IO: Błąd zapisu modułów BDMA na kartę pamięci.
+  COVERFLOW_SETTINGS: Ustawienia Coverflow
+  COVERFLOW_COUNT: Liczba okładek
+  COVERFLOW_SCALE: Skala środkowa
+  COVERFLOW_ANIM: Prędkość animacji
+  COVERFLOW_DIM: Przyciemnij boczne okładki
+  NONE: Brak
+  SMALL: Małe
+  LARGE: Duże
+  NORMAL: Normalne
+  FAV: Ulubione
+  FAVMODE: Tryb startowy ulubionych
+  FAV_HINT: Ulubiona
+  FAV_MSG: '%s nie jest dozwolone w Menu ulubionych.'
+  FAV_PERSISTENCE_MSG: '%s nie jest dozwolone, gdy element jest oznaczony jako ulubiony.'
+  NEUTRINO_DEVICE: Urządzenie Neutrino
+  HINT_NEUTRINO_DEVICE: Urządzenie zawierające neutrino.elf (w folderze NEUTRINO/ lub neutrino/). Auto skanuje mc0, potem mc1.
+  NARGS_QB: Szybki rozruch (-qb)
+  NARGS_CWD: Katalog roboczy (-cwd)
+  NARGS_CFG: Konfiguracja (-cfg)
+  NARGS_ELF: ELF rozruchowy (-elf)
+  NARGS_ATA0: Obraz ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Obraz ATA1 (-ata1)
+  NARGS_EXTRA: Dodatkowe argumenty
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Archiwum .tar okładek
+  DISABLE_ALL: Wyłącz wszystko
+  BOOT_LOADING_CONFIG: Wczytywanie ustawień...
+  BOOT_SCANNING_BDM: Skanowanie dysków USB / karty / sieci...
+  BOOT_SCANNING_NET: Uruchamianie sieci...
+  BOOT_SCANNING_HDD: Skanowanie HDD...
+  BOOT_READY: Gotowe.
+  UDPFS_GAMES: "Gry UDPFS"
+  UDPFSBD_GAMES: "Gry UDPFSBD"
+  NET_PROTOCOL: "Protokół sieciowy"
+  NET_NEEDS_NEUTRINO: "Gry sieciowe (UDP) uruchamiają się tylko przez rdzeń Neutrino. Sprawdź, czy plik neutrino.elf istnieje i czy format jest obsługiwany."
+  VCD_NOT_ON_NET: "Gry PS1 (.VCD) nie mogą być uruchamiane przez urządzenie sieciowe."
+  MX4SIO_PADEMU_WARN: "MX4SIO i emulacja pada współdzielą magistralę SIO2 i gra może się nie uruchomić."
+  HINT_OSD_SETTINGS_LNG: "Wymuś niestandardową konfigurację języka"
+  OSD_SETTINGS_TVASPECT: "Rozmiar ekranu"
+  FULL_SCREEN: "Pełny ekran"
+  OSD_SETTINGS_VMODE: "Tryb wideo"
+  SYSTEM_DEFAULT: "Domyślne systemu"
+  HIGH: "Wysoka"
+  LOW: "Niska"
+  XSENSITIVITY: "Czułość osi X analoga"
+  YSENSITIVITY: "Czułość osi Y analoga"
+  FILE_COUNT: "Znaleziono plików: %i"
+  CHEAT_SELECTION: "Wybór kodów"
+  HDD_HINT: "Dozwolony tylko jeden HDD; włączenie blokuje APA lub GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID nie zastosowano -- neutrino.elf jest na tej karcie (zmiana wyładowałaby Neutrino)."
+  POPSTARTER_DEVICE: "Urządzenie POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Urządzenie z POPS/POPSTARTER.ELF do uruchamiania VCD z PS1. Domyślnie = urządzenie startowe (cwd), następnie własne urządzenie VCD. Niestandardowe odsłania pole ścieżki."
+  BDMA_APPLY: "Zastosuj VCD BDMA przy starcie"
+  HINT_BDMA_APPLY: "Wł.: automatycznie instaluje pasujący sterownik exFAT uruchamianego VCD na karcie pamięci przed startem (zalecane). Wył.: zarządzaj tym samodzielnie za pomocą selektorów Źródło/Tryb BDMA poniżej."
+  NETBOOT_RESTART: "Uruchom ponownie OPL, aby zastosować zmianę protokołu uruchamiania sieciowego."
+  UDPFS_MODE: "Dostęp UDPFS"
+  "MENU": "Menu"
+  "APPS": "Aplikacje"
+  "DEBUG": "Kolory debugowania"
+  "COVERART": "Okładki"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operacje zapisu"
+  "MODE1": "Tryb 1"
+  "MODE2": "Tryb 2"
+  "MODE3": "Tryb 3"
+  "MODE4": "Tryb 4"
+  "MODE5": "Tryb 5"
+  "MODE6": "Tryb 6"
+  "ENABLEGSM": "Selektor GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Silnik kodów PS2RD"
+  "PADEMU_ENABLE": "Emulator pada"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulacja"
+  "PADEMU_VIB": "Wibracje"
+  "PADEMU_WORKAROUND": "Obejście fałszywego DS3"
+  "SFX": "Efekty dźwiękowe"
+  "BOOT_SND": "Dźwięk startowy"
+  "ENABLE_NOTIFICATIONS": "Powiadomienia"
+  "OPTIONS": "Opcje"
+  "GLOBAL_SETTINGS": "Globalne"
+  "INFO_GENRE": "Gatunek"
+  "INFO_RELEASE": "Wydanie"
+  "INFO_DESCRIPTION": "Opis"
+  "BLOCKDEVICE_SETTINGS": "Urządzenia blokowe"
+  "CONTROLLER_SETTINGS": "Ustawienia kontrolera"
+  "HINT_BDM_START": "Włącz/wyłącz menedżer urządzeń blokowych (BDM)."
+  "HINT_BLOCK_DEVICES": "Włącz/wyłącz urządzenia blokowe (np. USB)."
+  "USB_GAMES": "Gry USB"
+  "ILINK_GAMES": "Gry iLink"
+  "MX4SIO_GAMES": "Gry MX4SIO"
+  "PADMACROCONFIG": "Konfiguruj PADMACRO"
+  "PADMACRO_SETTINGS": "Ustawienia makr pada"
+  "PADMACRO_ENABLE": "Makra pada"
+  "PADMACRO_SLOWDOWN": "Spowolnienie analoga:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Zmniejsza zakres gałki analogowej po naciśnięciu przycisku"
+  "LEFT_ANALOG": "Lewa gałka"
+  "RIGHT_ANALOG": "Prawa gałka"
+  "PADMACRO_INVERT_AXIS": "Odwrócenie osi analoga:"
+  "HINT_PADMACRO_INVERT_AXIS": "Odwróć oś gałki analogowej"
+  "TURBO_SPEED": "Szybkość przycisku turbo"
+  "HINT_TURBO_SPEED": "Jak szybko naciskać przycisk, gdy turbo jest aktywne"
+  "ACT_WHILE_PRESSED": "Gdy przycisk wciśnięty"
+  "ACT_TOGGLED": "Przełączane przyciskiem"
+  "LANGUAGE_JAPANESE": "JAPOŃSKI"
+  "LANGUAGE_ENGLISH": "ANGIELSKI"
+  "LANGUAGE_FRENCH": "FRANCUSKI"
+  "LANGUAGE_SPANISH": "HISZPAŃSKI"
+  "LANGUAGE_GERMAN": "NIEMIECKI"
+  "LANGUAGE_ITALIAN": "WŁOSKI"
+  "LANGUAGE_DUTCH": "HOLENDERSKI"
+  "LANGUAGE_PORTUGUESE": "PORTUGALSKI"
+  "LANGUAGE_RUSSIAN": "ROSYJSKI"
+  "LANGUAGE_KOREAN": "KOREAŃSKI"
+  "LANGUAGE_TRAD_CHINESE": "CHIŃSKI TRADYCYJNY"
+  "LANGUAGE_SIMPL_CHINESE": "CHIŃSKI UPROSZCZONY"
+  "OSD_SETTINGS": "Ustawienia OSD"
+  "OSD_SETTINGS_LNG": "Język OSD"
+  "ENABLE_LNG": "Zmień język"
+  "BGM": "Muzyka w tle"
+  "BGM_VOLUME": "Głośność muzyki w tle"
+  "DEF_BGM_PATH": "Domyślna muzyka motywu"
+  "DEF_BGM_PATH_HINT": "Ustaw ścieżkę strumieniowania muzyki dla wbudowanego motywu."
+  "BOOT_SCANNING_MC": "Skanowanie kart pamięci..."
+  "BOOT_LOADING_DRIVERS": "Ładowanie sterowników pamięci..."
+  "BOOT_LOADING_USB": "Ładowanie sterownika pamięci USB..."
+  "BOOT_ARMING_MMCE": "Uzbrajanie identyfikatora gry MMCE..."
+  "BOOT_LOADING_SOUNDS": "Ładowanie dźwięków motywu..."
+  "BOOT_BUILDING_MENU": "Budowanie menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS włączone -- otwórz nową zakładkę UDPFS i naciśnij Potwierdź, aby połączyć. Po stronie PC uruchamiane jest udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Sieciowe urządzenie blokowe włączone -- jego zakładka pojawia się, gdy serwer PC odpowie (udpfsd -bdpath dla obrazu UDPFS, udpbd-server dla UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Nie znaleziono pliku VMC dla gry -- uruchamianie bez niego (gra używa prawdziwej karty)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino nie może uruchomić z tego urządzenia -- uruchamianie przerwane."
+  "NEUTRINO_TOML_SYNC_FAILED": "Konfiguracja sieciowa Neutrino (bsd toml) brakuje lub jest niezapisywalna -- uruchamianie przerwane, sprawdź folder neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Zbyt pofragmentowane dla Neutrino (%d fragmentów, limit %d wraz z VMC) -- próba użycia rdzenia OPL zamiast tego."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Zbyt pofragmentowane dla Neutrino (%d fragmentów, limit %d wraz z VMC) -- zdefragmentuj na PC; uruchamianie przerwane."
+  "NEUTRINO_GSM_COMP": "Zgodność Neutrino GSM"
+  "HINT_NEUTRINO_GSM_COMP": "Poprawka przełączania pól dla gier, które drżą lub rwą się przy wymuszonym trybie wideo Neutrino. Wymaga ustawionego trybu wideo Neutrino."
+  "NARGS_DBC": "Kolory debugowania (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Wyłącz VMC 1 (zachowaj kartę)"
+  "VMC_SLOT2_DISABLE": "Wyłącz VMC 2 (zachowaj kartę)"
+  "HINT_VMC_SLOT_DISABLE": "Uruchom bez VMC tego gniazda, zachowując skonfigurowaną kartę. Tylko uruchomienia Neutrino; gra używa wtedy prawdziwej karty w tym gnieździe."
+  "NEUTRINO_BSDFS": "System plików Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Wymuś system plików urządzenia blokowego Neutrino (-bsdfs). Auto = domyślnie zależnie od urządzenia. hdl/bd to opcje eksperckie; sparuj je z pasującym -dvd= w argumentach uruchamiania, jeśli automatyczny kształt ścieżki nie pasuje."
+  "PLASCOLOR": "Kolor mieszania plazmy"
+  "VCD_HIDE_GAMEID": "Ukryj ID gry PS1 (lista VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Tylko kosmetyczne -- ukryj wiodący prefiks ID gry (np. SLUS_005.51.) w nazwach list PS1/VCD. Nazwy bez ID są pokazywane bez zmian. Nie zmienia uruchamiania, okładek ani ulubionych."
+  "VCD_FIRST_DISC": "Tylko pierwszy dysk (wielopłytowe PS1)"
+  "HINT_VCD_FIRST_DISC": "Pokazuj tylko Dysk 1 wielopłytowej gry PS1 na listach urządzeń (styl POPSLoader). Ukrywa pliki o nazwach (Disc 2), (CD 2) itd. Wszystkie płyty pozostają na karcie do zmiany w trakcie gry; Ulubione nie są filtrowane."
+  "GAMES_DEVICE": "Urządzenie gry"
+  "DEFAULT_CORE": "Domyślny rdzeń ładowania"
+  "HINT_DEFAULT_CORE": "Globalny domyślny rdzeń dla gier, których rdzeń ładujący na grę ustawiono na Domyślny. <OPL> to rdzeń natywny; Neutrino łączy zewnętrzny neutrino.elf. Wybór na grę zawsze to nadpisuje."
+  "VCD_SETTINGS": "Ustawienia VCD"
+  "FINANCIAL_SUPPORT": "Wsparcie finansowe"

--- a/lng_fork/Portuguese.yml
+++ b/lng_fork/Portuguese.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Ordenar jogos por ordem alfabética
+  RUMBLE: Vibração do comando nos menus
+  HINT_RUMBLE: Vibração curta ao mover o cursor, confirmar ou voltar -- requer um DualShock em modo analógico
+  FOLDER_NAV: Navegar por pastas na lista de jogos
+  HINT_FOLDER_NAV: Mostra subpastas de CD/DVD como entradas navegáveis; selecionar para abrir, cancelar para voltar
+  SETTINGS_NO_HOME: Nenhum cartão de memória encontrado -- não é possível guardar as definições. O OPL arrancou de um dispositivo de rede, cujas definições têm de ficar num cartão local.
+  ERROR_SAVING_SETTINGS_TO: Não foi possível gravar as definições em %s (erro %d)
+  GENERAL_SETTINGS: Definições Gerais
+  DEVICE_SETTINGS: Definições de Dispositivo
+  LAUNCH_PS2_DISC: Lançar Disco PS2
+  DISC_LAUNCH_ERR: Nenhum disco PS2 na unidade.
+  DEFAULT: Predefinição
+  HINT_MODE7: Apenas Neutrino -- corrige jogos que ultrapassam um buffer IOP (-gc=7)
+  MODE7: Modo 7
+  ENABLEIMAGE: Imagem de Cheats PS2RD
+  HINT_ENABLEIMAGE: Aplica um patch .img PS2RD pré-compilado ao seu jogo.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Modo de Arranque MMCE
+  MMCE_PREFIX: Caminho de Prefixo MMCE
+  MMCE_SLOT: Slot MMCE
+  MMCEIGR_SLOT: Slot(s) de Bootcard IGR
+  HINT_MMCEIGR_SLOT: O comando para mudar para bootcard será enviado ao(s) slot(s) selecionado(s) no IGR
+  MMCE_ADVANCED: Avançado
+  MMCE_SETTINGS: Definições MMCE
+  MMCE_SEMA: Método de Fila de Sema de Bloqueio
+  HINT_MMCE_SEMA: THFIFO pode ajudar na compatibilidade mas piorar o desempenho
+  MMCE_WAIT_CYCLES: Ciclos de espera após /ACK baixo
+  HINT_MMCE_WAIT_CYCLES: Valores mais baixos podem melhorar o desempenho mas causar instabilidades
+  MMCE_USE_ALARMS: Usar alarmes de tempo limite
+  HINT_MMCE_USE_ALARMS: DESLIGADO pode ajudar o desempenho mas pode causar bloqueios por tempo limite MMCE
+  CORE_LOADER: Núcleo do Carregador
+  NEUTRINO_BAD_FORMAT: Neutrino não suporta este formato de ficheiro, a lançar com núcleo <OPL>
+  NEUTRINO_NOT_FOUND: ELF Neutrino não encontrado, a lançar com núcleo <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD requer um IP PS2 estático. Defina um nas Definições de Rede (DHCP está ativo).
+  NEUTRINO_SETTING_NA: Esta definição não é usada com o núcleo Neutrino.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF em falta
+  POPSTARTER_SMB_MISSING: Requisitos SMB do POPSTARTER em falta
+  WRITE_POPSTARTER_NET: Gravar Config de Rede do POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Guarda também estes valores de IP + partilha SMB nos ficheiros IPCONFIG.DAT / SMBCONFIG.DAT do POPSTARTER no cartão de memória (para VCD via SMB).
+  POPSTARTER_NET_ERR: Não foi possível gravar a configuração de rede do POPSTARTER no cartão de memória.
+  VCD: VCD
+  VCD_ON: A mostrar jogos VCD
+  VCD_OFF: A mostrar jogos de disco
+  NEUTRINO_ARGS: Args de Lançamento Neutrino
+  HINT_NEUTRINO_ARGS: Flags extra do Neutrino, separadas por espaço (ex. -mt=dvd). Global aplica-se a todos os jogos; por jogo acrescenta. Prefixe uma flag com $ para desativá-la sem apagar.
+  NEUTRINO_VIDEO: Vídeo Neutrino
+  HINT_NEUTRINO_VIDEO: Força o modo de vídeo GS do Neutrino (-gsm). Desligado mantém a predefinição do jogo.
+  NEUTRINO_PATH: Caminho do ELF Neutrino
+  HINT_NEUTRINO_PATH: Caminho completo para neutrino.elf (ex. mc0:NEUTRINO/neutrino.elf). Vazio = deteção automática em mc0/mc1.
+  POPSTARTER_PATH: Caminho de POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Caminho personalizado para POPSTARTER.ELF; usa silenciosamente a pasta POPS do dispositivo se vazio/ausente. Teclado limitado a 31 caracteres; caminhos mais longos via settings_riptopl.cfg.
+  BDMA_SOURCE: Fonte BDMA
+  HINT_BDMA_SOURCE: Dispositivo cuja pasta POPS contém os ficheiros do driver BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Modo BDMA
+  HINT_BDMA_MODE: Driver de dispositivo de bloco exFAT que o POPSTARTER carrega. Alterá-lo copia os módulos para o cartão; FAT32 = nenhum (driver integrado).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD interno
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Ficheiros de módulo BDMA não encontrados no dispositivo de origem.
+  BDMA_ERR_SPACE: Espaço insuficiente no cartão de memória para os módulos BDMA.
+  BDMA_ERR_IO: Erro ao gravar os módulos BDMA no cartão de memória.
+  COVERFLOW_SETTINGS: Definições de Coverflow
+  COVERFLOW_COUNT: Número de Capas
+  COVERFLOW_SCALE: Escala Central
+  COVERFLOW_ANIM: Velocidade de Animação
+  COVERFLOW_DIM: Escurecer Capas Laterais
+  NONE: Nenhum
+  SMALL: Pequeno
+  LARGE: Grande
+  NORMAL: Normal
+  FAV: Favoritos
+  FAVMODE: Modo de Arranque de Favoritos
+  FAV_HINT: Favorito
+  FAV_MSG: '%s não é permitido no Menu de Favoritos.'
+  FAV_PERSISTENCE_MSG: '%s não é permitido enquanto o item estiver marcado como favorito.'
+  NEUTRINO_DEVICE: Dispositivo Neutrino
+  HINT_NEUTRINO_DEVICE: Dispositivo que contém neutrino.elf (numa pasta NEUTRINO/ ou neutrino/). Auto analisa mc0 e depois mc1.
+  NARGS_QB: Arranque Rápido (-qb)
+  NARGS_CWD: Diretório de Trabalho (-cwd)
+  NARGS_CFG: Config (-cfg)
+  NARGS_ELF: ELF de Arranque (-elf)
+  NARGS_ATA0: Imagem ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Imagem ATA1 (-ata1)
+  NARGS_EXTRA: Args Extra
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Arquivo .tar de capas
+  DISABLE_ALL: Desativar tudo
+  BOOT_LOADING_CONFIG: A carregar definições...
+  BOOT_SCANNING_BDM: A analisar unidades USB / cartão / rede...
+  BOOT_SCANNING_NET: A iniciar a rede...
+  BOOT_SCANNING_HDD: A analisar HDD...
+  BOOT_READY: Pronto.
+  UDPFS_GAMES: "Jogos UDPFS"
+  UDPFSBD_GAMES: "Jogos UDPFSBD"
+  NET_PROTOCOL: "Protocolo de rede"
+  NET_NEEDS_NEUTRINO: "Os jogos de rede (UDP) só podem arrancar através do núcleo Neutrino. Verifique se o neutrino.elf está presente e se o formato é suportado."
+  VCD_NOT_ON_NET: "Os jogos PS1 (.VCD) não podem ser iniciados através do dispositivo de rede."
+  MX4SIO_PADEMU_WARN: "O MX4SIO e a emulação de comando partilham o barramento SIO2 e o jogo pode não arrancar."
+  HINT_OSD_SETTINGS_LNG: "Forçar uma configuração de idioma personalizada"
+  OSD_SETTINGS_TVASPECT: "Tamanho do ecrã"
+  FULL_SCREEN: "Ecrã inteiro"
+  OSD_SETTINGS_VMODE: "Modo de vídeo"
+  SYSTEM_DEFAULT: "Predefinição do sistema"
+  HIGH: "Alta"
+  LOW: "Baixa"
+  XSENSITIVITY: "Sensibilidade analógica do eixo X"
+  YSENSITIVITY: "Sensibilidade analógica do eixo Y"
+  FILE_COUNT: "Ficheiros encontrados: %i"
+  CHEAT_SELECTION: "Seleção de batotas"
+  HDD_HINT: "Só é permitido um HDD; ativá-lo bloqueia APA ou GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "GameID MMCE não aplicado -- o neutrino.elf está neste cartão (mudar iria descarregar o Neutrino)."
+  POPSTARTER_DEVICE: "Dispositivo POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Dispositivo com POPS/POPSTARTER.ELF para arranques VCD PS1. Predefinição = dispositivo de arranque (cwd) e depois o próprio dispositivo do VCD. Personalizado mostra um caminho livre."
+  BDMA_APPLY: "Aplicar VCD BDMA ao iniciar"
+  HINT_BDMA_APPLY: "Ligado: equipa automaticamente o controlador exFAT correspondente do VCD iniciado no cartão de memória antes do arranque (recomendado). Desligado: gira manualmente com os seletores de Origem/Modo BDMA abaixo."
+  NETBOOT_RESTART: "Reinicie o OPL para aplicar a alteração do protocolo de arranque de rede."
+  UDPFS_MODE: "Acesso UDPFS"
+  "MENU": "Menu"
+  "APPS": "Apps"
+  "DEBUG": "Cores de Depuração"
+  "COVERART": "Capa"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operações de Escrita"
+  "MODE1": "Modo 1"
+  "MODE2": "Modo 2"
+  "MODE3": "Modo 3"
+  "MODE4": "Modo 4"
+  "MODE5": "Modo 5"
+  "MODE6": "Modo 6"
+  "ENABLEGSM": "Seletor GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Motor de Trapaças PS2RD"
+  "PADEMU_ENABLE": "Emulador de Controle"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulação"
+  "PADEMU_VIB": "Vibração"
+  "PADEMU_WORKAROUND": "Solução para DS3 Falso"
+  "SFX": "Efeitos Sonoros"
+  "BOOT_SND": "Som de Inicialização"
+  "ENABLE_NOTIFICATIONS": "Notificações"
+  "OPTIONS": "Opções"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Gênero"
+  "INFO_RELEASE": "Lançamento"
+  "INFO_DESCRIPTION": "Descrição"
+  "BLOCKDEVICE_SETTINGS": "Dispositivos de Bloco"
+  "CONTROLLER_SETTINGS": "Configurações do Controle"
+  "HINT_BDM_START": "Ativar/desativar o Gerenciador de Dispositivos de Bloco (BDM)."
+  "HINT_BLOCK_DEVICES": "Ativar/desativar Dispositivos de Bloco (ex.: USB)."
+  "USB_GAMES": "Jogos USB"
+  "ILINK_GAMES": "Jogos iLink"
+  "MX4SIO_GAMES": "Jogos MX4SIO"
+  "PADMACROCONFIG": "Configurar PADMACRO"
+  "PADMACRO_SETTINGS": "Configurações de Macro do Controle"
+  "PADMACRO_ENABLE": "Macros do Controle"
+  "PADMACRO_SLOWDOWN": "Redução analógica:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Reduz o alcance do analógico quando o botão é pressionado"
+  "LEFT_ANALOG": "Analógico esquerdo"
+  "RIGHT_ANALOG": "Analógico direito"
+  "PADMACRO_INVERT_AXIS": "Inverter eixo analógico:"
+  "HINT_PADMACRO_INVERT_AXIS": "Inverte o eixo do analógico"
+  "TURBO_SPEED": "Velocidade do botão turbo"
+  "HINT_TURBO_SPEED": "Quão rápido pressionar o botão quando o turbo está ativo"
+  "ACT_WHILE_PRESSED": "Enquanto o botão está pressionado"
+  "ACT_TOGGLED": "Alternado pelo botão"
+  "LANGUAGE_JAPANESE": "JAPONÊS"
+  "LANGUAGE_ENGLISH": "INGLÊS"
+  "LANGUAGE_FRENCH": "FRANCÊS"
+  "LANGUAGE_SPANISH": "ESPANHOL"
+  "LANGUAGE_GERMAN": "ALEMÃO"
+  "LANGUAGE_ITALIAN": "ITALIANO"
+  "LANGUAGE_DUTCH": "HOLANDÊS"
+  "LANGUAGE_PORTUGUESE": "PORTUGUÊS"
+  "LANGUAGE_RUSSIAN": "RUSSO"
+  "LANGUAGE_KOREAN": "COREANO"
+  "LANGUAGE_TRAD_CHINESE": "CHINÊS TRADICIONAL"
+  "LANGUAGE_SIMPL_CHINESE": "CHINÊS SIMPLIFICADO"
+  "OSD_SETTINGS": "Configurações do OSD"
+  "OSD_SETTINGS_LNG": "Idioma do OSD"
+  "ENABLE_LNG": "Alterar idioma"
+  "BGM": "Música de Fundo"
+  "BGM_VOLUME": "Volume da Música de Fundo"
+  "DEF_BGM_PATH": "Música Padrão do Tema"
+  "DEF_BGM_PATH_HINT": "Definir caminho para transmitir a música do tema interno."
+  "BOOT_SCANNING_MC": "Verificando cartões de memória..."
+  "BOOT_LOADING_DRIVERS": "Carregando drivers de armazenamento..."
+  "BOOT_LOADING_USB": "Carregando driver de armazenamento USB..."
+  "BOOT_ARMING_MMCE": "Ativando ID de jogo MMCE..."
+  "BOOT_LOADING_SOUNDS": "Carregando sons do tema..."
+  "BOOT_BUILDING_MENU": "Construindo menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS ativado -- abra a nova aba UDPFS e pressione Confirmar para conectar. O lado do PC executa udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Dispositivo de bloco de rede ativado -- sua aba aparece assim que o servidor do PC responder (udpfsd -bdpath para Imagem UDPFS, udpbd-server para UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Arquivo VMC por jogo não encontrado -- inicializando sem ele (o jogo usa seu cartão real)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino não pode iniciar deste dispositivo -- inicialização cancelada."
+  "NEUTRINO_TOML_SYNC_FAILED": "Configuração de rede do Neutrino (bsd toml) ausente ou não gravável -- inicialização abortada, verifique a pasta neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Fragmentado demais para o Neutrino (%d fragmentos, limite %d incl. VMCs) -- tentando o núcleo OPL em vez disso."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Fragmentado demais para o Neutrino (%d fragmentos, limite %d incl. VMCs) -- desfragmente no PC; inicialização abortada."
+  "NEUTRINO_GSM_COMP": "Compatibilidade GSM do Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Correção de inversão de campo para jogos que tremem ou rasgam sob um modo de Vídeo Neutrino forçado. Requer um modo de Vídeo Neutrino definido."
+  "NARGS_DBC": "Cores de Depuração (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Desativar VMC 1 (manter cartão)"
+  "VMC_SLOT2_DISABLE": "Desativar VMC 2 (manter cartão)"
+  "HINT_VMC_SLOT_DISABLE": "Inicia sem o VMC deste slot, mantendo seu cartão configurado. Apenas inicializações do Neutrino; o jogo então usa o cartão real naquele slot."
+  "NEUTRINO_BSDFS": "Sistema de Arquivos do Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Força o sistema de arquivos de dispositivo de bloco do Neutrino (-bsdfs). Auto = padrão por dispositivo. hdl/bd são opções avançadas; combine-as com um -dvd= correspondente nos argumentos de inicialização se o formato do caminho automático não se encaixar."
+  "PLASCOLOR": "Cor de Mistura do Plasma"
+  "VCD_HIDE_GAMEID": "Ocultar ID de Jogo PS1 (lista VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Apenas cosmético -- oculta um prefixo de ID de jogo inicial (por exemplo, SLUS_005.51.) dos nomes das listas PS1/VCD. Nomes sem um ID são mostrados como estão. Não altera a inicialização, a capa nem os favoritos."
+  "VCD_FIRST_DISC": "Apenas o primeiro disco (PS1 multidisco)"
+  "HINT_VCD_FIRST_DISC": "Mostra apenas o Disco 1 de um jogo PS1 de múltiplos discos nas listas de dispositivos (estilo POPSLoader). Oculta arquivos nomeados (Disc 2), (CD 2), etc. Todos os discos permanecem no cartão para troca dentro do jogo; os Favoritos não são filtrados."
+  "GAMES_DEVICE": "Dispositivo do Jogo"
+  "DEFAULT_CORE": "Núcleo de Carregamento Padrão"
+  "HINT_DEFAULT_CORE": "Núcleo padrão global para jogos cujo Loader Core por jogo está definido como Padrão. <OPL> é o núcleo nativo; o Neutrino encadeia o neutrino.elf externo. Uma escolha por jogo sempre substitui isto."
+  "VCD_SETTINGS": "Configurações VCD"
+  "FINANCIAL_SUPPORT": "Apoio Financeiro"

--- a/lng_fork/Portuguese_BR.yml
+++ b/lng_fork/Portuguese_BR.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Ordenar jogos em ordem alfabética
+  RUMBLE: Vibração do controle nos menus
+  HINT_RUMBLE: Vibração curta ao mover o cursor, confirmar ou voltar -- precisa de um DualShock em modo analógico
+  FOLDER_NAV: Navegar por pastas na lista de jogos
+  HINT_FOLDER_NAV: Mostra subpastas de CD/DVD como itens navegáveis; selecione para abrir, cancele para voltar
+  SETTINGS_NO_HOME: Nenhum cartão de memória encontrado -- não é possível salvar as configurações. O OPL foi iniciado de um dispositivo de rede, cujas configurações precisam ficar em um cartão local.
+  ERROR_SAVING_SETTINGS_TO: Não foi possível salvar as configurações em %s (erro %d)
+  GENERAL_SETTINGS: Configurações Gerais
+  DEVICE_SETTINGS: Configurações de Dispositivo
+  LAUNCH_PS2_DISC: Iniciar Disco PS2
+  DISC_LAUNCH_ERR: Nenhum disco PS2 no drive.
+  DEFAULT: Padrão
+  HINT_MODE7: Apenas Neutrino -- corrige jogos que ultrapassam um buffer IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: Imagem de Cheats PS2RD
+  HINT_ENABLEIMAGE: Aplica um patch PS2RD .img pré-compilado ao seu jogo.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Modo de Inicialização MMCE
+  MMCE_PREFIX: Caminho de Prefixo MMCE
+  MMCE_SLOT: Slot MMCE
+  MMCEIGR_SLOT: Slot(s) do Bootcard IGR
+  HINT_MMCEIGR_SLOT: O comando de troca para bootcard será enviado ao(s) slot(s) selecionado(s) no IGR
+  MMCE_ADVANCED: Avançado
+  MMCE_SETTINGS: Configurações MMCE
+  MMCE_SEMA: Método de Enfileiramento do Sema de Bloqueio
+  HINT_MMCE_SEMA: THFIFO pode ajudar na compatibilidade, mas piorar o desempenho
+  MMCE_WAIT_CYCLES: Ciclos de espera após /ACK baixo
+  HINT_MMCE_WAIT_CYCLES: Valores menores podem melhorar o desempenho, mas causar instabilidades
+  MMCE_USE_ALARMS: Usar alarmes de timeout
+  HINT_MMCE_USE_ALARMS: OFF pode melhorar o desempenho, mas timeouts do MMCE podem causar travamentos
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino não suporta este formato de arquivo, iniciando com o core <OPL>
+  NEUTRINO_NOT_FOUND: ELF do Neutrino não encontrado, iniciando com o core <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD requer um IP estático no PS2. Defina um em Configurações de Rede (DHCP está ativo).
+  NEUTRINO_SETTING_NA: Esta configuração não é usada com o core Neutrino.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF não encontrado
+  POPSTARTER_SMB_MISSING: Requisitos SMB do POPSTARTER ausentes
+  WRITE_POPSTARTER_NET: Gravar Config de Rede do POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Salva também os valores de IP + compartilhamento SMB nos arquivos IPCONFIG.DAT / SMBCONFIG.DAT do POPSTARTER no cartão de memória (para VCD via SMB).
+  POPSTARTER_NET_ERR: Não foi possível gravar a configuração de rede do POPSTARTER no cartão de memória.
+  VCD: VCD
+  VCD_ON: Exibindo jogos VCD
+  VCD_OFF: Exibindo jogos em disco
+  NEUTRINO_ARGS: Args de Inicialização do Neutrino
+  HINT_NEUTRINO_ARGS: Flags extras do Neutrino, separadas por espaço (ex. -mt=dvd). Global aplica a todos os jogos; por jogo adiciona ao topo. Prefixe uma flag com $ para desativá-la sem excluir.
+  NEUTRINO_VIDEO: Vídeo do Neutrino
+  HINT_NEUTRINO_VIDEO: Forçar o modo de vídeo de saída GS do Neutrino (-gsm). Desligado mantém o padrão do jogo.
+  NEUTRINO_PATH: Caminho do ELF do Neutrino
+  HINT_NEUTRINO_PATH: 'Caminho completo para neutrino.elf (ex. mc0:NEUTRINO/neutrino.elf). Em branco = detecção automática em mc0/mc1.'
+  POPSTARTER_PATH: Caminho do POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Caminho personalizado para POPSTARTER.ELF; usa a pasta POPS do dispositivo se vazio/ausente. Teclado limita a 31 caracteres; caminhos mais longos via settings_riptopl.cfg.
+  BDMA_SOURCE: Origem do BDMA
+  HINT_BDMA_SOURCE: Dispositivo cuja pasta POPS contém os arquivos do driver BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Modo BDMA
+  HINT_BDMA_MODE: Driver de bloco exFAT que o POPSTARTER carrega. Alterar copia os módulos para o cartão; FAT32 = nenhum (driver integrado).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD interno
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Arquivos de módulo BDMA não encontrados no dispositivo de origem.
+  BDMA_ERR_SPACE: Espaço insuficiente no cartão de memória para os módulos BDMA.
+  BDMA_ERR_IO: Erro ao gravar os módulos BDMA no cartão de memória.
+  COVERFLOW_SETTINGS: Configurações do Coverflow
+  COVERFLOW_COUNT: Quantidade de Capas
+  COVERFLOW_SCALE: Escala Central
+  COVERFLOW_ANIM: Velocidade de Animação
+  COVERFLOW_DIM: Escurecer Capas Laterais
+  NONE: Nenhum
+  SMALL: Pequeno
+  LARGE: Grande
+  NORMAL: Normal
+  FAV: Favoritos
+  FAVMODE: Modo de Inicialização dos Favoritos
+  FAV_HINT: Favorito
+  FAV_MSG: '%s não permitido no Menu de Favoritos.'
+  FAV_PERSISTENCE_MSG: '%s não é permitido enquanto o item está marcado como favorito.'
+  NEUTRINO_DEVICE: Dispositivo do Neutrino
+  HINT_NEUTRINO_DEVICE: Dispositivo com o neutrino.elf (na pasta NEUTRINO/ ou neutrino/). Auto escaneia mc0 e depois mc1.
+  NARGS_QB: Inicialização Rápida (-qb)
+  NARGS_CWD: Diretório de Trabalho (-cwd)
+  NARGS_CFG: Configuração (-cfg)
+  NARGS_ELF: ELF de Boot (-elf)
+  NARGS_ATA0: Imagem ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Imagem ATA1 (-ata1)
+  NARGS_EXTRA: Args Extras
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Arquivo .tar de capas
+  DISABLE_ALL: Desativar tudo
+  BOOT_LOADING_CONFIG: Carregando configurações...
+  BOOT_SCANNING_BDM: Verificando unidades USB / cartão / rede...
+  BOOT_SCANNING_NET: Iniciando a rede...
+  BOOT_SCANNING_HDD: Verificando HDD...
+  BOOT_READY: Pronto.
+  UDPFS_GAMES: "Jogos UDPFS"
+  UDPFSBD_GAMES: "Jogos UDPFSBD"
+  NET_PROTOCOL: "Protocolo de Rede"
+  NET_NEEDS_NEUTRINO: "Jogos de rede (UDP) só iniciam pelo core Neutrino. Verifique se neutrino.elf existe e se o formato é compatível."
+  VCD_NOT_ON_NET: "Jogos PS1 (.VCD) não podem ser iniciados pelo dispositivo de rede."
+  MX4SIO_PADEMU_WARN: "MX4SIO e a emulação de controle usam o mesmo barramento SIO2 e o jogo pode não iniciar."
+  HINT_OSD_SETTINGS_LNG: "Forçar uma configuração de idioma personalizada"
+  OSD_SETTINGS_TVASPECT: "Tamanho da Tela"
+  FULL_SCREEN: "Tela Cheia"
+  OSD_SETTINGS_VMODE: "Modo de Vídeo"
+  SYSTEM_DEFAULT: "Padrão do Sistema"
+  HIGH: "Alta"
+  LOW: "Baixa"
+  XSENSITIVITY: "Sensibilidade do Eixo X Analógico"
+  YSENSITIVITY: "Sensibilidade do Eixo Y Analógico"
+  FILE_COUNT: "Arquivos encontrados: %i"
+  CHEAT_SELECTION: "Seleção de Cheats"
+  HDD_HINT: "Só um HDD permitido; ativar bloqueia APA ou GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID não aplicado -- neutrino.elf está neste cartão (trocar descarregaria o Neutrino)."
+  POPSTARTER_DEVICE: "Dispositivo do POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Dispositivo com POPS/POPSTARTER.ELF para iniciar VCDs de PS1. Padrão = dispositivo de boot (cwd) e depois o próprio dispositivo do VCD. Personalizado revela um caminho livre."
+  BDMA_APPLY: "Aplicar VCD BDMA ao Iniciar"
+  HINT_BDMA_APPLY: "Ligado: equipa automaticamente o driver exFAT do VCD iniciado no cartão de memória antes do boot (recomendado). Desligado: gerencie você mesmo pelos seletores de Origem/Modo BDMA abaixo."
+  NETBOOT_RESTART: "Reinicie o OPL para aplicar a mudança do protocolo de boot de rede."
+  UDPFS_MODE: "Acesso UDPFS"
+  "MENU": "Menu"
+  "APPS": "Apps"
+  "DEBUG": "Cores de Depuração"
+  "COVERART": "Capa"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operações de Escrita"
+  "MODE1": "Modo 1"
+  "MODE2": "Modo 2"
+  "MODE3": "Modo 3"
+  "MODE4": "Modo 4"
+  "MODE5": "Modo 5"
+  "MODE6": "Modo 6"
+  "ENABLEGSM": "Seletor GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Motor de Trapaças PS2RD"
+  "PADEMU_ENABLE": "Emulador de Controle"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulação"
+  "PADEMU_VIB": "Vibração"
+  "PADEMU_WORKAROUND": "Solução DS3 Falso"
+  "SFX": "Efeitos Sonoros"
+  "BOOT_SND": "Som de Inicialização"
+  "ENABLE_NOTIFICATIONS": "Notificações"
+  "OPTIONS": "Opções"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Gênero"
+  "INFO_RELEASE": "Lançamento"
+  "INFO_DESCRIPTION": "Descrição"
+  "BLOCKDEVICE_SETTINGS": "Dispositivos de Bloco"
+  "CONTROLLER_SETTINGS": "Configurações de Controle"
+  "HINT_BDM_START": "Liga/desliga o Gerenciador de Dispositivos de Bloco."
+  "HINT_BLOCK_DEVICES": "Liga/desliga Dispositivos de Bloco (ex.: USB)."
+  "USB_GAMES": "Jogos USB"
+  "ILINK_GAMES": "Jogos iLink"
+  "MX4SIO_GAMES": "Jogos MX4SIO"
+  "PADMACROCONFIG": "Configurar PADMACRO"
+  "PADMACRO_SETTINGS": "Configurações de macro do controle"
+  "PADMACRO_ENABLE": "Macros do controle"
+  "PADMACRO_SLOWDOWN": "Desaceleração analógica:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Reduz a amplitude do analógico ao pressionar o botão"
+  "LEFT_ANALOG": "Analógico esquerdo"
+  "RIGHT_ANALOG": "Analógico direito"
+  "PADMACRO_INVERT_AXIS": "Inverter eixo analógico:"
+  "HINT_PADMACRO_INVERT_AXIS": "Inverte o eixo do analógico"
+  "TURBO_SPEED": "Velocidade do turbo"
+  "HINT_TURBO_SPEED": "Rapidez ao pressionar o botão com o turbo ativo"
+  "ACT_WHILE_PRESSED": "Enquanto pressionado"
+  "ACT_TOGGLED": "Alternado pelo botão"
+  "LANGUAGE_JAPANESE": "JAPONÊS"
+  "LANGUAGE_ENGLISH": "INGLÊS"
+  "LANGUAGE_FRENCH": "FRANCÊS"
+  "LANGUAGE_SPANISH": "ESPANHOL"
+  "LANGUAGE_GERMAN": "ALEMÃO"
+  "LANGUAGE_ITALIAN": "ITALIANO"
+  "LANGUAGE_DUTCH": "HOLANDÊS"
+  "LANGUAGE_PORTUGUESE": "PORTUGUÊS"
+  "LANGUAGE_RUSSIAN": "RUSSO"
+  "LANGUAGE_KOREAN": "COREANO"
+  "LANGUAGE_TRAD_CHINESE": "CHINÊS TRADICIONAL"
+  "LANGUAGE_SIMPL_CHINESE": "CHINÊS SIMPLIFICADO"
+  "OSD_SETTINGS": "Configurações OSD"
+  "OSD_SETTINGS_LNG": "Idioma do OSD"
+  "ENABLE_LNG": "Alterar idioma"
+  "BGM": "Música de Fundo"
+  "BGM_VOLUME": "Volume da Música de Fundo"
+  "DEF_BGM_PATH": "Música Padrão do Tema"
+  "DEF_BGM_PATH_HINT": "Define o caminho da música para o tema interno."
+  "BOOT_SCANNING_MC": "Verificando cartões de memória..."
+  "BOOT_LOADING_DRIVERS": "Carregando drivers de armazenamento..."
+  "BOOT_LOADING_USB": "Carregando driver de armazenamento USB..."
+  "BOOT_ARMING_MMCE": "Preparando game-ID MMCE..."
+  "BOOT_LOADING_SOUNDS": "Carregando sons do tema..."
+  "BOOT_BUILDING_MENU": "Montando menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS ativado -- abra a nova aba UDPFS e pressione Confirmar para conectar. No lado do PC, execute udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Dispositivo de bloco de rede ativado -- sua aba aparece quando o servidor do PC responde (udpfsd -bdpath para Imagem UDPFS, udpbd-server para UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Arquivo VMC por jogo não encontrado -- iniciando sem ele (o jogo usa seu cartão real)."
+  "NEUTRINO_DEV_UNSUPPORTED": "O Neutrino não pode iniciar deste dispositivo -- inicialização abortada."
+  "NEUTRINO_TOML_SYNC_FAILED": "Configuração de rede do Neutrino (bsd toml) ausente ou não gravável -- inicialização abortada, verifique a pasta neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Muito fragmentado para o Neutrino (%d fragmentos, limite %d incl. VMCs) -- tentando o core OPL em vez disso."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Muito fragmentado para o Neutrino (%d fragmentos, limite %d incl. VMCs) -- desfragmente no PC; inicialização abortada."
+  "NEUTRINO_GSM_COMP": "Compatibilidade GSM do Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Correção de inversão de campos para jogos que tremem ou rasgam sob um modo de Vídeo do Neutrino forçado. Requer um modo de Vídeo do Neutrino definido."
+  "NARGS_DBC": "Cores de Depuração (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Desativar VMC 1 (manter cartão)"
+  "VMC_SLOT2_DISABLE": "Desativar VMC 2 (manter cartão)"
+  "HINT_VMC_SLOT_DISABLE": "Inicia sem o VMC deste slot, mantendo seu cartão configurado. Apenas inicializações do Neutrino; o jogo então usa o cartão real naquele slot."
+  "NEUTRINO_BSDFS": "Sistema de Arquivos do Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Força o sistema de arquivos de dispositivo de bloco do Neutrino (-bsdfs). Auto = padrão por dispositivo. hdl/bd são opções para especialistas; combine-as com um -dvd= correspondente nos argumentos de inicialização se o formato do caminho automático não servir."
+  "PLASCOLOR": "Cor da Mistura de Plasma"
+  "VCD_HIDE_GAMEID": "Ocultar ID do Jogo PS1 (lista VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Apenas cosmético -- oculta um prefixo de ID de jogo inicial (ex.: SLUS_005.51.) dos nomes das listas de PS1/VCD. Nomes sem um ID são mostrados como estão. Não altera a inicialização, a capa nem os favoritos."
+  "VCD_FIRST_DISC": "Apenas o primeiro disco (PS1 multidisco)"
+  "HINT_VCD_FIRST_DISC": "Mostra apenas o Disco 1 de um jogo de PS1 com múltiplos discos nas listas de dispositivos (estilo POPSLoader). Oculta arquivos nomeados (Disc 2), (CD 2), etc. Todos os discos permanecem no cartão para troca durante o jogo; os Favoritos não são filtrados."
+  "GAMES_DEVICE": "Dispositivo do Jogo"
+  "DEFAULT_CORE": "Núcleo de Carregamento Padrão"
+  "HINT_DEFAULT_CORE": "Core padrão global para jogos cujo Loader Core por jogo está definido como Padrão. <OPL> é o core nativo; o Neutrino encadeia o neutrino.elf externo. Uma escolha por jogo sempre substitui isto."
+  "VCD_SETTINGS": "Configurações VCD"
+  "FINANCIAL_SUPPORT": "Apoio Financeiro"

--- a/lng_fork/README.md
+++ b/lng_fork/README.md
@@ -1,0 +1,23 @@
+# Fork translation overlay
+
+Each `<Language>.yml` here is a small **overlay** that translates the UI strings this
+fork (RiptOPL) adds on top of upstream OPL — Neutrino, MMCE, BDMA, UDPBD, VCD, Coverflow,
+Favourites, and friends. Upstream's shared language repository doesn't carry those labels,
+so this overlay is what keeps them from falling back to English.
+
+Format — a single `translations:` map of label → translated string:
+
+```yml
+translations:
+  VCD_ON: Affichage des jeux VCD
+  COVERFLOW_SETTINGS: Paramètres Coverflow
+```
+
+At build time (`make languages`), `lang_compiler.py --overlay_translation_yml` merges each
+file into its language **only to fill gaps** — it never overwrites a real upstream/human
+translation, and a missing file just means English fallback. `<Language>` must match a name
+in the Makefile's `TRANSLATIONS` list (e.g. `French`, `Portuguese_BR`, `SChinese`).
+
+The shipped files are machine-generated best-effort translations; corrections are welcome.
+Keep acronyms, file paths, flags and `%s`/`%d`/`%i` specifiers verbatim. Full guide:
+[`../lng/README.md`](../lng/README.md).

--- a/lng_fork/Romana.yml
+++ b/lng_fork/Romana.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Sortează jocurile alfabetic
+  RUMBLE: Vibrația controllerului în meniuri
+  HINT_RUMBLE: Vibrație scurtă la mutarea cursorului, confirmare sau revenire -- necesită un DualShock în mod analog
+  FOLDER_NAV: Răsfoiește foldere în lista de jocuri
+  HINT_FOLDER_NAV: Afișează subfolderele de pe CD/DVD ca intrări navigabile; selectează pentru a deschide, anulează pentru a reveni
+  SETTINGS_NO_HOME: Niciun card de memorie găsit -- setările nu pot fi salvate. OPL a pornit de pe un dispozitiv de rețea, ale cărui setări trebuie să fie pe un card local.
+  ERROR_SAVING_SETTINGS_TO: Setările nu au putut fi scrise în %s (eroare %d)
+  GENERAL_SETTINGS: Setări Generale
+  DEVICE_SETTINGS: Setări Dispozitiv
+  LAUNCH_PS2_DISC: Lansează Disc PS2
+  DISC_LAUNCH_ERR: Niciun disc PS2 în unitate.
+  DEFAULT: Implicit
+  HINT_MODE7: Doar Neutrino -- corectează jocuri care depășesc un buffer IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: Imagine Cheat PS2RD
+  HINT_ENABLEIMAGE: Aplică un patch PS2RD .img pregătit pentru jocul tău.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Mod Pornire MMCE
+  MMCE_PREFIX: Cale Prefix MMCE
+  MMCE_SLOT: Slot MMCE
+  MMCEIGR_SLOT: Slot(uri) Bootcard IGR
+  HINT_MMCEIGR_SLOT: Comanda de comutare la bootcard va fi trimisă la slotul(urile) selectat(e) la IGR
+  MMCE_ADVANCED: Avansat
+  MMCE_SETTINGS: Setări MMCE
+  MMCE_SEMA: Metodă Blocare Coadă Sema
+  HINT_MMCE_SEMA: THFIFO poate ajuta compatibilitatea dar poate reduce performanța
+  MMCE_WAIT_CYCLES: Cicluri de așteptare după /ACK jos
+  HINT_MMCE_WAIT_CYCLES: Valorile mai mici pot îmbunătăți performanța dar pot cauza instabilități
+  MMCE_USE_ALARMS: Folosește alarme timeout
+  HINT_MMCE_USE_ALARMS: OFF poate ajuta performanța dar poate cauza blocări la timeout MMCE
+  CORE_LOADER: Nucleu Loader
+  NEUTRINO_BAD_FORMAT: Neutrino nu suportă acest format de fișier, lansare cu nucleul <OPL>
+  NEUTRINO_NOT_FOUND: ELF Neutrino negăsit, lansare cu nucleul <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD necesită un IP static pentru PS2. Setați unul în Config Rețea (DHCP este activ).
+  NEUTRINO_SETTING_NA: Această setare nu este folosită cu nucleul Neutrino.
+  POPSTARTER_NOT_FOUND: Lipsește POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Lipsesc cerințele SMB pentru POPSTARTER
+  WRITE_POPSTARTER_NET: Scrie Config Rețea POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Salvează și valorile IP + SMB în IPCONFIG.DAT / SMBCONFIG.DAT proprii ale POPSTARTER pe cardul de memorie (pentru VCD prin SMB).
+  POPSTARTER_NET_ERR: Nu s-a putut scrie configurația de rețea POPSTARTER pe cardul de memorie.
+  VCD: VCD
+  VCD_ON: Se afișează jocuri VCD
+  VCD_OFF: Se afișează jocuri disc
+  NEUTRINO_ARGS: Argumente Lansare Neutrino
+  HINT_NEUTRINO_ARGS: Indicatori Neutrino suplimentari, separați prin spațiu (ex. -mt=dvd). Global se aplică tuturor jocurilor; per-joc se adaugă în plus. Prefixați un indicator cu $ pentru a-l dezactiva fără a-l șterge.
+  NEUTRINO_VIDEO: Video Neutrino
+  HINT_NEUTRINO_VIDEO: Forțează modul video de ieșire GS al Neutrino (-gsm). Off păstrează implicit-ul jocului.
+  NEUTRINO_PATH: Cale ELF Neutrino
+  HINT_NEUTRINO_PATH: Calea completă spre neutrino.elf (ex. mc0:NEUTRINO/neutrino.elf). Gol = detectare automată pe mc0/mc1.
+  POPSTARTER_PATH: Cale POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Cale personalizată POPSTARTER.ELF; revine automat la dosarul POPS al dispozitivului dacă e gol/lipsă. Tastatura e limitată la 31 de caractere; căi mai lungi prin settings_riptopl.cfg.
+  BDMA_SOURCE: Sursă BDMA
+  HINT_BDMA_SOURCE: Dispozitivul al cărui dosar POPS conține fișierele driver BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Mod BDMA
+  HINT_BDMA_MODE: Driver dispozitiv bloc exFAT pe care POPSTARTER îl încarcă. Schimbarea lui copiază modulele pe card; FAT32 = niciunul (driver încorporat).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD intern
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Fișierele modul BDMA nu au fost găsite pe dispozitivul sursă.
+  BDMA_ERR_SPACE: Spațiu insuficient pe cardul de memorie pentru modulele BDMA.
+  BDMA_ERR_IO: Eroare la scrierea modulelor BDMA pe cardul de memorie.
+  COVERFLOW_SETTINGS: Setări Coverflow
+  COVERFLOW_COUNT: Număr Coperte
+  COVERFLOW_SCALE: Scară Centru
+  COVERFLOW_ANIM: Viteză Animație
+  COVERFLOW_DIM: Estompează Coperte Laterale
+  NONE: Niciunul
+  SMALL: Mic
+  LARGE: Mare
+  NORMAL: Normal
+  FAV: Favorite
+  FAVMODE: Mod Pornire Favorite
+  FAV_HINT: Favorit
+  FAV_MSG: '%s nu este permis prin Meniul de Favorite.'
+  FAV_PERSISTENCE_MSG: '%s nu este permis cât timp elementul este marcat ca favorit.'
+  NEUTRINO_DEVICE: Dispozitiv Neutrino
+  HINT_NEUTRINO_DEVICE: Dispozitivul care conține neutrino.elf (într-un dosar NEUTRINO/ sau neutrino/). Auto scanează mai întâi mc0, apoi mc1.
+  NARGS_QB: Pornire Rapidă (-qb)
+  NARGS_CWD: Dosar de Lucru (-cwd)
+  NARGS_CFG: Configurare (-cfg)
+  NARGS_ELF: ELF de Pornire (-elf)
+  NARGS_ATA0: Imagine ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Imagine ATA1 (-ata1)
+  NARGS_EXTRA: Argumente Suplimentare
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Arhivă .tar cu coperte
+  DISABLE_ALL: Dezactivează tot
+  BOOT_LOADING_CONFIG: Se încarcă setările...
+  BOOT_SCANNING_BDM: Se scanează unitățile USB / card / rețea...
+  BOOT_SCANNING_NET: Se pornește rețeaua...
+  BOOT_SCANNING_HDD: Se scanează HDD...
+  BOOT_READY: Gata.
+  UDPFS_GAMES: "Jocuri UDPFS"
+  UDPFSBD_GAMES: "Jocuri UDPFSBD"
+  NET_PROTOCOL: "Protocol de rețea"
+  NET_NEEDS_NEUTRINO: "Jocurile de rețea (UDP) pot fi pornite doar prin nucleul Neutrino. Verificați dacă neutrino.elf este prezent și dacă formatul este acceptat."
+  VCD_NOT_ON_NET: "Jocurile PS1 (.VCD) nu pot fi pornite de pe dispozitivul de rețea."
+  MX4SIO_PADEMU_WARN: "MX4SIO și emularea controlerului folosesc aceeași magistrală SIO2, iar jocul s-ar putea să nu pornească."
+  HINT_OSD_SETTINGS_LNG: "Impune o limbă personalizată"
+  OSD_SETTINGS_TVASPECT: "Dimensiune ecran"
+  FULL_SCREEN: "Ecran complet"
+  OSD_SETTINGS_VMODE: "Mod video"
+  SYSTEM_DEFAULT: "Implicit sistem"
+  HIGH: "Ridicată"
+  LOW: "Scăzută"
+  XSENSITIVITY: "Sensibilitate analogică axa X"
+  YSENSITIVITY: "Sensibilitate analogică axa Y"
+  FILE_COUNT: "Fișiere găsite: %i"
+  CHEAT_SELECTION: "Selectare cheat-uri"
+  HDD_HINT: "Este permis un singur HDD; activarea blochează APA sau GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID neaplicat -- neutrino.elf este pe acest card (schimbarea ar descărca Neutrino)."
+  POPSTARTER_DEVICE: "Dispozitiv POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Dispozitivul care conține POPS/POPSTARTER.ELF pentru pornirea PS1 VCD. Implicit = dispozitivul de pornire (cwd), apoi dispozitivul propriu al VCD-ului. Custom afișează un câmp liber pentru cale."
+  BDMA_APPLY: "Aplică VCD BDMA la pornire"
+  HINT_BDMA_APPLY: "Pornit: înainte de pornire pune automat pe cardul de memorie driverul exFAT potrivit al VCD-ului lansat (recomandat). Oprit: gestionați manual cu selectoarele BDMA Source/Mode de mai jos."
+  NETBOOT_RESTART: "Reporniți OPL pentru a aplica modificarea protocolului de pornire din rețea."
+  UDPFS_MODE: "Acces UDPFS"
+  "MENU": "Meniu"
+  "APPS": "Aplicații"
+  "DEBUG": "Culori depanare"
+  "COVERART": "Coperți"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operații de scriere"
+  "MODE1": "Mod 1"
+  "MODE2": "Mod 2"
+  "MODE3": "Mod 3"
+  "MODE4": "Mod 4"
+  "MODE5": "Mod 5"
+  "MODE6": "Mod 6"
+  "ENABLEGSM": "Selector GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Motor de coduri PS2RD"
+  "PADEMU_ENABLE": "Emulator controler"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulare"
+  "PADEMU_VIB": "Vibrație"
+  "PADEMU_WORKAROUND": "Soluție DS3 fals"
+  "SFX": "Efecte sonore"
+  "BOOT_SND": "Sunet la pornire"
+  "ENABLE_NOTIFICATIONS": "Notificări"
+  "OPTIONS": "Opțiuni"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Gen"
+  "INFO_RELEASE": "Lansare"
+  "INFO_DESCRIPTION": "Descriere"
+  "BLOCKDEVICE_SETTINGS": "Dispozitive bloc"
+  "CONTROLLER_SETTINGS": "Setări controler"
+  "HINT_BDM_START": "Activează/dezactivează Managerul de dispozitive bloc."
+  "HINT_BLOCK_DEVICES": "Activează/dezactivează dispozitivele bloc (ex. USB)."
+  "USB_GAMES": "Jocuri USB"
+  "ILINK_GAMES": "Jocuri iLink"
+  "MX4SIO_GAMES": "Jocuri MX4SIO"
+  "PADMACROCONFIG": "Configurează PADMACRO"
+  "PADMACRO_SETTINGS": "Setări macro controler"
+  "PADMACRO_ENABLE": "Macrouri controler"
+  "PADMACRO_SLOWDOWN": "Încetinire analogică:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Reduce raza manetei analogice când butonul este apăsat"
+  "LEFT_ANALOG": "Maneta stângă"
+  "RIGHT_ANALOG": "Maneta dreaptă"
+  "PADMACRO_INVERT_AXIS": "Inversare axă analogică:"
+  "HINT_PADMACRO_INVERT_AXIS": "Inversează axa manetei analogice"
+  "TURBO_SPEED": "Viteză buton turbo"
+  "HINT_TURBO_SPEED": "Cât de rapid se apasă butonul când turbo este activ"
+  "ACT_WHILE_PRESSED": "Cât timp butonul este apăsat"
+  "ACT_TOGGLED": "Comutat prin buton"
+  "LANGUAGE_JAPANESE": "JAPONEZĂ"
+  "LANGUAGE_ENGLISH": "ENGLEZĂ"
+  "LANGUAGE_FRENCH": "FRANCEZĂ"
+  "LANGUAGE_SPANISH": "SPANIOLĂ"
+  "LANGUAGE_GERMAN": "GERMANĂ"
+  "LANGUAGE_ITALIAN": "ITALIANĂ"
+  "LANGUAGE_DUTCH": "OLANDEZĂ"
+  "LANGUAGE_PORTUGUESE": "PORTUGHEZĂ"
+  "LANGUAGE_RUSSIAN": "RUSĂ"
+  "LANGUAGE_KOREAN": "COREEANĂ"
+  "LANGUAGE_TRAD_CHINESE": "CHINEZĂ TRADIȚIONALĂ"
+  "LANGUAGE_SIMPL_CHINESE": "CHINEZĂ SIMPLIFICATĂ"
+  "OSD_SETTINGS": "Setări OSD"
+  "OSD_SETTINGS_LNG": "Limbă OSD"
+  "ENABLE_LNG": "Schimbă limba"
+  "BGM": "Muzică de fundal"
+  "BGM_VOLUME": "Volum muzică de fundal"
+  "DEF_BGM_PATH": "Muzică temă implicită"
+  "DEF_BGM_PATH_HINT": "Setează calea pentru redarea muzicii temei interne."
+  "BOOT_SCANNING_MC": "Se scanează cardurile de memorie..."
+  "BOOT_LOADING_DRIVERS": "Se încarcă driverele de stocare..."
+  "BOOT_LOADING_USB": "Se încarcă driverul de stocare USB..."
+  "BOOT_ARMING_MMCE": "Se pregătește game-ID MMCE..."
+  "BOOT_LOADING_SOUNDS": "Se încarcă sunetele temei..."
+  "BOOT_BUILDING_MENU": "Se construiește meniul..."
+  "NET_UDPFS_TAB_HINT": "UDPFS activat -- deschide noua fila UDPFS si apasa Confirmare pentru a conecta. Partea PC ruleaza udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Dispozitiv bloc de retea activat -- fila sa apare dupa ce serverul PC raspunde (udpfsd -bdpath pentru UDPFS Image, udpbd-server pentru UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Fisierul VMC per joc nu a fost gasit -- se lanseaza fara el (jocul foloseste cardul real)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino nu poate lansa de pe acest dispozitiv -- lansare anulată."
+  "NEUTRINO_TOML_SYNC_FAILED": "Configuratia de retea Neutrino (bsd toml) lipseste sau nu poate fi scrisa -- lansare anulata, verifica folderul neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Prea fragmentat pentru Neutrino (%d fragmente, limita %d incl. VMC-uri) -- se incearca in schimb nucleul OPL."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Prea fragmentat pentru Neutrino (%d fragmente, limita %d incl. VMC-uri) -- defragmenteaza pe PC; lansare anulata."
+  "NEUTRINO_GSM_COMP": "Compatibilitate GSM Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Corectie de inversare a campurilor pentru jocurile care tremura sau se rup sub un mod Video Neutrino fortat. Necesita un mod Video Neutrino setat."
+  "NARGS_DBC": "Culori depanare (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Dezactivează VMC 1 (păstrează cardul)"
+  "VMC_SLOT2_DISABLE": "Dezactivează VMC 2 (păstrează cardul)"
+  "HINT_VMC_SLOT_DISABLE": "Lanseaza fara VMC-ul acestui slot, pastrand cardul configurat. Doar lansarile Neutrino; jocul foloseste apoi cardul real din acel slot."
+  "NEUTRINO_BSDFS": "Sistem de fișiere Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Forteaza sistemul de fisiere al dispozitivului bloc al Neutrino (-bsdfs). Auto = implicit pentru fiecare dispozitiv. hdl/bd sunt optiuni pentru experti; asociaza-le cu un -dvd= potrivit in argumentele de lansare daca forma caii automate nu se potriveste."
+  "PLASCOLOR": "Culoare amestec plasmă"
+  "VCD_HIDE_GAMEID": "Ascunde ID joc PS1 (listă VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Doar cosmetic -- ascunde un prefix de ID de joc de la inceput (de ex. SLUS_005.51.) din numele listelor PS1/VCD. Numele fara ID sunt afisate ca atare. Nu modifica lansarea, coperta sau favoritele."
+  "VCD_FIRST_DISC": "Doar primul disc (PS1 multi-disc)"
+  "HINT_VCD_FIRST_DISC": "Afiseaza doar Discul 1 al unui joc PS1 pe mai multe discuri in listele de dispozitive (stil POPSLoader). Ascunde fisierele denumite (Disc 2), (CD 2) etc. Toate discurile raman pe card pentru schimbarea in timpul jocului; Favoritele nu sunt filtrate."
+  "GAMES_DEVICE": "Dispozitivul jocului"
+  "DEFAULT_CORE": "Nucleu de încărcare implicit"
+  "HINT_DEFAULT_CORE": "Nucleul implicit global pentru jocurile al caror Nucleu de incarcare per joc este setat la Implicit. <OPL> este nucleul nativ; Neutrino inlantuie neutrino.elf extern. O alegere per joc suprascrie intotdeauna aceasta setare."
+  "VCD_SETTINGS": "Setări VCD"
+  "FINANCIAL_SUPPORT": "Sprijin financiar"

--- a/lng_fork/Russian.yml
+++ b/lng_fork/Russian.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Сортировать игры по алфавиту
+  RUMBLE: Вибрация контроллера в меню
+  HINT_RUMBLE: Короткая вибрация при перемещении курсора, подтверждении или возврате -- нужен DualShock в аналоговом режиме
+  FOLDER_NAV: Просмотр папок в списке игр
+  HINT_FOLDER_NAV: Показывать подпапки CD/DVD как элементы навигации; выберите, чтобы открыть, отмена -- чтобы вернуться назад
+  SETTINGS_NO_HOME: Карта памяти не найдена -- настройки нельзя сохранить. OPL запущен с сетевого устройства, а его настройки должны храниться на локальной карте.
+  ERROR_SAVING_SETTINGS_TO: Не удалось записать настройки в %s (ошибка %d)
+  GENERAL_SETTINGS: Общие настройки
+  DEVICE_SETTINGS: Настройки устройства
+  LAUNCH_PS2_DISC: Запуск диска PS2
+  DISC_LAUNCH_ERR: Диск PS2 не найден в приводе.
+  DEFAULT: По умолчанию
+  HINT_MODE7: Только Neutrino -- исправляет игры с переполнением буфера IOP (-gc=7)
+  MODE7: Режим 7
+  ENABLEIMAGE: PS2RD Cheat Image
+  HINT_ENABLEIMAGE: Применить готовый патч PS2RD .img к игре.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: Игры MMCE
+  MMCEMODE: Режим запуска MMCE
+  MMCE_PREFIX: Путь префикса MMCE
+  MMCE_SLOT: Слот MMCE
+  MMCEIGR_SLOT: Слот(ы) загрузочной карты IGR
+  HINT_MMCEIGR_SLOT: Команда переключения на загрузочную карту будет отправлена в выбранный слот(ы) при IGR
+  MMCE_ADVANCED: Дополнительно
+  MMCE_SETTINGS: Настройки MMCE
+  MMCE_SEMA: Метод блокировки очереди семафора
+  HINT_MMCE_SEMA: THFIFO может улучшить совместимость, но снизить производительность
+  MMCE_WAIT_CYCLES: Циклы ожидания после /ACK low
+  HINT_MMCE_WAIT_CYCLES: Меньшие значения могут улучшить производительность, но вызвать нестабильность
+  MMCE_USE_ALARMS: Использовать таймеры ожидания
+  HINT_MMCE_USE_ALARMS: OFF может улучшить производительность, но таймауты MMCE могут вызывать зависания
+  CORE_LOADER: Ядро загрузчика
+  NEUTRINO_BAD_FORMAT: Neutrino не поддерживает этот формат файла, запуск через ядро <OPL>
+  NEUTRINO_NOT_FOUND: ELF Neutrino не найден, запуск через ядро <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD требует статический IP PS2. Задайте его в сетевых настройках (DHCP сейчас включён).
+  NEUTRINO_SETTING_NA: Этот параметр не используется с ядром Neutrino.
+  POPSTARTER_NOT_FOUND: Отсутствует POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Отсутствуют необходимые SMB-файлы для POPSTARTER
+  WRITE_POPSTARTER_NET: Записать сетевую конфигурацию POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Также сохранить значения IP + SMB в IPCONFIG.DAT / SMBCONFIG.DAT POPSTARTER на карте памяти (для VCD через SMB).
+  POPSTARTER_NET_ERR: Не удалось записать сетевую конфигурацию POPSTARTER на карту памяти.
+  VCD: VCD
+  VCD_ON: Показаны VCD-игры
+  VCD_OFF: Показаны дисковые игры
+  NEUTRINO_ARGS: Аргументы запуска Neutrino
+  HINT_NEUTRINO_ARGS: Дополнительные флаги Neutrino через пробел (напр. -mt=dvd). Глобальные применяются ко всем играм; игровые добавляются поверх. Префикс $ отключает флаг без удаления.
+  NEUTRINO_VIDEO: Видео Neutrino
+  HINT_NEUTRINO_VIDEO: Принудительный видеорежим GS для Neutrino (-gsm). Off сохраняет настройки игры.
+  NEUTRINO_PATH: Путь к ELF Neutrino
+  HINT_NEUTRINO_PATH: Полный путь к neutrino.elf (напр. mc0:NEUTRINO/neutrino.elf). Пусто = автопоиск на mc0/mc1.
+  POPSTARTER_PATH: Путь к POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Нестандартный путь к POPSTARTER.ELF; при пустом/отсутствующем значении используется папка POPS устройства. Клавиатура ограничена 31 символом; более длинные пути — через settings_riptopl.cfg.
+  BDMA_SOURCE: Источник BDMA
+  HINT_BDMA_SOURCE: Устройство, в папке POPS которого находятся файлы драйвера BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Режим BDMA
+  HINT_BDMA_MODE: Драйвер блочного устройства exFAT, загружаемый POPSTARTER. При смене модули копируются на карту; FAT32 = без модулей (встроенный драйвер).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Внутренний HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Файлы модуля BDMA не найдены на исходном устройстве.
+  BDMA_ERR_SPACE: Недостаточно места на карте памяти для модулей BDMA.
+  BDMA_ERR_IO: Ошибка записи модулей BDMA на карту памяти.
+  COVERFLOW_SETTINGS: Настройки Coverflow
+  COVERFLOW_COUNT: Количество обложек
+  COVERFLOW_SCALE: Масштаб центра
+  COVERFLOW_ANIM: Скорость анимации
+  COVERFLOW_DIM: Затемнение боковых обложек
+  NONE: Нет
+  SMALL: Малый
+  LARGE: Большой
+  NORMAL: Нормальный
+  FAV: Избранное
+  FAVMODE: Режим запуска избранного
+  FAV_HINT: Избранное
+  FAV_MSG: '%s не разрешён в меню избранного.'
+  FAV_PERSISTENCE_MSG: '%s недоступно, пока элемент отмечен как избранный.'
+  NEUTRINO_DEVICE: Устройство Neutrino
+  HINT_NEUTRINO_DEVICE: 'Устройство, на котором находится neutrino.elf (в папке NEUTRINO/ или neutrino/). Автопоиск: сначала mc0, затем mc1.'
+  NARGS_QB: Быстрый запуск (-qb)
+  NARGS_CWD: Рабочая папка (-cwd)
+  NARGS_CFG: Конфигурация (-cfg)
+  NARGS_ELF: Загрузочный ELF (-elf)
+  NARGS_ATA0: Образ ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Образ ATA1 (-ata1)
+  NARGS_EXTRA: Дополнительные аргументы
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar-архив обложек
+  DISABLE_ALL: Отключить все
+  BOOT_LOADING_CONFIG: Загрузка настроек...
+  BOOT_SCANNING_BDM: Сканирование USB / карты / сетевых дисков...
+  BOOT_SCANNING_NET: Запуск сети...
+  BOOT_SCANNING_HDD: Сканирование HDD...
+  BOOT_READY: Готово.
+  UDPFS_GAMES: "UDPFS Игры"
+  UDPFSBD_GAMES: "UDPFSBD Игры"
+  NET_PROTOCOL: "Сетевой протокол"
+  NET_NEEDS_NEUTRINO: "Сетевые (UDP) игры запускаются только через ядро Neutrino. Проверьте наличие neutrino.elf и поддержку формата."
+  VCD_NOT_ON_NET: "PS1 (.VCD) игры нельзя запустить с сетевого устройства."
+  MX4SIO_PADEMU_WARN: "MX4SIO и эмуляция геймпада используют одну шину SIO2, и игра может не запуститься."
+  HINT_OSD_SETTINGS_LNG: "Принудительно задать язык системы"
+  OSD_SETTINGS_TVASPECT: "Размер экрана"
+  FULL_SCREEN: "Весь экран"
+  OSD_SETTINGS_VMODE: "Видеорежим"
+  SYSTEM_DEFAULT: "По умолчанию"
+  HIGH: "Высокая"
+  LOW: "Низкая"
+  XSENSITIVITY: "Чувствительность стика по X"
+  YSENSITIVITY: "Чувствительность стика по Y"
+  FILE_COUNT: "Найдено файлов: %i"
+  CHEAT_SELECTION: "Выбор читов"
+  HDD_HINT: "Разрешён только один HDD; включение блокирует APA или GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID не применён -- neutrino.elf на этой карте (смена выгрузит Neutrino)."
+  POPSTARTER_DEVICE: "Устройство POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Устройство с POPS/POPSTARTER.ELF для запуска PS1 VCD. По умолчанию = загрузочное устройство (cwd), затем устройство самого VCD. Custom открывает свободный ввод пути."
+  BDMA_APPLY: "Применять VCD BDMA при запуске"
+  HINT_BDMA_APPLY: "Вкл.: автоматически ставить на карту памяти подходящий exFAT-драйвер запускаемого VCD перед загрузкой (рекомендуется). Выкл.: настраивайте вручную через пункты BDMA Source/Mode ниже."
+  NETBOOT_RESTART: "Перезапустите OPL, чтобы применить изменение протокола сетевой загрузки."
+  UDPFS_MODE: "Доступ UDPFS"
+  "MENU": "Меню"
+  "APPS": "Приложения"
+  "DEBUG": "Отладочные цвета"
+  "COVERART": "Обложки"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Операции записи"
+  "MODE1": "Режим 1"
+  "MODE2": "Режим 2"
+  "MODE3": "Режим 3"
+  "MODE4": "Режим 4"
+  "MODE5": "Режим 5"
+  "MODE6": "Режим 6"
+  "ENABLEGSM": "Селектор GSM"
+  "OVERSCAN": "Оверскан"
+  "ENABLECHEAT": "Движок читов PS2RD"
+  "PADEMU_ENABLE": "Эмулятор геймпада"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Эмуляция"
+  "PADEMU_VIB": "Вибрация"
+  "PADEMU_WORKAROUND": "Обход для поддельного DS3"
+  "SFX": "Звуковые эффекты"
+  "BOOT_SND": "Звук запуска"
+  "ENABLE_NOTIFICATIONS": "Уведомления"
+  "OPTIONS": "Настройки"
+  "GLOBAL_SETTINGS": "Общие"
+  "INFO_GENRE": "Жанр"
+  "INFO_RELEASE": "Выпуск"
+  "INFO_DESCRIPTION": "Описание"
+  "BLOCKDEVICE_SETTINGS": "Блочные устройства"
+  "CONTROLLER_SETTINGS": "Настройки контроллера"
+  "HINT_BDM_START": "Включить/выключить менеджер блочных устройств."
+  "HINT_BLOCK_DEVICES": "Включить/выключить блочные устройства (например, USB)."
+  "USB_GAMES": "Игры USB"
+  "ILINK_GAMES": "Игры iLink"
+  "MX4SIO_GAMES": "Игры MX4SIO"
+  "PADMACROCONFIG": "Настроить PADMACRO"
+  "PADMACRO_SETTINGS": "Настройки макросов геймпада"
+  "PADMACRO_ENABLE": "Макросы геймпада"
+  "PADMACRO_SLOWDOWN": "Замедление аналога:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Уменьшать диапазон аналогового стика при нажатии кнопки"
+  "LEFT_ANALOG": "Левый стик"
+  "RIGHT_ANALOG": "Правый стик"
+  "PADMACRO_INVERT_AXIS": "Инверсия оси аналога:"
+  "HINT_PADMACRO_INVERT_AXIS": "Инвертировать ось аналогового стика"
+  "TURBO_SPEED": "Скорость турбо-кнопки"
+  "HINT_TURBO_SPEED": "Как быстро нажимать кнопку при активном турбо"
+  "ACT_WHILE_PRESSED": "Пока кнопка нажата"
+  "ACT_TOGGLED": "Переключается кнопкой"
+  "LANGUAGE_JAPANESE": "ЯПОНСКИЙ"
+  "LANGUAGE_ENGLISH": "АНГЛИЙСКИЙ"
+  "LANGUAGE_FRENCH": "ФРАНЦУЗСКИЙ"
+  "LANGUAGE_SPANISH": "ИСПАНСКИЙ"
+  "LANGUAGE_GERMAN": "НЕМЕЦКИЙ"
+  "LANGUAGE_ITALIAN": "ИТАЛЬЯНСКИЙ"
+  "LANGUAGE_DUTCH": "НИДЕРЛАНДСКИЙ"
+  "LANGUAGE_PORTUGUESE": "ПОРТУГАЛЬСКИЙ"
+  "LANGUAGE_RUSSIAN": "РУССКИЙ"
+  "LANGUAGE_KOREAN": "КОРЕЙСКИЙ"
+  "LANGUAGE_TRAD_CHINESE": "КИТАЙСКИЙ ТРАДИЦИОННЫЙ"
+  "LANGUAGE_SIMPL_CHINESE": "КИТАЙСКИЙ УПРОЩЁННЫЙ"
+  "OSD_SETTINGS": "Настройки OSD"
+  "OSD_SETTINGS_LNG": "Язык OSD"
+  "ENABLE_LNG": "Сменить язык"
+  "BGM": "Фоновая музыка"
+  "BGM_VOLUME": "Громкость фоновой музыки"
+  "DEF_BGM_PATH": "Музыка темы по умолчанию"
+  "DEF_BGM_PATH_HINT": "Задать путь к потоковой музыке для встроенной темы."
+  "BOOT_SCANNING_MC": "Сканирование карт памяти..."
+  "BOOT_LOADING_DRIVERS": "Загрузка драйверов накопителей..."
+  "BOOT_LOADING_USB": "Загрузка драйвера USB-накопителя..."
+  "BOOT_ARMING_MMCE": "Активация MMCE game-ID..."
+  "BOOT_LOADING_SOUNDS": "Загрузка звуков темы..."
+  "BOOT_BUILDING_MENU": "Построение меню..."
+  "NET_UDPFS_TAB_HINT": "UDPFS включён — откройте новую вкладку UDPFS и нажмите Подтвердить для подключения. На стороне ПК запускается udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Сетевое блочное устройство включено — его вкладка появляется, как только отвечает сервер на ПК (udpfsd -bdpath для UDPFS Image, udpbd-server для UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Файл VMC для этой игры не найден — запуск без него (игра использует свою реальную карту)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino не может запуститься с этого устройства -- запуск отменён."
+  "NEUTRINO_TOML_SYNC_FAILED": "Сетевая конфигурация Neutrino (bsd toml) отсутствует или недоступна для записи — запуск прерван, проверьте папку neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Слишком фрагментировано для Neutrino (%d фрагментов, лимит %d вкл. VMC) — вместо этого пробуем ядро OPL."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Слишком фрагментировано для Neutrino (%d фрагментов, лимит %d вкл. VMC) — выполните дефрагментацию на ПК; запуск прерван."
+  "NEUTRINO_GSM_COMP": "Совместимость Neutrino GSM"
+  "HINT_NEUTRINO_GSM_COMP": "Исправление с перестановкой полей (field-flipping) для игр, которые трясутся или рвутся при принудительном видеорежиме Neutrino. Требуется заданный видеорежим Neutrino."
+  "NARGS_DBC": "Отладочные цвета (-dbc)"
+  "NARGS_LOGO": "Логотип PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Отключить VMC 1 (сохранить карту)"
+  "VMC_SLOT2_DISABLE": "Отключить VMC 2 (сохранить карту)"
+  "HINT_VMC_SLOT_DISABLE": "Запуск без VMC этого слота с сохранением настройки его карты. Только для запусков через Neutrino; тогда игра использует реальную карту в этом слоте."
+  "NEUTRINO_BSDFS": "Файловая система Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Принудительно задать файловую систему блочного устройства Neutrino (-bsdfs). Auto = значение по умолчанию для устройства. hdl/bd — экспертные варианты; сочетайте их с соответствующим -dvd= в аргументах запуска, если форма автоматического пути не подходит."
+  "PLASCOLOR": "Цвет смешивания плазмы"
+  "VCD_HIDE_GAMEID": "Скрыть ID игры PS1 (список VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Только косметически — скрыть ведущий префикс с ID игры (например SLUS_005.51.) из имён в списке PS1/VCD. Имена без ID показываются как есть. Не влияет на запуск, обложки и избранное."
+  "VCD_FIRST_DISC": "Только первый диск (многодисковые PS1)"
+  "HINT_VCD_FIRST_DISC": "Показывать в списках устройств только Диск 1 многодисковой игры PS1 (в стиле POPSLoader). Скрывает файлы с именами (Disc 2), (CD 2) и т. п. Все диски остаются на карте для смены в игре; Избранное не фильтруется."
+  "GAMES_DEVICE": "Устройство игры"
+  "DEFAULT_CORE": "Ядро загрузчика по умолчанию"
+  "HINT_DEFAULT_CORE": "Глобальное ядро по умолчанию для игр, у которых индивидуальное ядро загрузчика (Loader Core) установлено в Default. <OPL> — это встроенное ядро; Neutrino подключает внешний neutrino.elf. Индивидуальный выбор для игры всегда имеет приоритет над этим."
+  "VCD_SETTINGS": "Настройки VCD"
+  "FINANCIAL_SUPPORT": "Финансовая поддержка"

--- a/lng_fork/Ryukyuan.yml
+++ b/lng_fork/Ryukyuan.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: ゲームやアルファベット順に並びゆん
+  RUMBLE: メニューぬ中ぬコントローラー振動
+  HINT_RUMBLE: カーソル動かすねー、決定しやい戻いやいすしぇー短さん振動すん —— アナログモードぬDualShockぬ要ゆん
+  FOLDER_NAV: ゲームリストぬ中ぬフォルダー見ゆん
+  HINT_FOLDER_NAV: CD/DVDぬサブフォルダー、見ゆる項目んかい見しゆん；選むねー開ち、キャンセルねー戻ゆん
+  SETTINGS_NO_HOME: メモリーカードぇー見当たらん —— 設定ぇー保存ならん。OPLぇーネットワーク機器から起動さっとーくとぅ、設定ぇーローカルカードんかいあらんとーならん。
+  ERROR_SAVING_SETTINGS_TO: "%sんかい設定ぇー書ちきらんたん (エラー %d)"
+  GENERAL_SETTINGS: 一般設定
+  DEVICE_SETTINGS: 機器設定
+  LAUNCH_PS2_DISC: PS2 ディスク起動
+  DISC_LAUNCH_ERR: ドライブにPS2ディスクがあらんむん。
+  DEFAULT: デフォルト
+  HINT_MODE7: Neutrino 専用 -- IOP バッファーをあふれゆるゲームを修正(-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD チートイメージ
+  HINT_ENABLEIMAGE: ゲームにPS2RD .img パッチを当てゅん。
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE ゲーム
+  MMCEMODE: MMCE 起動モード
+  MMCE_PREFIX: MMCE プレフィックスパス
+  MMCE_SLOT: MMCE スロット
+  MMCEIGR_SLOT: IGR ブートカードスロット
+  HINT_MMCEIGR_SLOT: IGR 時、選択したスロットにブートカードコマンドを送ゆん
+  MMCE_ADVANCED: 詳細
+  MMCE_SETTINGS: MMCE 設定
+  MMCE_SEMA: ロックセマエンキュー方式
+  HINT_MMCE_SEMA: THFIFO は互換性向上に役立つが、パフォーマンスが落ちゅる場合あん
+  MMCE_WAIT_CYCLES: /ACK ロー後の待機サイクル
+  HINT_MMCE_WAIT_CYCLES: 値を小さくすればパフォーマンス向上するが、不安定になゆる場合あん
+  MMCE_USE_ALARMS: タイムアウトアラームを使用
+  HINT_MMCE_USE_ALARMS: OFF にすればパフォーマンス向上するが、MMCE タイムアウト時にフリーズすることあん
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino はこのファイル形式に対応しとらん、<OPL> コアで起動すん
+  NEUTRINO_NOT_FOUND: Neutrino ELF が見つからん、<OPL> コアで起動すん
+  UDPBD_NEEDS_STATIC_IP: UDPBD には静的PS2 IPが必要やん。ネットワーク設定で指定しみそーれ（DHCP 有効中）。
+  NEUTRINO_SETTING_NA: この設定は Neutrino コアでは使わんむん。
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF が見つからん
+  POPSTARTER_SMB_MISSING: POPSTARTER の SMB 要件が足らん
+  WRITE_POPSTARTER_NET: POPSTARTER ネットワーク設定を書き込む
+  HINT_WRITE_POPSTARTER_NET: IP と SMB 共有の値をメモリーカード上の POPSTARTER 用 IPCONFIG.DAT / SMBCONFIG.DAT にも保存すん（VCD-over-SMB 向け）。
+  POPSTARTER_NET_ERR: POPSTARTER ネットワーク設定をメモリーカードに書き込めんかた。
+  VCD: VCD
+  VCD_ON: VCD ゲームを表示中
+  VCD_OFF: ディスクゲームを表示中
+  NEUTRINO_ARGS: Neutrino 起動引数
+  HINT_NEUTRINO_ARGS: 'Neutrino 追加フラグをスペース区切りで入力（例: -mt=dvd）。グローバルは全ゲームに適用、ゲーム別は追加分。フラグの前に $ を付けると削除せずに無効化できゅん。'
+  NEUTRINO_VIDEO: Neutrino ビデオ
+  HINT_NEUTRINO_VIDEO: Neutrino の GS 出力ビデオモードを強制指定(-gsm)。Off でゲームのデフォルトを維持すん。
+  NEUTRINO_PATH: Neutrino ELF パス
+  HINT_NEUTRINO_PATH: 'neutrino.elf のフルパス（例: mc0:NEUTRINO/neutrino.elf）。空白の場合は mc0/mc1 を自動検索すん。'
+  POPSTARTER_PATH: POPSTARTER.ELF パス
+  HINT_POPSTARTER_PATH: カスタム POPSTARTER.ELF パス。空白・未検出の場合はデバイスの POPS フォルダーに自動フォールバックすん。キーボードは31文字まで、長いパスは settings_riptopl.cfg で設定可。
+  BDMA_SOURCE: BDMA ソース
+  HINT_BDMA_SOURCE: BDMAssault ドライバーファイル（usbd.irx.* / usbhdfsd.irx.*）を持つデバイス。
+  BDMA_MODE: BDMA モード
+  HINT_BDMA_MODE: POPSTARTER が読み込む exFAT ブロックデバイスドライバー。変更するとモジュールをカードにコピーすん。FAT32 = 組み込みドライバー（コピーなし）。
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: 内蔵HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: ソースデバイスに BDMA モジュールファイルが見つからん。
+  BDMA_ERR_SPACE: BDMA モジュールを保存するメモリーカードの空き容量が足らん。
+  BDMA_ERR_IO: BDMA モジュールのメモリーカードへの書き込みにエラーが発生したん。
+  COVERFLOW_SETTINGS: Coverflow 設定
+  COVERFLOW_COUNT: カバー表示数
+  COVERFLOW_SCALE: 中央スケール
+  COVERFLOW_ANIM: アニメーション速度
+  COVERFLOW_DIM: サイドカバーを暗くすん
+  NONE: なし
+  SMALL: 小
+  LARGE: 大
+  NORMAL: 標準
+  FAV: お気に入り
+  FAVMODE: お気に入り起動モード
+  FAV_HINT: お気に入り
+  FAV_MSG: '%s はお気に入りメニューから起動できやびらん。'
+  FAV_PERSISTENCE_MSG: '%s はお気に入りに登録中、この操作はできやびらん。'
+  NEUTRINO_DEVICE: Neutrino 機器
+  HINT_NEUTRINO_DEVICE: neutrino.elf を持つ機器（NEUTRINO/ または neutrino/ フォルダー内）。自動検索は mc0 から mc1 の順に行ゅん。
+  NARGS_QB: クイック起動 (-qb)
+  NARGS_CWD: 作業ディレクトリ (-cwd)
+  NARGS_CFG: 設定ファイル (-cfg)
+  NARGS_ELF: 起動 ELF (-elf)
+  NARGS_ATA0: ATA0 イメージ (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 イメージ (-ata1)
+  NARGS_EXTRA: 追加引数
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: カバーアートの.tarアーカイブ
+  DISABLE_ALL: すべて無効化
+  BOOT_LOADING_CONFIG: 設定を読み込み中...
+  BOOT_SCANNING_BDM: USB / カード / ネットワークをスキャン中...
+  BOOT_SCANNING_NET: ネットワークを開始中...
+  BOOT_SCANNING_HDD: HDD をスキャン中...
+  BOOT_READY: 準備完了。
+  UDPFS_GAMES: "UDPFSぬゲーム"
+  UDPFSBD_GAMES: "UDPFSBDぬゲーム"
+  NET_PROTOCOL: "ネットワークプロトコル"
+  NET_NEEDS_NEUTRINO: "ネットワーク（UDP）ぬゲームやNeutrino coreっしどぅブートないん。neutrino.elfぬあいねー、フォーマットん対応しちょーるかくとぅ確認さびら。"
+  VCD_NOT_ON_NET: "PS1（.VCD）ぬゲームやネットワーク機器っし起動でぇきらん。"
+  MX4SIO_PADEMU_WARN: "MX4SIOとぅパッドエミュレーションやSIO2バスいっしょーに使いる、ゲームぬブートしんでぇる事ぬあん。"
+  HINT_OSD_SETTINGS_LNG: "カスタムぬ言語設定を強制すん"
+  OSD_SETTINGS_TVASPECT: "画面ぬ大ささ"
+  FULL_SCREEN: "全画面"
+  OSD_SETTINGS_VMODE: "ビデオモード"
+  SYSTEM_DEFAULT: "システムぬ既定"
+  HIGH: "高さん"
+  LOW: "低さん"
+  XSENSITIVITY: "アナログX軸ぬ感度"
+  YSENSITIVITY: "アナログY軸ぬ感度"
+  FILE_COUNT: "見ぃきたファイル：%i"
+  CHEAT_SELECTION: "チートぬ選択"
+  HDD_HINT: "HDDやひとぅっちゃーどぅ許さりーる、有効にないねーAPAかGPTぬロックさりーん。"
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameIDや適用さらん -- neutrino.elfやくぬカードんかいあん（替いーねーNeutrinoぬアンロードさりーん）。"
+  POPSTARTER_DEVICE: "POPSTARTER.ELF機器"
+  HINT_POPSTARTER_DEVICE: "PS1 VCDぬ起動んかいPOPS/POPSTARTER.ELF収みてぃある機器。既定＝ブート機器（cwd）ぬ後、VCD自身ぬ機器。カスタムやフリーテキストぬパス表示すん。"
+  BDMA_APPLY: "起動時んかいVCD BDMAを適用"
+  HINT_BDMA_APPLY: "オン：ブート前んかい起動さるVCDんかい合ーるexFATドライバーをメモリーカードんかい自動装備すん（推奨）。オフ：下ぬBDMA Source/Modeぬ選択っし自分し管理すん。"
+  NETBOOT_RESTART: "ネットワークブートプロトコルぬ変更を適用すんちOPLを再起動さびら。"
+  UDPFS_MODE: "UDPFS アクセス"
+  "MENU": "メニュー"
+  "APPS": "アプリ"
+  "DEBUG": "デバッグ色"
+  "COVERART": "カバー絵"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "書ちくみ動作"
+  "MODE1": "Mode 1"
+  "MODE2": "Mode 2"
+  "MODE3": "Mode 3"
+  "MODE4": "Mode 4"
+  "MODE5": "Mode 5"
+  "MODE6": "Mode 6"
+  "ENABLEGSM": "GSM 選択"
+  "OVERSCAN": "オーバースキャン"
+  "ENABLECHEAT": "PS2RD チートエンジン"
+  "PADEMU_ENABLE": "パッドエミュレータ"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "エミュレーション"
+  "PADEMU_VIB": "振動"
+  "PADEMU_WORKAROUND": "にせDS3 対処"
+  "SFX": "音効果"
+  "BOOT_SND": "起動音"
+  "ENABLE_NOTIFICATIONS": "通知"
+  "OPTIONS": "オプション"
+  "GLOBAL_SETTINGS": "ぜんたい"
+  "INFO_GENRE": "ジャンル"
+  "INFO_RELEASE": "発売"
+  "INFO_DESCRIPTION": "説明"
+  "BLOCKDEVICE_SETTINGS": "ブロックデバイス"
+  "CONTROLLER_SETTINGS": "コントローラ設定"
+  "HINT_BDM_START": "Block Device Manager ぬオン/オフ。"
+  "HINT_BLOCK_DEVICES": "ブロックデバイス（例：USB）ぬオン/オフ。"
+  "USB_GAMES": "USB ゲーム"
+  "ILINK_GAMES": "iLink ゲーム"
+  "MX4SIO_GAMES": "MX4SIO ゲーム"
+  "PADMACROCONFIG": "PADMACRO ぬ設定"
+  "PADMACRO_SETTINGS": "パッドマクロ設定"
+  "PADMACRO_ENABLE": "パッドマクロ"
+  "PADMACRO_SLOWDOWN": "アナログ減速："
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "ボタン押ちゃる時アナログスティックぬ範囲小さくすん"
+  "LEFT_ANALOG": "左スティック"
+  "RIGHT_ANALOG": "右スティック"
+  "PADMACRO_INVERT_AXIS": "アナログ軸反転："
+  "HINT_PADMACRO_INVERT_AXIS": "アナログスティックぬ軸反転すん"
+  "TURBO_SPEED": "ターボボタン速さ"
+  "HINT_TURBO_SPEED": "ターボ有効時ぬボタン押す速さ"
+  "ACT_WHILE_PRESSED": "ボタン押しゃーる間"
+  "ACT_TOGGLED": "ボタンし切替"
+  "LANGUAGE_JAPANESE": "日本語"
+  "LANGUAGE_ENGLISH": "英語"
+  "LANGUAGE_FRENCH": "フランス語"
+  "LANGUAGE_SPANISH": "スペイン語"
+  "LANGUAGE_GERMAN": "ドイツ語"
+  "LANGUAGE_ITALIAN": "イタリア語"
+  "LANGUAGE_DUTCH": "オランダ語"
+  "LANGUAGE_PORTUGUESE": "ポルトガル語"
+  "LANGUAGE_RUSSIAN": "ロシア語"
+  "LANGUAGE_KOREAN": "韓国語"
+  "LANGUAGE_TRAD_CHINESE": "繁体字中国語"
+  "LANGUAGE_SIMPL_CHINESE": "簡体字中国語"
+  "OSD_SETTINGS": "OSD 設定"
+  "OSD_SETTINGS_LNG": "OSD 言葉"
+  "ENABLE_LNG": "言葉替ゆん"
+  "BGM": "BGM"
+  "BGM_VOLUME": "BGM 音量"
+  "DEF_BGM_PATH": "標準テーマ音楽"
+  "DEF_BGM_PATH_HINT": "内蔵テーマぬ音楽ストリームぬパス設定すん。"
+  "BOOT_SCANNING_MC": "メモリーカードスキャン中…"
+  "BOOT_LOADING_DRIVERS": "ストレージドライバ読込中…"
+  "BOOT_LOADING_USB": "USB ストレージドライバ読込中…"
+  "BOOT_ARMING_MMCE": "MMCE ゲームID 準備中…"
+  "BOOT_LOADING_SOUNDS": "テーマ音読込中…"
+  "BOOT_BUILDING_MENU": "メニュー作成中…"
+  "NET_UDPFS_TAB_HINT": "UDPFSがオン -- 新しいUDPFSタブ開きてぃ、Confirm押ちゃーい繋じゅん。PCぬ側ー udpfsd -fsroot <games folder> 走らしゅん。"
+  "NET_UDPBD_TAB_HINT": "ネットワークブロックデバイスがオン -- PCサーバーが返事すしぇータブぬ出ぃてぃちゅん(UDPFS Imageーudpfsd -bdpath、UDPBDーudpbd-server)。"
+  "NEUTRINO_VMC_MISSING": "ゲームぐとぅぬVMCファイルぬ見ぃきらん -- くれーねーらんまま起動すん(ゲームー、まくとぅぬカード使ゆん)。"
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino やくぬデバイスから起動でぃきらん -- 起動中止。"
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrinoぬネットワーク設定(bsd toml)ねーらん、書ちきーならん -- 起動ー止みたん。neutrinoフォルダー確かみーり。"
+  "NEUTRINO_TOO_FRAGMENTED": "Neutrinoんかいー分かりーぎさん(%dぬフラグメント、限界%d VMCsくみてぃ) -- 代わいにOPLコア試ちょーん。"
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Neutrinoんかいー分かりーぎさん(%dぬフラグメント、限界%d VMCsくみてぃ) -- PCさーにデフラグさーい。起動ー止みたん。"
+  "NEUTRINO_GSM_COMP": "Neutrino GSM 互換性"
+  "HINT_NEUTRINO_GSM_COMP": "強制ぬNeutrino Videoモードんかいてぃ揺りーん、破りーるゲームぬためぬフィールドフリップぬ直し。Neutrino Videoモードぬ設定ぬ要いん。"
+  "NARGS_DBC": "デバッグ色 (-dbc)"
+  "NARGS_LOGO": "PS2 ロゴ (-logo)"
+  "VMC_SLOT1_DISABLE": "VMC 1 無効（カード残す）"
+  "VMC_SLOT2_DISABLE": "VMC 2 無効（カード残す）"
+  "HINT_VMC_SLOT_DISABLE": "くぬスロットぬカードー設定さんまま、くぬスロットぬVMCねーらんさーに起動すん。Neutrinoぬ起動びけーん。ゲームー、くぬスロットぬまくとぅぬカード使ゆん。"
+  "NEUTRINO_BSDFS": "Neutrino ファイルシステム"
+  "HINT_NEUTRINO_BSDFS": "Neutrinoぬブロックデバイスファイルシステム(-bsdfs)ぬ強制。Auto=デバイスぐとぅぬデフォルト。hdl/bdーエキスパートぬオプションやん。オートぬパスぬ形ぬ合わんねー、起動ぬargsんかい合うる-dvd=とぅ一緒に使ーい。"
+  "PLASCOLOR": "プラズマ混色"
+  "VCD_HIDE_GAMEID": "PS1 ゲームID 隠す（VCD リスト）"
+  "HINT_VCD_HIDE_GAMEID": "見た目びけーん -- PS1/VCDぬリストぬ名前から頭ぬゲームID(例:SLUS_005.51.)隠しゅん。IDねーらん名前ーそぅままぬ見しゅん。起動、カバーアート、favouritesー変わらん。"
+  "VCD_FIRST_DISC": "最初ぬディスクだき（複数ディスクPS1）"
+  "HINT_VCD_FIRST_DISC": "デバイスリストゥんかい、マルチディスクぬPS1ゲームぬディスク1 びけーん見しゅん(POPSLoaderぬやーい)。(Disc 2)、(CD 2)ぬぐとぅる名前ぬファイルー隠しゅん。ディスクー全部カードんかいぬくてぃ、ゲームぬ中さーに取ぃ替ぃーならん。Favouritesーフィルターさらん。"
+  "GAMES_DEVICE": "ゲームぬデバイス"
+  "DEFAULT_CORE": "標準ローダーコア"
+  "HINT_DEFAULT_CORE": "ゲームぐとぅぬLoader CoreぬDefaultんかいなとーるゲームぬグローバルなデフォルトコア。<OPL>ーネイティブぬコアやん。Neutrinoー外ぬneutrino.elfちなじゅん。ゲームぐとぅぬ選択ー、いちんくれー上書きすん。"
+  "VCD_SETTINGS": "VCD 設定"
+  "FINANCIAL_SUPPORT": "資金支援"

--- a/lng_fork/SChinese.yml
+++ b/lng_fork/SChinese.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: 按字母顺序排列游戏
+  RUMBLE: 菜单中手柄振动
+  HINT_RUMBLE: 移动光标、确认或返回时短暂振动 —— 需要 DualShock 处于模拟模式
+  FOLDER_NAV: 在游戏列表中浏览文件夹
+  HINT_FOLDER_NAV: 将 CD/DVD 的子文件夹显示为可浏览项；选择打开，取消返回
+  SETTINGS_NO_HOME: 未找到记忆卡 —— 无法保存设置。OPL 从网络设备启动，其设置必须存放在本地卡上。
+  ERROR_SAVING_SETTINGS_TO: 无法将设置写入 %s（错误 %d）
+  GENERAL_SETTINGS: 常规设置
+  DEVICE_SETTINGS: 设备设置
+  LAUNCH_PS2_DISC: 启动 PS2 光盘
+  DISC_LAUNCH_ERR: 驱动器中没有 PS2 光盘。
+  DEFAULT: 默认
+  HINT_MODE7: 仅限 Neutrino —— 修复溢出 IOP 缓冲区的游戏 (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD 金手指镜像
+  HINT_ENABLEIMAGE: 为游戏应用预构建的 PS2RD .img 补丁。
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE 启动模式
+  MMCE_PREFIX: MMCE 前缀路径
+  MMCE_SLOT: MMCE 卡槽
+  MMCEIGR_SLOT: IGR 启动卡槽
+  HINT_MMCEIGR_SLOT: 触发 IGR 时，切换到启动卡的命令将发送至所选卡槽
+  MMCE_ADVANCED: 高级
+  MMCE_SETTINGS: MMCE 设置
+  MMCE_SEMA: 锁信号量排队方式
+  HINT_MMCE_SEMA: THFIFO 可能提升兼容性，但会降低性能
+  MMCE_WAIT_CYCLES: /ACK 低电平后等待周期数
+  HINT_MMCE_WAIT_CYCLES: 较低值可能提升性能，但可能导致不稳定
+  MMCE_USE_ALARMS: 使用超时报警
+  HINT_MMCE_USE_ALARMS: 关闭可能提升性能，但 MMCE 超时时可能导致死机
+  CORE_LOADER: 核心加载器
+  NEUTRINO_BAD_FORMAT: Neutrino 不支持此文件格式，将使用 <OPL> 核心启动
+  NEUTRINO_NOT_FOUND: 未找到 Neutrino ELF，将使用 <OPL> 核心启动
+  UDPBD_NEEDS_STATIC_IP: UDPBD 需要静态 PS2 IP。请在网络配置中设置（当前已启用 DHCP）。
+  NEUTRINO_SETTING_NA: 此设置不适用于 Neutrino 核心。
+  POPSTARTER_NOT_FOUND: 缺少 POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: 缺少 POPSTARTER SMB 所需文件
+  WRITE_POPSTARTER_NET: 写入 POPSTARTER 网络配置
+  HINT_WRITE_POPSTARTER_NET: 同时将 IP 和 SMB 共享值保存到存储卡上 POPSTARTER 的 IPCONFIG.DAT / SMBCONFIG.DAT（用于 VCD over SMB）。
+  POPSTARTER_NET_ERR: 无法将 POPSTARTER 网络配置写入存储卡。
+  VCD: VCD
+  VCD_ON: 正在显示 VCD 游戏
+  VCD_OFF: 正在显示光盘游戏
+  NEUTRINO_ARGS: Neutrino 启动参数
+  HINT_NEUTRINO_ARGS: 额外的 Neutrino 标志，以空格分隔（如 -mt=dvd）。全局参数适用于所有游戏；单游戏参数在此基础上追加。在标志前加 $ 可禁用而不删除。
+  NEUTRINO_VIDEO: Neutrino 视频
+  HINT_NEUTRINO_VIDEO: 强制设置 Neutrino 的 GS 输出视频模式 (-gsm)。关闭则保留游戏默认值。
+  NEUTRINO_PATH: Neutrino ELF 路径
+  HINT_NEUTRINO_PATH: neutrino.elf 的完整路径（如 mc0:NEUTRINO/neutrino.elf）。留空则自动在 mc0/mc1 上检测。
+  POPSTARTER_PATH: POPSTARTER.ELF 路径
+  HINT_POPSTARTER_PATH: 自定义 POPSTARTER.ELF 路径；留空或缺失时自动回退至设备 POPS 文件夹。键盘输入上限 31 字符；更长路径请通过 settings_riptopl.cfg 设置。
+  BDMA_SOURCE: BDMA 来源
+  HINT_BDMA_SOURCE: 存放 BDMAssault 驱动文件（usbd.irx.* / usbhdfsd.irx.*）的 POPS 文件夹所在设备。
+  BDMA_MODE: BDMA 模式
+  HINT_BDMA_MODE: POPSTARTER 加载的 exFAT 块设备驱动。更改后会将模块复制到存储卡；FAT32 = 无（使用内置驱动）。
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: 内置硬盘
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: 在来源设备上未找到 BDMA 模块文件。
+  BDMA_ERR_SPACE: 存储卡空间不足，无法存放 BDMA 模块。
+  BDMA_ERR_IO: 将 BDMA 模块写入存储卡时出错。
+  COVERFLOW_SETTINGS: Coverflow 设置
+  COVERFLOW_COUNT: 封面数量
+  COVERFLOW_SCALE: 中心缩放
+  COVERFLOW_ANIM: 动画速度
+  COVERFLOW_DIM: 暗化侧边封面
+  NONE: 无
+  SMALL: 小
+  LARGE: 大
+  NORMAL: 普通
+  FAV: 收藏夹
+  FAVMODE: 收藏夹启动模式
+  FAV_HINT: 收藏
+  FAV_MSG: '%s 不允许通过收藏夹菜单访问。'
+  FAV_PERSISTENCE_MSG: '%s 在该项目被标记为收藏时不可用。'
+  NEUTRINO_DEVICE: Neutrino 设备
+  HINT_NEUTRINO_DEVICE: 存放 neutrino.elf 的设备（位于 NEUTRINO/ 或 neutrino/ 文件夹）。自动依次扫描 mc0 和 mc1。
+  NARGS_QB: 快速启动 (-qb)
+  NARGS_CWD: 工作目录 (-cwd)
+  NARGS_CFG: 配置文件 (-cfg)
+  NARGS_ELF: 启动 ELF (-elf)
+  NARGS_ATA0: ATA0 镜像 (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 镜像 (-ata1)
+  NARGS_EXTRA: 额外参数
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: 封面图 .tar 归档
+  DISABLE_ALL: 全部禁用
+  BOOT_LOADING_CONFIG: 正在加载设置...
+  BOOT_SCANNING_BDM: 正在扫描 USB / 存储卡 / 网络驱动器...
+  BOOT_SCANNING_NET: 正在启动网络...
+  BOOT_SCANNING_HDD: 正在扫描 HDD...
+  BOOT_READY: 就绪。
+  UDPFS_GAMES: "UDPFS 游戏"
+  UDPFSBD_GAMES: "UDPFSBD 游戏"
+  NET_PROTOCOL: "网络协议"
+  NET_NEEDS_NEUTRINO: "网络（UDP）游戏只能通过 Neutrino 核心启动。请检查 neutrino.elf 是否存在且格式受支持。"
+  VCD_NOT_ON_NET: "PS1（.VCD）游戏无法通过网络设备启动。"
+  MX4SIO_PADEMU_WARN: "MX4SIO 与手柄模拟共用 SIO2 总线，游戏可能无法启动。"
+  HINT_OSD_SETTINGS_LNG: "强制使用自定义语言配置"
+  OSD_SETTINGS_TVASPECT: "屏幕尺寸"
+  FULL_SCREEN: "全屏"
+  OSD_SETTINGS_VMODE: "视频模式"
+  SYSTEM_DEFAULT: "系统默认"
+  HIGH: "高"
+  LOW: "低"
+  XSENSITIVITY: "模拟摇杆 X 轴灵敏度"
+  YSENSITIVITY: "模拟摇杆 Y 轴灵敏度"
+  FILE_COUNT: "找到文件：%i"
+  CHEAT_SELECTION: "金手指选择"
+  HDD_HINT: "仅允许一个 HDD，启用后将锁定为 APA 或 GPT。"
+  MMCE_GAMEID_NEUTRINO_SKIP: "未应用 MMCE GameID -- 此卡上存在 neutrino.elf（切换会卸载 Neutrino）。"
+  POPSTARTER_DEVICE: "POPSTARTER.ELF 设备"
+  HINT_POPSTARTER_DEVICE: "用于 PS1 VCD 启动、存放 POPS/POPSTARTER.ELF 的设备。默认 = 启动设备（cwd），其次为 VCD 自身设备。自定义会显示自由输入路径。"
+  BDMA_APPLY: "启动时应用 VCD BDMA"
+  HINT_BDMA_APPLY: "开启：启动前自动将所启动 VCD 对应的 exFAT 驱动装载到记忆卡（推荐）。关闭：使用下方的 BDMA 源/模式选择器自行管理。"
+  NETBOOT_RESTART: "重启 OPL 以应用网络启动协议的更改。"
+  UDPFS_MODE: "UDPFS 访问"
+  "MENU": "菜单"
+  "APPS": "应用"
+  "DEBUG": "调试颜色"
+  "COVERART": "封面图"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "写入操作"
+  "MODE1": "模式 1"
+  "MODE2": "模式 2"
+  "MODE3": "模式 3"
+  "MODE4": "模式 4"
+  "MODE5": "模式 5"
+  "MODE6": "模式 6"
+  "ENABLEGSM": "GSM 选择器"
+  "OVERSCAN": "过扫描"
+  "ENABLECHEAT": "PS2RD 金手指引擎"
+  "PADEMU_ENABLE": "手柄模拟器"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "模拟"
+  "PADEMU_VIB": "振动"
+  "PADEMU_WORKAROUND": "伪 DS3 兼容处理"
+  "SFX": "音效"
+  "BOOT_SND": "启动音效"
+  "ENABLE_NOTIFICATIONS": "通知"
+  "OPTIONS": "选项"
+  "GLOBAL_SETTINGS": "全局"
+  "INFO_GENRE": "类型"
+  "INFO_RELEASE": "发行"
+  "INFO_DESCRIPTION": "简介"
+  "BLOCKDEVICE_SETTINGS": "块设备"
+  "CONTROLLER_SETTINGS": "手柄设置"
+  "HINT_BDM_START": "开启/关闭块设备管理器（BDM）。"
+  "HINT_BLOCK_DEVICES": "开启/关闭块设备（如 USB）。"
+  "USB_GAMES": "USB 游戏"
+  "ILINK_GAMES": "iLink 游戏"
+  "MX4SIO_GAMES": "MX4SIO 游戏"
+  "PADMACROCONFIG": "配置 PADMACRO"
+  "PADMACRO_SETTINGS": "手柄宏设置"
+  "PADMACRO_ENABLE": "手柄宏"
+  "PADMACRO_SLOWDOWN": "模拟摇杆减速："
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "按下按键时缩小模拟摇杆的行程范围"
+  "LEFT_ANALOG": "左摇杆"
+  "RIGHT_ANALOG": "右摇杆"
+  "PADMACRO_INVERT_AXIS": "模拟轴反转："
+  "HINT_PADMACRO_INVERT_AXIS": "反转模拟摇杆轴向"
+  "TURBO_SPEED": "连发按键速度"
+  "HINT_TURBO_SPEED": "连发激活时按键的按压速度"
+  "ACT_WHILE_PRESSED": "按住时生效"
+  "ACT_TOGGLED": "按键切换"
+  "LANGUAGE_JAPANESE": "日语"
+  "LANGUAGE_ENGLISH": "英语"
+  "LANGUAGE_FRENCH": "法语"
+  "LANGUAGE_SPANISH": "西班牙语"
+  "LANGUAGE_GERMAN": "德语"
+  "LANGUAGE_ITALIAN": "意大利语"
+  "LANGUAGE_DUTCH": "荷兰语"
+  "LANGUAGE_PORTUGUESE": "葡萄牙语"
+  "LANGUAGE_RUSSIAN": "俄语"
+  "LANGUAGE_KOREAN": "韩语"
+  "LANGUAGE_TRAD_CHINESE": "繁体中文"
+  "LANGUAGE_SIMPL_CHINESE": "简体中文"
+  "OSD_SETTINGS": "OSD 设置"
+  "OSD_SETTINGS_LNG": "OSD 语言"
+  "ENABLE_LNG": "更改语言"
+  "BGM": "背景音乐"
+  "BGM_VOLUME": "背景音乐音量"
+  "DEF_BGM_PATH": "默认主题音乐"
+  "DEF_BGM_PATH_HINT": "设置内置主题的流式音乐路径。"
+  "BOOT_SCANNING_MC": "正在扫描记忆卡……"
+  "BOOT_LOADING_DRIVERS": "正在加载存储驱动……"
+  "BOOT_LOADING_USB": "正在加载 USB 存储驱动……"
+  "BOOT_ARMING_MMCE": "正在准备 MMCE 游戏 ID……"
+  "BOOT_LOADING_SOUNDS": "正在加载主题音效……"
+  "BOOT_BUILDING_MENU": "正在构建菜单……"
+  "NET_UDPFS_TAB_HINT": "UDPFS 已开启 —— 打开新的 UDPFS 选项卡并按确认以连接。PC 端运行 udpfsd -fsroot <games folder>。"
+  "NET_UDPBD_TAB_HINT": "网络块设备已开启 —— 一旦 PC 服务器响应，其选项卡即会出现（UDPFS 映像用 udpfsd -bdpath，UDPBD 用 udpbd-server）。"
+  "NEUTRINO_VMC_MISSING": "未找到该游戏的 VMC 文件 —— 不使用它启动（游戏使用其真实卡）。"
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino 无法从此设备启动——已中止启动。"
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino 网络配置（bsd toml）缺失或不可写入 —— 启动已中止，请检查 neutrino 文件夹。"
+  "NEUTRINO_TOO_FRAGMENTED": "对 Neutrino 而言碎片过多（%d 个碎片，上限 %d，含 VMC）—— 改为尝试 OPL 核心。"
+  "NEUTRINO_TOO_FRAGMENTED_NET": "对 Neutrino 而言碎片过多（%d 个碎片，上限 %d，含 VMC）—— 请在 PC 上进行碎片整理；启动已中止。"
+  "NEUTRINO_GSM_COMP": "Neutrino GSM 兼容性"
+  "HINT_NEUTRINO_GSM_COMP": "针对在强制 Neutrino 视频模式下抖动或撕裂的游戏的场翻转修复。需要设置一个 Neutrino 视频模式。"
+  "NARGS_DBC": "调试颜色 (-dbc)"
+  "NARGS_LOGO": "PS2 标志 (-logo)"
+  "VMC_SLOT1_DISABLE": "禁用 VMC 1（保留卡）"
+  "VMC_SLOT2_DISABLE": "禁用 VMC 2（保留卡）"
+  "HINT_VMC_SLOT_DISABLE": "在保留该插槽卡配置的同时，不使用此插槽的 VMC 启动。仅限 Neutrino 启动；游戏随后会使用该插槽中的真实卡。"
+  "NEUTRINO_BSDFS": "Neutrino 文件系统"
+  "HINT_NEUTRINO_BSDFS": "强制 Neutrino 的块设备文件系统 (-bsdfs)。Auto = 按设备默认值。hdl/bd 为专家选项；如果自动路径形态不合适，请在启动参数中搭配相应的 -dvd=。"
+  "PLASCOLOR": "等离子混合颜色"
+  "VCD_HIDE_GAMEID": "隐藏 PS1 游戏 ID（VCD 列表）"
+  "HINT_VCD_HIDE_GAMEID": "仅为外观 —— 从 PS1/VCD 列表名称中隐藏开头的游戏 ID 前缀（例如 SLUS_005.51.）。没有 ID 的名称按原样显示。不会更改启动、封面图或收藏夹。"
+  "VCD_FIRST_DISC": "仅第一张碟（多碟 PS1）"
+  "HINT_VCD_FIRST_DISC": "在设备列表中仅显示多碟 PS1 游戏的第 1 碟（POPSLoader 风格）。隐藏名为 (Disc 2)、(CD 2) 等的文件。所有碟片仍保留在卡上以供游戏内换碟；收藏夹不会被过滤。"
+  "GAMES_DEVICE": "游戏所在设备"
+  "DEFAULT_CORE": "默认加载器核心"
+  "HINT_DEFAULT_CORE": "针对将每个游戏的 Loader Core 设为 Default 的游戏所用的全局默认核心。<OPL> 为原生核心；Neutrino 会链式调用外部的 neutrino.elf。单个游戏的选择始终会覆盖此设置。"
+  "VCD_SETTINGS": "VCD 设置"
+  "FINANCIAL_SUPPORT": "资金支持"

--- a/lng_fork/Spanish.yml
+++ b/lng_fork/Spanish.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Ordenar juegos alfabéticamente
+  RUMBLE: Vibración del mando en los menús
+  HINT_RUMBLE: Vibración breve al mover el cursor, confirmar o volver -- requiere un DualShock en modo analógico
+  FOLDER_NAV: Explorar carpetas en la lista de juegos
+  HINT_FOLDER_NAV: Muestra subcarpetas de CD/DVD como entradas navegables; selecciona para abrir, cancela para volver
+  SETTINGS_NO_HOME: No se encontró tarjeta de memoria -- no se puede guardar la configuración. OPL se inició desde un dispositivo de red, cuya configuración debe residir en una tarjeta local.
+  ERROR_SAVING_SETTINGS_TO: No se pudo escribir la configuración en %s (error %d)
+  GENERAL_SETTINGS: Configuración general
+  DEVICE_SETTINGS: Configuración de dispositivo
+  LAUNCH_PS2_DISC: Lanzar disco PS2
+  DISC_LAUNCH_ERR: No hay disco PS2 en la unidad.
+  DEFAULT: Por defecto
+  HINT_MODE7: Solo Neutrino -- corrige juegos que desbordan un búfer IOP (-gc=7)
+  MODE7: Modo 7
+  ENABLEIMAGE: Imagen de trucos PS2RD
+  HINT_ENABLEIMAGE: Aplica un parche .img precompilado de PS2RD a tu juego.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Modo de inicio MMCE
+  MMCE_PREFIX: Ruta de prefijo MMCE
+  MMCE_SLOT: Ranura MMCE
+  MMCEIGR_SLOT: Ranura(s) de arranque IGR
+  HINT_MMCEIGR_SLOT: El comando de cambio a tarjeta de arranque se enviará a la(s) ranura(s) seleccionada(s) en IGR
+  MMCE_ADVANCED: Avanzado
+  MMCE_SETTINGS: Configuración MMCE
+  MMCE_SEMA: Método de encolado de semáforo de bloqueo
+  HINT_MMCE_SEMA: THFIFO puede mejorar la compatibilidad pero empeorar el rendimiento
+  MMCE_WAIT_CYCLES: Ciclos de espera tras /ACK bajo
+  HINT_MMCE_WAIT_CYCLES: Valores más bajos pueden mejorar el rendimiento pero causar inestabilidades
+  MMCE_USE_ALARMS: Usar alarmas de tiempo de espera
+  HINT_MMCE_USE_ALARMS: OFF puede mejorar el rendimiento pero puede causar que los tiempos de espera de MMCE provoquen bloqueos
+  CORE_LOADER: Núcleo del cargador
+  NEUTRINO_BAD_FORMAT: Neutrino no soporta este formato de archivo, lanzando con núcleo <OPL>
+  NEUTRINO_NOT_FOUND: ELF de Neutrino no encontrado, lanzando con núcleo <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD necesita una IP estática en PS2. Configúrala en Red (DHCP está activo).
+  NEUTRINO_SETTING_NA: Esta configuración no se usa con el núcleo Neutrino.
+  POPSTARTER_NOT_FOUND: Falta POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Faltan requisitos SMB de POPSTARTER
+  WRITE_POPSTARTER_NET: Escribir configuración de red de POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: También guarda estos valores de IP + recurso SMB en el propio IPCONFIG.DAT / SMBCONFIG.DAT de POPSTARTER en la tarjeta de memoria (para VCD por SMB).
+  POPSTARTER_NET_ERR: No se pudo escribir la configuración de red de POPSTARTER en la tarjeta de memoria.
+  VCD: VCD
+  VCD_ON: Mostrando juegos VCD
+  VCD_OFF: Mostrando juegos de disco
+  NEUTRINO_ARGS: Argumentos de lanzamiento de Neutrino
+  HINT_NEUTRINO_ARGS: Flags adicionales de Neutrino separados por espacios (ej. -mt=dvd). Global se aplica a todos los juegos; por juego se añade encima. Prefija un flag con $ para desactivarlo sin borrarlo.
+  NEUTRINO_VIDEO: Vídeo de Neutrino
+  HINT_NEUTRINO_VIDEO: Fuerza el modo de vídeo GS de Neutrino (-gsm). Apagado mantiene el predeterminado del juego.
+  NEUTRINO_PATH: Ruta del ELF de Neutrino
+  HINT_NEUTRINO_PATH: Ruta completa a neutrino.elf (ej. mc0:NEUTRINO/neutrino.elf). En blanco = detección automática en mc0/mc1.
+  POPSTARTER_PATH: 'Ruta de POPSTARTER.ELF'
+  HINT_POPSTARTER_PATH: Ruta personalizada de POPSTARTER.ELF; usa la carpeta POPS del dispositivo si está en blanco o falta. El teclado admite hasta 31 caracteres; rutas más largas mediante settings_riptopl.cfg.
+  BDMA_SOURCE: Fuente BDMA
+  HINT_BDMA_SOURCE: Dispositivo cuya carpeta POPS contiene los archivos del controlador BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Modo BDMA
+  HINT_BDMA_MODE: Controlador de dispositivo de bloque exFAT que carga POPSTARTER. Cambiarlo copia los módulos a la tarjeta; FAT32 = ninguno (controlador integrado).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: HDD interno
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Archivos de módulo BDMA no encontrados en el dispositivo fuente.
+  BDMA_ERR_SPACE: Espacio insuficiente en la tarjeta de memoria para los módulos BDMA.
+  BDMA_ERR_IO: Error al escribir los módulos BDMA en la tarjeta de memoria.
+  COVERFLOW_SETTINGS: Configuración de Coverflow
+  COVERFLOW_COUNT: Cantidad de carátulas
+  COVERFLOW_SCALE: Escala central
+  COVERFLOW_ANIM: Velocidad de animación
+  COVERFLOW_DIM: Atenuar carátulas laterales
+  NONE: Ninguno
+  SMALL: Pequeño
+  LARGE: Grande
+  NORMAL: Normal
+  FAV: Favoritos
+  FAVMODE: Modo de inicio de favoritos
+  FAV_HINT: Favorito
+  FAV_MSG: '%s no está permitido en el menú de favoritos.'
+  FAV_PERSISTENCE_MSG: '%s no está permitido mientras el elemento está marcado como favorito.'
+  NEUTRINO_DEVICE: Dispositivo de Neutrino
+  HINT_NEUTRINO_DEVICE: Dispositivo que contiene neutrino.elf (en una carpeta NEUTRINO/ o neutrino/). Auto escanea mc0 y luego mc1.
+  NARGS_QB: Arranque rápido (-qb)
+  NARGS_CWD: Directorio de trabajo (-cwd)
+  NARGS_CFG: Configuración (-cfg)
+  NARGS_ELF: ELF de arranque (-elf)
+  NARGS_ATA0: Imagen ATA0 (-ata0)
+  NARGS_ATA0ID: ID de ATA0 (-ata0id)
+  NARGS_ATA1: Imagen ATA1 (-ata1)
+  NARGS_EXTRA: Args adicionales
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Archivo .tar de carátulas
+  DISABLE_ALL: Desactivar todo
+  BOOT_LOADING_CONFIG: Cargando ajustes...
+  BOOT_SCANNING_BDM: Analizando unidades USB / tarjeta / red...
+  BOOT_SCANNING_NET: Iniciando la red...
+  BOOT_SCANNING_HDD: Analizando HDD...
+  BOOT_READY: Listo.
+  UDPFS_GAMES: "Juegos UDPFS"
+  UDPFSBD_GAMES: "Juegos UDPFSBD"
+  NET_PROTOCOL: "Protocolo de red"
+  NET_NEEDS_NEUTRINO: "Los juegos de red (UDP) solo pueden arrancar con el núcleo Neutrino. Comprueba que neutrino.elf esté presente y que el formato sea compatible."
+  VCD_NOT_ON_NET: "Los juegos PS1 (.VCD) no se pueden iniciar a través del dispositivo de red."
+  MX4SIO_PADEMU_WARN: "MX4SIO y la emulación de mando comparten el bus SIO2 y el juego podría no arrancar."
+  HINT_OSD_SETTINGS_LNG: "Forzar una configuración de idioma personalizada"
+  OSD_SETTINGS_TVASPECT: "Tamaño de pantalla"
+  FULL_SCREEN: "Pantalla completa"
+  OSD_SETTINGS_VMODE: "Modo de vídeo"
+  SYSTEM_DEFAULT: "Predeterminado del sistema"
+  HIGH: "Alta"
+  LOW: "Baja"
+  XSENSITIVITY: "Sensibilidad analógica eje X"
+  YSENSITIVITY: "Sensibilidad analógica eje Y"
+  FILE_COUNT: "Archivos encontrados: %i"
+  CHEAT_SELECTION: "Selección de trucos"
+  HDD_HINT: "Solo se permite un HDD; activarlo bloquea APA o GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "GameID MMCE no aplicado -- neutrino.elf está en esta tarjeta (cambiarlo descargaría Neutrino)."
+  POPSTARTER_DEVICE: "Dispositivo POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Dispositivo que contiene POPS/POPSTARTER.ELF para los arranques VCD PS1. Predeterminado = dispositivo de arranque (cwd) y luego el dispositivo propio del VCD. Personalizado muestra una ruta libre."
+  BDMA_APPLY: "Aplicar VCD BDMA al iniciar"
+  HINT_BDMA_APPLY: "Activado: equipa automáticamente el controlador exFAT correspondiente del VCD iniciado en la tarjeta de memoria antes de arrancar (recomendado). Desactivado: gestiónalo tú mismo con los selectores de Origen/Modo BDMA de abajo."
+  NETBOOT_RESTART: "Reinicia OPL para aplicar el cambio de protocolo de arranque de red."
+  UDPFS_MODE: "Acceso UDPFS"
+  "MENU": "Menú"
+  "APPS": "Aplicaciones"
+  "DEBUG": "Colores de depuración"
+  "COVERART": "Carátula"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Operaciones de escritura"
+  "MODE1": "Modo 1"
+  "MODE2": "Modo 2"
+  "MODE3": "Modo 3"
+  "MODE4": "Modo 4"
+  "MODE5": "Modo 5"
+  "MODE6": "Modo 6"
+  "ENABLEGSM": "Selector GSM"
+  "OVERSCAN": "Sobrebarrido"
+  "ENABLECHEAT": "Motor de trucos PS2RD"
+  "PADEMU_ENABLE": "Emulador de mando"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulación"
+  "PADEMU_VIB": "Vibración"
+  "PADEMU_WORKAROUND": "Solución para DS3 falso"
+  "SFX": "Efectos de sonido"
+  "BOOT_SND": "Sonido de inicio"
+  "ENABLE_NOTIFICATIONS": "Notificaciones"
+  "OPTIONS": "Opciones"
+  "GLOBAL_SETTINGS": "Global"
+  "INFO_GENRE": "Género"
+  "INFO_RELEASE": "Lanzamiento"
+  "INFO_DESCRIPTION": "Descripción"
+  "BLOCKDEVICE_SETTINGS": "Dispositivos de bloque"
+  "CONTROLLER_SETTINGS": "Ajustes del mando"
+  "HINT_BDM_START": "Activa/desactiva el Gestor de dispositivos de bloque (BDM)."
+  "HINT_BLOCK_DEVICES": "Activa/desactiva los dispositivos de bloque (p. ej. USB)."
+  "USB_GAMES": "Juegos USB"
+  "ILINK_GAMES": "Juegos iLink"
+  "MX4SIO_GAMES": "Juegos MX4SIO"
+  "PADMACROCONFIG": "Configurar PADMACRO"
+  "PADMACRO_SETTINGS": "Ajustes de macros de mando"
+  "PADMACRO_ENABLE": "Macros de mando"
+  "PADMACRO_SLOWDOWN": "Ralentización analógica:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Reduce el rango del stick analógico al pulsar el botón"
+  "LEFT_ANALOG": "Stick izquierdo"
+  "RIGHT_ANALOG": "Stick derecho"
+  "PADMACRO_INVERT_AXIS": "Inversión de eje analógico:"
+  "HINT_PADMACRO_INVERT_AXIS": "Invierte el eje del stick analógico"
+  "TURBO_SPEED": "Velocidad del botón turbo"
+  "HINT_TURBO_SPEED": "Con qué rapidez pulsar el botón cuando el turbo está activo"
+  "ACT_WHILE_PRESSED": "Mientras se pulsa el botón"
+  "ACT_TOGGLED": "Alternado por el botón"
+  "LANGUAGE_JAPANESE": "JAPONÉS"
+  "LANGUAGE_ENGLISH": "INGLÉS"
+  "LANGUAGE_FRENCH": "FRANCÉS"
+  "LANGUAGE_SPANISH": "ESPAÑOL"
+  "LANGUAGE_GERMAN": "ALEMÁN"
+  "LANGUAGE_ITALIAN": "ITALIANO"
+  "LANGUAGE_DUTCH": "NEERLANDÉS"
+  "LANGUAGE_PORTUGUESE": "PORTUGUÉS"
+  "LANGUAGE_RUSSIAN": "RUSO"
+  "LANGUAGE_KOREAN": "COREANO"
+  "LANGUAGE_TRAD_CHINESE": "CHINO TRADICIONAL"
+  "LANGUAGE_SIMPL_CHINESE": "CHINO SIMPLIFICADO"
+  "OSD_SETTINGS": "Ajustes de OSD"
+  "OSD_SETTINGS_LNG": "Idioma del OSD"
+  "ENABLE_LNG": "Cambiar idioma"
+  "BGM": "Música de fondo"
+  "BGM_VOLUME": "Volumen de la música de fondo"
+  "DEF_BGM_PATH": "Música predeterminada del tema"
+  "DEF_BGM_PATH_HINT": "Define la ruta para reproducir música del tema interno."
+  "BOOT_SCANNING_MC": "Escaneando tarjetas de memoria..."
+  "BOOT_LOADING_DRIVERS": "Cargando controladores de almacenamiento..."
+  "BOOT_LOADING_USB": "Cargando controlador de almacenamiento USB..."
+  "BOOT_ARMING_MMCE": "Preparando ID de juego MMCE..."
+  "BOOT_LOADING_SOUNDS": "Cargando sonidos del tema..."
+  "BOOT_BUILDING_MENU": "Construyendo menú..."
+  "NET_UDPFS_TAB_HINT": "UDPFS activado -- abre la nueva pestaña UDPFS y pulsa Confirmar para conectar. El lado de la PC ejecuta udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Dispositivo de bloques de red activado -- su pestaña aparece una vez que el servidor de la PC responde (udpfsd -bdpath para Imagen UDPFS, udpbd-server para UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Archivo VMC por juego no encontrado -- lanzando sin él (el juego usa su tarjeta real)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino no puede iniciar desde este dispositivo -- inicio cancelado."
+  "NEUTRINO_TOML_SYNC_FAILED": "La configuración de red de Neutrino (bsd toml) falta o no se puede escribir -- lanzamiento cancelado, comprueba la carpeta de neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Demasiado fragmentado para Neutrino (%d fragmentos, límite %d incl. VMCs) -- probando el núcleo OPL en su lugar."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Demasiado fragmentado para Neutrino (%d fragmentos, límite %d incl. VMCs) -- desfragmenta en la PC; lanzamiento cancelado."
+  "NEUTRINO_GSM_COMP": "Compatibilidad GSM de Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Corrección de inversión de campos para juegos que tiemblan o se desgarran bajo un modo de Video de Neutrino forzado. Requiere un modo de Video de Neutrino establecido."
+  "NARGS_DBC": "Colores de depuración (-dbc)"
+  "NARGS_LOGO": "Logo de PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Desactivar VMC 1 (conservar tarjeta)"
+  "VMC_SLOT2_DISABLE": "Desactivar VMC 2 (conservar tarjeta)"
+  "HINT_VMC_SLOT_DISABLE": "Lanza sin la VMC de esta ranura manteniendo su tarjeta configurada. Solo para lanzamientos de Neutrino; el juego usa entonces la tarjeta real en esa ranura."
+  "NEUTRINO_BSDFS": "Sistema de archivos de Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Fuerza el sistema de archivos de dispositivo de bloques de Neutrino (-bsdfs). Auto = valor predeterminado por dispositivo. hdl/bd son opciones para expertos; combínalas con un -dvd= correspondiente en los argumentos de lanzamiento si la forma de la ruta automática no encaja."
+  "PLASCOLOR": "Color de mezcla del plasma"
+  "VCD_HIDE_GAMEID": "Ocultar ID de juego PS1 (lista VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Solo cosmético -- oculta un prefijo inicial de ID de juego (p. ej. SLUS_005.51.) de los nombres de las listas PS1/VCD. Los nombres sin ID se muestran tal cual. No cambia el lanzamiento, la carátula ni los favoritos."
+  "VCD_FIRST_DISC": "Solo primer disco (PS1 multidisco)"
+  "HINT_VCD_FIRST_DISC": "Muestra solo el Disco 1 de un juego de PS1 multidisco en las listas de dispositivos (estilo POPSLoader). Oculta los archivos llamados (Disc 2), (CD 2), etc. Todos los discos permanecen en la tarjeta para el intercambio dentro del juego; los Favoritos no se filtran."
+  "GAMES_DEVICE": "Dispositivo del juego"
+  "DEFAULT_CORE": "Núcleo de carga predeterminado"
+  "HINT_DEFAULT_CORE": "Núcleo predeterminado global para los juegos cuyo Núcleo del Cargador por juego está establecido en Predeterminado. <OPL> es el núcleo nativo; Neutrino encadena el neutrino.elf externo. Una elección por juego siempre anula esto."
+  "VCD_SETTINGS": "Ajustes de VCD"
+  "FINANCIAL_SUPPORT": "Apoyo económico"

--- a/lng_fork/Swedish.yml
+++ b/lng_fork/Swedish.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Sortera spel alfabetiskt
+  RUMBLE: Handkontrollsvibration i menyer
+  HINT_RUMBLE: Kort vibration när du flyttar markören, bekräftar eller går tillbaka -- kräver en DualShock i analogt läge
+  FOLDER_NAV: Bläddra bland mappar i spellistan
+  HINT_FOLDER_NAV: Visa undermappar på CD/DVD som bläddringsbara poster; välj för att öppna, avbryt för att gå tillbaka
+  SETTINGS_NO_HOME: Inget minneskort hittades -- inställningarna kan inte sparas. OPL startades från en nätverksenhet, vars inställningar måste finnas på ett lokalt kort.
+  ERROR_SAVING_SETTINGS_TO: Kunde inte skriva inställningarna till %s (fel %d)
+  GENERAL_SETTINGS: Allmänna inställningar
+  DEVICE_SETTINGS: Enhetsinställningar
+  LAUNCH_PS2_DISC: Starta PS2-skiva
+  DISC_LAUNCH_ERR: Ingen PS2-skiva i enheten.
+  DEFAULT: Standard
+  HINT_MODE7: Endast Neutrino -- åtgärdar spel som överskrider en IOP-buffert (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Fuskbild
+  HINT_ENABLEIMAGE: Applicera en förbyggd PS2RD .img-patch på ditt spel.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE Startläge
+  MMCE_PREFIX: MMCE Prefix-sökväg
+  MMCE_SLOT: MMCE Slot
+  MMCEIGR_SLOT: IGR Startkorts-slot(s)
+  HINT_MMCEIGR_SLOT: Kommandot att byta till startkort skickas till vald(a) slot(s) vid IGR
+  MMCE_ADVANCED: Avancerat
+  MMCE_SETTINGS: MMCE Inställningar
+  MMCE_SEMA: Lås Sema-kömetod
+  HINT_MMCE_SEMA: THFIFO kan förbättra kompatibilitet men försämra prestanda
+  MMCE_WAIT_CYCLES: Vänta cykler efter /ACK låg
+  HINT_MMCE_WAIT_CYCLES: Lägre värden kan förbättra prestanda men orsaka instabilitet
+  MMCE_USE_ALARMS: Använd timeout-alarm
+  HINT_MMCE_USE_ALARMS: AV kan förbättra prestanda men kan orsaka att MMCE-timeouts leder till frysningar
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino stöder inte detta filformat, startar med <OPL>-kärnan
+  NEUTRINO_NOT_FOUND: Neutrino ELF hittades inte, startar med <OPL>-kärnan
+  UDPBD_NEEDS_STATIC_IP: UDPBD kräver en statisk PS2-IP. Ange en i Nätverkskonfiguration (DHCP är för närvarande på).
+  NEUTRINO_SETTING_NA: Denna inställning används inte med Neutrino-kärnan.
+  POPSTARTER_NOT_FOUND: Saknar POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Saknar POPSTARTER SMB-krav
+  WRITE_POPSTARTER_NET: Skriv POPSTARTER Nätverkskonfiguration
+  HINT_WRITE_POPSTARTER_NET: Spara även dessa IP + SMB-delningsvärden till POPSTARTER's egna IPCONFIG.DAT / SMBCONFIG.DAT på minneskortet (för VCD via SMB).
+  POPSTARTER_NET_ERR: Kunde inte skriva POPSTARTER-nätverkskonfiguration till minneskortet.
+  VCD: VCD
+  VCD_ON: Visar VCD-spel
+  VCD_OFF: Visar skivspel
+  NEUTRINO_ARGS: Neutrino Startargument
+  HINT_NEUTRINO_ARGS: Extra Neutrino-flaggor, blankstegsavskilda (t.ex. -mt=dvd). Global gäller alla spel; per-spel läggs till ovanpå. Prefix en flagga med $ för att inaktivera den utan att ta bort den.
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: Tvinga Neutrinos GS-utdatavideoläge (-gsm). Av behåller spelets standard.
+  NEUTRINO_PATH: Neutrino ELF Sökväg
+  HINT_NEUTRINO_PATH: Fullständig sökväg till neutrino.elf (t.ex. mc0:NEUTRINO/neutrino.elf). Tom = automatisk sökning på mc0/mc1.
+  POPSTARTER_PATH: POPSTARTER.ELF Sökväg
+  HINT_POPSTARTER_PATH: Anpassad POPSTARTER.ELF-sökväg; faller tyst tillbaka till enhetens POPS-mapp om tom/saknas. Tangentbord begränsas till 31 tecken; längre sökvägar via settings_riptopl.cfg.
+  BDMA_SOURCE: BDMA Källa
+  HINT_BDMA_SOURCE: Enhet vars POPS-mapp innehåller dina BDMAssault-drivrutinsfiler (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: BDMA Läge
+  HINT_BDMA_MODE: exFAT-blockenhets-drivrutin som POPSTARTER läser in. Att ändra detta kopierar modulerna till kortet; FAT32 = ingen (inbyggd drivrutin).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Intern HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: BDMA-modulfiler hittades inte på källenheten.
+  BDMA_ERR_SPACE: Otillräckligt minneskortsutrymme för BDMA-modulerna.
+  BDMA_ERR_IO: Fel vid skrivning av BDMA-modulerna till minneskortet.
+  COVERFLOW_SETTINGS: Coverflow Inställningar
+  COVERFLOW_COUNT: Antal omslag
+  COVERFLOW_SCALE: Centrumskala
+  COVERFLOW_ANIM: Animationshastighet
+  COVERFLOW_DIM: Dämpa sidoomslag
+  NONE: Ingen
+  SMALL: Liten
+  LARGE: Stor
+  NORMAL: Normal
+  FAV: Favoriter
+  FAVMODE: Favoriter Startläge
+  FAV_HINT: Favorit
+  FAV_MSG: '%s är inte tillåtet via Favoritmenyn.'
+  FAV_PERSISTENCE_MSG: '%s är inte tillåtet medan objektet är markerat som favorit.'
+  NEUTRINO_DEVICE: Neutrino-enhet
+  HINT_NEUTRINO_DEVICE: Enhet som innehåller neutrino.elf (i en NEUTRINO/- eller neutrino/-mapp). Auto söker igenom mc0 sedan mc1.
+  NARGS_QB: Snabbstart (-qb)
+  NARGS_CWD: Arbetskatalog (-cwd)
+  NARGS_CFG: Konfiguration (-cfg)
+  NARGS_ELF: Start-ELF (-elf)
+  NARGS_ATA0: ATA0-avbild (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1-avbild (-ata1)
+  NARGS_EXTRA: Extra argument
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: .tar-arkiv med omslag
+  DISABLE_ALL: Inaktivera alla
+  BOOT_LOADING_CONFIG: Läser in inställningar...
+  BOOT_SCANNING_BDM: Söker igenom USB / kort / nätverksenheter...
+  BOOT_SCANNING_NET: Startar nätverk...
+  BOOT_SCANNING_HDD: Söker igenom HDD...
+  BOOT_READY: Klar.
+  UDPFS_GAMES: "UDPFS-spel"
+  UDPFSBD_GAMES: "UDPFSBD-spel"
+  NET_PROTOCOL: "Nätverksprotokoll"
+  NET_NEEDS_NEUTRINO: "Nätverksspel (UDP) kan bara starta via Neutrino-kärnan. Kontrollera att neutrino.elf finns och att formatet stöds."
+  VCD_NOT_ON_NET: "PS1-spel (.VCD) kan inte startas via nätverksenheten."
+  MX4SIO_PADEMU_WARN: "MX4SIO och handkontrollsemulering delar SIO2-bussen och spelet kanske inte startar."
+  HINT_OSD_SETTINGS_LNG: "Tvinga en anpassad språkinställning"
+  OSD_SETTINGS_TVASPECT: "Skärmstorlek"
+  FULL_SCREEN: "Helskärm"
+  OSD_SETTINGS_VMODE: "Videoläge"
+  SYSTEM_DEFAULT: "Systemstandard"
+  HIGH: "Hög"
+  LOW: "Låg"
+  XSENSITIVITY: "Känslighet analog X-axel"
+  YSENSITIVITY: "Känslighet analog Y-axel"
+  FILE_COUNT: "Filer hittade: %i"
+  CHEAT_SELECTION: "Fuskval"
+  HDD_HINT: "Endast en HDD tillåts; aktivering låser APA eller GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID tillämpades inte -- neutrino.elf finns på detta kort (att byta skulle ladda ur Neutrino)."
+  POPSTARTER_DEVICE: "POPSTARTER.ELF-enhet"
+  HINT_POPSTARTER_DEVICE: "Enhet med POPS/POPSTARTER.ELF för start av PS1-VCD:er. Standard = startenhet (cwd) sedan VCD:ns egen enhet. Anpassad visar ett fritt sökvägsfält."
+  BDMA_APPLY: "Tillämpa VCD BDMA vid start"
+  HINT_BDMA_APPLY: "På: utrustar automatiskt den startade VCD:ns matchande exFAT-drivrutin på minneskortet före start (rekommenderas). Av: hantera det själv med BDMA-källa/läge-väljarna nedan."
+  NETBOOT_RESTART: "Starta om OPL för att tillämpa ändringen av nätverksstartprotokollet."
+  UDPFS_MODE: "UDPFS-åtkomst"
+  "MENU": "Meny"
+  "APPS": "Appar"
+  "DEBUG": "Felsökningsfärger"
+  "COVERART": "Omslagsbild"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Skrivåtgärder"
+  "MODE1": "Läge 1"
+  "MODE2": "Läge 2"
+  "MODE3": "Läge 3"
+  "MODE4": "Läge 4"
+  "MODE5": "Läge 5"
+  "MODE6": "Läge 6"
+  "ENABLEGSM": "GSM-väljare"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD Fuskmotor"
+  "PADEMU_ENABLE": "Handkontrollsemulator"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emulering"
+  "PADEMU_VIB": "Vibration"
+  "PADEMU_WORKAROUND": "Falsk DS3-lösning"
+  "SFX": "Ljudeffekter"
+  "BOOT_SND": "Startljud"
+  "ENABLE_NOTIFICATIONS": "Notiser"
+  "OPTIONS": "Alternativ"
+  "GLOBAL_SETTINGS": "Globalt"
+  "INFO_GENRE": "Genre"
+  "INFO_RELEASE": "Utgivning"
+  "INFO_DESCRIPTION": "Beskrivning"
+  "BLOCKDEVICE_SETTINGS": "Blockenheter"
+  "CONTROLLER_SETTINGS": "Handkontrollsinställningar"
+  "HINT_BDM_START": "Slå på/av Block Device Manager."
+  "HINT_BLOCK_DEVICES": "Slå på/av blockenheter (t.ex. USB)."
+  "USB_GAMES": "USB-spel"
+  "ILINK_GAMES": "iLink-spel"
+  "MX4SIO_GAMES": "MX4SIO-spel"
+  "PADMACROCONFIG": "Konfigurera PADMACRO"
+  "PADMACRO_SETTINGS": "Pad-makroinställningar"
+  "PADMACRO_ENABLE": "Pad-makron"
+  "PADMACRO_SLOWDOWN": "Analog nedbromsning:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Minska den analoga spakens omfång när knappen trycks in"
+  "LEFT_ANALOG": "Vänster spak"
+  "RIGHT_ANALOG": "Höger spak"
+  "PADMACRO_INVERT_AXIS": "Invertera analog axel:"
+  "HINT_PADMACRO_INVERT_AXIS": "Invertera den analoga spakens axel"
+  "TURBO_SPEED": "Turboknappens hastighet"
+  "HINT_TURBO_SPEED": "Hur snabbt knappen trycks in när turbo är aktiv"
+  "ACT_WHILE_PRESSED": "Medan knappen hålls in"
+  "ACT_TOGGLED": "Växlas med knappen"
+  "LANGUAGE_JAPANESE": "JAPANSKA"
+  "LANGUAGE_ENGLISH": "ENGELSKA"
+  "LANGUAGE_FRENCH": "FRANSKA"
+  "LANGUAGE_SPANISH": "SPANSKA"
+  "LANGUAGE_GERMAN": "TYSKA"
+  "LANGUAGE_ITALIAN": "ITALIENSKA"
+  "LANGUAGE_DUTCH": "NEDERLÄNDSKA"
+  "LANGUAGE_PORTUGUESE": "PORTUGISISKA"
+  "LANGUAGE_RUSSIAN": "RYSKA"
+  "LANGUAGE_KOREAN": "KOREANSKA"
+  "LANGUAGE_TRAD_CHINESE": "TRADITIONELL KINESISKA"
+  "LANGUAGE_SIMPL_CHINESE": "FÖRENKLAD KINESISKA"
+  "OSD_SETTINGS": "OSD-inställningar"
+  "OSD_SETTINGS_LNG": "OSD-språk"
+  "ENABLE_LNG": "Byt språk"
+  "BGM": "Bakgrundsmusik"
+  "BGM_VOLUME": "Bakgrundsmusikvolym"
+  "DEF_BGM_PATH": "Standardtemamusik"
+  "DEF_BGM_PATH_HINT": "Ange sökväg för att strömma musik till det interna temat."
+  "BOOT_SCANNING_MC": "Söker efter minneskort..."
+  "BOOT_LOADING_DRIVERS": "Läser in lagringsdrivrutiner..."
+  "BOOT_LOADING_USB": "Läser in USB-lagringsdrivrutin..."
+  "BOOT_ARMING_MMCE": "Aktiverar MMCE spel-ID..."
+  "BOOT_LOADING_SOUNDS": "Läser in temaljud..."
+  "BOOT_BUILDING_MENU": "Bygger meny..."
+  "NET_UDPFS_TAB_HINT": "UDPFS på -- öppna den nya UDPFS-fliken och tryck Bekräfta för att ansluta. På PC-sidan körs udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Nätverksblockenhet på -- dess flik visas när PC-servern svarar (udpfsd -bdpath för UDPFS Image, udpbd-server för UDPBD)."
+  "NEUTRINO_VMC_MISSING": "VMC-fil per spel hittades inte -- startar utan den (spelet använder sitt verkliga kort)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino kan inte starta från denna enhet -- start avbruten."
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrinos nätverkskonfiguration (bsd toml) saknas eller går inte att skriva -- start avbruten, kontrollera neutrino-mappen."
+  "NEUTRINO_TOO_FRAGMENTED": "För fragmenterad för Neutrino (%d fragment, gräns %d inkl. VMC) -- försöker med OPL-kärnan istället."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "För fragmenterad för Neutrino (%d fragment, gräns %d inkl. VMC) -- defragmentera på PC:n; start avbruten."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM-kompatibilitet"
+  "HINT_NEUTRINO_GSM_COMP": "Fältväxlingsfix för spel som skakar eller river under ett framtvingat Neutrino Video-läge. Kräver att ett Neutrino Video-läge är inställt."
+  "NARGS_DBC": "Felsökningsfärger (-dbc)"
+  "NARGS_LOGO": "PS2-logotyp (-logo)"
+  "VMC_SLOT1_DISABLE": "Inaktivera VMC 1 (behåll kort)"
+  "VMC_SLOT2_DISABLE": "Inaktivera VMC 2 (behåll kort)"
+  "HINT_VMC_SLOT_DISABLE": "Starta utan denna plats VMC medan dess kort förblir konfigurerat. Endast Neutrino-start; spelet använder då det verkliga kortet i den platsen."
+  "NEUTRINO_BSDFS": "Neutrino-filsystem"
+  "HINT_NEUTRINO_BSDFS": "Tvinga Neutrinos blockenhets-filsystem (-bsdfs). Auto = standard per enhet. hdl/bd är expertalternativ; kombinera dem med ett matchande -dvd= i startargumenten om den automatiska sökvägsformen inte passar."
+  "PLASCOLOR": "Plasmablandningsfärg"
+  "VCD_HIDE_GAMEID": "Dölj PS1 spel-ID (VCD-lista)"
+  "HINT_VCD_HIDE_GAMEID": "Endast kosmetiskt -- dölj ett inledande spel-ID-prefix (t.ex. SLUS_005.51.) från namn i PS1/VCD-listan. Namn utan ett ID visas som de är. Ändrar inte start, omslagsbilder eller favoriter."
+  "VCD_FIRST_DISC": "Endast första skivan (flerskivig PS1)"
+  "HINT_VCD_FIRST_DISC": "Visa endast Disc 1 av ett PS1-spel med flera skivor i enhetslistorna (POPSLoader-stil). Döljer filer med namn som (Disc 2), (CD 2) osv. Alla skivor stannar kvar på kortet för byte under spelet; Favoriter filtreras inte."
+  "GAMES_DEVICE": "Spelets enhet"
+  "DEFAULT_CORE": "Standardladdarkärna"
+  "HINT_DEFAULT_CORE": "Global standardkärna för spel vars Loader Core per spel är inställd på Default. <OPL> är den inbyggda kärnan; Neutrino kedjar den externa neutrino.elf. Ett val per spel åsidosätter alltid detta."
+  "VCD_SETTINGS": "VCD-inställningar"
+  "FINANCIAL_SUPPORT": "Ekonomiskt stöd"

--- a/lng_fork/TChinese.yml
+++ b/lng_fork/TChinese.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: 遊戲按字母排序
+  RUMBLE: 選單中控制器震動
+  HINT_RUMBLE: 移動游標、確認或返回時短暫震動 -- 需要類比模式的 DualShock
+  FOLDER_NAV: 在遊戲清單中瀏覽資料夾
+  HINT_FOLDER_NAV: 將 CD/DVD 的子資料夾顯示為可瀏覽項目，選取開啟，取消返回
+  SETTINGS_NO_HOME: 找不到記憶卡 -- 無法儲存設定。OPL 從網路裝置啟動，設定必須存放在本機記憶卡上。
+  ERROR_SAVING_SETTINGS_TO: 無法將設定寫入 %s（錯誤 %d）
+  GENERAL_SETTINGS: 一般設定
+  DEVICE_SETTINGS: 裝置設定
+  LAUNCH_PS2_DISC: 啟動 PS2 光碟
+  DISC_LAUNCH_ERR: 光碟機中沒有 PS2 光碟。
+  DEFAULT: 預設
+  HINT_MODE7: 僅限 Neutrino — 修正導致 IOP 緩衝區溢位的遊戲 (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD 金手指映像
+  HINT_ENABLEIMAGE: 為遊戲套用預建的 PS2RD .img 補丁。
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: MMCE 啟動模式
+  MMCE_PREFIX: MMCE 前置路徑
+  MMCE_SLOT: MMCE 插槽
+  MMCEIGR_SLOT: IGR 開機卡插槽
+  HINT_MMCEIGR_SLOT: IGR 時，切換開機卡指令將發送至所選插槽
+  MMCE_ADVANCED: 進階
+  MMCE_SETTINGS: MMCE 設定
+  MMCE_SEMA: 鎖定 Sema 排隊方式
+  HINT_MMCE_SEMA: THFIFO 可能提升相容性，但會降低效能
+  MMCE_WAIT_CYCLES: /ACK 低電位後等待週期數
+  HINT_MMCE_WAIT_CYCLES: 較低的值可能提升效能，但可能造成不穩定
+  MMCE_USE_ALARMS: 使用逾時警報
+  HINT_MMCE_USE_ALARMS: 關閉可能提升效能，但 MMCE 逾時時可能造成當機
+  CORE_LOADER: 核心載入器
+  NEUTRINO_BAD_FORMAT: Neutrino 不支援此檔案格式，改以 <OPL> 核心啟動
+  NEUTRINO_NOT_FOUND: 找不到 Neutrino ELF，改以 <OPL> 核心啟動
+  UDPBD_NEEDS_STATIC_IP: UDPBD 需要靜態 PS2 IP。請在網路設定中指定（目前已啟用 DHCP）。
+  NEUTRINO_SETTING_NA: 此設定不適用於 Neutrino 核心。
+  POPSTARTER_NOT_FOUND: 找不到 POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: POPSTARTER SMB 相依檔案不存在
+  WRITE_POPSTARTER_NET: 寫入 POPSTARTER 網路設定
+  HINT_WRITE_POPSTARTER_NET: 同時將 IP 及 SMB 共享值儲存至記憶卡上 POPSTARTER 自身的 IPCONFIG.DAT / SMBCONFIG.DAT（用於 VCD over SMB）。
+  POPSTARTER_NET_ERR: 無法將 POPSTARTER 網路設定寫入記憶卡。
+  VCD: VCD
+  VCD_ON: 顯示 VCD 遊戲
+  VCD_OFF: 顯示光碟遊戲
+  NEUTRINO_ARGS: Neutrino 啟動參數
+  HINT_NEUTRINO_ARGS: 額外的 Neutrino 旗標，以空格分隔（例如 -mt=dvd）。全域設定套用至所有遊戲；個別遊戲設定疊加於其上。在旗標前加 $ 可停用而不刪除。
+  NEUTRINO_VIDEO: Neutrino 影像
+  HINT_NEUTRINO_VIDEO: 強制指定 Neutrino 的 GS 輸出影像模式 (-gsm)。關閉則保留遊戲預設值。
+  NEUTRINO_PATH: Neutrino ELF 路徑
+  HINT_NEUTRINO_PATH: neutrino.elf 的完整路徑（例如 mc0:NEUTRINO/neutrino.elf）。留空則自動在 mc0/mc1 偵測。
+  POPSTARTER_PATH: POPSTARTER.ELF 路徑
+  HINT_POPSTARTER_PATH: 自訂 POPSTARTER.ELF 路徑；留空或找不到時自動改用裝置 POPS 資料夾。鍵盤輸入上限 31 字元；較長路徑請透過 settings_riptopl.cfg 設定。
+  BDMA_SOURCE: BDMA 來源
+  HINT_BDMA_SOURCE: 存放 BDMAssault 驅動程式檔案 (usbd.irx.* / usbhdfsd.irx.*) 之 POPS 資料夾所在裝置。
+  BDMA_MODE: BDMA 模式
+  HINT_BDMA_MODE: POPSTARTER 載入的 exFAT 區塊裝置驅動程式。變更時會將模組複製至記憶卡；FAT32 = 無（使用內建驅動程式）。
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: 內置硬碟
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: 在來源裝置上找不到 BDMA 模組檔案。
+  BDMA_ERR_SPACE: 記憶卡空間不足，無法存放 BDMA 模組。
+  BDMA_ERR_IO: 將 BDMA 模組寫入記憶卡時發生錯誤。
+  COVERFLOW_SETTINGS: Coverflow 設定
+  COVERFLOW_COUNT: 封面數量
+  COVERFLOW_SCALE: 中央縮放
+  COVERFLOW_ANIM: 動畫速度
+  COVERFLOW_DIM: 暗化側邊封面
+  NONE: 無
+  SMALL: 小
+  LARGE: 大
+  NORMAL: 正常
+  FAV: 最愛
+  FAVMODE: 最愛啟動模式
+  FAV_HINT: 最愛
+  FAV_MSG: '%s 不允許透過最愛選單操作。'
+  FAV_PERSISTENCE_MSG: '%s 在項目標記為最愛時不可使用。'
+  NEUTRINO_DEVICE: Neutrino 裝置
+  HINT_NEUTRINO_DEVICE: 存放 neutrino.elf 的裝置（位於 NEUTRINO/ 或 neutrino/ 資料夾）。Auto 模式依序掃描 mc0 再掃描 mc1。
+  NARGS_QB: 快速開機 (-qb)
+  NARGS_CWD: 工作目錄 (-cwd)
+  NARGS_CFG: 設定檔 (-cfg)
+  NARGS_ELF: 開機 ELF (-elf)
+  NARGS_ATA0: ATA0 映像 (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 映像 (-ata1)
+  NARGS_EXTRA: 額外參數
+  NARGS_AUTO_NOTE: 'Auto: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: 封面圖 .tar 封存檔
+  DISABLE_ALL: 全部停用
+  BOOT_LOADING_CONFIG: 正在載入設定...
+  BOOT_SCANNING_BDM: 正在掃描 USB / 記憶卡 / 網路磁碟...
+  BOOT_SCANNING_NET: 正在啟動網路...
+  BOOT_SCANNING_HDD: 正在掃描 HDD...
+  BOOT_READY: 就緒。
+  UDPFS_GAMES: "UDPFS 遊戲"
+  UDPFSBD_GAMES: "UDPFSBD 遊戲"
+  NET_PROTOCOL: "網路協定"
+  NET_NEEDS_NEUTRINO: "網路（UDP）遊戲只能透過 Neutrino 核心啟動。請檢查 neutrino.elf 是否存在且格式受支援。"
+  VCD_NOT_ON_NET: "PS1（.VCD）遊戲無法透過網路裝置啟動。"
+  MX4SIO_PADEMU_WARN: "MX4SIO 與手把模擬共用 SIO2 匯流排，遊戲可能無法啟動。"
+  HINT_OSD_SETTINGS_LNG: "強制使用自訂語言設定"
+  OSD_SETTINGS_TVASPECT: "螢幕尺寸"
+  FULL_SCREEN: "全螢幕"
+  OSD_SETTINGS_VMODE: "視訊模式"
+  SYSTEM_DEFAULT: "系統預設"
+  HIGH: "高"
+  LOW: "低"
+  XSENSITIVITY: "類比搖桿 X 軸靈敏度"
+  YSENSITIVITY: "類比搖桿 Y 軸靈敏度"
+  FILE_COUNT: "找到檔案：%i"
+  CHEAT_SELECTION: "金手指選擇"
+  HDD_HINT: "僅允許一個 HDD，啟用後將鎖定為 APA 或 GPT。"
+  MMCE_GAMEID_NEUTRINO_SKIP: "未套用 MMCE GameID -- 此卡上存在 neutrino.elf（切換會卸載 Neutrino）。"
+  POPSTARTER_DEVICE: "POPSTARTER.ELF 裝置"
+  HINT_POPSTARTER_DEVICE: "用於 PS1 VCD 啟動、存放 POPS/POPSTARTER.ELF 的裝置。預設 = 啟動裝置（cwd），其次為 VCD 自身裝置。自訂會顯示自由輸入路徑。"
+  BDMA_APPLY: "啟動時套用 VCD BDMA"
+  HINT_BDMA_APPLY: "開啟：啟動前自動將所啟動 VCD 對應的 exFAT 驅動裝載到記憶卡（建議）。關閉：使用下方的 BDMA 來源/模式選擇器自行管理。"
+  NETBOOT_RESTART: "重新啟動 OPL 以套用網路啟動協定的變更。"
+  UDPFS_MODE: "UDPFS 存取"
+  "MENU": "選單"
+  "APPS": "應用程式"
+  "DEBUG": "除錯顏色"
+  "COVERART": "封面圖"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "寫入操作"
+  "MODE1": "模式 1"
+  "MODE2": "模式 2"
+  "MODE3": "模式 3"
+  "MODE4": "模式 4"
+  "MODE5": "模式 5"
+  "MODE6": "模式 6"
+  "ENABLEGSM": "GSM 選擇器"
+  "OVERSCAN": "過掃描"
+  "ENABLECHEAT": "PS2RD 金手指引擎"
+  "PADEMU_ENABLE": "手把模擬器"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "模擬"
+  "PADEMU_VIB": "震動"
+  "PADEMU_WORKAROUND": "偽 DS3 相容處理"
+  "SFX": "音效"
+  "BOOT_SND": "開機音效"
+  "ENABLE_NOTIFICATIONS": "通知"
+  "OPTIONS": "選項"
+  "GLOBAL_SETTINGS": "全域"
+  "INFO_GENRE": "類型"
+  "INFO_RELEASE": "發行"
+  "INFO_DESCRIPTION": "說明"
+  "BLOCKDEVICE_SETTINGS": "區塊裝置"
+  "CONTROLLER_SETTINGS": "控制器設定"
+  "HINT_BDM_START": "開啟／關閉區塊裝置管理員。"
+  "HINT_BLOCK_DEVICES": "開啟／關閉區塊裝置（例如 USB）。"
+  "USB_GAMES": "USB 遊戲"
+  "ILINK_GAMES": "iLink 遊戲"
+  "MX4SIO_GAMES": "MX4SIO 遊戲"
+  "PADMACROCONFIG": "設定 PADMACRO"
+  "PADMACRO_SETTINGS": "手把巨集設定"
+  "PADMACRO_ENABLE": "手把巨集"
+  "PADMACRO_SLOWDOWN": "類比減速："
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "按下按鈕時降低類比搖桿的範圍"
+  "LEFT_ANALOG": "左搖桿"
+  "RIGHT_ANALOG": "右搖桿"
+  "PADMACRO_INVERT_AXIS": "類比軸反轉："
+  "HINT_PADMACRO_INVERT_AXIS": "反轉類比搖桿軸向"
+  "TURBO_SPEED": "連發按鈕速度"
+  "HINT_TURBO_SPEED": "連發啟用時按下按鈕的速度"
+  "ACT_WHILE_PRESSED": "按住按鈕時"
+  "ACT_TOGGLED": "以按鈕切換"
+  "LANGUAGE_JAPANESE": "日文"
+  "LANGUAGE_ENGLISH": "英文"
+  "LANGUAGE_FRENCH": "法文"
+  "LANGUAGE_SPANISH": "西班牙文"
+  "LANGUAGE_GERMAN": "德文"
+  "LANGUAGE_ITALIAN": "義大利文"
+  "LANGUAGE_DUTCH": "荷蘭文"
+  "LANGUAGE_PORTUGUESE": "葡萄牙文"
+  "LANGUAGE_RUSSIAN": "俄文"
+  "LANGUAGE_KOREAN": "韓文"
+  "LANGUAGE_TRAD_CHINESE": "繁體中文"
+  "LANGUAGE_SIMPL_CHINESE": "簡體中文"
+  "OSD_SETTINGS": "OSD 設定"
+  "OSD_SETTINGS_LNG": "OSD 語言"
+  "ENABLE_LNG": "變更語言"
+  "BGM": "背景音樂"
+  "BGM_VOLUME": "背景音樂音量"
+  "DEF_BGM_PATH": "預設主題音樂"
+  "DEF_BGM_PATH_HINT": "設定內建主題串流音樂的路徑。"
+  "BOOT_SCANNING_MC": "正在掃描記憶卡…"
+  "BOOT_LOADING_DRIVERS": "正在載入儲存裝置驅動程式…"
+  "BOOT_LOADING_USB": "正在載入 USB 儲存裝置驅動程式…"
+  "BOOT_ARMING_MMCE": "正在啟用 MMCE game-ID…"
+  "BOOT_LOADING_SOUNDS": "正在載入主題音效…"
+  "BOOT_BUILDING_MENU": "正在建立選單…"
+  "NET_UDPFS_TAB_HINT": "UDPFS 已開啟——開啟新的 UDPFS 分頁並按下確認以連線。PC 端執行 udpfsd -fsroot <games folder>。"
+  "NET_UDPBD_TAB_HINT": "網路區塊裝置已開啟——當 PC 伺服器回應後，其分頁便會出現（UDPFS 映像用 udpfsd -bdpath，UDPBD 用 udpbd-server）。"
+  "NEUTRINO_VMC_MISSING": "找不到各遊戲的 VMC 檔案——將不使用它啟動（遊戲會使用其實體卡片）。"
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino 無法從此裝置啟動 -- 已中止啟動。"
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino 網路設定（bsd toml）遺失或無法寫入——已中止啟動，請檢查 neutrino 資料夾。"
+  "NEUTRINO_TOO_FRAGMENTED": "對 Neutrino 而言過於分散（%d 個片段，上限 %d 含 VMC）——改為嘗試 OPL 核心。"
+  "NEUTRINO_TOO_FRAGMENTED_NET": "對 Neutrino 而言過於分散（%d 個片段，上限 %d 含 VMC）——請在 PC 上進行重組；已中止啟動。"
+  "NEUTRINO_GSM_COMP": "Neutrino GSM 相容性"
+  "HINT_NEUTRINO_GSM_COMP": "針對在強制 Neutrino Video 模式下抖動或撕裂的遊戲，提供欄位翻轉（field-flipping）修正。需先設定 Neutrino Video 模式。"
+  "NARGS_DBC": "除錯顏色 (-dbc)"
+  "NARGS_LOGO": "PS2 標誌 (-logo)"
+  "VMC_SLOT1_DISABLE": "停用 VMC 1（保留卡片）"
+  "VMC_SLOT2_DISABLE": "停用 VMC 2（保留卡片）"
+  "HINT_VMC_SLOT_DISABLE": "在保留此插槽卡片設定的情況下，不使用此插槽的 VMC 啟動。僅限 Neutrino 啟動；遊戲隨後會使用該插槽中的實體卡片。"
+  "NEUTRINO_BSDFS": "Neutrino 檔案系統"
+  "HINT_NEUTRINO_BSDFS": "強制指定 Neutrino 的區塊裝置檔案系統（-bsdfs）。Auto = 各裝置預設值。hdl/bd 為進階選項；若自動路徑形式不符，請在啟動參數中搭配對應的 -dvd= 使用。"
+  "PLASCOLOR": "電漿混合顏色"
+  "VCD_HIDE_GAMEID": "隱藏 PS1 遊戲 ID（VCD 清單）"
+  "HINT_VCD_HIDE_GAMEID": "僅為外觀效果——在 PS1/VCD 清單名稱中隱藏開頭的遊戲 ID 前綴（例如 SLUS_005.51.）。沒有 ID 的名稱會照原樣顯示。不會變更啟動、封面圖或我的最愛。"
+  "VCD_FIRST_DISC": "僅第一片光碟（多片 PS1）"
+  "HINT_VCD_FIRST_DISC": "在裝置清單中只顯示多光碟 PS1 遊戲的第 1 片光碟（POPSLoader 風格）。隱藏名稱含 (Disc 2)、(CD 2) 等的檔案。所有光碟仍保留在卡片上以供遊戲中切換；我的最愛不受篩選影響。"
+  "GAMES_DEVICE": "遊戲裝置"
+  "DEFAULT_CORE": "預設載入核心"
+  "HINT_DEFAULT_CORE": "當各遊戲的 Loader Core 設為 Default 時，套用的全域預設核心。<OPL> 為原生核心；Neutrino 會串接外部的 neutrino.elf。各遊戲的個別選擇一律優先於此設定。"
+  "VCD_SETTINGS": "VCD 設定"
+  "FINANCIAL_SUPPORT": "財務支持"

--- a/lng_fork/Turkish.yml
+++ b/lng_fork/Turkish.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Oyunları Alfabetik Sırala
+  RUMBLE: Menülerde Kumanda Titreşimi
+  HINT_RUMBLE: İmleci taşırken, onaylarken veya geri dönerken kısa titreşim -- analog moddaki bir DualShock gerekir
+  FOLDER_NAV: Oyun Listesinde Klasörlere Göz At
+  HINT_FOLDER_NAV: CD/DVD alt klasörlerini gezilebilir öğeler olarak göster; açmak için seç, geri dönmek için iptal et
+  SETTINGS_NO_HOME: Hafıza kartı bulunamadı -- ayarlar kaydedilemez. OPL bir ağ aygıtından başlatıldı, ayarları yerel bir kartta durmalı.
+  ERROR_SAVING_SETTINGS_TO: Ayarlar %s konumuna yazılamadı (hata %d)
+  GENERAL_SETTINGS: Genel Ayarlar
+  DEVICE_SETTINGS: Cihaz Ayarları
+  LAUNCH_PS2_DISC: PS2 Diski Başlat
+  DISC_LAUNCH_ERR: Sürücüde PS2 diski yok.
+  DEFAULT: Varsayılan
+  HINT_MODE7: Yalnızca Neutrino -- IOP arabelleğini aşan oyunları düzeltir (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: PS2RD Hile Görüntüsü
+  HINT_ENABLEIMAGE: Oyununuza önceden derlenmiş bir PS2RD .img yaması uygulayın.
+  UDPBD_GAMES: UDPBD Oyunları
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Oyunları
+  MMCEMODE: MMCE Başlangıç Modu
+  MMCE_PREFIX: MMCE Önek Yolu
+  MMCE_SLOT: MMCE Yuvası
+  MMCEIGR_SLOT: IGR Önyükleme Kartı Yuvası
+  HINT_MMCEIGR_SLOT: IGR'de seçili yuvalara önyükleme kartı komutu gönderilir
+  MMCE_ADVANCED: Gelişmiş
+  MMCE_SETTINGS: MMCE Ayarları
+  MMCE_SEMA: Kilit Sema Sıralama Yöntemi
+  HINT_MMCE_SEMA: THFIFO uyumluluğu artırabilir ancak performansı düşürebilir
+  MMCE_WAIT_CYCLES: /ACK düşüşünden sonra bekleme döngüleri
+  HINT_MMCE_WAIT_CYCLES: Düşük değerler performansı artırabilir ancak kararsızlığa yol açabilir
+  MMCE_USE_ALARMS: Zaman aşımı alarmlarını kullan
+  HINT_MMCE_USE_ALARMS: KAPALI performansı artırabilir ancak MMCE zaman aşımları donmalara neden olabilir
+  CORE_LOADER: Yükleyici Çekirdeği
+  NEUTRINO_BAD_FORMAT: Neutrino bu dosya biçimini desteklemiyor, <OPL> çekirdeğiyle başlatılıyor
+  NEUTRINO_NOT_FOUND: Neutrino ELF bulunamadı, <OPL> çekirdeğiyle başlatılıyor
+  UDPBD_NEEDS_STATIC_IP: UDPBD sabit bir PS2 IP adresi gerektirir. Ağ Ayarlarından belirleyin (DHCP şu an açık).
+  NEUTRINO_SETTING_NA: Bu ayar Neutrino çekirdeğiyle kullanılmaz.
+  POPSTARTER_NOT_FOUND: POPSTARTER.ELF eksik
+  POPSTARTER_SMB_MISSING: POPSTARTER SMB gereksinimleri eksik
+  WRITE_POPSTARTER_NET: POPSTARTER Ağ Yapılandırmasını Yaz
+  HINT_WRITE_POPSTARTER_NET: Bu IP + SMB paylaşım değerlerini hafıza kartındaki POPSTARTER'ın IPCONFIG.DAT / SMBCONFIG.DAT dosyalarına da kaydet (SMB üzerinden VCD için).
+  POPSTARTER_NET_ERR: POPSTARTER ağ yapılandırması hafıza kartına yazılamadı.
+  VCD: VCD
+  VCD_ON: VCD oyunları gösteriliyor
+  VCD_OFF: Disk oyunları gösteriliyor
+  NEUTRINO_ARGS: Neutrino Başlatma Parametreleri
+  HINT_NEUTRINO_ARGS: 'Ekstra Neutrino bayrakları, boşlukla ayrılmış (ör. -mt=dvd). Global tüm oyunlara uygulanır; oyun başına üstüne eklenir. Bir bayrağı silmeden devre dışı bırakmak için $ öneki ekleyin.'
+  NEUTRINO_VIDEO: Neutrino Video
+  HINT_NEUTRINO_VIDEO: "Neutrino'nun GS çıkış video modunu zorla (-gsm). Kapalı = oyunun varsayılanını kullan."
+  NEUTRINO_PATH: Neutrino ELF Yolu
+  HINT_NEUTRINO_PATH: neutrino.elf için tam yol (ör. mc0:NEUTRINO/neutrino.elf). Boş = mc0/mc1 üzerinde otomatik algıla.
+  POPSTARTER_PATH: POPSTARTER.ELF Yolu
+  HINT_POPSTARTER_PATH: Özel POPSTARTER.ELF yolu; boş/eksikse cihazın POPS klasörüne geri döner. Klavye 31 karakterle sınırlıdır; daha uzun yollar için settings_riptopl.cfg kullanın.
+  BDMA_SOURCE: BDMA Kaynağı
+  HINT_BDMA_SOURCE: BDMAssault sürücü dosyalarını (usbd.irx.* / usbhdfsd.irx.*) barındıran POPS klasörünün bulunduğu cihaz.
+  BDMA_MODE: BDMA Modu
+  HINT_BDMA_MODE: POPSTARTER'ın yüklediği exFAT blok aygıtı sürücüsü. Değiştirmek modülleri karta kopyalar; FAT32 = yok (yerleşik sürücü).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Dahili HDD
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: BDMA modül dosyaları kaynak cihazda bulunamadı.
+  BDMA_ERR_SPACE: Hafıza kartında BDMA modülleri için yeterli alan yok.
+  BDMA_ERR_IO: BDMA modülleri hafıza kartına yazılırken hata oluştu.
+  COVERFLOW_SETTINGS: Coverflow Ayarları
+  COVERFLOW_COUNT: Kapak Sayısı
+  COVERFLOW_SCALE: Merkez Ölçeği
+  COVERFLOW_ANIM: Animasyon Hızı
+  COVERFLOW_DIM: Yan Kapakları Karart
+  NONE: Yok
+  SMALL: Küçük
+  LARGE: Büyük
+  NORMAL: Normal
+  FAV: Favoriler
+  FAVMODE: Favoriler Başlangıç Modu
+  FAV_HINT: Favori
+  FAV_MSG: '%s Favoriler Menüsünden erişilemiyor.'
+  FAV_PERSISTENCE_MSG: '%s, öğe favori olarak işaretliyken kullanılamaz.'
+  NEUTRINO_DEVICE: Neutrino Cihazı
+  HINT_NEUTRINO_DEVICE: neutrino.elf dosyasını barındıran cihaz (NEUTRINO/ veya neutrino/ klasöründe). Otomatik olarak önce mc0, sonra mc1 taranır.
+  NARGS_QB: Hızlı Başlatma (-qb)
+  NARGS_CWD: Çalışma Dizini (-cwd)
+  NARGS_CFG: Yapılandırma (-cfg)
+  NARGS_ELF: Önyükleme ELF (-elf)
+  NARGS_ATA0: ATA0 Görüntüsü (-ata0)
+  NARGS_ATA0ID: ATA0 ID (-ata0id)
+  NARGS_ATA1: ATA1 Görüntüsü (-ata1)
+  NARGS_EXTRA: Ekstra Parametreler
+  NARGS_AUTO_NOTE: 'Otomatik: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Kapak resmi .tar arşivi
+  DISABLE_ALL: Tümünü Devre Dışı Bırak
+  BOOT_LOADING_CONFIG: Ayarlar yükleniyor...
+  BOOT_SCANNING_BDM: USB / kart / ağ sürücüleri taranıyor...
+  BOOT_SCANNING_NET: Ağ başlatılıyor...
+  BOOT_SCANNING_HDD: HDD taranıyor...
+  BOOT_READY: Hazır.
+  UDPFS_GAMES: "UDPFS Oyunları"
+  UDPFSBD_GAMES: "UDPFSBD Oyunları"
+  NET_PROTOCOL: "Ağ Protokolü"
+  NET_NEEDS_NEUTRINO: "Ağ (UDP) oyunları yalnızca Neutrino çekirdeğiyle başlatılabilir. neutrino.elf'in mevcut olduğunu ve biçimin desteklendiğini doğrulayın."
+  VCD_NOT_ON_NET: "PS1 (.VCD) oyunları ağ aygıtı üzerinden başlatılamaz."
+  MX4SIO_PADEMU_WARN: "MX4SIO ile kol emülasyonu SIO2 veri yolunu paylaşır ve oyun başlatılamayabilir."
+  HINT_OSD_SETTINGS_LNG: "Özel bir dil yapılandırması zorla"
+  OSD_SETTINGS_TVASPECT: "Ekran Boyutu"
+  FULL_SCREEN: "Tam Ekran"
+  OSD_SETTINGS_VMODE: "Video Modu"
+  SYSTEM_DEFAULT: "Sistem Varsayılanı"
+  HIGH: "Yüksek"
+  LOW: "Düşük"
+  XSENSITIVITY: "Analog X Ekseni Hassasiyeti"
+  YSENSITIVITY: "Analog Y Ekseni Hassasiyeti"
+  FILE_COUNT: "Bulunan dosyalar: %i"
+  CHEAT_SELECTION: "Hile Seçimi"
+  HDD_HINT: "Yalnızca bir HDD'ye izin verilir; etkinleştirmek APA veya GPT'yi kilitler."
+  MMCE_GAMEID_NEUTRINO_SKIP: "MMCE GameID uygulanmadı -- neutrino.elf bu kartta (değiştirmek Neutrino'yu bellekten kaldırır)."
+  POPSTARTER_DEVICE: "POPSTARTER.ELF Aygıtı"
+  HINT_POPSTARTER_DEVICE: "PS1 VCD başlatmaları için POPS/POPSTARTER.ELF içeren aygıt. Varsayılan = önyükleme aygıtı (cwd), ardından VCD'nin kendi aygıtı. Özel, serbest metin yolu gösterir."
+  BDMA_APPLY: "Başlatmada VCD BDMA Uygula"
+  HINT_BDMA_APPLY: "Açık: başlatılan VCD'ye uygun exFAT sürücüsünü önyüklemeden önce hafıza kartına otomatik yerleştir (önerilir). Kapalı: aşağıdaki BDMA Kaynak/Mod seçicileriyle kendiniz yönetin."
+  NETBOOT_RESTART: "Ağ önyükleme protokolü değişikliğini uygulamak için OPL'yi yeniden başlatın."
+  UDPFS_MODE: "UDPFS Erişimi"
+  "MENU": "Menü"
+  "APPS": "Uygulamalar"
+  "DEBUG": "Hata Ayıklama Renkleri"
+  "COVERART": "Kapak Resmi"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Yazma İşlemleri"
+  "MODE1": "Mod 1"
+  "MODE2": "Mod 2"
+  "MODE3": "Mod 3"
+  "MODE4": "Mod 4"
+  "MODE5": "Mod 5"
+  "MODE6": "Mod 6"
+  "ENABLEGSM": "GSM Seçici"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "PS2RD Hile Motoru"
+  "PADEMU_ENABLE": "Kol Emülatörü"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Emülasyon"
+  "PADEMU_VIB": "Titreşim"
+  "PADEMU_WORKAROUND": "Sahte DS3 Geçici Çözümü"
+  "SFX": "Ses Efektleri"
+  "BOOT_SND": "Açılış Sesi"
+  "ENABLE_NOTIFICATIONS": "Bildirimler"
+  "OPTIONS": "Seçenekler"
+  "GLOBAL_SETTINGS": "Genel"
+  "INFO_GENRE": "Tür"
+  "INFO_RELEASE": "Çıkış"
+  "INFO_DESCRIPTION": "Açıklama"
+  "BLOCKDEVICE_SETTINGS": "Blok Aygıtlar"
+  "CONTROLLER_SETTINGS": "Kumanda Ayarları"
+  "HINT_BDM_START": "Blok Aygıt Yöneticisini aç/kapat."
+  "HINT_BLOCK_DEVICES": "Blok Aygıtları aç/kapat (ör. USB)."
+  "USB_GAMES": "USB Oyunları"
+  "ILINK_GAMES": "iLink Oyunları"
+  "MX4SIO_GAMES": "MX4SIO Oyunları"
+  "PADMACROCONFIG": "PADMACRO Yapılandır"
+  "PADMACRO_SETTINGS": "Kol makro Ayarları"
+  "PADMACRO_ENABLE": "Kol makroları"
+  "PADMACRO_SLOWDOWN": "Analog yavaşlatma:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Düğmeye basıldığında analog çubuğun hareket aralığını azalt"
+  "LEFT_ANALOG": "Sol çubuk"
+  "RIGHT_ANALOG": "Sağ çubuk"
+  "PADMACRO_INVERT_AXIS": "Analog eksen ters çevirme:"
+  "HINT_PADMACRO_INVERT_AXIS": "Analog çubuk eksenini ters çevir"
+  "TURBO_SPEED": "Turbo düğme hızı"
+  "HINT_TURBO_SPEED": "Turbo etkinken düğmeye ne kadar hızlı basılacağı"
+  "ACT_WHILE_PRESSED": "Düğmeye basılıyken"
+  "ACT_TOGGLED": "Düğme ile açılıp kapanır"
+  "LANGUAGE_JAPANESE": "JAPONCA"
+  "LANGUAGE_ENGLISH": "İNGİLİZCE"
+  "LANGUAGE_FRENCH": "FRANSIZCA"
+  "LANGUAGE_SPANISH": "İSPANYOLCA"
+  "LANGUAGE_GERMAN": "ALMANCA"
+  "LANGUAGE_ITALIAN": "İTALYANCA"
+  "LANGUAGE_DUTCH": "FELEMENKÇE"
+  "LANGUAGE_PORTUGUESE": "PORTEKİZCE"
+  "LANGUAGE_RUSSIAN": "RUSÇA"
+  "LANGUAGE_KOREAN": "KORECE"
+  "LANGUAGE_TRAD_CHINESE": "GELENEKSEL ÇİNCE"
+  "LANGUAGE_SIMPL_CHINESE": "BASİTLEŞTİRİLMİŞ ÇİNCE"
+  "OSD_SETTINGS": "OSD ayarları"
+  "OSD_SETTINGS_LNG": "OSD Dili"
+  "ENABLE_LNG": "Dili değiştir"
+  "BGM": "Arka Plan Müziği"
+  "BGM_VOLUME": "Arka Plan Müziği Sesi"
+  "DEF_BGM_PATH": "Varsayılan Tema Müziği"
+  "DEF_BGM_PATH_HINT": "Dahili tema için akış müziği yolunu ayarla."
+  "BOOT_SCANNING_MC": "Hafıza kartları taranıyor..."
+  "BOOT_LOADING_DRIVERS": "Depolama sürücüleri yükleniyor..."
+  "BOOT_LOADING_USB": "USB depolama sürücüsü yükleniyor..."
+  "BOOT_ARMING_MMCE": "MMCE oyun kimliği hazırlanıyor..."
+  "BOOT_LOADING_SOUNDS": "Tema sesleri yükleniyor..."
+  "BOOT_BUILDING_MENU": "Menü oluşturuluyor..."
+  "NET_UDPFS_TAB_HINT": "UDPFS açık -- yeni UDPFS sekmesini aç ve bağlanmak için Onayla'ya bas. PC tarafında udpfsd -fsroot <games folder> çalışır."
+  "NET_UDPBD_TAB_HINT": "Ağ blok aygıtı açık -- PC sunucusu yanıt verdiğinde sekmesi görünür (UDPFS Image için udpfsd -bdpath, UDPBD için udpbd-server)."
+  "NEUTRINO_VMC_MISSING": "Oyuna özel VMC dosyası bulunamadı -- onsuz başlatılıyor (oyun gerçek kartını kullanır)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino bu aygıttan başlatılamıyor -- başlatma iptal edildi."
+  "NEUTRINO_TOML_SYNC_FAILED": "Neutrino ağ yapılandırması (bsd toml) eksik veya yazılamıyor -- başlatma iptal edildi, neutrino klasörünü kontrol edin."
+  "NEUTRINO_TOO_FRAGMENTED": "Neutrino için fazla parçalanmış (%d parça, sınır %d VMC'ler dahil) -- bunun yerine OPL çekirdeği deneniyor."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Neutrino için fazla parçalanmış (%d parça, sınır %d VMC'ler dahil) -- PC'de birleştirin; başlatma iptal edildi."
+  "NEUTRINO_GSM_COMP": "Neutrino GSM Uyumluluğu"
+  "HINT_NEUTRINO_GSM_COMP": "Zorlanmış bir Neutrino Video modu altında titreyen veya yırtılan oyunlar için alan çevirme düzeltmesi. Ayarlanmış bir Neutrino Video modu gerektirir."
+  "NARGS_DBC": "Hata Ayıklama Renkleri (-dbc)"
+  "NARGS_LOGO": "PS2 Logosu (-logo)"
+  "VMC_SLOT1_DISABLE": "VMC 1'i devre dışı bırak (kartı koru)"
+  "VMC_SLOT2_DISABLE": "VMC 2'yi devre dışı bırak (kartı koru)"
+  "HINT_VMC_SLOT_DISABLE": "Bu yuvanın kartı yapılandırılmış kalırken bu yuvanın VMC'si olmadan başlat. Yalnızca Neutrino başlatmaları; oyun daha sonra o yuvadaki gerçek kartı kullanır."
+  "NEUTRINO_BSDFS": "Neutrino Dosya Sistemi"
+  "HINT_NEUTRINO_BSDFS": "Neutrino'nun blok aygıt dosya sistemini zorla (-bsdfs). Auto = aygıta özgü varsayılan. hdl/bd uzman seçenekleridir; otomatik yol yapısı uymuyorsa bunları başlatma argümanlarındaki eşleşen bir -dvd= ile birlikte kullanın."
+  "PLASCOLOR": "Plazma Karışım Rengi"
+  "VCD_HIDE_GAMEID": "PS1 Oyun Kimliğini Gizle (VCD listesi)"
+  "HINT_VCD_HIDE_GAMEID": "Yalnızca görsel -- PS1/VCD liste adlarından baştaki oyun kimliği önekini (örn. SLUS_005.51.) gizle. Kimliği olmayan adlar olduğu gibi gösterilir. Başlatmayı, kapak resmini veya favorileri değiştirmez."
+  "VCD_FIRST_DISC": "Yalnızca ilk disk (çok diskli PS1)"
+  "HINT_VCD_FIRST_DISC": "Cihaz listelerinde çok diskli bir PS1 oyununun yalnızca Disk 1'ini göster (POPSLoader tarzı). (Disc 2), (CD 2) vb. adlı dosyaları gizler. Oyun içi disk değiştirme için tüm diskler kartta kalır; Favoriler filtrelenmez."
+  "GAMES_DEVICE": "Oyunun Aygıtı"
+  "DEFAULT_CORE": "Varsayılan Yükleyici Çekirdeği"
+  "HINT_DEFAULT_CORE": "Oyuna özel Yükleyici Çekirdeği Default olarak ayarlanmış oyunlar için genel varsayılan çekirdek. <OPL> yerel çekirdektir; Neutrino harici neutrino.elf'i zincirler. Oyuna özel bir seçim bunu her zaman geçersiz kılar."
+  "VCD_SETTINGS": "VCD Ayarları"
+  "FINANCIAL_SUPPORT": "Mali Destek"

--- a/lng_fork/Vietnamese.yml
+++ b/lng_fork/Vietnamese.yml
@@ -1,0 +1,229 @@
+translations:
+  AUTOSORT: Sắp xếp trò chơi theo bảng chữ cái
+  RUMBLE: Rung tay cầm trong menu
+  HINT_RUMBLE: Rung ngắn khi di chuyển con trỏ, xác nhận hoặc quay lại -- cần DualShock ở chế độ analog
+  FOLDER_NAV: Duyệt thư mục trong danh sách trò chơi
+  HINT_FOLDER_NAV: Hiển thị thư mục con của CD/DVD dưới dạng mục duyệt được; chọn để mở, hủy để quay lại
+  SETTINGS_NO_HOME: Không tìm thấy thẻ nhớ -- không thể lưu cài đặt. OPL đã khởi động từ thiết bị mạng, cài đặt phải nằm trên thẻ nhớ cục bộ.
+  ERROR_SAVING_SETTINGS_TO: Không thể ghi cài đặt vào %s (lỗi %d)
+  GENERAL_SETTINGS: Cài đặt chung
+  DEVICE_SETTINGS: Cài đặt thiết bị
+  LAUNCH_PS2_DISC: Khởi động đĩa PS2
+  DISC_LAUNCH_ERR: Không có đĩa PS2 trong ổ đĩa.
+  DEFAULT: Mặc định
+  HINT_MODE7: Chỉ dành cho Neutrino -- sửa lỗi game tràn bộ nhớ IOP (-gc=7)
+  MODE7: Mode 7
+  ENABLEIMAGE: Hình ảnh cheat PS2RD
+  HINT_ENABLEIMAGE: Áp dụng bản vá PS2RD .img dựng sẵn cho game của bạn.
+  UDPBD_GAMES: UDPBD Games
+  MMCE: MMCE
+  MMCE_GAMES: MMCE Games
+  MMCEMODE: Chế độ khởi động MMCE
+  MMCE_PREFIX: Đường dẫn tiền tố MMCE
+  MMCE_SLOT: Khe cắm MMCE
+  MMCEIGR_SLOT: Khe cắm bootcard IGR
+  HINT_MMCEIGR_SLOT: Lệnh chuyển sang bootcard sẽ được gửi đến khe đã chọn khi IGR
+  MMCE_ADVANCED: Nâng cao
+  MMCE_SETTINGS: Cài đặt MMCE
+  MMCE_SEMA: Phương thức xếp hàng Lock Sema
+  HINT_MMCE_SEMA: THFIFO có thể cải thiện tương thích nhưng giảm hiệu năng
+  MMCE_WAIT_CYCLES: Chu kỳ chờ sau /ACK thấp
+  HINT_MMCE_WAIT_CYCLES: Giá trị thấp hơn có thể cải thiện hiệu năng nhưng gây mất ổn định
+  MMCE_USE_ALARMS: Dùng cảnh báo hết giờ
+  HINT_MMCE_USE_ALARMS: TẮT có thể cải thiện hiệu năng nhưng khi MMCE hết giờ có thể bị đóng băng
+  CORE_LOADER: Loader Core
+  NEUTRINO_BAD_FORMAT: Neutrino không hỗ trợ định dạng này, khởi động bằng lõi <OPL>
+  NEUTRINO_NOT_FOUND: Không tìm thấy Neutrino ELF, khởi động bằng lõi <OPL>
+  UDPBD_NEEDS_STATIC_IP: UDPBD cần IP tĩnh cho PS2. Đặt trong Cấu hình mạng (DHCP đang bật).
+  NEUTRINO_SETTING_NA: Cài đặt này không dùng với lõi Neutrino.
+  POPSTARTER_NOT_FOUND: Thiếu POPSTARTER.ELF
+  POPSTARTER_SMB_MISSING: Thiếu yêu cầu SMB cho POPSTARTER
+  WRITE_POPSTARTER_NET: Ghi cấu hình mạng POPSTARTER
+  HINT_WRITE_POPSTARTER_NET: Cũng lưu các giá trị IP + SMB vào IPCONFIG.DAT / SMBCONFIG.DAT của POPSTARTER trên thẻ nhớ (dành cho VCD qua SMB).
+  POPSTARTER_NET_ERR: Không thể ghi cấu hình mạng POPSTARTER vào thẻ nhớ.
+  VCD: VCD
+  VCD_ON: Đang hiển thị game VCD
+  VCD_OFF: Đang hiển thị game đĩa
+  NEUTRINO_ARGS: Tham số khởi động Neutrino
+  HINT_NEUTRINO_ARGS: Cờ Neutrino bổ sung, cách nhau bằng dấu cách (vd. -mt=dvd). Toàn cục áp dụng cho tất cả game; riêng game cộng thêm. Thêm $ trước cờ để tắt mà không xóa.
+  NEUTRINO_VIDEO: Video Neutrino
+  HINT_NEUTRINO_VIDEO: Buộc chế độ video GS của Neutrino (-gsm). Tắt giữ mặc định của game.
+  NEUTRINO_PATH: Đường dẫn Neutrino ELF
+  HINT_NEUTRINO_PATH: Đường dẫn đầy đủ tới neutrino.elf (vd. mc0:NEUTRINO/neutrino.elf). Để trống = tự tìm trên mc0/mc1.
+  POPSTARTER_PATH: Đường dẫn POPSTARTER.ELF
+  HINT_POPSTARTER_PATH: Đường dẫn tùy chỉnh POPSTARTER.ELF; tự dùng thư mục POPS trên thiết bị nếu để trống/thiếu. Bàn phím giới hạn 31 ký tự; đường dài hơn qua settings_riptopl.cfg.
+  BDMA_SOURCE: Nguồn BDMA
+  HINT_BDMA_SOURCE: Thiết bị có thư mục POPS chứa các tệp driver BDMAssault (usbd.irx.* / usbhdfsd.irx.*).
+  BDMA_MODE: Chế độ BDMA
+  HINT_BDMA_MODE: Driver thiết bị khối exFAT mà POPSTARTER tải. Thay đổi sẽ sao chép module vào thẻ; FAT32 = không cần (driver tích hợp sẵn).
+  BDMA_SRC_USB: USB
+  BDMA_SRC_MX4SIO: MX4SIO
+  BDMA_SRC_MMCE: MMCE
+  BDMA_SRC_HDD: Ổ cứng trong
+  BDMA_MODE_FAT32: USB (FAT32)
+  BDMA_MODE_USBEXFAT: USB (exFAT)
+  BDMA_MODE_MX4SIO: MX4SIO (exFAT)
+  BDMA_MODE_MMCE: MMCE (exFAT)
+  BDMA_MODE_ATA: HDD (exFAT)
+  BDMA_ERR_SRC: Không tìm thấy tệp module BDMA trên thiết bị nguồn.
+  BDMA_ERR_SPACE: Thẻ nhớ không đủ dung lượng cho module BDMA.
+  BDMA_ERR_IO: Lỗi khi ghi module BDMA vào thẻ nhớ.
+  COVERFLOW_SETTINGS: Cài đặt Coverflow
+  COVERFLOW_COUNT: Số lượng bìa
+  COVERFLOW_SCALE: Tỉ lệ trung tâm
+  COVERFLOW_ANIM: Tốc độ hoạt ảnh
+  COVERFLOW_DIM: Làm tối bìa bên
+  NONE: Không có
+  SMALL: Nhỏ
+  LARGE: Lớn
+  NORMAL: Bình thường
+  FAV: Yêu thích
+  FAVMODE: Chế độ khởi động Yêu thích
+  FAV_HINT: Yêu thích
+  FAV_MSG: '%s không được phép trong Menu Yêu thích.'
+  FAV_PERSISTENCE_MSG: '%s không được phép khi mục đang được đánh dấu yêu thích.'
+  NEUTRINO_DEVICE: Thiết bị Neutrino
+  HINT_NEUTRINO_DEVICE: Thiết bị chứa neutrino.elf (trong thư mục NEUTRINO/ hoặc neutrino/). Tự động quét mc0 rồi mc1.
+  NARGS_QB: Khởi động nhanh (-qb)
+  NARGS_CWD: Thư mục làm việc (-cwd)
+  NARGS_CFG: Cấu hình (-cfg)
+  NARGS_ELF: ELF khởi động (-elf)
+  NARGS_ATA0: Ảnh ATA0 (-ata0)
+  NARGS_ATA0ID: ID ATA0 (-ata0id)
+  NARGS_ATA1: Ảnh ATA1 (-ata1)
+  NARGS_EXTRA: Tham số bổ sung
+  NARGS_AUTO_NOTE: 'Tự động: -bsd -dvd -gc -gsm -mc -dbc -logo'
+  ENABLE_ART_TAR: Kho .tar ảnh bìa
+  DISABLE_ALL: Tắt tất cả
+  BOOT_LOADING_CONFIG: Đang tải cài đặt...
+  BOOT_SCANNING_BDM: Đang quét ổ USB / thẻ / mạng...
+  BOOT_SCANNING_NET: Đang khởi động mạng...
+  BOOT_SCANNING_HDD: Đang quét HDD...
+  BOOT_READY: Sẵn sàng.
+  UDPFS_GAMES: "Trò chơi UDPFS"
+  UDPFSBD_GAMES: "Trò chơi UDPFSBD"
+  NET_PROTOCOL: "Giao thức mạng"
+  NET_NEEDS_NEUTRINO: "Trò chơi mạng (UDP) chỉ có thể khởi động qua lõi Neutrino. Hãy kiểm tra neutrino.elf có tồn tại và định dạng được hỗ trợ."
+  VCD_NOT_ON_NET: "Trò chơi PS1 (.VCD) không thể khởi chạy qua thiết bị mạng."
+  MX4SIO_PADEMU_WARN: "MX4SIO và giả lập tay cầm dùng chung bus SIO2 nên trò chơi có thể không khởi động được."
+  HINT_OSD_SETTINGS_LNG: "Buộc dùng cấu hình ngôn ngữ tùy chỉnh"
+  OSD_SETTINGS_TVASPECT: "Kích thước màn hình"
+  FULL_SCREEN: "Toàn màn hình"
+  OSD_SETTINGS_VMODE: "Chế độ hình ảnh"
+  SYSTEM_DEFAULT: "Mặc định hệ thống"
+  HIGH: "Cao"
+  LOW: "Thấp"
+  XSENSITIVITY: "Độ nhạy trục X analog"
+  YSENSITIVITY: "Độ nhạy trục Y analog"
+  FILE_COUNT: "Tệp tìm thấy: %i"
+  CHEAT_SELECTION: "Chọn cheat"
+  HDD_HINT: "Chỉ cho phép một HDD, khi bật sẽ khóa APA hoặc GPT."
+  MMCE_GAMEID_NEUTRINO_SKIP: "Không áp dụng MMCE GameID -- neutrino.elf nằm trên thẻ này (chuyển đổi sẽ gỡ Neutrino)."
+  POPSTARTER_DEVICE: "Thiết bị POPSTARTER.ELF"
+  HINT_POPSTARTER_DEVICE: "Thiết bị chứa POPS/POPSTARTER.ELF để khởi chạy PS1 VCD. Mặc định = thiết bị khởi động (cwd) rồi đến thiết bị của chính VCD. Tùy chỉnh sẽ hiện ô nhập đường dẫn tự do."
+  BDMA_APPLY: "Áp dụng VCD BDMA khi khởi chạy"
+  HINT_BDMA_APPLY: "Bật: tự động nạp driver exFAT phù hợp của VCD được khởi chạy vào thẻ nhớ trước khi khởi động (khuyến nghị). Tắt: tự quản lý bằng bộ chọn Nguồn/Chế độ BDMA bên dưới."
+  NETBOOT_RESTART: "Khởi động lại OPL để áp dụng thay đổi giao thức khởi động mạng."
+  UDPFS_MODE: "Truy cập UDPFS"
+  "MENU": "Menu"
+  "APPS": "Ứng dụng"
+  "DEBUG": "Màu Gỡ lỗi"
+  "COVERART": "Ảnh bìa"
+  "IP_ADDRESS_TYPE_DHCP": "DHCP"
+  "PORT": "Port"
+  "ADDR_TYPE_IP": "IP"
+  "ADDR_TYPE_NETBIOS": "NetBIOS"
+  "ENABLE_WRITE": "Thao tác ghi"
+  "MODE1": "Chế độ 1"
+  "MODE2": "Chế độ 2"
+  "MODE3": "Chế độ 3"
+  "MODE4": "Chế độ 4"
+  "MODE5": "Chế độ 5"
+  "MODE6": "Chế độ 6"
+  "ENABLEGSM": "Bộ chọn GSM"
+  "OVERSCAN": "Overscan"
+  "ENABLECHEAT": "Bộ máy Cheat PS2RD"
+  "PADEMU_ENABLE": "Giả lập Tay cầm"
+  "DS34USB_MODE": "DualShock3/4 USB"
+  "PADEMU_PORT": "Giả lập"
+  "PADEMU_VIB": "Rung"
+  "PADEMU_WORKAROUND": "Cách khắc phục Giả DS3"
+  "SFX": "Hiệu ứng âm thanh"
+  "BOOT_SND": "Âm thanh khởi động"
+  "ENABLE_NOTIFICATIONS": "Thông báo"
+  "OPTIONS": "Tùy chọn"
+  "GLOBAL_SETTINGS": "Toàn cục"
+  "INFO_GENRE": "Thể loại"
+  "INFO_RELEASE": "Phát hành"
+  "INFO_DESCRIPTION": "Mô tả"
+  "BLOCKDEVICE_SETTINGS": "Thiết bị khối"
+  "CONTROLLER_SETTINGS": "Cài đặt Tay cầm"
+  "HINT_BDM_START": "Bật/tắt Trình quản lý Thiết bị khối (BDM)."
+  "HINT_BLOCK_DEVICES": "Bật/tắt Thiết bị khối (ví dụ: USB)."
+  "USB_GAMES": "Game USB"
+  "ILINK_GAMES": "Game iLink"
+  "MX4SIO_GAMES": "Game MX4SIO"
+  "PADMACROCONFIG": "Cấu hình PADMACRO"
+  "PADMACRO_SETTINGS": "Cài đặt Macro Tay cầm"
+  "PADMACRO_ENABLE": "Macro Tay cầm"
+  "PADMACRO_SLOWDOWN": "Giảm tốc analog:"
+  "HINT_PADMACRO_SLOWDOWN_AXIS": "Giảm phạm vi của cần analog khi nhấn nút"
+  "LEFT_ANALOG": "Cần trái"
+  "RIGHT_ANALOG": "Cần phải"
+  "PADMACRO_INVERT_AXIS": "Đảo trục analog:"
+  "HINT_PADMACRO_INVERT_AXIS": "Đảo ngược trục cần analog"
+  "TURBO_SPEED": "Tốc độ nút turbo"
+  "HINT_TURBO_SPEED": "Tốc độ nhấn nút khi turbo đang bật"
+  "ACT_WHILE_PRESSED": "Khi giữ nút"
+  "ACT_TOGGLED": "Bật/tắt bằng nút"
+  "LANGUAGE_JAPANESE": "TIẾNG NHẬT"
+  "LANGUAGE_ENGLISH": "TIẾNG ANH"
+  "LANGUAGE_FRENCH": "TIẾNG PHÁP"
+  "LANGUAGE_SPANISH": "TIẾNG TÂY BAN NHA"
+  "LANGUAGE_GERMAN": "TIẾNG ĐỨC"
+  "LANGUAGE_ITALIAN": "TIẾNG Ý"
+  "LANGUAGE_DUTCH": "TIẾNG HÀ LAN"
+  "LANGUAGE_PORTUGUESE": "TIẾNG BỒ ĐÀO NHA"
+  "LANGUAGE_RUSSIAN": "TIẾNG NGA"
+  "LANGUAGE_KOREAN": "TIẾNG HÀN"
+  "LANGUAGE_TRAD_CHINESE": "TIẾNG TRUNG PHỒN THỂ"
+  "LANGUAGE_SIMPL_CHINESE": "TIẾNG TRUNG GIẢN THỂ"
+  "OSD_SETTINGS": "Cài đặt OSD"
+  "OSD_SETTINGS_LNG": "Ngôn ngữ OSD"
+  "ENABLE_LNG": "Đổi ngôn ngữ"
+  "BGM": "Nhạc nền"
+  "BGM_VOLUME": "Âm lượng nhạc nền"
+  "DEF_BGM_PATH": "Nhạc chủ đề mặc định"
+  "DEF_BGM_PATH_HINT": "Đặt đường dẫn phát nhạc cho chủ đề nội bộ."
+  "BOOT_SCANNING_MC": "Đang quét thẻ nhớ..."
+  "BOOT_LOADING_DRIVERS": "Đang tải trình điều khiển lưu trữ..."
+  "BOOT_LOADING_USB": "Đang tải trình điều khiển lưu trữ USB..."
+  "BOOT_ARMING_MMCE": "Đang kích hoạt game-ID MMCE..."
+  "BOOT_LOADING_SOUNDS": "Đang tải âm thanh chủ đề..."
+  "BOOT_BUILDING_MENU": "Đang dựng menu..."
+  "NET_UDPFS_TAB_HINT": "UDPFS đang bật -- mở tab UDPFS mới và nhấn Confirm để kết nối. Phía PC chạy udpfsd -fsroot <games folder>."
+  "NET_UDPBD_TAB_HINT": "Thiết bị khối qua mạng đang bật -- tab của nó xuất hiện khi máy chủ PC phản hồi (udpfsd -bdpath cho UDPFS Image, udpbd-server cho UDPBD)."
+  "NEUTRINO_VMC_MISSING": "Không tìm thấy tệp VMC theo từng game -- đang khởi chạy mà không có nó (game dùng thẻ thật của nó)."
+  "NEUTRINO_DEV_UNSUPPORTED": "Neutrino không thể khởi chạy từ thiết bị này -- đã hủy khởi chạy."
+  "NEUTRINO_TOML_SYNC_FAILED": "Cấu hình mạng của Neutrino (bsd toml) bị thiếu hoặc không ghi được -- đã hủy khởi chạy, hãy kiểm tra thư mục neutrino."
+  "NEUTRINO_TOO_FRAGMENTED": "Quá phân mảnh đối với Neutrino (%d mảnh, giới hạn %d bao gồm cả VMC) -- đang thử dùng lõi OPL thay thế."
+  "NEUTRINO_TOO_FRAGMENTED_NET": "Quá phân mảnh đối với Neutrino (%d mảnh, giới hạn %d bao gồm cả VMC) -- hãy chống phân mảnh trên PC; đã hủy khởi chạy."
+  "NEUTRINO_GSM_COMP": "Tương thích GSM Neutrino"
+  "HINT_NEUTRINO_GSM_COMP": "Bản sửa lỗi đảo trường (field-flipping) cho các game bị rung hoặc xé hình dưới chế độ Neutrino Video được ép buộc. Cần đặt một chế độ Neutrino Video."
+  "NARGS_DBC": "Màu Gỡ lỗi (-dbc)"
+  "NARGS_LOGO": "Logo PS2 (-logo)"
+  "VMC_SLOT1_DISABLE": "Tắt VMC 1 (giữ thẻ)"
+  "VMC_SLOT2_DISABLE": "Tắt VMC 2 (giữ thẻ)"
+  "HINT_VMC_SLOT_DISABLE": "Khởi chạy mà không dùng VMC của khe này trong khi vẫn giữ thẻ của nó được cấu hình. Chỉ áp dụng khi khởi chạy bằng Neutrino; game sau đó sẽ dùng thẻ thật trong khe đó."
+  "NEUTRINO_BSDFS": "Hệ thống tệp Neutrino"
+  "HINT_NEUTRINO_BSDFS": "Buộc hệ thống tệp thiết bị khối của Neutrino (-bsdfs). Auto = mặc định theo từng thiết bị. hdl/bd là các tùy chọn dành cho chuyên gia; hãy ghép chúng với một -dvd= tương ứng trong đối số khởi chạy nếu dạng đường dẫn tự động không phù hợp."
+  "PLASCOLOR": "Màu hòa trộn Plasma"
+  "VCD_HIDE_GAMEID": "Ẩn Game ID PS1 (danh sách VCD)"
+  "HINT_VCD_HIDE_GAMEID": "Chỉ mang tính thẩm mỹ -- ẩn tiền tố game-ID ở đầu (ví dụ SLUS_005.51.) khỏi tên trong danh sách PS1/VCD. Các tên không có ID sẽ hiển thị nguyên trạng. Không thay đổi việc khởi chạy, ảnh bìa hay mục yêu thích."
+  "VCD_FIRST_DISC": "Chỉ đĩa đầu tiên (PS1 nhiều đĩa)"
+  "HINT_VCD_FIRST_DISC": "Chỉ hiển thị Đĩa 1 của một game PS1 nhiều đĩa trong danh sách thiết bị (kiểu POPSLoader). Ẩn các tệp có tên (Disc 2), (CD 2), v.v. Tất cả các đĩa vẫn nằm trên thẻ để hoán đổi trong game; Mục yêu thích không bị lọc."
+  "GAMES_DEVICE": "Thiết bị của Game"
+  "DEFAULT_CORE": "Lõi tải mặc định"
+  "HINT_DEFAULT_CORE": "Lõi mặc định toàn cục cho các game có Loader Core theo từng game được đặt thành Default. <OPL> là lõi gốc; Neutrino nối chuỗi tới neutrino.elf bên ngoài. Lựa chọn theo từng game luôn ghi đè giá trị này."
+  "VCD_SETTINGS": "Cài đặt VCD"
+  "FINANCIAL_SUPPORT": "Hỗ trợ tài chính"


### PR DESCRIPTION
Restores the fork's translation overlay, so the 31 shipped languages actually translate *this fork's* labels instead of falling back to English.

## Three parts

- **`lng_fork/`** — 32 files, byte-identical to fork master
- **`lang_compiler.py`** — the `--overlay_translation_yml` action, byte-identical to fork. Purely additive; the single "deletion" in the diff is one `if` condition growing a third arm.
- **`Makefile`** — `LNG_FORK_DIR`, plus the overlay step in the `TRANSLATIONS_LNG` rule, run immediately before `--make_lng`

## How it behaves — verified, not assumed

The overlay **fills gaps only** and never clobbers a human translation, so once upstream translates a label the overlay quietly steps aside. Proven on French after a full regenerate:

| label | upstream state | result |
|---|---|---|
| `AUTOSORT` | already had *"Tri alphabétique"* | **left alone** |
| `RUMBLE` | fork-only, untranslated | **filled** |
| `HINT_RUMBLE` | fork-only, untranslated | **filled** |

It's also idempotent — a filled label becomes a plain string and is skipped next run.

Critically, it **never writes to `lng_src/`**, which `download_lng.sh` rewrites from upstream on every build. That's the entire reason the overlay lives in its own directory rather than as edits to the language files.

## Verification

Wiped `lng_src/`, `lng/*.lng` and the autogen files, then re-ran `download_lng` and `languages` from scratch: **31 `.lng` files built**, `LANG_EXIT=0`, followed by a full ELF build at `MAKE_EXIT=0` with zero undefined references.

## One deliberate oddity

`RUMBLE`/`HINT_RUMBLE` now have translations while the feature itself is still greyed out pending item 43. That's fine and intentional — the label text is ready for whenever the pad-clock rework unblocks rumble.