### PR TITLE
rebuild-33: the APPS identity/dedup/art layer (untracked by the checklist)

### DIFF
--- a/include/appsupport.h
+++ b/include/appsupport.h
@@ -5,10 +5,12 @@
 
 #define APP_MODE_UPDATE_DELAY 240
 
-#define APP_TITLE_MAX 128
-#define APP_PATH_MAX  128
-#define APP_BOOT_MAX  64
-#define APP_ARGV1_MAX 128
+#define APP_TITLE_MAX      128
+#define APP_PATH_MAX       128
+#define APP_BOOT_MAX       64
+#define APP_STARTUP_MAX    255
+#define APP_ARGV1_MAX      128
+#define APP_ART_DEVICE_MAX 32
 
 #define APP_CONFIG_TITLE "title"
 #define APP_CONFIG_BOOT  "boot"
@@ -21,6 +23,10 @@ typedef struct
     char title[APP_TITLE_MAX + 1];
     char path[APP_PATH_MAX + 1];
     char boot[APP_BOOT_MAX + 1];
+    char startup[APP_STARTUP_MAX + 1];
+    char artDevice[APP_ART_DEVICE_MAX];
+    char artLookup[APP_BOOT_MAX + 1];
+    int artMode;
     char argv1[APP_ARGV1_MAX + 1];
     u8 legacy;
 } app_info_t;
@@ -28,5 +34,6 @@ typedef struct
 void appInit(item_list_t *itemList);
 item_list_t *appGetObject(int initOnly);
 void appPostUpdateCallback(int mode);
+int appGetArtMode(const char *startup);
 
 #endif

--- a/include/opl.h
+++ b/include/opl.h
@@ -63,6 +63,7 @@
 #define OPL_VMODE_CHANGE_CONFIRMATION_TIMEOUT_MS 10000
 
 int oplPath2Mode(const char *path);
+int oplGetAppImageByMode(int mode, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm);
 int oplGetAppImage(const char *device, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm);
 int oplScanApps(int (*callback)(const char *path, config_set_t *appConfig, void *arg), void *arg);
 int oplShouldAppsUpdate(void);

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -10,11 +10,17 @@
 #include "include/bdmsupport.h"
 #include "include/ethsupport.h"
 #include "include/hddsupport.h"
+#include "include/texcache.h"
+#include "include/textures.h"
 
 #include <elf-loader.h>
 
 static int appForceUpdate = 1;
 static int appItemCount = 0;
+static char appStartupPath[256];
+static char appResolvedStartupPath[256];
+static int *appArtLookupTable;
+static int appArtLookupTableSize = 0;
 
 static config_set_t *configApps;
 static app_info_t *appsList;
@@ -29,6 +35,12 @@ struct app_info_linked
 static item_list_t appItemList;
 
 static void appFreeList(void);
+static void appFreeArtLookup(void);
+static int appBuildArtLookup(void);
+static void appFreeLinkedList(struct app_info_linked *appsLinkedList);
+static app_info_t *appLookupByStartup(const char *startup);
+static void appSetArtSource(app_info_t *app);
+static void appSetResolvedStartup(app_info_t *app);
 
 static struct config_value_t *appGetConfigValue(int id)
 {
@@ -74,7 +86,7 @@ static float appGetELFSize(char *path)
 
 static char *appGetBoot(char *device, int max, char *path)
 {
-    char *pos, *filenamesep;
+    char *pos;
 
     // Looking for the boot device & filename from the path
     pos = strrchr(path, ':');
@@ -86,22 +98,321 @@ static char *appGetBoot(char *device, int max, char *path)
         device[len] = '\0';
     }
 
-    filenamesep = strchr(path, '/');
-    if (filenamesep != NULL)
-        return filenamesep + 1;
+    return appGetELFName(path);
+}
 
-    if (pos) {
-        return pos + 1;
+static unsigned int appHashStartup(const char *value)
+{
+    unsigned int hash = 5381;
+
+    while (value != NULL && *value != '\0') {
+        hash = ((hash << 5) + hash) ^ (unsigned char)*value;
+        value++;
     }
 
-    return path;
+    return hash;
+}
+
+// Canonical-identity comparison for APP dedup (#253). Identity is the resolved startup (the full
+// ELF path incl. its concrete device prefix) -- NEVER the title: two distinct APPs may share a
+// title, and one APP may have two titles (conf_apps.cfg key vs title.cfg). `mass:`/`mass?:` legacy
+// forms are already resolved to a concrete massN: by appSetResolvedStartup, so the slot prefix also
+// keeps the same relative path on two DIFFERENT physical devices distinct. Compared equal here:
+// '/' vs '\\', repeated separators, trailing separators, and case (the BDM filesystems OPL scans
+// apps from are FAT/exFAT -- case-insensitive; a case-differing pair on a case-sensitive fs would
+// have to collide on device+path in every other respect, which does not occur in practice).
+static int appStartupKeyEqual(const char *a, const char *b)
+{
+    if (a == NULL || b == NULL)
+        return 0;
+    // An empty startup is NOT an identity: it marks a record whose ELF path could not be resolved
+    // (e.g. a conf_apps.cfg line with an empty value), and appBuildArtLookup already skips such
+    // records as identity-less. Two of them must never merge -- one would silently vanish from the
+    // list (CodeRabbit review of #255).
+    if (a[0] == '\0' || b[0] == '\0')
+        return 0;
+
+    for (;;) {
+        char ca = *a;
+        char cb = *b;
+
+        if (ca == '\\')
+            ca = '/';
+        if (cb == '\\')
+            cb = '/';
+        if (ca >= 'A' && ca <= 'Z')
+            ca += 'a' - 'A';
+        if (cb >= 'A' && cb <= 'Z')
+            cb += 'a' - 'A';
+        if (ca != cb)
+            return 0;
+        if (ca == '\0')
+            return 1;
+        a++;
+        b++;
+        if (ca == '/') {
+            // Collapse separator runs; a trailing run is consumed here too, so the loop's next
+            // iteration compares '\0' against '\0' -- trailing separators never differentiate.
+            while (*a == '/' || *a == '\\')
+                a++;
+            while (*b == '/' || *b == '\\')
+                b++;
+        }
+    }
+}
+
+// Drop duplicate discoveries from the freshly built appsList (#253: the same APP listed several
+// times). The list is [legacy conf_apps.cfg entries...][scanned title.cfg entries...]; one APP
+// present in BOTH channels (the normal migration path from conf_apps.cfg to per-app title.cfg)
+// otherwise appears twice. First occurrence wins: order-stable, and because legacy entries sort
+// first, only SCANNED records are ever dropped -- legacy records keep their indices, preserving the
+// "legacy id <-> conf_apps.cfg node position" mapping appGetConfigValue relies on, the user's
+// conf_apps.cfg edits, and the title that Favourites records bind to. A scanned duplicate still
+// donates its argv1 (title.cfg-only metadata) to an empty-handed legacy survivor. Legacy-vs-legacy
+// collisions (two conf_apps.cfg keys pointing at the same ELF) are KEPT: dropping one would shift
+// the config-node mapping, and a duplicated hand-edited entry is the user's own data.
+static int appDroppedCount;
+static void appDedupList(void)
+{
+    appDroppedCount = 0;
+    if (appsList == NULL || appItemCount <= 1)
+        return;
+
+    int kept = 0;
+    for (int i = 0; i < appItemCount; i++) {
+        int dup = -1;
+        for (int j = 0; j < kept; j++) {
+            if (appStartupKeyEqual(appsList[j].startup, appsList[i].startup)) {
+                dup = j;
+                break;
+            }
+        }
+        if (dup >= 0 && !appsList[i].legacy) {
+            appDroppedCount++;
+            LOG("APPSUPPORT dedup: dropping scanned '%s' (%s) -- already listed as '%s' (%s)\n",
+                appsList[i].title, appsList[i].startup, appsList[dup].title, appsList[dup].startup);
+            if (appsList[dup].argv1[0] == '\0' && appsList[i].argv1[0] != '\0') {
+                strncpy(appsList[dup].argv1, appsList[i].argv1, APP_ARGV1_MAX + 1);
+                appsList[dup].argv1[APP_ARGV1_MAX] = '\0';
+            }
+            continue;
+        }
+        if (kept != i)
+            memcpy(&appsList[kept], &appsList[i], sizeof(app_info_t));
+        kept++;
+    }
+    appItemCount = kept;
+}
+
+// #253 diagnostics: write every entry's resolved identity to <config home>/apps-dump.txt so a
+// reporter's file answers "which two prefixes did this app come in through" without a serial
+// cable. Called only with debug enabled (gEnableDebug); small text file, rewritten per rebuild.
+static void appDumpDiscovery(void)
+{
+    char path[300];
+    FILE *f;
+
+    snprintf(path, sizeof(path), "%sapps-dump.txt", configGetDir());
+    f = fopen(path, "w");
+    if (f == NULL) {
+        LOG("APPSUPPORT unable to write %s\n", path);
+        return;
+    }
+    fprintf(f, "# RiptOPL app discovery dump: %d apps, %d duplicate(s) dropped by dedup\n", appItemCount, appDroppedCount);
+    fprintf(f, "# [index] [source] title | path | boot | resolved startup\n");
+    for (int i = 0; appsList != NULL && i < appItemCount; i++) {
+        fprintf(f, "%3d [%s] %s | %s | %s | %s\n",
+                i, appsList[i].legacy ? "legacy" : "scan", appsList[i].title,
+                appsList[i].path, appsList[i].boot, appsList[i].startup);
+    }
+    // Claim success only when the whole file is confirmed on disk -- the same
+    // evidence-over-status-codes rule as the config save path (#245).
+    if (fclose(f) == 0)
+        LOG("APPSUPPORT discovery dump written to %s\n", path);
+    else
+        LOG("APPSUPPORT discovery dump write FAILED on close: %s\n", path);
+}
+
+
+static const char *appBuildStartupPath(const char *path, const char *boot)
+{
+    if (path[0] != '\0') {
+        const char *leaf = appGetELFName((char *)path);
+        if (strcmp(path, boot) == 0 || (leaf != path && strcmp(leaf, boot) == 0))
+            return path;
+
+        snprintf(appStartupPath, sizeof(appStartupPath), "%s/%s", path, boot);
+        return appStartupPath;
+    }
+
+    return boot;
+}
+
+static const char *appResolveLegacyMassStartup(const char *startup)
+{
+    int fd;
+    const char *suffix;
+
+    if (startup == NULL)
+        return NULL;
+
+    if (strncmp(startup, "mass?:", 6) == 0)
+        suffix = startup + 6;
+    else if (strncmp(startup, "mass:", 5) == 0)
+        suffix = startup + 5;
+    else
+        return startup;
+
+    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+        snprintf(appResolvedStartupPath, sizeof(appResolvedStartupPath), "mass%d:%s", i, suffix);
+
+        fd = open(appResolvedStartupPath, O_RDONLY);
+        if (fd >= 0) {
+            close(fd);
+            return appResolvedStartupPath;
+        }
+    }
+
+    return startup;
+}
+
+static void appSetArtSource(app_info_t *app)
+{
+    char *artLookup;
+
+    if (app == NULL)
+        return;
+
+    app->artDevice[0] = '\0';
+    app->artLookup[0] = '\0';
+    app->artMode = -1;
+
+    if (app->startup[0] == '\0')
+        return;
+
+    artLookup = appGetBoot(app->artDevice, sizeof(app->artDevice), app->startup);
+    if (artLookup != NULL) {
+        strncpy(app->artLookup, artLookup, APP_BOOT_MAX + 1);
+        app->artLookup[APP_BOOT_MAX] = '\0';
+    }
+
+    if (app->artDevice[0] != '\0')
+        app->artMode = oplPath2Mode(app->artDevice);
+}
+
+static void appSetResolvedStartup(app_info_t *app)
+{
+    const char *startup;
+
+    if (app == NULL) {
+        return;
+    }
+
+    startup = appResolveLegacyMassStartup(appBuildStartupPath(app->path, app->boot));
+    if (startup == NULL) {
+        app->startup[0] = '\0';
+        appSetArtSource(app);
+        return;
+    }
+
+    strncpy(app->startup, startup, APP_STARTUP_MAX);
+    app->startup[APP_STARTUP_MAX] = '\0';
+    appSetArtSource(app);
+}
+
+static void appFreeArtLookup(void)
+{
+    if (appArtLookupTable != NULL) {
+        free(appArtLookupTable);
+        appArtLookupTable = NULL;
+    }
+
+    appArtLookupTableSize = 0;
+}
+
+static int appBuildArtLookup(void)
+{
+    int size;
+
+    appFreeArtLookup();
+
+    if (appsList == NULL || appItemCount <= 0)
+        return 0;
+
+    size = 1;
+    while (size < appItemCount * 2)
+        size <<= 1;
+
+    if (size < 2)
+        size = 2;
+
+    appArtLookupTable = malloc(size * sizeof(int));
+    if (appArtLookupTable == NULL)
+        return -1;
+
+    for (int i = 0; i < size; i++)
+        appArtLookupTable[i] = -1;
+
+    for (int i = 0; i < appItemCount; i++) {
+        unsigned int slot;
+
+        if (appsList[i].startup[0] == '\0')
+            continue;
+
+        slot = appHashStartup(appsList[i].startup) & (size - 1);
+        while (appArtLookupTable[slot] != -1)
+            slot = (slot + 1) & (size - 1);
+
+        appArtLookupTable[slot] = i;
+    }
+
+    appArtLookupTableSize = size;
+    return 0;
+}
+
+static app_info_t *appLookupByStartup(const char *startup)
+{
+    if (startup == NULL || appsList == NULL)
+        return NULL;
+
+    if (appArtLookupTable != NULL && appArtLookupTableSize > 0) {
+        unsigned int slot = appHashStartup(startup) & (appArtLookupTableSize - 1);
+
+        while (appArtLookupTable[slot] != -1) {
+            int index = appArtLookupTable[slot];
+
+            if (!strcmp(appsList[index].startup, startup))
+                return &appsList[index];
+
+            slot = (slot + 1) & (appArtLookupTableSize - 1);
+        }
+    }
+
+    for (int i = 0; i < appItemCount; i++) {
+        if (!strcmp(appsList[i].startup, startup))
+            return &appsList[i];
+    }
+
+    return NULL;
+}
+
+int appGetArtMode(const char *startup)
+{
+    app_info_t *app = appLookupByStartup(startup);
+
+    if (app == NULL)
+        return -1;
+
+    return app->artMode;
 }
 
 void appInit(item_list_t *itemList)
 {
     LOG("APPSUPPORT Init\n");
     appForceUpdate = 1;
-    configGetInt(configGetByType(CONFIG_OPL), "app_frames_delay", &appItemList.delay);
+    appItemList.delay = gArtDelay;
+    if (configApps != NULL)
+        configFree(configApps);
     configApps = oplGetLegacyAppsConfig();
     appsList = NULL;
     appItemList.enabled = 1;
@@ -126,8 +437,11 @@ static int appNeedsUpdate(item_list_t *itemList)
     if (oplShouldAppsUpdate())
         update = 1;
 
-    if (update)
+    if (update) {
+        if (configApps != NULL)
+            configFree(configApps);
         configApps = oplGetLegacyAppsConfig();
+    }
 
     return update;
 }
@@ -145,9 +459,11 @@ static int addAppsLegacyList(struct app_info_linked **appsLinkedList)
     cur = configApps->head;
     while (cur != NULL) {
         if (*appsLinkedList == NULL) {
-            *appsLinkedList = malloc(sizeof(struct app_info_linked));
-            app = *appsLinkedList;
-            app->next = NULL;
+            app = malloc(sizeof(struct app_info_linked));
+            if (app != NULL) {
+                app->next = NULL;
+                *appsLinkedList = app;
+            }
         } else {
             app = malloc(sizeof(struct app_info_linked));
             if (app != NULL) {
@@ -182,10 +498,11 @@ static int addAppsLegacyList(struct app_info_linked **appsLinkedList)
             strncpy(app->app.boot, cur->val, APP_BOOT_MAX + 1);
             app->app.boot[APP_BOOT_MAX] = '\0';
             strncpy(app->app.path, cur->val, APP_PATH_MAX + 1);
-            app->app.path[APP_BOOT_MAX] = '\0';
+            app->app.path[APP_PATH_MAX] = '\0';
         }
 
         app->app.legacy = 1;
+        appSetResolvedStartup(&app->app);
         count++;
         cur = cur->next;
     }
@@ -201,9 +518,11 @@ static int appScanCallback(const char *path, config_set_t *appConfig, void *arg)
 
     if (configGetStr(appConfig, APP_CONFIG_TITLE, &title) != 0 && configGetStr(appConfig, APP_CONFIG_BOOT, &boot) != 0) {
         if (*appsLinkedList == NULL) {
-            *appsLinkedList = malloc(sizeof(struct app_info_linked));
-            app = *appsLinkedList;
-            app->next = NULL;
+            app = malloc(sizeof(struct app_info_linked));
+            if (app != NULL) {
+                app->next = NULL;
+                *appsLinkedList = app;
+            }
         } else {
             app = malloc(sizeof(struct app_info_linked));
             if (app != NULL) {
@@ -229,18 +548,25 @@ static int appScanCallback(const char *path, config_set_t *appConfig, void *arg)
         } else
             app->app.argv1[0] = '\0';
         app->app.legacy = 0;
+        appSetResolvedStartup(&app->app);
         return 0;
     } else {
         LOG("APPSUPPORT item has no boot/title.\n");
         return 1;
     }
-
-    return -1;
 }
 
 static int appUpdateItemList(item_list_t *itemList)
 {
-    struct app_info_linked *appsLinkedList, *appNext;
+    struct app_info_linked *appsLinkedList;
+    struct app_info_linked *appsLinkedListHead;
+
+    /* Drain any in-flight art worker requests that reference appsList /
+     * appArtLookupTable before freeing them; without this the art worker
+     * thread (gArtThreadId) can race against the free/realloc below via
+     * appGetImage -> appLookupByStartup (use-after-free / data race). */
+    cacheAbortMmceImageLoadsTimed(500);
+    (void)cacheCancelPendingImageLoadsTimed(500);
 
     appFreeList();
 
@@ -251,6 +577,7 @@ static int appUpdateItemList(item_list_t *itemList)
 
     // Scan devices for apps.
     appItemCount += oplScanApps(&appScanCallback, &appsLinkedList);
+    appsLinkedListHead = appsLinkedList;
 
     // Generate apps list
     if (appItemCount > 0) {
@@ -258,30 +585,57 @@ static int appUpdateItemList(item_list_t *itemList)
 
         if (appsList != NULL) {
             int i;
-            for (i = 0; appsLinkedList != NULL; i++) { // appsLinkedList contains items in reverse order.
-                memcpy(&appsList[appItemCount - i - 1], &appsLinkedList->app, sizeof(app_info_t));
+            struct app_info_linked *app = appsLinkedList;
 
-                appNext = appsLinkedList->next;
-                free(appsLinkedList);
-                appsLinkedList = appNext;
-            }
+            for (i = 0; app != NULL; i++, app = app->next) // appsLinkedList contains items in reverse order.
+                memcpy(&appsList[appItemCount - i - 1], &app->app, sizeof(app_info_t));
+
+            // One APP discoverable through both channels (conf_apps.cfg + device-scanned title.cfg)
+            // must appear ONCE (#253). Runs before the art table is built so its startup hashes map
+            // to the deduped rows.
+            appDedupList();
         } else {
             LOG("APPSUPPORT unable to allocate memory.\n");
             appItemCount = 0;
         }
     }
 
+    // #253 diagnostics: with debug enabled, dump every entry's resolved identity so a
+    // reporter's file answers "which two prefixes did this app come in through" without a
+    // serial cable. Tiny text file at the config home, rewritten each rebuild -- including
+    // the zero-app rebuild, or a stale dump would outlive the truth (CodeRabbit #262).
+    if (gEnableDebug)
+        appDumpDiscovery();
+
+    if (appBuildArtLookup() < 0)
+        LOG("APPSUPPORT unable to allocate art lookup table.\n");
+
+    appFreeLinkedList(appsLinkedListHead);
+
     LOG("APPSUPPORT %d apps loaded\n", appItemCount);
 
     return appItemCount;
 }
 
+static void appFreeLinkedList(struct app_info_linked *appsLinkedList)
+{
+    while (appsLinkedList != NULL) {
+        struct app_info_linked *appNext = appsLinkedList->next;
+        free(appsLinkedList);
+        appsLinkedList = appNext;
+    }
+}
+
 static void appFreeList(void)
 {
+    appFreeArtLookup();
+
     if (appsList != NULL) {
+        free(appsList);
         appsList = NULL;
-        appItemCount = 0;
     }
+
+    appItemCount = 0;
 }
 
 static int appGetItemCount(item_list_t *itemList)
@@ -303,12 +657,7 @@ static int appGetItemNameLength(item_list_t *itemList, int id)
    The path is used immediately, before a subsequent call to appGetItemStartup(). */
 static char *appGetItemStartup(item_list_t *itemList, int id)
 {
-    if (appsList[id].legacy) {
-        struct config_value_t *cur = appGetConfigValue(id);
-        return appGetELFName(cur->val);
-    } else {
-        return appsList[id].boot;
-    }
+    return appsList[id].startup;
 }
 
 static void appDeleteItem(item_list_t *itemList, int id)
@@ -371,14 +720,18 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
     if (strncmp(filename, oldPrefix, strlen(oldPrefix)) == 0) {
         size_t oldPrefixLen = strlen(oldPrefix);
         size_t newPrefixLen = strlen(newPrefix);
-        memmove(filename + newPrefixLen, filename + oldPrefixLen, strlen(filename) - oldPrefixLen + 1);
-
-        memcpy(filename, newPrefix, newPrefixLen);
+        // The expansion grows the string by (newPrefixLen - oldPrefixLen) bytes; only
+        // shift if the result plus its NUL still fits, to avoid a stack overflow when
+        // filename is already at its maximum length.
+        if (strlen(filename) + (newPrefixLen - oldPrefixLen) < sizeof(filename)) {
+            memmove(filename + newPrefixLen, filename + oldPrefixLen, strlen(filename) - oldPrefixLen + 1);
+            memcpy(filename, newPrefix, newPrefixLen);
+        }
     }
 
     // If legacy apps state mass? find the first connected mass device with the corresponding filename and set the unit number for launch.
     if (!strncmp("mass?", filename, 5)) {
-        for (int i = 0; i < BDM_MODE4; i++) {
+        for (int i = 0; i < MAX_BDM_DEVICES; i++) {
             filename[4] = i + '0';
             fd = open(filename, O_RDONLY);
             if (fd >= 0) {
@@ -392,6 +745,7 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
     if (fd >= 0) {
         int mode, argc = 0;
         char partition[128];
+        char altStartup[256];
         char *argv[1];
         close(fd);
 
@@ -406,11 +760,15 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
             snprintf(partition, sizeof(partition), "%s:", gOPLPart);
 
         if (configGetStr(configSet, CONFIG_ITEM_ALTSTARTUP, &argv1) != 0) {
-            argv[0] = (char *)argv1;
+            // Copy before deinit(): argv1 points into the config heap which
+            // deinit() -> configEnd() frees just below; passing it to the loader
+            // afterward would be a use-after-free (A6).
+            snprintf(altStartup, sizeof(altStartup), "%s", argv1);
+            argv[0] = altStartup;
             argc = 1;
         }
 
-        deinit(UNMOUNT_EXCEPTION, mode); // CAREFUL: deinit will call appCleanUp, so configApps/cur will be freed
+        deinit(UNMOUNT_EXCEPTION, mode); // CAREFUL: deinit will call appCleanUp, which frees appsList, appArtLookupTable, and configApps
         LoadELFFromFileWithPartition(filename, partition, argc, argv);
     } else
         guiMsgBox(_l(_STR_ERR_FILE_INVALID), 0, NULL);
@@ -457,14 +815,27 @@ static config_set_t *appGetConfig(item_list_t *itemList, int id)
 
 static int appGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
-    char device[8], *startup;
+    app_info_t *app;
 
-    startup = appGetBoot(device, sizeof(device), value);
+    // Absolute (theme-folder) requests (#298): info-page attribute caches (Rating/Players/Vmode/Scan)
+    // are created with an absolute prefix and key their request on the attribute VALUE ("4", "ntsc",
+    // ...) -- never an app startup -- so the appLookupByStartup gate below must not run for them, or
+    // texcache would memoize a bogus miss and the placeholder renders forever. `folder` is the theme
+    // path; build it directly like hddGetImage does.
+    if (!isRelative) {
+        char path[256];
+        snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
+        return texDiscoverLoad(resultTex, path, -1);
+    }
+
+    app = appLookupByStartup(value);
+    if (app == NULL || app->artMode < 0)
+        return -1;
 
     if (!strcmp(folder, "ART"))
-        return oplGetAppImage(device, folder, isRelative, startup, suffix, resultTex, psm);
-    else
-        return oplGetAppImage(device, folder, isRelative, value, suffix, resultTex, psm);
+        return oplGetAppImageByMode(app->artMode, folder, isRelative, app->artLookup[0] != '\0' ? app->artLookup : app->boot, suffix, resultTex, psm);
+
+    return oplGetAppImageByMode(app->artMode, folder, isRelative, value, suffix, resultTex, psm);
 }
 
 static int appGetTextId(item_list_t *itemList)
@@ -484,6 +855,10 @@ static void appCleanUp(item_list_t *itemList, int exception)
         LOG("APPSUPPORT CleanUp\n");
 
         appFreeList();
+        if (configApps != NULL) {
+            configFree(configApps);
+            configApps = NULL;
+        }
     }
 }
 
@@ -494,6 +869,10 @@ static void appShutdown(item_list_t *itemList)
         LOG("APPSUPPORT Shutdown\n");
 
         appFreeList();
+        if (configApps != NULL) {
+            configFree(configApps);
+            configApps = NULL;
+        }
     }
 }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -691,6 +691,23 @@ int oplPath2Mode(const char *path)
     return -1;
 }
 
+// Art lookup addressed by IO MODE rather than by a device string. appsupport resolves each app's art
+// source to a mode once at scan time (appSetArtSource), so the per-cover lookup does not have to
+// re-derive it from a path on every request.
+int oplGetAppImageByMode(int mode, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
+{
+    item_list_t *listSupport;
+
+    if (mode < 0 || mode >= MODE_COUNT)
+        return -1;
+
+    listSupport = list_support[mode].support;
+    if ((listSupport != NULL) && (listSupport->enabled))
+        return listSupport->itemGetImage(listSupport, folder, isRelative, value, suffix, resultTex, psm);
+
+    return -1;
+}
+
 int oplGetAppImage(const char *device, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     int i, remaining, elfbootmode;


### PR DESCRIPTION
The 60-item checklist has **no entry for APPS at all**, so this entire subsystem was never scheduled and nobody noticed it was missing. The audit found **13 absent functions** and **four absent `app_info_t` fields**.

## What was missing

| | |
|---|---|
| **duplicate apps (#253)** | `appHashStartup` / `appStartupKeyEqual` / `appDedupList` — the same app discovered through two paths listed twice |
| **per-app art** | `appSetArtSource` / `appGetArtMode` plus the `artDevice` / `artLookup` / `artMode` fields. Each app's art source resolves to an **IO mode once at scan time**, instead of being re-derived from a path on every cover request |
| **legacy startup resolution** | `appResolveLegacyMassStartup` / `appBuildStartupPath` / `appSetResolvedStartup` and the `startup[]` field — a bare `mass:` or `mass?:` startup from an old config couldn't be resolved to a real device |
| **diagnostics** | `appDumpDiscovery` |

## Wholesale, but only after a two-way contract check

`appsupport.c` and `appsupport.h` are byte-identical to fork master. That's safe here for a reason I verified rather than assumed:

- **Forward** — every external symbol the fork's `appsupport.c` calls, scanned against this tree. Exactly **one** was absent: `oplGetAppImageByMode`. Added to `opl.c` beside `oplGetAppImage` (art lookup addressed by IO mode rather than by device string, which is what `appSetArtSource`'s resolved mode feeds).
- **Reverse** — every `app*` symbol this tree calls from *outside* appsupport, scanned against the fork's version. **None missing** — the fork is a strict superset, so nothing currently calling into appsupport can break.

That two-way check is the discipline this rebuild learned the hard way: a wholesale file drop is only safe once **both** directions of its contract are known. Getting one direction right is what produced the guiLock deadlock, the usbd black screen, and the dead Coverflow animation.

## Verification

Clean build, `MAKE_EXIT=0`, first try. All 13 previously-absent functions and all four `app_info_t` fields confirmed present afterwards.