### PR TITLE
rebuild-34: missing release data files + CI on master and pull requests

### DIFF
--- a/.github/workflows/flavours.yml
+++ b/.github/workflows/flavours.yml
@@ -8,10 +8,20 @@ name: build-flavours
 # This file is the ONLY RiptOPL addition on the rebuild base branch; the source tree stays
 # byte-identical to upstream. Each ELF self-identifies via LOCALVERSION ("-<FLAVOUR>" suffix).
 
+# Until now this fired ONLY on push to rebuild/**, so master had NO CI at all and pull requests were
+# never built -- a regression could land on master unbuilt. The rebuild becomes master at v1.0, so
+# master must be covered before that happens, not after.
+#
+# push is restricted to the two INTEGRATION branches on purpose. Adding pull_request while leaving
+# push on 'rebuild/**' made every PR build TWICE (once for the branch push, once for the PR event) --
+# observed on PR #410, 6 build jobs where 3 were wanted. Feature branches are covered by their PR;
+# these two branches are covered by the merge that lands on them.
 on:
   push:
     branches:
-      - 'rebuild/**'
+      - master
+      - rebuild/main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/neutrino/bsd-udpfsbd.toml
+++ b/neutrino/bsd-udpfsbd.toml
@@ -1,0 +1,26 @@
+# RiptOPL-supplied Neutrino backing-store config for UDPFS (the UDPRDMA block-device transport).
+#
+# Neutrino ships udpfs_bd.irx but has no built-in -bsd token for it (it's only a commented
+# alternative inside the stock bsd-udpbd.toml). RiptOPL launches UDPFS games with -bsd=udpfsbd,
+# so copy THIS file into your Neutrino install's config/ folder, e.g.:
+#     mc?:/neutrino/config/bsd-udpfsbd.toml
+# It mirrors Neutrino's stock bsd-udpbd.toml but loads udpfs_bd.irx (UDPRDMA) instead of
+# udpbd.irx (SUDPBDv2). Edit the ip= line below to your PS2's static IP if needed.
+
+# Name of loaded config, to show to user
+name = "UDPFS BDM driver (UDPRDMA)"
+
+# Drivers this driver depends on (config file must exist)
+depends = ["i_bdm", "i_dev9_hidden"]
+
+# Modules to load
+[[module]]
+file = "smap.irx"
+env = ["LE", "EE"]
+[[module]]
+file = "ministack.irx"
+args = ["ip=192.168.1.10"]
+env = ["LE", "EE"]
+[[module]]
+file = "udpfs_bd.irx"
+env = ["LE", "EE"]

--- a/pc/PS2-Servers.url
+++ b/pc/PS2-Servers.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=https://github.com/NathanNeurotic/PS2-Servers


### PR DESCRIPTION
Three gaps from the completeness audit, all outside the C source.

## 1. `neutrino/bsd-udpfsbd.toml` — functional, not just packaging

Neutrino ships `udpfs_bd.irx` but has **no built-in `-bsd` token for it** — it's only a commented alternative inside its stock `bsd-udpbd.toml`. RiptOPL launches UDPFS games with `-bsd=udpfsbd`, so this file is what the user copies into `<neutrino>/config/`.

Without it shipping, a UDPFS-over-Neutrino launch has no backing-store config to reference and **simply cannot work**. This is the only file in the fork's `neutrino/` directory.

## 2. `pc/PS2-Servers.url`

A two-line shortcut. Small — but the fork's release packaging step hard-fails on `test -f pc/PS2-Servers.url` under `set -eu`, so its absence would break the release build the moment items 58/59 land.

## 3. CI on master and pull requests

`flavours.yml` fired **only** on `push: rebuild/**`. So master had **no CI at all** and pull requests were never built — a regression could land on master unbuilt.

The rebuild becomes master at v1.0, so this needs to be true *before* that happens, not after.

## Not included, and why

The rolling-release workflow itself (items 58/59) **cannot be copied wholesale**. It references:

- `install_coherent_mmce.sh` — MMCE, deferred
- `GSM1080P` variant builds — item 29, deferred
- MEGA credentials that exist only as repo secrets

It also publishes **public releases**, so it wants deliberate adaptation and a decision on which variants to ship — not a blind port. Scoped separately.