### PR TITLE
rebuild-27: four verified user-facing bugs from the v1.0 completeness audit

### DIFF
--- a/include/menusys.h
+++ b/include/menusys.h
@@ -115,7 +115,7 @@ char *submenuItemGetText(submenu_item_t *it);
 char *menuItemGetText(menu_item_t *it);
 config_set_t *menuLoadConfig();
 config_set_t *gameMenuLoadConfig(struct UIItem *ui);
-void menuSaveConfig();
+int menuSaveConfig();
 
 void menuRenderMain();
 void menuRenderMenu();

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1624,10 +1624,12 @@ struct UIItem diaControllerConfig[] = {
     {UI_ENUM, CFG_YSENSITIVITY, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Left Stick Navigation", -1}}},
-    {UI_SPACER},
-    {UI_BOOL, UICFG_ENABLE_ANALOG_NAV, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
+    // NOTE(rebuild): checklist item 44 ("Left Stick Navigation") is deliberately NOT re-added -- the
+    // analog stick always merges into the d-pad and the REAL control is the X/Y Sensitivity rows
+    // above (Off = a 128 deadzone, which is what actually disables stick navigation). The boolean
+    // was dead in the fork too: gEnableAnalogNav has no reader anywhere and its checkbox was never
+    // synced in the UI page, so the row rendered as a flippable control wired to nothing. Removed
+    // rather than greyed, because unlike MMCE/rumble this feature is never coming back.
 
     // Menu Rumble moved here from the old General Settings (diaConfig) by the layout restructure.
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_RUMBLE}}},

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -18,6 +18,7 @@
 #include "include/system.h"
 #include "include/ioman.h"
 #include "include/sound.h"
+#include "include/favsupport.h" // gFAVStartMode -- the Favourites tab counts as "something to show"
 #include "include/vcdsupport.h" // vcdViewActive() -- VCD launches never use Neutrino
 #include "include/bdmsupport.h" // bdmSupportIsUDPBD() -- UDPBD games are Neutrino-only
 #include <assert.h>
@@ -65,6 +66,7 @@ static menu_list_t *menu;
 static menu_list_t *selected_item;
 
 static int actionStatus;
+static int menuSaveResult; // last per-game configWrite() result, published by _menuSaveConfig
 static int itemConfigId;
 static config_set_t *itemConfig;
 
@@ -190,7 +192,8 @@ static void _menuSaveConfig()
 
     WaitSema(menuSemaId);
     result = configWrite(itemConfig);
-    itemConfigId = -1; // to invalidate cache and force reload
+    itemConfigId = -1;       // to invalidate cache and force reload
+    menuSaveResult = result; // publish BEFORE actionStatus=0 -- that flag is the waiter's release signal
     actionStatus = 0;
     SignalSema(menuSemaId);
 
@@ -235,10 +238,12 @@ config_set_t *gameMenuLoadConfig(struct UIItem *ui)
     return itemConfig;
 }
 
-void menuSaveConfig()
+int menuSaveConfig()
 {
     actionStatus = 1;
+    menuSaveResult = 0;
     guiHandleDeferedIO(&actionStatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuSaveConfig);
+    return menuSaveResult;
 }
 
 static void menuInitMainMenu(void)
@@ -1035,8 +1040,14 @@ void menuHandleInputMenu()
     }
 
     if (getKeyOn(KEY_START) || getKeyOn(gSelectButton == KEY_CIRCLE ? KEY_CROSS : KEY_CIRCLE)) {
-        // Check if there is anything to show the user, at all.
-        if (gAPPStartMode || gETHStartMode || gBDMStartMode || gHDDStartMode) {
+        // Check if there is anything to show the user, at all. This MUST list every tab that can
+        // hold rows, or the user gets trapped in the settings menu with no way back to the list:
+        // gFAVStartMode was missing, so a Favourites-only setup could not escape at all.
+        // bdmEffectiveStartMode() rather than raw gBDMStartMode: UDPBD floors the BDM start mode, so
+        // a UDPBD-only rig has rows while gBDMStartMode itself is still disabled.
+        // NOTE(rebuild): the fork also ORs gMMCEStartMode here; that global arrives with checklist
+        // item 1, and until then no MMCE tab can hold rows, so omitting it changes nothing.
+        if (gAPPStartMode || gETHStartMode || bdmEffectiveStartMode() || gHDDStartMode || gFAVStartMode) {
             guiSwitchScreen(GUI_SCREEN_MAIN);
             refreshMenuPosition();
         }
@@ -1344,9 +1355,15 @@ void menuHandleInputGameMenu()
         } else if (menuID == GAME_SAVE_CHANGES) {
             if (guiGameSaveConfig(itemConfig, selected_item->item->userdata))
                 configSetInt(itemConfig, CONFIG_ITEM_CONFIGSOURCE, CONFIG_SOURCE_USER);
-            menuSaveConfig();
-            saveConfig(CONFIG_GAME, 0);
-            guiMsgBox(_l(_STR_GAME_SETTINGS_SAVED), 0, NULL);
+            int okItem = menuSaveConfig();           // per-game CFG/<id>.cfg (itemConfig)
+            int okGame = saveConfig(CONFIG_GAME, 0); // the global game config set
+            // #245: claim "saved" only when BOTH writes actually persisted. This modal was
+            // UNCONDITIONAL, so a failed write showed "Game settings saved" immediately followed
+            // by the async "error writing settings!" toast -- the exact contradiction Andrew
+            // reported. On failure the error toast already names the path and errno; don't also
+            // lie that it saved.
+            if (okItem && okGame)
+                guiMsgBox(_l(_STR_GAME_SETTINGS_SAVED), 0, NULL);
             guiGameLoadConfig(selected_item->item->userdata, gameMenuLoadConfig(NULL));
         } else if (menuID == GAME_TEST_CHANGES) {
             guiGameTestSettings(selected_item->item->current->item.id, selected_item->item->userdata, itemConfig);

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1057,7 +1057,10 @@ void sbSetDiscAttributes(config_set_t *config, int isPS1, int isCD)
 
 int sbLoadCheats(const char *path, const char *file)
 {
-    char cheatfile[64];
+    // 256, not 64: the path prefix here is a full device root (e.g. "mass0:/" plus an OPL data
+    // folder), and a 64-byte buffer silently TRUNCATED the "<path>CHT/<file>.cht" it builds -- so
+    // cheats simply never loaded on longer BDM paths, with no diagnostic. Matches the fork.
+    char cheatfile[256];
     int cheatMode = 0;
 
     if (GetCheatsEnabled()) {


### PR DESCRIPTION
All four came out of the 5-axis completeness audit and were **hand-verified against `origin/rebuild/main` before fixing**. They're independent, so they land as one cleanup checkpoint.

## 1. You could get trapped in the settings menu

The START / back escape to the game list was gated on:

```c
if (gAPPStartMode || gETHStartMode || gBDMStartMode || gHDDStartMode)
```

**`gFAVStartMode` was missing** — so a user running *only* Favourites, a reachable configuration since item 33 landed, had **no way out of the settings menu at all**.

Also switched raw `gBDMStartMode` → `bdmEffectiveStartMode()`: UDPBD floors the BDM start mode, so a UDPBD-only rig has rows while `gBDMStartMode` itself reads disabled. A `NOTE(rebuild)` records that the fork also ORs `gMMCEStartMode` — that global arrives with item 1, and no MMCE tab can hold rows until then.

## 2. Per-game "Save Changes" always claimed success — #245 regressed

`menuSaveConfig()` and `saveConfig(CONFIG_GAME, 0)` were both called with their results **discarded**, then `_STR_GAME_SETTINGS_SAVED` was shown unconditionally.

That is precisely the contradiction Andrew reported on #245: *"Game settings saved"* immediately followed by the async *"error writing settings!"* toast.

`menuSaveConfig()` now returns the write result — published into `menuSaveResult` **before** `actionStatus = 0`, since that flag is the waiter's release signal — and the modal only claims success when **both** writes persisted. On failure the existing error toast already names the path and errno, so there's no need to also lie that it saved.

## 3. A fourth lying UI row — for a feature that was deliberately killed

"Left Stick Navigation" rendered as a live, flippable toggle in Controller Settings, with **zero `gui.c` references** and no `gEnableAnalogNav` in this tree.

**Removed rather than greyed.** Unlike MMCE and rumble, this one is never coming back: the analog stick always merges into the d-pad, and the real control is the X/Y Sensitivity rows (Off = a 128 deadzone). Worth recording that the row is dead in the **fork** too — `gEnableAnalogNav` has a global and config load/save there, but no reader anywhere and the checkbox is never synced.

## 4. Cheats silently never loaded on longer paths

```c
char cheatfile[64];   // was
char cheatfile[256];  // now, matching the fork
```

The prefix here is a full device root, so `"<path>CHT/<file>.cht"` **truncated** on any reasonably long BDM path — losing the filename with no diagnostic at all.

## Checked and deliberately not touched

The audit flagged `_STR_GSM_1080P_WARNING/PROCEED/SURE` as referenced-but-undefined. They sit inside `#ifdef GSM_1080P`, which only compiles in the `GSM1080P=1` variant we don't build (item 29 is on WAIT). **Not a build break** — those labels arrive with that item.

## Verification

Clean build, `MAKE_EXIT=0`. All four fixes confirmed present in the built tree by grep afterwards. Two build failures en route (`gMMCEStartMode` doesn't exist here; `menusys.c` needed `favsupport.h`) — both caught and resolved.