### PR TITLE
rebuild-37: defer the #Size stat off the scroll path

### DIFF
--- a/include/menusys.h
+++ b/include/menusys.h
@@ -116,6 +116,9 @@ char *menuItemGetText(menu_item_t *it);
 config_set_t *menuLoadConfig();
 config_set_t *gameMenuLoadConfig(struct UIItem *ui);
 int menuSaveConfig();
+// Queue an async re-read of the current item's config WITH the #Size stat enabled. The scroll-path
+// load skips that stat (see sbSetConfigStatSize); the info screen calls this so #Size still resolves.
+void menuRequestInfoSize(void);
 
 void menuRenderMain();
 void menuRenderMenu();

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -65,6 +65,11 @@ void sbCreatePath(const base_game_info_t *game, char *path, const char *prefix, 
 void sbDelete(base_game_info_t **list, const char *prefix, const char *sep, int gamecount, int id);
 void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int gamecount, int id, char *newname);
 config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const char *sep);
+// Gate for sbPopulateConfig's per-game size stat. OFF while scrolling the game list -- over SMB a
+// fresh stat() of an ISO can cost seconds, and the main page only needs the metadata-derived badges
+// (#DiscType/#Media/#Format), never #Size. The info screen flips it on via menuRequestInfoSize() so
+// #Size still resolves on demand. (1 = stat, 0 = skip.)
+void sbSetConfigStatSize(int enable);
 void sbCreateFolders(const char *path, int createDiscImgFolders);
 
 // ISO9660 filesystem management functions.

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -7,6 +7,7 @@
 #include "include/opl.h"
 #include "include/diag.h"
 #include "include/menusys.h"
+#include "include/supportbase.h" // sbSetConfigStatSize -- defer the #Size stat off the scroll path
 #include "include/iosupport.h"
 #include "include/renderman.h"
 #include "include/fntsys.h"
@@ -184,6 +185,59 @@ static void _menuLoadConfig()
     }
     actionStatus = 0;
     SignalSema(menuSemaId);
+}
+
+// Opening the info screen needs #Size, which the scroll-time config load deliberately skips
+// (sbConfigStatSize off -> no slow per-game stat while browsing). Rebuild the current item's
+// config once with the size resolved and swap it in, but only if the selection is unchanged --
+// the user may have scrolled away before this IO request ran. game->sizeMB is cached afterwards,
+// so subsequent scrolls/info views show the size with no further stat.
+static void _menuResolveInfoSize()
+{
+    item_list_t *list = NULL;
+    config_set_t *loadedConfig = NULL;
+    int configId = -1;
+
+    WaitSema(menuSemaId);
+    if (selected_item != NULL && selected_item->item != NULL && selected_item->item->current != NULL && itemConfigId >= 0 && itemConfigId == selected_item->item->current->item.id) {
+        list = selected_item->item->userdata;
+        configId = itemConfigId;
+    }
+    SignalSema(menuSemaId);
+
+    if (list == NULL || configId < 0)
+        return;
+
+    // itemGetConfig runs OUTSIDE the semaphore on purpose: it is the slow call (a CFG read plus the
+    // ISO stat this whole mechanism exists to defer), and holding menuSemaId across it would block
+    // the GUI thread for exactly as long as the stat we are trying to keep off the scroll path.
+    sbSetConfigStatSize(1);
+    loadedConfig = list->itemGetConfig(list, configId);
+    sbSetConfigStatSize(0);
+
+    if (loadedConfig == NULL)
+        return;
+
+    // Re-check the selection under the sema: if the user scrolled away while the stat ran, the
+    // freshly loaded config belongs to a row that is no longer current -- drop it rather than
+    // publish someone else's #Size.
+    WaitSema(menuSemaId);
+    if (selected_item != NULL && selected_item->item != NULL && selected_item->item->current != NULL && itemConfigId == configId && itemConfigId == selected_item->item->current->item.id) {
+        if (itemConfig != NULL)
+            configFree(itemConfig);
+        itemConfig = loadedConfig;
+        loadedConfig = NULL;
+    }
+    SignalSema(menuSemaId);
+
+    if (loadedConfig != NULL)
+        configFree(loadedConfig);
+}
+
+// Queued when the info screen opens: resolve #Size for the current item without blocking the UI.
+void menuRequestInfoSize(void)
+{
+    ioPutRequest(IO_CUSTOM_SIMPLEACTION, &_menuResolveInfoSize);
 }
 
 static void _menuSaveConfig()

--- a/src/opl.c
+++ b/src/opl.c
@@ -417,8 +417,20 @@ static void itemExecSquare(struct menu_item *curMenu)
     // Folder browsing: a folder row has no info screen (#Size/#DiscType would stat a directory).
     if (curMenu->current && curMenu->current->item.isFolder)
         return;
-    if (curMenu->current && gTheme->infoElems.first)
+    if (curMenu->current && gTheme->infoElems.first) {
+        // #Size is skipped while scrolling so the badges paint instantly; resolve it now (async) --
+        // but NEVER for a VCD (PS1) list. A VCD carries no meaningful #Size: vcdFillGameList tags the
+        // entry .VCD/GAME_FORMAT_ISO (vcdsupport.c), so sbPopulateConfig stats the CD/DVD folder while
+        // .VCDs actually live in POPS/ -- the stat always misses, game->sizeMB stays 0 and never
+        // caches, so it re-runs on EVERY entry. That makes the resolve a pure redundant CFG re-read +
+        // failing stat on the shared MMCE/fileXio channel whose only visible effect is raising the
+        // busy spinner (Andrew, #120). Skipping it for VCD strictly REDUCES channel traffic and drops
+        // no displayed data (the info page shows no size for a VCD anyway).
+        item_list_t *support = curMenu->userdata;
+        if (support == NULL || !vcdViewActive(support->mode))
+            menuRequestInfoSize();
         guiSwitchScreen(GUI_SCREEN_INFO);
+    }
 }
 
 // R3: toggle the current row's favourite star (checklist item 33). On the Favourites tab

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -912,6 +912,18 @@ void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int 
     }
 }
 
+// When 0 (the default, used while scrolling the game list) sbPopulateConfig skips the
+// per-game size stat -- over SMB a fresh stat() of an ISO can cost several seconds, and the
+// main page only needs the metadata-derived badges (#DiscType/#Media/#Format), never #Size.
+// The info screen flips this on via menuRequestInfoSize() so #Size still resolves on demand;
+// game->sizeMB is cached after the first resolve, so later scrolls show the size for free.
+static int sbConfigStatSize = 0;
+
+void sbSetConfigStatSize(int enable)
+{
+    sbConfigStatSize = enable;
+}
+
 config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const char *sep)
 {
     char path[256];
@@ -921,17 +933,32 @@ config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const
     config_set_t *config = configAlloc(0, NULL, path);
     configRead(config); // Does not matter if the config file could be loaded or not.
 
-    // Get game size if not already set
-    if (game->sizeMB == 0) {
+    // Get game size if not already set (deferred off the scroll path; see sbConfigStatSize). A .VCD (PS1) has
+    // no meaningful ISO size and its file lives in POPS/, not CD/DVD/, so statting the CD/DVD path always
+    // misses, leaves sizeMB at 0, never caches, and re-probes the shared MMCE bus on every info entry (#120).
+    // Hard-stop it by EXTENSION here (not mutable view state) so a .VCD can never reach the ISO stat path,
+    // even during the L3 view-toggle window (game->sizeMB stays 0 -> "0 MiB" is still written below).
+    const int isVcd = !strcasecmp(game->extension, ".VCD");
+
+    // Folder browsing: prepend the current subpath so the stat resolves a game that lives inside a
+    // subfolder. sbBrowseSub is "" at the device root, collapsing subseg away. Without this a
+    // folder-nav game stats a path that does not exist and silently reports 0 MiB.
+    char subseg[FOLDER_SUB_MAX + 2];
+    if (sbBrowseSub[0] != '\0')
+        snprintf(subseg, sizeof(subseg), "%s%s", sbBrowseSub, sep);
+    else
+        subseg[0] = '\0';
+
+    if (sbConfigStatSize && !isVcd && game->sizeMB == 0) {
         char gamepath[256];
 
         if (game->format == GAME_FORMAT_ISO) {
-            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->name, game->extension);
+            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, subseg, game->name, game->extension);
 
             if (stat(gamepath, &st) == 0)
                 game->sizeMB = st.st_size >> 20;
         } else if (game->format == GAME_FORMAT_OLD_ISO) {
-            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s.%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->startup, game->name, game->extension);
+            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s.%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, subseg, game->startup, game->name, game->extension);
 
             if (stat(gamepath, &st) == 0)
                 game->sizeMB = st.st_size >> 20;


### PR DESCRIPTION
The per-game `#Size` stat ran on **every** config load — including the one the game list does while you scroll. Over SMB a fresh `stat()` of an ISO can cost seconds, and the main page never displays `#Size`; it only needs the metadata-derived badges (`#DiscType`/`#Media`/`#Format`).

This is squarely #340 surface: work on the scroll hot path that produces nothing visible.

### The mechanism
`sbConfigStatSize` (`src/supportbase.c`) now gates that stat, defaulting to **0**. The info screen — the only page that shows `#Size` — turns it on for one async re-read via `menuRequestInfoSize()`, so the number still appears, just off the hot path. `game->sizeMB` is cached after the first resolve, so later scrolls and info views get it for free.

`_menuResolveInfoSize` runs on the IO worker and is written around two hazards:

- **`itemGetConfig` is called outside `menuSemaId` on purpose.** It's the slow call (CFG read + the very stat being deferred); holding the sema across it would block the GUI thread for exactly as long as the stat we just moved off the path.
- **The selection is re-checked under the sema afterwards.** The user can scroll away while the stat runs, so a late result is dropped rather than published onto whatever row is now current. The `loadedConfig` ownership handoff frees the config on every path.

### Two correctness fixes fall out of the same statement
Both live in the exact lines this change rewrites — leaving either half-wrong while editing around it would have been worse than the wider diff.

**VCD hard-stop.** A `.VCD` carries no meaningful `#Size`: `vcdFillGameList` tags the entry `.VCD`/`GAME_FORMAT_ISO`, so `sbPopulateConfig` stats `CD`/`DVD` while `.VCD`s live in `POPS/`. The stat **always** misses, `sizeMB` stays 0, nothing caches, and it re-ran on every info entry — a pure redundant CFG re-read plus a failing stat on the shared MMCE/fileXio channel, whose only visible effect was raising the busy spinner (Andrew, #120). Gated by **extension** in `sbPopulateConfig` (not mutable view state, so the L3 toggle window can't slip a VCD onto the ISO stat path) and again by `vcdViewActive` at the call site, which skips queueing the request at all.

**Folder-browse subpath.** `sbPopulateConfig` composed the stat path **without** `sbBrowseSub`, so with folder nav on (`gEnableFolderNav`, default OFF) any game inside a subfolder stat'd a path that doesn't exist and silently reported `0 MiB`. `subseg` collapses to `""` at the device root, so root behaviour is unchanged.

### Verified before pushing
- Full `make -j8` clean in the ps2dev container — `MAKE_EXIT=0`.
- **clang-format 12** (the exact version CI pins) reports no diff on all five changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)