### PR TITLE
rebuild-38: bound the deferred-IO wait so stuck storage can't freeze the GUI

### DIFF
--- a/include/gui.h
+++ b/include/gui.h
@@ -167,8 +167,14 @@ void guiCheckNotifications(int checkTheme, int checkLang);
  * @param message The message to display while working
  * @param type the io operation type
  * @param data the data for the operation
+ * @param timeoutMs abandon the wait after this many ms if the deferred IO never completes (a wedged
+ *        IOP fileXio channel on failing storage); 0 = wait forever (network compat-list update).
  */
-void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data);
+// Bound for guiHandleDeferedIO's wait on a deferred config save/load. Far beyond any real config
+// write; only a genuinely stuck device (which would otherwise freeze the GUI forever on "Saving...")
+// reaches it, after which the caller falls into its normal failure path ("Error saving settings").
+#define OPL_DEFERRED_IO_TIMEOUT_MS 30000
+void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data, int timeoutMs);
 
 void guiGameHandleDeferedIO(int *ptr, struct UIItem *ui, int type, void *data);
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -2737,12 +2737,38 @@ int guiMsgBox(const char *text, int addAccept, struct UIItem *ui)
     return terminate - 1;
 }
 
-void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data)
+void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data, int timeoutMs)
 {
-    ioPutRequest(type, data);
+    // A rejected request never runs, so nothing will ever clear *ptr -- without this the loop below
+    // would spin forever on a queue-full/failed put. Clear it here so the caller falls into its
+    // normal failure path instead of hanging.
+    if (ioPutRequest(type, data) != IO_OK) {
+        *ptr = 0;
+        return;
+    }
 
-    while (*ptr)
+    // Bound the wait when the caller asks (timeoutMs > 0). A deferred IO that never completes -- a
+    // failing HDD/card that wedges the single IOP fileXio channel mid-write -- would otherwise spin
+    // here forever and freeze the GUI on "Saving..." with no escape. After a timeout far beyond any
+    // real config save/load we stop waiting and clear the status, so the caller falls into its normal
+    // failure path (saveConfig -> "Error saving settings"), exactly like the put-failure branch above.
+    // This does NOT recover the stuck IOP -- the IO worker runs requests one at a time and stays
+    // blocked on the wedged one until reboot -- but a readable error beats an apparent hard lock.
+    // Memory-safe: every caller's *ptr is a file-static int and `data` a file-static handler, so a
+    // late write by the still-blocked IO thread is harmless. timeoutMs <= 0 keeps the original
+    // unbounded wait (the compat-list update, which is a network fetch with no meaningful bound).
+    // clock() is the same idiom used elsewhere in this file; the (clock() - startTick) ELAPSED form
+    // is single-wrap-safe, unlike an absolute clock()+limit deadline.
+    clock_t startTick = clock();
+    clock_t limitTicks = (clock_t)timeoutMs * (CLOCKS_PER_SEC / 1000);
+    while (*ptr) {
+        if (timeoutMs > 0 && (clock() - startTick) >= limitTicks) {
+            LOG("guiHandleDeferedIO: deferred IO unfinished after %d ms; storage stuck, abandoning wait\n", timeoutMs);
+            *ptr = 0;
+            break;
+        }
         guiRenderTextScreen(message);
+    }
 }
 
 void guiGameHandleDeferedIO(int *ptr, struct UIItem *ui, int type, void *data)

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -279,7 +279,7 @@ config_set_t *menuLoadConfig()
 {
     actionStatus = 1;
     itemConfigId = -1;
-    guiHandleDeferedIO(&actionStatus, _l(_STR_LOADING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuRequestConfig);
+    guiHandleDeferedIO(&actionStatus, _l(_STR_LOADING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuRequestConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
     return itemConfig;
 }
 
@@ -296,7 +296,7 @@ int menuSaveConfig()
 {
     actionStatus = 1;
     menuSaveResult = 0;
-    guiHandleDeferedIO(&actionStatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuSaveConfig);
+    guiHandleDeferedIO(&actionStatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuSaveConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
     return menuSaveResult;
 }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1797,7 +1797,7 @@ int loadConfig(int types)
     lscstatus = types;
     lscret = 0;
 
-    guiHandleDeferedIO(&lscstatus, _l(_STR_LOADING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_loadConfig);
+    guiHandleDeferedIO(&lscstatus, _l(_STR_LOADING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_loadConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
 
     return lscret;
 }
@@ -1808,7 +1808,7 @@ int saveConfig(int types, int showUI)
     lscstatus = types;
     lscret = 0;
 
-    guiHandleDeferedIO(&lscstatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_saveConfig);
+    guiHandleDeferedIO(&lscstatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_saveConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
 
     if (showUI) {
         if (lscret) {
@@ -2075,7 +2075,7 @@ int oplUpdateGameCompatSingle(int id, item_list_t *support, config_set_t *config
     CompatUpdSingleConfigSet = configSet;
     CompatUpdSingleStatus = 1;
 
-    guiHandleDeferedIO(&CompatUpdSingleStatus, _l(_STR_PLEASE_WAIT), IO_CUSTOM_SIMPLEACTION, &_updateCompatSingle);
+    guiHandleDeferedIO(&CompatUpdSingleStatus, _l(_STR_PLEASE_WAIT), IO_CUSTOM_SIMPLEACTION, &_updateCompatSingle, 0); // network fetch: wait unbounded
 
     return CompatUpdateStatus;
 }


### PR DESCRIPTION
`guiHandleDeferedIO` fired the request and then spun `while (*ptr)` forever. **Two ways that never ends:**

1. **`ioPutRequest`'s return was discarded.** A rejected request never runs, so nothing ever clears `*ptr` — the loop spins on a put that never happened.
2. **A deferred IO that genuinely never completes** — a failing HDD/card that wedges the single IOP fileXio channel mid-write — parks the UI on *"Saving settings..."* with no escape but a power cycle.

Both now exit. The put failure clears `*ptr` and returns; the wait takes a `timeoutMs` and, past it, logs, clears `*ptr` and breaks. Either way the caller falls into its normal failure path (`saveConfig` → "Error saving settings") instead of hanging.

This does **not** recover the stuck IOP — the IO worker runs one request at a time and stays blocked until reboot — but a readable error beats an apparent hard lock.

### Values
`OPL_DEFERRED_IO_TIMEOUT_MS = 30000` on the four config save/load sites. The compat-list update passes `0` (unbounded): it's a network fetch with no meaningful bound.

**Memory-safe by construction:** every caller's `*ptr` is a file-static `int` and `data` a file-static handler, so a late write by the still-blocked IO thread lands on live storage.

**Wrap-safe:** the `(clock() - startTick)` *elapsed* form is single-wrap-safe, unlike an absolute `clock()+limit` deadline. `clock()`/`CLOCKS_PER_SEC` is already the established idiom in this file (cf. `OPL_VMODE_CHANGE_CONFIRMATION_TIMEOUT_MS`).

### Deliberately NOT ported from the fork's version
Each would be dead or dangerous here rather than merely absent:

- **The cover-art drain** (`cacheAbortMmceImageLoadsTimed` / `cacheCancelPendingImageLoadsTimed`). Both are **stubs in this tree that return 1 unconditionally** — and correctly so: the rebuild runs the official **synchronous** art cache, so nothing is ever pending or in-flight and "drained" is always trivially true. Porting the calls would be pure dead code dressed up as a fix for #45. They become real only if a threaded cache returns (item 45).
- **`padRumbleFlush()`** — rumble is item 43, on WAIT with the pad-clock rework.
- **`cacheLowerCallerPriority()` / `cacheRestoreCallerPriority()`** — they don't exist here, and they manipulate the **GUI thread's priority**. This rebuild has already been burned once by exactly that (rebuild-16 left the GUI pinned at priority 90 after any `ioBlockOps(1)`; fixed in rebuild-20). Their stated role is belt-and-suspenders for the threaded art cache this tree doesn't run — GUI-thread priority juggling with no hardware gate isn't a trade worth making.

### Verified before pushing
- `make -j8` → `MAKE_EXIT=0` in the ps2dev container.
- **clang-format 12** (the version CI pins) clean on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)