### PR TITLE
rebuild-36: fork parity — binary attrs, network defaults, two label strings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,23 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Binary loader/driver payloads shipped verbatim to the memory card: the POPSTARTER assets plus the
+# BDMAssault IRX variants. NEVER line-ending normalize these -- a stray CRLF<->LF pass corrupts the
+# IRX and POPSTARTER then fails to load it.
+#
+# BOTH lines are needed, and the directory rule is spelled POPS/ on purpose. The BDMAssault variants
+# are named usbd.irx.ata / usbhdfsd.irx.mmce / ... -- the extension is the MODE, so they do NOT end
+# in ".irx" and `*.irx` alone misses every one of them. Upstream spells this rule `pops/*`, which
+# matches nothing on a case-sensitive checkout (the directory is POPS/), so the CI runner never
+# applied it; using the real casing here is a deliberate divergence, not a typo.
+POPS/* binary
+*.irx binary
+
+# Internet shortcuts are a Windows-native format and must check out with CRLF. pc/PS2-Servers.url is
+# copied straight into the release package, so this is load-bearing at publish time, not cosmetic.
+*.url text eol=crlf
+*.bat text eol=crlf
+
 # Custom for Visual Studio
 *.cs   diff=csharp
 

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -141,7 +141,7 @@ gui_strings:
 - label: ERROR_LOADING_ID
   string: Error while loading the Game ID.
 - label: AUTOSORT
-  string: Automatic Sorting
+  string: Sort Games Alphabetically
 - label: ERR_LOADING_LANGFILE
   string: Error loading the language file.
 - label: DEBUG
@@ -305,7 +305,7 @@ gui_strings:
 - label: BDM_PREFIX
   string: BDM Prefix Path
 - label: HINT_EXITPATH
-  string: Boots custom ELF after an IGR.
+  string: "Boots a custom ELF after an IGR. Keep it on the memory card (mc0:/mc1:) -- the post-reset loader can't reach MMCE; for MMCE, chain through an MC loader like PS2BBL."
 - label: HINT_SPINDOWN
   string: Value in minute(s), 0 to disable spin down.
 - label: HDD_SPINDOWN

--- a/src/opl.c
+++ b/src/opl.c
@@ -2392,13 +2392,20 @@ static void setDefaults(void)
     hddCacheSize = 8;
     smbCacheSize = 16;
 
-    ps2_ip_use_dhcp = 1;
+    // Network defaults are ONE coherent set, not four independent knobs -- restoring the fork's
+    // opinionated fresh-install profile (this had reverted to the upstream 192.168.0.x / DHCP one).
+    // Static addressing on 192.168.1.x, the far more common home subnet, with the PS2 and the PC on
+    // the same wire: the UDP transports (UDPBD / UDPFS / NBD) run on a ministack that needs a STATIC
+    // ip, so defaulting to DHCP hands a fresh install a config those transports cannot use.
+    // gPCShareAddressIsNetBIOS follows the same logic -- raw-IP SMB addressing is what matches the
+    // static defaults directly below; NetBIOS name resolution is the opt-in.
+    ps2_ip_use_dhcp = 0;
     gETHOpMode = ETH_OP_MODE_AUTO;
-    gPCShareAddressIsNetBIOS = 1;
+    gPCShareAddressIsNetBIOS = 0; // raw-IP SMB addressing by default (matches the static defaults below)
     gPCShareNBAddress[0] = '\0';
     ps2_ip[0] = 192;
     ps2_ip[1] = 168;
-    ps2_ip[2] = 0;
+    ps2_ip[2] = 1;
     ps2_ip[3] = 10;
     ps2_netmask[0] = 255;
     ps2_netmask[1] = 255;
@@ -2406,15 +2413,15 @@ static void setDefaults(void)
     ps2_netmask[3] = 0;
     ps2_gateway[0] = 192;
     ps2_gateway[1] = 168;
-    ps2_gateway[2] = 0;
+    ps2_gateway[2] = 1;
     ps2_gateway[3] = 1;
     pc_ip[0] = 192;
     pc_ip[1] = 168;
-    pc_ip[2] = 0;
-    pc_ip[3] = 2;
+    pc_ip[2] = 1;
+    pc_ip[3] = 100;
     ps2_dns[0] = 192;
     ps2_dns[1] = 168;
-    ps2_dns[2] = 0;
+    ps2_dns[2] = 1;
     ps2_dns[3] = 1;
     gPCPort = 1111; // RiptOPL default SMB port (was 445): matches the bundled PC server tooling
     gPCShareName[0] = '\0';


### PR DESCRIPTION
Three verified divergences from the fork. Each was re-checked by hand against `origin/master` rather than taken on faith from the audit list — **two other entries on that list did not survive checking** and are documented below rather than "fixed".

### 1. `.gitattributes` had lost every binary/eol rule
Restored, with a deliberate correction. Upstream spells the directory rule `pops/*`, which matches **nothing** on a case-sensitive checkout because the directory is `POPS/` — so the Linux CI runner never applied it. Spelled `POPS/` here.

Both rules are needed:

```
POPS/* binary
*.irx  binary
```

The BDMAssault variants are named `usbd.irx.ata`, `usbhdfsd.irx.mmce`, … — **the extension is the mode**, so they don't end in `.irx` and `*.irx` alone misses all eight.

`*.url text eol=crlf` is load-bearing at publish time: `pc/PS2-Servers.url` is copied straight into the release package. Dropped the fork's `.github/patches/*.patch` line — there's no patches dir here (mmceman patches deliberately unported, items 1–3).

Verified `git add --renormalize .` rewrites **no** blob: the `.url` is already stored LF, and `POPS/*` were already binary by auto-detection.

### 2. Fresh-install network defaults had reverted to upstream's (item 53)
These are **one coherent set**, not four independent knobs, so all of it moves together:

| | was (upstream) | now (fork) |
|---|---|---|
| `ps2_ip_use_dhcp` | 1 | 0 |
| PS2 / gateway / DNS | `192.168.0.x` | `192.168.1.x` |
| `pc_ip` | `192.168.0.2` | `192.168.1.100` |
| `gPCShareAddressIsNetBIOS` | 1 | 0 |

The UDP transports (UDPBD / UDPFS / NBD) run on a ministack that **requires a static IP**, so defaulting to DHCP handed a fresh install a config those transports cannot use.

This was not visible as a popup: `showNetDhcpPopup` is gated on a UDP transport actually being selected, and `gNetworkProtocol` defaults to `NET_PROTO_OFF`.

### 3. Two label strings were upstream's, not the fork's
- `AUTOSORT`: "Automatic Sorting" → **"Sort Games Alphabetically"**
- `HINT_EXITPATH`: one flat sentence → the fork's text, which is the only place the MMCE-after-IGR limitation is explained.

These are in-place **value** edits: 492 labels before and after, order verified **identical**, so the position-consumed `.lng` contract is untouched. Not an append — the append-at-END rule doesn't apply.

### Not done — the claims didn't hold up
- **"auto-start countdown gated on the visible spinner flag"** — our `guiUpdater` and the `CFG_AUTOSTARTLAST` visibility calls are byte-identical to the fork (`gui.c:476-486` / `535-539` vs fork `484-493` / `572-576`). No divergence exists.
- **"`CONFIG_NET_NBD_DEFAULT_EXPORT` is load-only (never saved)"** — true, but the **fork is load-only too** (one `configGetStrCopy`, no setter, in both trees). Shared upstream limitation, not a rebuild gap.

### Split out on purpose
The deferred `#Size` mechanism (`sbConfigStatSize`) is the one remaining minor-list item with real behavioural risk — it changes what happens on the **scroll hot path**, which is the #340 surface itself. It gets its own step so it can be bisected independently on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)