### PR TITLE
rebuild-31b: apply CI's clang-format diff verbatim

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -9,7 +9,7 @@
 #include "include/ioman.h"
 #include "modules/iopcore/common/cdvd_config.h"
 #include "include/cheatman.h"
-#include "include/tar.h"      // CHT/cht.tar cheat archives (#154)
+#include "include/tar.h" // CHT/cht.tar cheat archives (#154)
 #include "include/pggsm.h"
 #include "include/cheatman.h"
 #include "include/ps2cnf.h"


### PR DESCRIPTION
**rebuild-31 merged with `check-format` red.** The three build flavours passed and `check-format` isn't a required check, so the merge went through — I read the first lines of the check output and not the last two. My error, and worth recording rather than quietly fixing.

The failure itself is one line. The include I added in rebuild-31 was padded to align its trailing comment with its neighbours, but the surrounding includes carry no trailing comments, so clang-format 12 wants a single space:

```diff
-#include "include/tar.h"      // CHT/cht.tar cheat archives (#154)
+#include "include/tar.h" // CHT/cht.tar cheat archives (#154)
```

Applied **exactly as CI printed it**, per the standing rule — never hand-format.

This is the trailing-comment alignment trap the project memo already records: it bites whenever a commented line is inserted next to uncommented ones. I avoided it deliberately in rebuild-13 by restructuring a comment, then walked straight into it here because the include went in via `sed` rather than the editor.