### PR TITLE
rebuild-29: render the per-page theme families (item 37 + FAV/VCD pages)

### DIFF
--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1074,12 +1074,25 @@ void menuRenderMain(void)
 {
     item_list_t *list = selected_item->item->userdata;
 
-    if (list->mode == APP_MODE) {
+    if (vcdViewActive(list->mode)) {
+        // VCD/PS1 listings render with the vcd family (vcdMain*; each slot falls back at parse time to
+        // appsMain* then main*). The VCD list uses its OWN items-list slot (vcdItemsList) so it keeps a
+        // SEPARATE cover cache from the device's ISO list -- the view reuses the device's game list
+        // (same item ids), so a shared cache thrashes on every L3 toggle. This also covers the
+        // Favourites tab's own VCD view: VCD favourites render with the PS1 family, not the favs one.
+        menuRenderElements(gTheme->vcdMainElems.first);
+        gTheme->itemsList = thmResolveItemsList(&gTheme->vcdMainElems, gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
+    } else if (list->mode == FAV_MODE) {
+        menuRenderElements(gTheme->favsMainElems.first);
+        gTheme->itemsList = thmResolveItemsList(&gTheme->favsMainElems, gTheme->favsItemsList ? gTheme->favsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
+    } else if (list->mode == APP_MODE) {
         menuRenderElements(gTheme->appsMainElems.first);
-        gTheme->itemsList = gTheme->appsItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->appsMainElems, gTheme->appsItemsList ? gTheme->appsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else {
         menuRenderElements(gTheme->mainElems.first);
-        gTheme->itemsList = gTheme->gamesItemsList;
+        // Always falls back to gamesItemsList, never NULL: the scroll/paging code (menuNextV/PrevV/
+        // Page) derefs gTheme->itemsList->extended with no NULL check.
+        gTheme->itemsList = thmResolveItemsList(&gTheme->mainElems, gTheme->gamesItemsList, selected_item->item->icon_id);
     }
 }
 
@@ -1172,12 +1185,18 @@ void menuRenderInfo(void)
 {
     item_list_t *list = selected_item->item->userdata;
 
-    if (list->mode == APP_MODE) {
+    if (vcdViewActive(list->mode)) {
+        menuRenderElements(gTheme->vcdInfoElems.first);
+        gTheme->itemsList = thmResolveItemsList(&gTheme->vcdInfoElems, gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
+    } else if (list->mode == FAV_MODE) {
+        menuRenderElements(gTheme->favsInfoElems.first);
+        gTheme->itemsList = thmResolveItemsList(&gTheme->favsInfoElems, gTheme->favsItemsList ? gTheme->favsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
+    } else if (list->mode == APP_MODE) {
         menuRenderElements(gTheme->appsInfoElems.first);
-        gTheme->itemsList = gTheme->appsItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->appsInfoElems, gTheme->appsItemsList ? gTheme->appsItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else {
         menuRenderElements(gTheme->infoElems.first);
-        gTheme->itemsList = gTheme->gamesItemsList;
+        gTheme->itemsList = thmResolveItemsList(&gTheme->infoElems, gTheme->gamesItemsList, selected_item->item->icon_id);
     }
 }
 


### PR DESCRIPTION
`themes.c` has been parsing, validating, cover-caching and **freeing** four theme element families and two ItemsList slots that **nothing ever drew**:

- `favsMainElems` / `favsInfoElems` / `favsItemsList`
- `vcdMainElems` / `vcdInfoElems` / `vcdItemsList`

`menuRenderMain` and `menuRenderInfo` only branched on `APP_MODE`, so the **Favourites tab** and the **L3 VCD (PS1) view** both rendered with the generic games layout. A theme shipping `favs_main` / `vcd_main` sections had them silently ignored.

## Item 37 was the other half of the same hole

`thmResolveItemsList` — per-device theme filters — was **defined** at `themes.c:212` and **declared** at `themes.h:189` with **zero callers**. Every page used the global first ItemsList regardless of which device tab was on screen, so a theme's `devices=`-filtered list layouts never applied.

That's the **third** instance of the exact bug that hid `thmTriggerCoverflowAnim` for twelve checkpoints: compiled in, fully dead. (My own earlier audit reported item 37 as PRESENT — it matched the definition.)

## The cover-cache half matters most

The VCD view reuses the device's own game list — **same item ids, different art**. Sharing `gamesItemsList` meant the ISO list and the VCD list shared one cover cache and **thrashed it on every L3 toggle**. `vcdItemsList` exists precisely to give the VCD view its own cache slot, and it was being ignored.

## Safety

Both render functions now dispatch vcd → FAV → APP → games, and **every** branch resolves through `thmResolveItemsList` so the paging math matches the rows actually drawn (`drawItemsList` gates on the same `devices=` rule).

Every branch falls back to `gamesItemsList` and **never to NULL** — the scroll/paging code (`menuNextV`/`menuPrevV`/`menuNextPage`) dereferences `gTheme->itemsList->extended` with no NULL check.

## Adapted, not copied

The fork's `menuRenderElements` takes `(theme_elems_t *, allowItemConfig, renderConfig)` because it also carries the #49/#120 MMCE item-config gating. This tree's signature is still `menuRenderElements(elem->first)`, so the dispatch is ported **without** that refactor — it belongs to the MMCE work, not here.

## Verification

Clean build, `MAKE_EXIT=0`, first try. `thmResolveItemsList` now has 8 references in `menusys.c` (was 0 outside its own definition), and all six previously-dead theme fields are consumed.

Worth a look on hardware with a theme that defines `favs_main`/`vcd_main`, and specifically an L3 toggle back and forth to confirm covers no longer re-load each time.