### PR TITLE
rebuild-28: two dead launch-path features -- PS2RD .img cheats + MX4SIO sio2man

### DIFF
--- a/ee_core/include/cheat_api.h
+++ b/ee_core/include/cheat_api.h
@@ -6,6 +6,7 @@
 
 void EnableCheats(void);
 void DisableCheats(void);
+void LinkImage(void);
 
 /**
  * code_t - a code object

--- a/ee_core/include/modules.h
+++ b/ee_core/include/modules.h
@@ -14,6 +14,7 @@ enum OPL_MODULE_ID {
     OPL_MODULE_ID_ILINKBD,
 
     // mx4sio mode modules
+    OPL_MODULE_ID_SIO2MAN,
     OPL_MODULE_ID_MX4SIOBD,
 
     // SMB mode modules

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -141,7 +141,9 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
             LoadOPLModule(OPL_MODULE_ID_ILINKBD, 0, 0, NULL);
             break;
         case BDM_M4S_MODE:
-            LoadOPLModule(OPL_MODULE_ID_MX4SIOBD, 0, 0, NULL);
+            // mx4sio_bd requires PS2SDK's sio2man. Do not start it if that dependency failed.
+            if (LoadOPLModule(OPL_MODULE_ID_SIO2MAN, 0, 0, NULL) > 0)
+                LoadOPLModule(OPL_MODULE_ID_MX4SIOBD, 0, 0, NULL);
             break;
         case BDM_HDD_MODE:
             break;

--- a/ee_core/src/main.c
+++ b/ee_core/src/main.c
@@ -92,6 +92,9 @@ static int eecoreInit(int argc, char **argv)
         EnableCheats();
     }
 
+    if (config->gImage)
+        LinkImage();
+
     if (config->EnableGSMOp) {
         UpdateGSMParams(
             config->GsmConfig.interlace,

--- a/src/system.c
+++ b/src/system.c
@@ -683,6 +683,11 @@ static unsigned int sendIrxKernelRAM(const char *startup, const char *mode_str, 
         irxptr_tab[modcount++].ptr = (void *)&IEEE1394_bd_irx;
     }
     if (modules & CORE_IRX_MX4SIO) {
+        // mx4sio_bd requires PS2SDK's sio2man after the game-side IOP reset. Without it the block
+        // device never comes up in-game and the launch hangs. Keep these adjacent and ordered;
+        // ee_core loads them in the same order.
+        irxptr_tab[modcount].info = size_sio2man_irx | SET_OPL_MOD_ID(OPL_MODULE_ID_SIO2MAN);
+        irxptr_tab[modcount++].ptr = (void *)&sio2man_irx;
         irxptr_tab[modcount].info = size_mx4sio_bd_irx | SET_OPL_MOD_ID(OPL_MODULE_ID_MX4SIOBD);
         irxptr_tab[modcount++].ptr = (void *)&mx4sio_bd_irx;
     }
@@ -1561,6 +1566,10 @@ void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdv
         config->gCheatList = GetCheatsList();
     } else
         config->gCheatList = NULL;
+
+    // PS2RD .img cheats (item 26). Without this the EE loads the .img into RAM and then never hands
+    // the pointer to the core, so LinkImage() had nothing to link and the whole feature was dead.
+    config->gImage = GetImageEnabled() ? (u32 *)GetImage() : NULL;
 
     sprintf(config->g_ps2_ip, "%u.%u.%u.%u", local_ip_address[0], local_ip_address[1], local_ip_address[2], local_ip_address[3]);
     sprintf(config->g_ps2_netmask, "%u.%u.%u.%u", local_netmask[0], local_netmask[1], local_netmask[2], local_netmask[3]);


### PR DESCRIPTION
Both from the completeness audit, both hand-verified before fixing. Both are in-game launch path with no menu or scroll exposure, so they land together.

## 1. Item 26 — PS2RD `.img` cheats were dead on *both* halves

Recorded DONE in step 08. In reality nothing connected the two ends:

- `src/system.c` never assigned `config->gImage`, so it stayed **NULL forever**
- `ee_core/src/main.c` never called `LinkImage()`, which had **zero callers**
- the prototype was missing from `ee_core/include/cheat_api.h`

The EE side already loads the `.img` into RAM (`cheatman.c` / `supportbase.c`), `LinkImage()` was already implemented, and the `gImage` field already existed in `coreconfig.h`. **The feature was one assignment and one call away from working the entire time.**

Same failure mode as item 27: recorded complete, silently inert.

## 2. MX4SIO games got no `sio2man` after the game-side IOP reset

`OPL_MODULE_ID_SIO2MAN` **did not exist anywhere in this tree.**

`mx4sio_bd` requires PS2SDK's `sio2man`, and after `ee_core` resets the IOP only the modules handed over in `irxptr_tab` exist — so the block device never came up in-game. `sio2man_irx` was already embedded and already loaded at **menu** time (`system.c:239`); what was missing was the **game-side handoff**.

- `ee_core/include/modules.h` — `OPL_MODULE_ID_SIO2MAN`, at the fork's position
- `src/system.c` — push `sio2man_irx` into `irxptr_tab` alongside `mx4sio_bd_irx`
- `ee_core/src/iopmgr.c` — load `sio2man` **first**, and only start `mx4sio_bd` if it succeeded (fork parity: don't start a driver whose dependency failed)

**This is a strong candidate for the unexplained "MX4SIO hang"** in the 2026-07-21 hardware batch, which has never had a root cause.

## Enum safety, checked before inserting mid-enum

`OPL_MODULE_ID_*` is packed into the **high byte** of `irxptr_tab[].info` via `SET_OPL_MOD_ID(x) = x << 24` and read back with `GET_OPL_MOD_ID`. It's a symbolic tag, **not a positional table index**, and the EE side and `ee_core` compile from the same `modules.h` in a single build — so inserting an id mid-enum shifts both sides identically. Nothing persists these values across builds.

Worth stating explicitly because mid-struct and mid-enum insertions have bitten this project before.

## Verification

Clean build, `MAKE_EXIT=0`, first try. Both fixes confirmed present in the built tree by grep.

Neither is testable in an emulator — `.img` cheats and MX4SIO both need real hardware, so Zack's pass is the verification.