### PR TITLE
rebuild-35: take over the release pipeline (items 58/59)

### DIFF
--- a/.github/scripts/build_rolling_extras.sh
+++ b/.github/scripts/build_rolling_extras.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Build the "extra" RIPTOPL release builds for the rolling release:
+#   * the EXTRA_FEATURES x PADEMU x DUALSENSE variant matrix -> rolling/variants/
+#   * the debug configs                          -> rolling/debug/
+#
+# Called by EACH SDK build job in rolling-release.yml. $1 is the SDK suffix appended to each
+# filename: "-PS2DEVPINNEDSDK" for the digest-pinned ps2dev snapshot
+# build, "-PS2DEVLATESTSDK" for the ps2dev:latest build -- so the VARIANTS and DEBUG zips carry
+# every SDK flavour of every build. $2 is the LOCALVERSION
+# toolchain brand ("PS2DEVPINNEDSDK"/"PS2DEVLATESTSDK") embedded in each ELF's version string: filenames get renamed
+# and moved to cards, and the debug/variant builds are exactly the ones that show up in bug
+# reports -- the on-screen version must self-identify the toolchain like the main builds do.
+#
+# Best-effort per build: a single failing config is logged + skipped, never sinking the publish.
+# MUST run AFTER the main release ELF is already staged, since each build does `make clean`.
+# No version in the filenames -- the version lives in the zip names (rolling-release.yml).
+set -eu
+
+SDK_SUFFIX="${1:-}"
+BRAND="${2:-}"
+BRAND_ARG=""
+[ -n "$BRAND" ] && BRAND_ARG="LOCALVERSION=$BRAND"
+
+echo "== Building RIPTOPL variants (suffix='${SDK_SUFFIX}' brand='${BRAND}') =="
+mkdir -p rolling/variants
+for pad in PADEMU=0 PADEMU=1; do
+  for ex in EXTRA_FEATURES=0 EXTRA_FEATURES=1; do
+    for ds5 in DUALSENSE=0 DUALSENSE=1; do
+      make clean >/dev/null 2>&1 || true
+      if make --trace $pad $ex $ds5 NOT_PACKED=1 $BRAND_ARG && [ -f opl.elf ]; then
+        ds5_label=$([ "${ds5#DUALSENSE=}" = "1" ] && echo "-ds5" || echo "")
+        mv opl.elf "rolling/variants/RIPTOPL-pademu${pad#PADEMU=}-extra${ex#EXTRA_FEATURES=}${ds5_label}${SDK_SUFFIX}.ELF"
+      else
+        echo "WARN: variant '$pad $ex $ds5'${SDK_SUFFIX} failed to build; skipping it"
+      fi
+    done
+  done
+done
+echo "Variants present:"; ls -la rolling/variants || true
+
+echo "== Building RIPTOPL debug builds (suffix='${SDK_SUFFIX}') =="
+mkdir -p rolling/debug
+for dbg in iopcore_debug ingame_debug eesio_debug iopcore_ppctty_debug ingame_ppctty_debug DTL_T10000=1; do
+  make clean >/dev/null 2>&1 || true
+  if make --trace $dbg $BRAND_ARG && [ -f opl.elf ]; then
+    mv opl.elf "rolling/debug/RIPTOPL-${dbg%=1}${SDK_SUFFIX}.ELF"
+  else
+    echo "WARN: debug '$dbg'${SDK_SUFFIX} failed to build; skipping it"
+  fi
+done
+echo "Debug present:"; ls -la rolling/debug || true

--- a/.github/workflows/neutrino-watch.yml
+++ b/.github/workflows/neutrino-watch.yml
@@ -1,0 +1,74 @@
+name: Neutrino Watch
+
+# Keeps the rolling release "cutting edge" with respect to the upstream Neutrino core.
+#
+# Pushes to master already refresh the rolling release on their own (rolling-release.yml), which
+# re-fetches the latest Neutrino each run. This watcher covers the OTHER half: when the official
+# Neutrino repo publishes a newer build than the one currently bundled in our rolling release, it
+# re-dispatches rolling-release.yml so the package rebundles the latest Neutrino -- without waiting
+# for an OPL commit.
+#
+# It is only a slow safety net -- any push to master rebundles Neutrino anyway -- so it ticks about
+# once every 10 days rather than the every-3h it used to; use workflow_dispatch for an on-demand check.
+#
+# Cheap + conditional: every run is two read-only API calls; it only dispatches a rebuild when the
+# upstream Neutrino version actually differs from what's already bundled (parsed from the rolling
+# release notes' "Included build:" line that rolling-release.yml writes). workflow_dispatch via the
+# GITHUB_TOKEN DOES start a new run (it's the documented exception to the no-recursion rule).
+
+on:
+  schedule:
+    # ~Every 10 days. cron has no "every N days" operator that spans month boundaries, so pin the
+    # days explicitly: the 1st, 11th and 21st (gaps of 10, 10, then 8-11 into the next month).
+    # Deliberately NOT "*/10" for day-of-month -- that also fires on the 31st, one day after the
+    # 21st+10 tick, i.e. two runs back to back in the 7 long months.
+    # Off-hour + offset minute to dodge the top-of-hour cron backlog.
+    - cron: "41 5 1,11,21 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write # required to dispatch rolling-release.yml
+
+concurrency:
+  group: neutrino-watch
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NEUTRINO_REPO: rickgaiser/neutrino
+    steps:
+      - name: Compare upstream Neutrino against the bundled build; rebuild rolling if newer
+        run: |
+          set -eu
+          # Upstream: version embedded in the .7z asset name of Neutrino's "latest" pre-release.
+          NEU="$(gh release view latest --repo "$NEUTRINO_REPO" --json assets \
+            --jq '.assets[].name' 2>/dev/null | grep -E '^neutrino_.*\.7z$' | head -n1 \
+            | sed -e 's/^neutrino_//' -e 's/\.7z$//' || true)"
+          # Currently bundled: parsed from our rolling release notes (rolling-release.yml writes
+          # "Included build: <ver> -- ...").
+          CUR="$(gh release view rolling --repo "$GITHUB_REPOSITORY" --json body \
+            --jq '.body' 2>/dev/null | sed -n 's/.*Included build: \([^ ]*\).*/\1/p' | head -n1 || true)"
+          echo "upstream Neutrino = [$NEU]"
+          echo "rolling bundles   = [$CUR]"
+
+          if [ -z "$NEU" ]; then
+            echo "Could not read the upstream Neutrino version (transient?); nothing to do."
+            exit 0
+          fi
+          # Act ONLY on a genuine version difference. If CUR is empty -- rolling has never bundled
+          # Neutrino yet, OR a prior rolling build's best-effort fetch failed and wrote no
+          # "Included build:" line -- do NOT dispatch: otherwise a persistent upstream outage would
+          # re-trigger a full (expensive) rebuild on every cron tick. That state self-heals on the
+          # next push to master (rolling-release re-fetches Neutrino) or a manual rolling dispatch.
+          if [ -z "$CUR" ]; then
+            echo "Rolling has no recorded bundled Neutrino version; deferring to the next push-to-master rebuild."
+          elif [ "$NEU" != "$CUR" ]; then
+            echo "Neutrino changed ($CUR -> $NEU): dispatching rolling-release.yml to rebundle."
+            gh workflow run rolling-release.yml --repo "$GITHUB_REPOSITORY" --ref master
+          else
+            echo "Rolling already bundles the latest Neutrino ($NEU). Nothing to do."
+          fi

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -1,0 +1,815 @@
+name: Rolling Release
+
+# Continuously publishes the current master build to a single "rolling" pre-release
+# so it can be pulled directly from GitHub at a stable URL as development progresses.
+#
+# Builds with TWO toolchains so a regression in either is visible from the rolling channel
+# (and a hardware failure can be triaged by WHICH flavours reproduce it). Each ships as its own
+# labeled APP_RIPTOPL-<SDK>/ folder + bare ELF; recommended download order is by reliability:
+#   * ps2dev/ps2dev:latest       -> -PS2DEVLATESTSDK  (current SDK, stock drivers; RECOMMENDED #1 --
+#                                                      what RiptOPL is developed and tested against)
+#   * ps2dev/ps2dev@sha256 (pin) -> -PS2DEVPINNEDSDK  (a DIGEST PIN of ps2dev:latest taken on a day it
+#                                                      was known good; SAFE FALLBACK for when the moving
+#                                                      latest tag regresses, see issue #102)
+#
+# A source snapshot (RIPTOPL-<version>-src.zip) of the exact built commit is also
+# published, so every rolling build is self-preserving: testers can restore and
+# rebuild precisely what they ran, even if history is later rewritten.
+#
+# Deliberately additive and self-contained:
+#   * Publishes ONLY to the "rolling" tag / pre-release (created on first run).
+#   * Does NOT modify the curated tagged releases, the existing "latest" pre-release
+#     managed by compilation.yml, or any branch. It only uploads release assets.
+#   * Builds run inside their toolchain containers; publishing runs on the host
+#     runner, which ships the gh CLI.
+#
+# The WOPLSDK flavour (wOPL's digest-pinned ghcr.io container) was REMOVED 2026-07-27: it crashed
+# at the initial setup menu and was not worth fixing, since the two remaining flavours are healthy
+# and already cover both "pinned" and "bleeding-edge" triage (issue #270).
+#
+# GATING: the ps2dev:latest (PS2DEVLATESTSDK) build must COMPILE -- if it fails to build the
+# publish FAILS loudly. Both flavours ship as their own labeled folder
+# (APP_RIPTOPL-PS2DEVPINNEDSDK / -PS2DEVLATESTSDK) -- there is NO unlabeled default, so a
+# toolchain can never be swapped in silently. Each ELF self-identifies: the version string
+# carries "-PS2DEVPINNEDSDK" / "-PS2DEVLATESTSDK" (LOCALVERSION). Note the compile gate
+# catches BUILD breakage only: ps2dev:latest tracks a MOVING tag whose ps2sdk drifts daily and
+# can yield a green-but-non-booting binary (issue #102), which is why the pinned PS2DEVPINNEDSDK flavour
+# is kept as the safe fallback -- see the release notes "Get started".
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Per-ref: master pushes still supersede each other (rolling), but a v* tag release runs in its
+# own group, so a new master push can't cancel an in-flight release cut (or vice versa).
+concurrency:
+  group: rolling-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-rolling-pinned:
+    runs-on: ubuntu-latest
+    container: ps2dev/ps2dev@sha256:c64ae69c9817865ed98ff054e4ae5360b9e280ed952c97946bca95d9d35be995
+    # Fallback/compatibility toolchain: best-effort, must not block the rolling publish.
+    continue-on-error: true
+    steps:
+      # Install git BEFORE checkout: without it, actions/checkout falls back to an API
+      # tarball (no .git directory) and git describe fails, collapsing the version string.
+      # Required by every ps2dev image, pinned or latest -- they are Alpine and ship no git.
+      # The retired ps2max container carried these preinstalled, which is why this job did
+      # not need the step before the pin.
+      - name: Install host dependencies (Alpine only)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache \
+              bash \
+              make \
+              git \
+              zip \
+              unzip \
+              tar \
+              gzip \
+              xz \
+              python3 \
+              py3-pip \
+              py3-yaml \
+              gmp \
+              mpfr4 \
+              mpc1 \
+              perl \
+              cmake \
+              pkgconf \
+              coreutils \
+              findutils \
+              grep \
+              sed \
+              gawk \
+              diffutils
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Mark workspace safe and fetch history
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --prune --unshallow || true
+
+      # NOTE(rebuild): the fork runs a step here that is not applicable yet --
+      #   Install menu-coherent mmceman (#254)
+      # It returns with its checklist item (MMCE = items 1-3, GSM 1080p = item 29), both of
+      # which are on WAIT. Removed rather than left to fail/WARN every single run.
+
+      - name: Build (make clean release)
+        # LOCALVERSION brands the in-ELF version string ("-PS2DEVPINNEDSDK") so hardware reports
+        # self-identify which toolchain's binary produced them (Makefile appends it).
+        run: make --trace clean && make --trace LOCALVERSION=PS2DEVPINNEDSDK release
+
+      - name: Stage rolling assets (pinned = PS2DEVPINNEDSDK)
+        run: |
+          set -eu
+          mkdir -p rolling
+          # Publish ONLY the stable, version-agnostic name. Versioned filenames
+          # embed the commit, so they change every run and pile up as stale
+          # assets -- confusing on a rolling channel.
+          MAIN_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+          if [ -z "${MAIN_ELF:-}" ] || [ ! -f "$MAIN_ELF" ]; then
+            echo "No RIPTOPL ELF produced by the pinned build" >&2
+            exit 1
+          fi
+          cp -f "$MAIN_ELF" rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF
+          # IRX provenance manifest: hash every prebuilt module consumed from this container's SDK.
+          # A silent SDK-side driver swap (the mmceman class) then shows up as a manifest diff
+          # between runs instead of as a hardware mystery.
+          sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST-PS2DEVPINNEDSDK.txt 2>/dev/null || true
+          echo "Staged pinned rolling assets:"
+          ls -la rolling
+
+      - name: Build + stage DualSense (DS5) loader (PS2DEVPINNEDSDK)
+        # DualSense (DS5 USB) is HW-validated (maintainer, 2026-07-06) but kept OFF in the default
+        # build by choice. Ship a ready-made DUALSENSE=1 loader for THIS SDK flavour as a named
+        # top-level asset so DS5 owners can pick their preferred (recommended) flavour without
+        # digging in the VARIANTS zip. Best-effort: a DS5 build hiccup must not sink the main flavour.
+        # LOCALVERSION carries "-PS2DEVPINNEDSDK-ds5" so hardware reports self-identify.
+        run: |
+          make --trace clean
+          rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the DS5 output is unambiguous
+          if make --trace LOCALVERSION=PS2DEVPINNEDSDK-ds5 DUALSENSE=1 release; then
+            DS5_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+            if [ -n "${DS5_ELF:-}" ] && [ -f "$DS5_ELF" ]; then
+              cp -f "$DS5_ELF" rolling/RIPTOPL-PS2DEVPINNEDSDK-ds5.ELF
+            else
+              echo "WARN: PS2DEVPINNEDSDK DUALSENSE=1 build produced no ELF; skipping DS5 asset this run" >&2
+            fi
+          else
+            echo "WARN: PS2DEVPINNEDSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
+          fi
+
+      - name: Build variant + debug extras (pinned = PS2DEVPINNEDSDK)
+        # Runs AFTER staging so the per-build `make clean` can't wipe the saved main ELF.
+        run: sh ./.github/scripts/build_rolling_extras.sh "-PS2DEVPINNEDSDK" "PS2DEVPINNEDSDK"
+
+      - name: Upload pinned rolling assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: rolling-assets-pinned
+          path: rolling
+          if-no-files-found: error
+
+  build-rolling-ps2dev-latest:
+    runs-on: ubuntu-latest
+    container: ps2dev/ps2dev:latest
+    # PS2DEVLATESTSDK (target) toolchain: REQUIRED to COMPILE. If this fails to build, the publish
+    # fails loudly. It ships as its own labeled APP_RIPTOPL-PS2DEVLATESTSDK/ folder (no default slot).
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      # Dependencies BEFORE checkout: with no git in the container, actions/checkout falls
+      # back to an API tarball (no .git at all) -> `git fetch --unshallow` fails, the Makefile's
+      # `test -d .git` marks the build "-dirty", and the version collapses to an uninformative
+      # "vX.Y.Z-Beta-N-dirty" (exactly what hardware reporters were pasting back at us).
+      - name: Install host dependencies (Alpine only)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            # Consolidated ps2dev Alpine prerequisites: build tools, scripting, packaging, and gcc runtime libs.
+            apk add --no-cache \
+              bash \
+              make \
+              git \
+              zip \
+              unzip \
+              tar \
+              gzip \
+              xz \
+              python3 \
+              py3-pip \
+              py3-yaml \
+              gmp \
+              mpfr4 \
+              mpc1 \
+              perl \
+              cmake \
+              pkgconf \
+              coreutils \
+              findutils \
+              grep \
+              sed \
+              gawk \
+              diffutils
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Mark workspace safe and fetch history
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --prune --unshallow || true
+
+      - name: Get version
+        id: ver
+        run: echo "version=$(make oplversion)" >> "$GITHUB_OUTPUT"
+
+      # NOTE(rebuild): the fork runs a step here that is not applicable yet --
+      #   Install menu-coherent mmceman (latest-only)
+      # It returns with its checklist item (MMCE = items 1-3, GSM 1080p = item 29), both of
+      # which are on WAIT. Removed rather than left to fail/WARN every single run.
+
+      - name: Build (make clean release)
+        # LOCALVERSION brands the in-ELF version string ("-PS2DEVLATESTSDK") so hardware reports
+        # self-identify which toolchain's binary produced them (Makefile appends it).
+        run: make --trace clean && make --trace LOCALVERSION=PS2DEVLATESTSDK release
+
+      - name: Detailed changelog
+        run: sh ./make_changelog.sh
+
+      - name: Stage rolling assets (ps2dev-latest = primary)
+        run: |
+          set -eu
+          mkdir -p rolling
+          # Publish ONLY the stable, version-agnostic name for the primary build.
+          MAIN_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+          if [ -z "${MAIN_ELF:-}" ] || [ ! -f "$MAIN_ELF" ]; then
+            echo "No RIPTOPL ELF produced by the ps2dev-latest build" >&2
+            exit 1
+          fi
+          cp -f "$MAIN_ELF" rolling/RIPTOPL.ELF
+          [ -f DETAILED_CHANGELOG ] && cp -f DETAILED_CHANGELOG rolling/ || true
+          # IRX provenance manifest for the primary container's SDK prebuilts (see the pinned job).
+          sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST-PS2DEVLATESTSDK.txt 2>/dev/null || true
+          # Standalone language pack (lang_*.lng + their non-Latin fonts, which are NOT embedded in the
+          # ELF) -- build it off the just-built lng/ and stage it so 'rolling' carries it too. Soft-fail
+          # so a LANGS hiccup can't break rolling.
+          if ./lng_pack.sh && ls RIPTOPL-LANGS-*.zip >/dev/null 2>&1; then
+            cp -f RIPTOPL-LANGS-*.zip rolling/
+          else
+            echo "WARN: language pack not produced this run"
+          fi
+          echo "Staged ps2dev-latest rolling assets:"
+          ls -la rolling
+
+      - name: Build + stage DualSense (DS5) loader (PS2DEVLATESTSDK)
+        # Named DUALSENSE=1 loader on the ps2dev:latest toolchain. Like the plain PS2DEVLATESTSDK
+        # build this rides the moving SDK tag (may not boot -- issue #102); DS5 owners who want a
+        # reliable build should prefer the -PS2DEVPINNEDSDK-ds5 asset. Best-effort so a
+        # DS5 hiccup can't sink the required primary flavour. LOCALVERSION carries "-PS2DEVLATESTSDK-ds5".
+        run: |
+          make --trace clean
+          rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the DS5 output is unambiguous
+          if make --trace LOCALVERSION=PS2DEVLATESTSDK-ds5 DUALSENSE=1 release; then
+            DS5_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+            if [ -n "${DS5_ELF:-}" ] && [ -f "$DS5_ELF" ]; then
+              cp -f "$DS5_ELF" rolling/RIPTOPL-PS2DEVLATESTSDK-ds5.ELF
+            else
+              echo "WARN: PS2DEVLATESTSDK DUALSENSE=1 build produced no ELF; skipping DS5 asset this run" >&2
+            fi
+          else
+            echo "WARN: PS2DEVLATESTSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
+          fi
+
+      # NOTE(rebuild): the fork runs a step here that is not applicable yet --
+      #   Build + stage experimental 1080p GSM loader (PS2DEVLATESTSDK)
+      # It returns with its checklist item (MMCE = items 1-3, GSM 1080p = item 29), both of
+      # which are on WAIT. Removed rather than left to fail/WARN every single run.
+
+      - name: Build variant + debug extras (ps2dev:latest = standard)
+        # Runs after staging the main ELF so the per-build `make clean` can't wipe it.
+        run: sh ./.github/scripts/build_rolling_extras.sh "-PS2DEVLATESTSDK" "PS2DEVLATESTSDK"
+
+      - name: Upload ps2dev-latest rolling assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: rolling-assets-ps2dev-latest
+          path: rolling
+          if-no-files-found: error
+
+  build-rolling-officialsdk:
+    runs-on: ubuntu-latest
+    # OFFICIALSDK (third flavour): the EXACT container official OPL's rolling pre-release
+    # compiles in (ghcr.io/ps2homebrew/ps2homebrew:main) -- a separate SDK lineage from
+    # ps2dev/ps2dev, so hardware reports can split toolchain effects from RiptOPL code.
+    # Best-effort by design (continue-on-error): main ELF only, no ds5/1080p/extras; a
+    # failure here must never block the two ps2dev flavours from publishing.
+    continue-on-error: true
+    container: ghcr.io/ps2homebrew/ps2homebrew:main
+    steps:
+      # The ps2homebrew image ships official OPL's build deps; the guarded installs only
+      # top up this fork's extras (py3-yaml for the language overlay compiler, zip/gawk
+      # for packaging) and no-op on either package manager if everything is present.
+      - name: Install host dependencies (either package manager)
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache bash make git zip unzip tar gzip xz python3 py3-pip py3-yaml gawk coreutils findutils grep sed diffutils || true
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq bash make git zip unzip python3 python3-yaml gawk || true
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Mark workspace safe and fetch history
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --prune --unshallow || true
+
+      # NOTE(rebuild): the fork runs a menu-coherent mmceman install here. MMCE is checklist
+      # items 1-3, on WAIT, and this tree embeds no mmceman at all -- so the step would rebuild a
+      # driver nothing loads. It returns with item 1.
+
+      - name: Build (make clean release)
+        # LOCALVERSION brands the in-ELF version string ("-OFFICIALSDK") so hardware
+        # reports self-identify which toolchain's binary produced them.
+        run: make --trace clean && make --trace LOCALVERSION=OFFICIALSDK release
+
+      - name: Stage rolling assets (officialsdk)
+        run: |
+          set -eu
+          mkdir -p rolling
+          MAIN_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
+          if [ -z "${MAIN_ELF:-}" ] || [ ! -f "$MAIN_ELF" ]; then
+            echo "No RIPTOPL ELF produced by the officialsdk build" >&2
+            exit 1
+          fi
+          cp -f "$MAIN_ELF" rolling/RIPTOPL-OFFICIALSDK.ELF
+          # IRX provenance manifest for this container's SDK prebuilts.
+          sha256sum "$PS2SDK"/iop/irx/*.irx > rolling/IRX-MANIFEST-OFFICIALSDK.txt 2>/dev/null || true
+          echo "Staged officialsdk rolling assets:"
+          ls -la rolling
+
+      - name: Upload officialsdk rolling assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: rolling-assets-officialsdk
+          path: rolling
+          if-no-files-found: error
+
+  publish-rolling:
+    needs: [build-rolling-pinned, build-rolling-ps2dev-latest, build-rolling-officialsdk]
+    # NOTE(rebuild): publish gate. Downstream this job has NO ref check -- anything that is not a
+    # v* tag falls through to TAG="rolling" and cuts a PUBLIC prerelease (see the tag/title block
+    # below). That is correct on master, but the rebuild branch is not master yet, so the only way
+    # to exercise this pipeline before cutover -- workflow_dispatch from rebuild/main -- would
+    # publish a real release built from an unfinished tree. Gating here keeps the three build jobs
+    # (the part worth rehearsing) running on a dispatch and uploads their artifacts, while
+    # withholding only the publish. On master and on v* tags the condition is true, so shipping
+    # behaviour is byte-for-byte what the fork does today.
+    if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OPL_VERSION: ${{ needs.build-rolling-ps2dev-latest.outputs.version }}
+      # Human-readable label for the FALLBACK (-PS2DEVPINNEDSDK) build, shown in the release notes.
+      # This flavour is a DIGEST PIN of ps2dev:latest, so the label is the date the pin was taken.
+      # Bump it and the container digest together in build-rolling-pinned when re-pinning.
+      SDK_VER: "ps2dev:latest pinned 2026-07-28"
+      # MEGA archival credentials (repo secrets MEGA_USERNAME / MEGA_PASSWORD). Exposed under the
+      # names USERNAME / PASSWORD because the upload action (Difegue/action-megacmd) reads exactly
+      # those env names, and because it lets the MEGA steps gate on `env.USERNAME != ''` -- a fork
+      # (or any run) without the secrets simply SKIPS the MEGA archive instead of failing.
+      USERNAME: ${{ secrets.MEGA_USERNAME }}
+      PASSWORD: ${{ secrets.MEGA_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Download ps2dev-latest rolling assets
+        # The PRIMARY build: required (its job failing already failed the workflow).
+        uses: actions/download-artifact@v8
+        with:
+          name: rolling-assets-ps2dev-latest
+          path: rolling
+
+      - name: Download pinned rolling assets
+        # Optional: the pinned fallback build may have failed; publish what we have.
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: rolling-assets-pinned
+          path: rolling
+
+      - name: Download officialsdk rolling assets
+        # Optional: the official-SDK flavour is best-effort; publish what we have.
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: rolling-assets-officialsdk
+          path: rolling
+
+
+      - name: Name assets with the build version
+        run: |
+          set -eu
+          # Apply ONE authoritative version (from the primary ps2dev:latest build, which now
+          # resolves full git history) to BOTH toolchains. The source commit is identical, so
+          # the only difference is the toolchain-brand suffix (-PS2DEVPINNEDSDK / -PS2DEVLATESTSDK).
+          VER="${OPL_VERSION:-}"
+          if [ -z "$VER" ]; then
+            VER="rolling-${GITHUB_SHA}"
+          fi
+          echo "VERSIONED_BASE=RIPTOPL-${VER}" >> "$GITHUB_ENV"
+          if [ -f rolling/RIPTOPL.ELF ]; then
+            mv -f rolling/RIPTOPL.ELF "rolling/RIPTOPL-${VER}-PS2DEVLATESTSDK.ELF"
+          fi
+          if [ -f rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF ]; then
+            mv -f rolling/RIPTOPL-PS2DEVPINNEDSDK.ELF "rolling/RIPTOPL-${VER}-PS2DEVPINNEDSDK.ELF"
+          fi
+          if [ -f rolling/RIPTOPL-OFFICIALSDK.ELF ]; then
+            mv -f rolling/RIPTOPL-OFFICIALSDK.ELF "rolling/RIPTOPL-${VER}-OFFICIALSDK.ELF"
+          fi
+          # DualSense (DS5) named loaders, one per SDK flavour (best-effort -- any may be absent).
+          for sdk in PS2DEVPINNEDSDK PS2DEVLATESTSDK; do
+            if [ -f "rolling/RIPTOPL-${sdk}-ds5.ELF" ]; then
+              mv -f "rolling/RIPTOPL-${sdk}-ds5.ELF" "rolling/RIPTOPL-${VER}-${sdk}-ds5.ELF"
+            fi
+          done
+          echo "Renamed assets:"
+          ls -la rolling
+
+      - name: Archive source snapshot
+        run: |
+          set -eu
+          # Bundle the exact source that produced these ELFs so the rolling build
+          # is self-preserving: a tester can always restore and rebuild this precise
+          # commit later, even if history is rewritten or a branch disappears.
+          # git archive snapshots only TRACKED files at HEAD (== the built commit);
+          # generated files (e.g. the gitignored lang_autogen.h) are intentionally
+          # excluded because the build regenerates them. The project has no
+          # submodules, so HEAD is the complete source tree. --prefix gives a clean
+          # top-level folder on extraction. --format=zip uses git's built-in zip
+          # writer (no external tooling needed).
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git archive --format=zip \
+            --prefix="${VERSIONED_BASE}-src/" \
+            -o "rolling/${VERSIONED_BASE}-src.zip" \
+            HEAD
+          echo "Source snapshot:"
+          ls -la "rolling/${VERSIONED_BASE}-src.zip"
+
+      - name: Compute SHA256 checksums
+        run: |
+          set -eu
+          # Publish SHA256 of every binary + the source snapshot so each rolling build is
+          # verifiable for restoration/archival. SHA256SUMS.txt is uploaded as a release
+          # asset and the same hashes are listed in the release notes below.
+          cd rolling
+          : > SHA256SUMS.txt
+          for f in *.ELF *-src.zip; do
+            if [ -f "$f" ]; then sha256sum "$f" >> SHA256SUMS.txt; fi
+          done
+          echo "SHA256SUMS.txt:"
+          cat SHA256SUMS.txt
+
+      - name: Build RIPTOPL release package
+        run: |
+          set -eu
+          # Full installable package the user copies to a memory card / device:
+          #                                              drivers (no coherent-mmce override); SAFE FALLBACK.
+          #   APP_RIPTOPL-PS2DEVPINNEDSDK/RIPTOPL.ELF   -- digest pin of ps2dev:latest; SAFE FALLBACK.
+          #   APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF -- ps2dev:latest (bleeding-edge MOVING tag; may not
+          #                                              boot, issue #102). No unlabeled default folder.
+          #   POPSTARTER/                     -- Legacy manual MC bundle + network templates/marker.
+          #   POPS/                           -- POPSTARTER.ELF + every auto-installed MC external + BDMA variants.
+          #   neutrino/                       -- the official latest Neutrino core (rickgaiser/neutrino), extracted for drag-and-drop.
+          #   PS2-Servers.url                 -- link to the UDPFS / SMB / UDPBD all-in-one PC server.
+          PKG=riptopl_pkg
+          rm -rf "$PKG"
+          mkdir -p "$PKG/APP_RIPTOPL-PS2DEVLATESTSDK" "$PKG/POPSTARTER" "$PKG/POPS"
+          # PS2DEVLATESTSDK is the required-to-build flavour (its build job failing already fails
+          # the workflow); the two pinned flavours are best-effort, each in its own labeled folder.
+          # This belt-and-braces check just asserts the PS2DEVLATESTSDK ELF landed before packaging.
+          LATEST_ELF="rolling/${VERSIONED_BASE}-PS2DEVLATESTSDK.ELF"
+          PINNED_ELF="rolling/${VERSIONED_BASE}-PS2DEVPINNEDSDK.ELF"
+          if [ ! -f "$LATEST_ELF" ]; then
+            echo "PS2DEVLATESTSDK (ps2dev:latest) ELF missing -- its build job failing already fails the workflow" >&2
+            exit 1
+          fi
+          cp -f "$LATEST_ELF" "$PKG/APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF"
+          if [ -f "$PINNED_ELF" ]; then
+            mkdir -p "$PKG/APP_RIPTOPL-PS2DEVPINNEDSDK"
+            cp -f "$PINNED_ELF" "$PKG/APP_RIPTOPL-PS2DEVPINNEDSDK/RIPTOPL.ELF"
+          else
+            echo "WARN: pinned fallback build missing this run; package ships without APP_RIPTOPL-PS2DEVPINNEDSDK" >&2
+          fi
+          OFFICIAL_ELF="rolling/${VERSIONED_BASE}-OFFICIALSDK.ELF"
+          if [ -f "$OFFICIAL_ELF" ]; then
+            mkdir -p "$PKG/APP_RIPTOPL-OFFICIALSDK"
+            cp -f "$OFFICIAL_ELF" "$PKG/APP_RIPTOPL-OFFICIALSDK/RIPTOPL.ELF"
+          else
+            echo "WARN: officialsdk build missing this run; package ships without APP_RIPTOPL-OFFICIALSDK" >&2
+          fi
+          cp -f POPS/{smbman.irx,ps2ip.irx,ps2smap.irx,ps2dev9.irx,SMSUTILS.irx,poweroff.irx,del.icn,list.icn,icon.sys} "$PKG/POPSTARTER/"
+          cp -f popsmb/* "$PKG/POPSTARTER/"
+          cp -f POPS/* "$PKG/POPS/"
+          # Keep PC-side servers in their dedicated release stream. The shortcut opens the maintained
+          # PS2 Servers all-in-one launcher for UDPFS, SMBv1 and UDPBD; no server binaries or source are
+          # embedded in the RiptOPL install package.
+          test -f pc/PS2-Servers.url
+          cp -f pc/PS2-Servers.url "$PKG/PS2-Servers.url"
+          # neutrino/ (package folder) -- the official latest pre-release of the Neutrino core,
+          # EXTRACTED into a plain folder so the user just drag-and-drops it onto the card (no
+          # zip-in-zip). Best-effort: a fetch/extract failure still publishes the rest. The archive
+          # root holds neutrino.elf + config/ + modules/, so the neutrino/ folder copies straight to
+          # mc?:/neutrino/. RiptOPL adds ONLY config/bsd-udpfsbd.toml (UDPFS); else the official build.
+          NEUTRINO_VER=""
+          if gh release download latest --repo rickgaiser/neutrino --dir "$PKG" --pattern '*.7z' --clobber 2>/dev/null; then
+            NEUTRINO_ARCHIVE="$(cd "$PKG" && ls neutrino_*.7z 2>/dev/null | head -n1)"
+            NEUTRINO_VER="$(printf '%s' "$NEUTRINO_ARCHIVE" | sed -e 's/^neutrino_//' -e 's/\.7z$//')"
+            echo "Bundled neutrino: $NEUTRINO_ARCHIVE"
+            SEVENZ="$(command -v 7z || command -v 7za || true)"
+            if [ -z "$SEVENZ" ]; then sudo apt-get update -qq && sudo apt-get install -y -qq p7zip-full && SEVENZ="$(command -v 7z || command -v 7za)"; fi
+            NEUT_ABS="$(cd "$PKG" && pwd)/$NEUTRINO_ARCHIVE"
+            # Extract into $PKG/neutrino/ and drop the raw .7z. Neutrino ships udpfs_bd.irx but no
+            # built-in -bsd token for it; RiptOPL launches UDPFS via -bsd=udpfsbd, so add that config
+            # next to the others in config/. Require neutrino.elf at the folder root, else omit.
+            if [ -n "$SEVENZ" ] && "$SEVENZ" x -y -o"$PKG/neutrino" "$NEUT_ABS" >/dev/null && [ -e "$PKG/neutrino/neutrino.elf" ]; then
+              mkdir -p "$PKG/neutrino/config" && cp neutrino/bsd-udpfsbd.toml "$PKG/neutrino/config/bsd-udpfsbd.toml"
+              rm -f "$NEUT_ABS"
+              echo "Extracted Neutrino into $PKG/neutrino (added config/bsd-udpfsbd.toml for UDPFS)."
+              # UDPFS Files mode launches with stock -bsd=udpfs, which needs Neutrino's own
+              # config/bsd-udpfs.toml + udpfs modules. The bundle is a MOVING target re-fetched
+              # every publish -- assert the dependency so an upstream re-layout is caught here,
+              # not as a mystery black screen on hardware.
+              if [ ! -e "$PKG/neutrino/config/bsd-udpfs.toml" ]; then
+                echo "WARN: bundled Neutrino has no config/bsd-udpfs.toml -- UDPFS 'Files' launches would fail with this bundle" >&2
+              fi
+            else
+              echo "WARN: could not extract a usable Neutrino (no neutrino.elf at archive root); package omits it this run" >&2
+              rm -rf "$PKG/neutrino" "$NEUT_ABS"
+              NEUTRINO_VER=""
+            fi
+          else
+            echo "WARN: could not fetch neutrino latest pre-release; package omits it this run"
+          fi
+          echo "NEUTRINO_VER=${NEUTRINO_VER}" >> "$GITHUB_ENV"
+          REL="${OPL_VERSION:-rolling}"
+          # <SHA256>: first 16 hex of the RIPTOPL.ELF SHA256 (integrity + uniqueness; full hash is
+          # in SHA256SUMS-style listing inside the zip is overkill, the short tag suffices).
+          # SHA is taken from the always-present PS2DEVLATESTSDK ELF purely for a stable unique tag.
+          SHA="$(sha256sum "$PKG/APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF" | cut -c1-16)"
+          ZIP="RIPTOPL-${REL}-${SHA}.zip"
+          (
+            cd "$PKG"
+            zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-PS2DEVLATESTSDK POPSTARTER POPS PS2-Servers.url >/dev/null
+            if [ -d APP_RIPTOPL-PS2DEVPINNEDSDK ]; then zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-PS2DEVPINNEDSDK >/dev/null; fi
+            if [ -d APP_RIPTOPL-OFFICIALSDK ]; then zip -r -X "../rolling/${ZIP}" APP_RIPTOPL-OFFICIALSDK >/dev/null; fi
+            # the extracted neutrino/ folder (drag-and-drop; replaces the old zip-in-zip neutrino_*.7z)
+            if [ -d neutrino ]; then zip -r -X "../rolling/${ZIP}" neutrino >/dev/null; fi
+          )
+          echo "Built rolling/${ZIP}:"
+          unzip -l "rolling/${ZIP}"
+
+      - name: Pack RIPTOPL VARIANTS + DEBUG zips
+        run: |
+          set -eu
+          # The EXTRA_FEATURES x PADEMU variants and the debug builds (each in BOTH SDK flavours:
+          # standard = -PS2DEVLATESTSDK, plus -PS2DEVPINNEDSDK) -> two separate release zips. Remove the
+          # loose dirs afterward so the final 'gh release upload rolling/*' stays file-only.
+          REL="${OPL_VERSION:-rolling}"
+          for kind in variants debug; do
+            up="$(echo "$kind" | tr '[:lower:]' '[:upper:]')"
+            if [ -d "rolling/$kind" ] && [ -n "$(ls -A "rolling/$kind" 2>/dev/null)" ]; then
+              ZN="RIPTOPL-${up}-${REL}.zip"
+              (cd "rolling/$kind" && zip -r -X "../${ZN}" . >/dev/null)
+              echo "Packed rolling/${ZN}:"
+              unzip -l "rolling/${ZN}"
+            else
+              echo "No $kind builds present; skipping RIPTOPL ${up} zip."
+            fi
+            rm -rf "rolling/$kind" 2>/dev/null || true
+          done
+
+      - name: Build release notes
+        run: |
+          set -eu
+          HAS_PS2DEVPINNEDSDK=no
+          [ -f "rolling/${VERSIONED_BASE}-PS2DEVPINNEDSDK.ELF" ] && HAS_PS2DEVPINNEDSDK=yes
+          HAS_OFFICIALSDK=no
+          [ -f "rolling/${VERSIONED_BASE}-OFFICIALSDK.ELF" ] && HAS_OFFICIALSDK=yes
+          {
+            if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+              printf 'RiptOPL %s -- tagged release.\n\n' "$OPL_VERSION"
+            else
+              printf 'RiptOPL -- rolling build of master (not a stable release).\n\n'
+            fi
+            printf 'Version: %s\n' "$OPL_VERSION"
+            printf 'Commit: %s/%s/commit/%s\n' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_SHA"
+            printf 'Built: %s UTC\n' "$(date -u '+%Y-%m-%d %H:%M')"
+            printf 'Run: %s/%s/actions/runs/%s\n' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
+            printf '\n## Get started -- which build should I download?\n'
+            printf 'Grab **RIPTOPL-*.zip** and extract it. It ships up to three loader folders that differ ONLY by\n'
+            printf 'the SDK toolchain each was built with -- the RiptOPL code in every one is identical. Pick a folder\n'
+            printf 'and copy its RIPTOPL.ELF to your launch method. Recommended in this order (by reliability):\n'
+            printf '\n'
+            printf '  1. **APP_RIPTOPL-PS2DEVLATESTSDK/** -- built on the ps2dev:latest toolchain (version ends\n'
+            printf '     "-PS2DEVLATESTSDK"). This is the RECOMMENDED download: it uses the current SDK, with the\n'
+            printf '     stock drivers RiptOPL is developed and tested against.\n'
+            printf '  2. **APP_RIPTOPL-PS2DEVPINNEDSDK/** -- the SAME ps2dev SDK, pinned by digest to a day it\n'
+            printf '     was known good (version ends "-PS2DEVPINNEDSDK").\n'
+            printf '     The SAFE FALLBACK. Because #1 tracks a MOVING tag, it can occasionally regress on some\n'
+            printf '     consoles (see issue #102) -- if it black-screens at startup or the cursor does not\n'
+            printf '     respond, use this one and please say so in the report.\n'
+            if [ "$HAS_OFFICIALSDK" = yes ]; then
+              printf '  3. **APP_RIPTOPL-OFFICIALSDK/** -- built in the EXACT container official OPL'"'"'s rolling\n'
+              printf '     pre-release compiles in (ghcr.io/ps2homebrew/ps2homebrew:main; version ends\n'
+              printf '     "-OFFICIALSDK"). A separate SDK lineage from ps2dev -- useful for isolating\n'
+              printf '     toolchain effects when comparing against official OPL on the same console.\n'
+            fi
+            printf '\n'
+            printf 'When something misbehaves on hardware, please say WHICH flavour you ran (the in-app version\n'
+            printf 'string suffix tells you). A PS2DEVLATESTSDK-only failure points at an SDK regression; a\n'
+            printf 'both-flavour failure points at RiptOPL code. Those bits triple the value of a report.\n'
+            printf '\n'
+            printf '**DualSense / DS5 (USB) owners:** each flavour also ships a ready-made DUALSENSE=1 loader as\n'
+            printf 'a named `RIPTOPL-<version>-<SDK>-ds5.ELF` asset (see "Other downloads"). Same reliability order\n'
+            printf 'applies -- prefer `-PS2DEVPINNEDSDK-ds5`. The default builds keep DualSense OFF.\n'
+            printf '\n## Bundled Neutrino core\n'
+            printf 'Required for the per-game Neutrino launch mode. From the official repo:\n'
+            printf '  https://github.com/rickgaiser/neutrino\n'
+            if [ -n "${NEUTRINO_VER:-}" ]; then
+              printf '  Included build: %s as the neutrino/ folder in the package -- RiptOPL adds only\n' "$NEUTRINO_VER"
+              printf '  config/bsd-udpfsbd.toml (for UDPFS); otherwise the official build. Just copy the\n'
+              printf '  whole neutrino/ folder to mc?:/ (it already holds neutrino.elf + config/ + modules/).\n'
+            else
+              printf '  (Could not bundle Neutrino this run -- please grab the latest build from the link above.)\n'
+            fi
+            printf '  Neutrino is the work of its authors; RiptOPL only bundles the official build for convenience.\n'
+            printf '\n## PC network servers\n'
+            printf 'The RiptOPL package no longer embeds a PC SMB server. Open **PS2-Servers.url** from the\n'
+            printf 'package, or visit https://github.com/NathanNeurotic/PS2-Servers, for the maintained\n'
+            printf 'UDPFS / SMBv1 / UDPBD all-in-one launcher. Follow its protocol-specific setup and\n'
+            printf 'match RiptOPL network settings to the server you start.\n'
+            printf '\n## In this build\n'
+            printf -- '- External Neutrino core option: per-game core selector + global/per-game launch args\n'
+            printf -- '- Coverflow cover-art render mode (default theme)\n'
+            printf -- '- Favourites tab (R3 toggles a game; star marker)\n'
+            printf -- '- PS1 / VCD via POPSTARTER as a per-device view (L3)\n'
+            printf -- '- Category settings layout\n'
+            printf -- '- Per-game VMC shared with Neutrino on writable BDM (honours OPL VMC groups)\n'
+            printf -- '- Visual GameID barcode for Pixel FX / RetroGEM / PS2Digital (Display page, OFF by default)\n'
+            printf -- '- RetroGEM Game ID optical barcode for POPStarter / PS1 VCD launches (POPStarter Settings page, ON by default)\n'
+
+            printf -- '- Neutrino args: prefix a flag with $ to disable it without deleting; "Test launch" boots without saving\n'
+            printf -- '- DualSense / DS5 USB controller support\n'
+            printf -- '- PS2-Servers.url: opens the maintained UDPFS / SMBv1 / UDPBD all-in-one PC launcher\n'
+            printf '\n## Needs testing -- please report from real hardware\n'
+            printf -- '- GameID barcode: enable it on the Display page, then confirm your Pixel FX / RetroGEM /\n'
+            printf -- '  PS2Digital auto-loads the per-game profile (the HDMI latch is hardware-only -- not emulator-testable).\n'
+            printf -- '- VMC -> Neutrino: confirm your save mounts when launching via Neutrino on USB / exFAT / MX4SIO.\n'
+            printf -- '  (Neutrino cannot yet write a VMC to internal HDD APA/PFS -- upstream neutrino#132 -- so VMC\n'
+            printf -- '  sharing is block-device only for now.)\n'
+            printf -- '- PC network servers: use the linked PS2 Servers AIO, match the settings shown by its launcher,\n'
+            printf -- '  and confirm the game list populates and an ISO boots over your chosen protocol on real hardware.\n'
+            printf '\n## Other downloads\n'
+            if [ -f "rolling/RIPTOPL-VARIANTS-${OPL_VERSION:-rolling}.zip" ]; then
+              printf -- '- RIPTOPL-VARIANTS-*.zip: EXTRA_FEATURES x PADEMU build configs, both SDK flavours\n'
+            fi
+            if [ -f "rolling/RIPTOPL-DEBUG-${OPL_VERSION:-rolling}.zip" ]; then
+              printf -- '- RIPTOPL-DEBUG-*.zip: debug builds (iopcore/ingame/eesio/ppctty/DTL_T10000), both SDKs -- diagnostics\n'
+            fi
+            if [ "$HAS_PS2DEVPINNEDSDK" = yes ]; then
+              printf -- '- %s-PS2DEVPINNEDSDK.ELF: bare loader, digest-pinned ps2dev snapshot %s (SAFE FALLBACK -- pinned, boots reliably)\n' "$VERSIONED_BASE" "$SDK_VER"
+            else
+              printf -- '- (pinned %s PS2DEVPINNEDSDK build FAILED this run)\n' "$SDK_VER"
+            fi
+            printf -- '- %s-PS2DEVLATESTSDK.ELF: bare loader, ps2dev:latest toolchain (RECOMMENDED -- current SDK; see "Get started")\n' "$VERSIONED_BASE"
+            if [ "$HAS_OFFICIALSDK" = yes ]; then
+              printf -- '- %s-OFFICIALSDK.ELF: bare loader, official OPL'"'"'s ps2homebrew:main container (toolchain A/B vs official)\n' "$VERSIONED_BASE"
+            fi
+            for sdk in PS2DEVPINNEDSDK PS2DEVLATESTSDK; do
+              if [ -f "rolling/${VERSIONED_BASE}-${sdk}-ds5.ELF" ]; then
+                printf -- '- %s-%s-ds5.ELF: %s toolchain WITH DualSense (DS5 USB) pad support (same reliability as the %s bare loader above)\n' "$VERSIONED_BASE" "$sdk" "$sdk" "$sdk"
+              fi
+            done
+            printf -- '- IRX-MANIFEST*.txt: SHA256 of every SDK-prebuilt IOP module each toolchain consumed\n'
+            printf -- '- %s-src.zip: source snapshot to rebuild this exact commit\n' "$VERSIONED_BASE"
+            if ls rolling/RIPTOPL-LANGS-*.zip >/dev/null 2>&1; then
+              printf -- '- RIPTOPL-LANGS-*.zip: extra UI language files (.lng + non-Latin fonts) -- copy into your OPL folder\n'
+            fi
+            printf '\nSHA256 (also published as SHA256SUMS.txt):\n'
+            printf '```\n'
+            cat rolling/SHA256SUMS.txt
+            printf '```\n'
+            printf '\nUpdated on every push to master. This is the single rolling channel; stable builds are the v* tagged releases.\n'
+          } > notes.md
+          echo "PS2DEVPINNEDSDK flavour present: $HAS_PS2DEVPINNEDSDK"
+          cat notes.md
+          echo "Assets to publish:"
+          ls -la rolling
+
+      - name: Publish (rolling on master, curated release on a v* tag)
+        run: |
+          set -eu
+          # The ref decides the publish target: a v* tag cuts the curated per-version release
+          # (full, unless an -rc pre-release); master/dispatch updates the single rolling channel.
+          # Either path publishes the SAME staged asset set, so packaging can never diverge again.
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF_NAME}"; TITLE="${GITHUB_REF_NAME}"; TARGET=""
+            case "${GITHUB_REF}" in *-rc*) PREREL="--prerelease";; *) PREREL="";; esac
+          else
+            TAG="rolling"; TITLE="Rolling (master)"; PREREL="--prerelease"; TARGET="--target $GITHUB_SHA"
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Updating existing release: $TAG"
+            # Remove every existing asset first so renamed/stale builds from prior
+            # runs cannot accumulate; then upload the current fixed-name set.
+            for asset in $(gh release view "$TAG" --json assets --jq '.assets[].name'); do
+              echo "Deleting old asset: $asset"
+              gh release delete-asset "$TAG" "$asset" --yes || true
+            done
+            gh release edit "$TAG" --title "$TITLE" --notes-file notes.md $PREREL
+            gh release upload "$TAG" rolling/* --clobber
+          else
+            echo "Creating release: $TAG"
+            gh release create "$TAG" rolling/* \
+              --title "$TITLE" \
+              --notes-file notes.md \
+              $PREREL \
+              $TARGET
+          fi
+
+      # --- MEGA archival (master rolling builds only) -----------------------------------------
+      # The GitHub 'rolling' release above keeps OVERWRITING the latest build. To keep a PERMANENT
+      # record, every master rolling build is ALSO archived to MEGA as ONE immutable, self-contained
+      # zip of the entire release payload. Runs AFTER Publish so the GitHub release is completely
+      # unchanged and a MEGA hiccup can never block or alter it -- MEGA is purely additive. Gated to
+      # master + secrets present, so v* tag cuts and secret-less forks skip it cleanly.
+      - name: Build all-in-one MEGA archive
+        if: github.ref == 'refs/heads/master' && env.USERNAME != '' && env.PASSWORD != ''
+        run: |
+          set -eu
+          # Validate the payload BEFORE archiving so a broken publish fails loudly instead of pushing
+          # a half-empty "permanent" archive to MEGA.
+          if [ ! -d rolling ] || [ -z "$(ls -A rolling 2>/dev/null)" ]; then
+            echo "rolling/ is empty -- refusing to build a MEGA archive" >&2
+            exit 1
+          fi
+          if ! ls rolling/*-src.zip >/dev/null 2>&1; then
+            echo "No *-src.zip source snapshot in rolling/ -- refusing to archive an incomplete payload" >&2
+            exit 1
+          fi
+
+          VER="${OPL_VERSION:-rolling}"
+          SHORT_SHA="$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          ARCHIVE="RIPTOPL-ROLLING-${VER}-${GITHUB_RUN_NUMBER}-${SHORT_SHA}.zip"
+
+          # Build the archive OUTSIDE rolling/ (requirement): if it lived in rolling/ it could zip
+          # itself and, worse, be swept into the GitHub release by `gh release upload rolling/*`.
+          #
+          # Archive the INSTALLABLE + REPRODUCIBLE payload only. The two big diagnostic BUNDLES are
+          # deliberately EXCLUDED from the permanent MEGA copy:
+          #   RIPTOPL-VARIANTS-*.zip  (~120 MB -- every PADEMU x EXTRA_FEATURES x DUALSENSE combo, both SDKs)
+          #   RIPTOPL-DEBUG-*.zip     (~91 MB  -- iopcore/ingame/eesio/ppctty/DTL debug builds, both SDKs)
+          # They dominate the size (~10x: ~233 MB -> ~22 MB), they still ship on the GitHub rolling
+          # release for the CURRENT build, and a *permanent* per-build archive is for restoring or
+          # rebuilding an installable build -- not for old diagnostic permutations (when you debug,
+          # it is almost always the current build). Everything a restorer needs is kept: the
+          # installable package zip, the bare loader ELFs, the source snapshot, SHA256SUMS.txt, the
+          # IRX manifests and the language pack.
+          rm -rf mega-out
+          mkdir -p mega-out
+          MEGA_FILES=""
+          for f in rolling/*; do
+            b="$(basename "$f")"
+            case "$b" in
+              RIPTOPL-VARIANTS-*.zip|RIPTOPL-DEBUG-*.zip)
+                echo "MEGA archive: excluding diagnostic bundle $b" ;;
+              *)
+                MEGA_FILES="$MEGA_FILES $b" ;;
+            esac
+          done
+          ( cd rolling && zip -r -X "../mega-out/${ARCHIVE}" $MEGA_FILES >/dev/null )
+
+          echo "MEGA_ARCHIVE=mega-out/${ARCHIVE}" >> "$GITHUB_ENV"
+          # Suggested layout: /RiptOPL/Rolling/<version>/run_<run number>/ -- run number keeps every
+          # build in its own immutable folder (nothing is ever overwritten on MEGA).
+          echo "MEGA_REMOTE_DIR=/RiptOPL/Rolling/${VER}/run_${GITHUB_RUN_NUMBER}/" >> "$GITHUB_ENV"
+
+          echo "== MEGA archive contents =="
+          unzip -l "mega-out/${ARCHIVE}"
+          echo "== MEGA archive SHA256 =="
+          sha256sum "mega-out/${ARCHIVE}" | tee "mega-out/${ARCHIVE}.sha256"
+
+      - name: Upload the all-in-one archive to MEGA
+        if: github.ref == 'refs/heads/master' && env.USERNAME != '' && env.PASSWORD != ''
+        # Pinned to a full commit SHA rather than @master: this third-party action runs with the
+        # MEGA credentials, so freeze it to a reviewed snapshot instead of trusting whatever is on
+        # its master branch at build time. bf698c6 == the action's v1.4.0 release == the master HEAD
+        # validated for this change, so behavior is identical. Bump deliberately (re-review first).
+        uses: Difegue/action-megacmd@bf698c68edaf91143b2a52d3468595202011bf17 # v1.4.0
+        with:
+          # Runs `mega-put -c <archive> <remotedir>/`: -c creates the remote folder path if missing,
+          # the trailing slash puts the file INTO that folder. Uploads ONLY the single all-in-one
+          # zip -- individual assets are NOT uploaded separately. Credentials come from the job-level
+          # USERNAME/PASSWORD env, which this action reads by those exact names.
+          args: put -c ${{ env.MEGA_ARCHIVE }} ${{ env.MEGA_REMOTE_DIR }}


### PR DESCRIPTION
Ports the fork's release plumbing onto the rebuild branch so the rolling channel, the MEGA archive and the `v*` tag cut all belong to this tree.

| file | state |
|---|---|
| `.github/workflows/neutrino-watch.yml` | byte-identical to fork |
| `.github/scripts/build_rolling_extras.sh` | byte-identical to fork |
| `.github/workflows/rolling-release.yml` | adapted — +24 / −48 |

### Removed (feature is on WAIT)
Each removal leaves a `NOTE(rebuild)` comment naming its checklist item, so re-adding the feature re-adds the step.

- **3× "Install menu-coherent mmceman"** (pinned / latest-only / officialsdk) → items 1–3. This tree embeds no mmceman at all, so the step would rebuild a driver nothing loads. `install_coherent_mmce.sh` and the `.github/patches/mmceman-*.patch` files are deliberately **not** ported.
- **1× "Build + stage experimental 1080p GSM loader"** (`GSM1080P=1`) → item 29.

### Added: a publish gate
`publish-rolling` had **no** ref check, and the tag/title block falls through to `TAG="rolling"` for anything that isn't a `v*` tag. So the one way to rehearse this pipeline before cutover — `workflow_dispatch` from `rebuild/main` — would have cut a **real public prerelease from an unfinished tree**.

```yaml
if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
```

All three build jobs still run on a dispatch (that's the part worth rehearsing, and their artifacts are downloadable); only the publish is withheld. On master and on `v*` tags the condition is true, so **shipping behaviour is byte-for-byte what the fork does today**.

### Audit
Nothing here executes until it publishes, so it was audited statically rather than trusted:

- **Staged repo paths all exist** — `POPS/` (19 files, incl. all 9 brace-listed), `popsmb/` (3), `pc/PS2-Servers.url`, `neutrino/bsd-udpfsbd.toml`. `POPS/` and `popsmb/` are copied under `set -eu` with no guard, so a miss would hard-fail publish.
- **Referenced scripts all exist** — `lng_pack.sh`, `make_changelog.sh`, `build_rolling_extras.sh`.
- **Makefile flags all exist** — `EXTRA_FEATURES`, `PADEMU`, `DUALSENSE`, `DTL_T10000`, plus all five debug targets.
- **Release notes are true of THIS tree.** Spot-checked the two least obvious claims: the POPStarter/VCD RetroGEM barcode (`retrogemGetVcdGameID`, `src/retrogem.c:220`, wired at `src/vcdsupport.c:1497`) and Neutrino "Test launch" + `$`-prefix arg disable (`src/menusys.c:297`, `src/system.c:1039`). The notes never mentioned MMCE or 1080p, so nothing to strip.

### Dormancy
Trigger stays **master + `v*` only** — this file cannot publish by accident from `rebuild/main`. `neutrino-watch` is dormant too: schedules only run from the default branch, and it dispatches `--ref master`; with the `rolling` tag now archived to `rolling-alpha` it parses an empty bundled version and, by its own guard, does nothing rather than triggering a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)