### PR TITLE
rebuild-30: three IOP buffer-safety fixes never re-added

### DIFF
--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -101,6 +101,7 @@ static void oplShutdown(int poff)
     if (vmcShutdownCb != NULL)
         vmcShutdownCb();
     DeviceUnmount();
+
     if (poff) {
         DeviceStop();
 #ifdef __USE_DEV9
@@ -388,7 +389,13 @@ static int cdvdman_read(u32 lsn, u32 sectors, u16 sector_size, void *buf)
 
             // Copy the data for buffer.
             // For any sector other than 2048 one sector at a time is copied.
-            memcpy((void *)((u32)buf + offset), cdvdman_buf, nbytes);
+            // Copy only the data cdvdman_read_sectors actually produced
+            // (nsectors * 2048): cdvdman_buf holds 2048 bytes per sector, so using
+            // nbytes (nsectors * sector_size, e.g. 2340) over-read cdvdman_buf past
+            // its valid data and could write past the destination sector. For the
+            // non-2048 sizes, offset + 2048 stays within sector_size and the manual
+            // header fixup below fills the rest of the slot.
+            memcpy((void *)((u32)buf + offset), cdvdman_buf, nsectors * 2048);
 
             // For these custom sizes we need to manually fix the header.
             // For 2340 we have 12bytes. 4 are position.

--- a/modules/iopcore/cdvdman/searchfile.c
+++ b/modules/iopcore/cdvdman/searchfile.c
@@ -80,20 +80,27 @@ lbl_startlocate:
         }
 #endif
 
-        // copy the path into main 'dir' var
+        // copy the path segment into cdvdman_dirname, bounded to the buffer. The
+        // #ifdef debug check above only break()s in debug builds; release had no
+        // protection against a segment longer than the 32-byte buffer.
+        if (len >= (int)sizeof(cdvdman_dirname))
+            len = sizeof(cdvdman_dirname) - 1;
         strncpy(cdvdman_dirname, p, len);
         cdvdman_dirname[len] = 0;
     } else {
-#ifdef __IOPCORE_DEBUG
+        // No slash: p is the final filename. Bound the copy (release previously
+        // used an unbounded strcpy, with only a debug-only break check).
         len = strlen(p);
-
+#ifdef __IOPCORE_DEBUG
         if (len >= sizeof(cdvdman_dirname)) {
             DPRINTF("cdvdman_locatefile: filename too long: (%d chars) \"%s\"\n", len, p);
             asm volatile("break\n");
         }
 #endif
-
-        strcpy(cdvdman_dirname, p);
+        if (len >= (int)sizeof(cdvdman_dirname))
+            len = sizeof(cdvdman_dirname) - 1;
+        strncpy(cdvdman_dirname, p, len);
+        cdvdman_dirname[len] = 0;
     }
 
     while (tocLength > 0) {
@@ -114,6 +121,11 @@ lbl_startlocate:
 
             filename_len = tocEntryPointer->filenameLength;
             if (filename_len) {
+                // filenameLength is on-disc data (u8, 0-255); clamp to the buffer so a
+                // non-compliant or crafted ISO cannot overflow cdvdman_curdir[15]. The
+                // match below only strncmp()s the first 12 chars, so this is lossless.
+                if (filename_len >= (int)sizeof(cdvdman_curdir))
+                    filename_len = sizeof(cdvdman_curdir) - 1;
                 strncpy(cdvdman_curdir, tocEntryPointer->filename, filename_len); // copy filename
                 cdvdman_curdir[filename_len] = 0;
 

--- a/modules/network/smbinit/smbauth.c
+++ b/modules/network/smbinit/smbauth.c
@@ -55,7 +55,13 @@ static unsigned char *NTLM_Password_Hash(const char *password, unsigned char *ci
     memset(passwd_buf, 0, sizeof(passwd_buf));
 
     /* turn the password to unicode */
-    for (i = 0, j = 0; i < strlen(password); i++, j += 2)
+    // Bound the expansion: each input byte writes 2 bytes into passwd_buf[512], so a password longer
+    // than 255 characters walked straight off the end of this stack buffer. The loop was bounded only
+    // on strlen(password), which is attacker/config controlled.
+    size_t pass_len = strlen(password);
+    if (pass_len > 255)
+        pass_len = 255;
+    for (i = 0, j = 0; i < (int)pass_len; i++, j += 2)
         passwd_buf[j] = password[i];
 
     /* get the message digest */


### PR DESCRIPTION
All three from the completeness audit. Memory-safety hardening in IOP modules — invisible until it bites, and all of it reachable from data OPL doesn't control (on-disc ISO structures, a config-supplied SMB password).

## 1. `cdvdman_locatefile()` ISO path walk

Three separate holes in one function:

- the **final path segment** used an **unbounded `strcpy()`** into `cdvdman_dirname[32]`. The only length check sat inside `#ifdef __IOPCORE_DEBUG`, so **release builds had no protection at all**
- the directory-segment branch `strncpy`'d without clamping `len` first
- **`filename_len` comes straight off the disc** (`u8 filenameLength`, 0–255) and was used to `strncpy` into `cdvdman_curdir[15]` — a non-compliant or crafted ISO could overflow it

The clamp is lossless: the match below only `strncmp()`s the first 12 chars.

*Taken wholesale — the file's entire diff versus the fork **is** this hardening.*

## 2. `cdvdman_read()` over-copy for non-2048-byte sectors

`memcpy` used `nbytes` (= `nsectors * sector_size`, e.g. **2340**) but `cdvdman_buf` only holds **2048** bytes per sector — so it read past the valid data and could write past the destination sector.

Now copies `nsectors * 2048`. For the custom sizes, `offset + 2048` stays inside `sector_size` and the manual header fixup below fills the rest of the slot.

*Taken wholesale — its diff is this plus one blank line.*

## 3. `NTLM_Password_Hash()` stack overflow

The UTF-16 expansion writes **2 bytes per input character** into `passwd_buf[512]`, but the loop was bounded only on `strlen(password)`. A password longer than 255 characters walked straight off a stack buffer. Clamped to 255.

**Applied surgically, not wholesale.** The fork's version of this file also moves `SERVER_USE_{PLAINTEXT,ENCRYPTED}_PASSWORD` into `oplsmb.h` as part of the SMB2 work, and SMB2 is item 4 on WAIT — taking the file would have pulled in defines this tree doesn't have.

## Verification

Clean build, `MAKE_EXIT=0`, first try.