### PR TITLE
rebuild-39: settings saved to HDD/USB were never loaded back

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1147,13 +1147,21 @@ static int checkLoadConfigBDM(int types)
     int bdm_result;
     int is_hdd = 0;
 
+    // Probe the CURRENT settings filename, then the legacy one, so an existing install is still
+    // discovered (read-fallback migration; the next save rewrites it under the current name).
+    // These MUST be the CONFIG_OPL_FILENAME macros: config.c writes the file through them, so a
+    // hardcoded name here silently searches for a file this build never creates.
     // check USB
-    bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
+    bdm_result = bdmFindPartition(path, CONFIG_OPL_FILENAME, 0);
+    if (!bdm_result)
+        bdm_result = bdmFindPartition(path, CONFIG_OPL_FILENAME_LEGACY, 0);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
         // wait for up to 5 seconds for the HDD to spin up and become accessible...
         if (hddLoadModules() >= 0 && bdmHDDIsPresent(5000)) {
-            bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
+            bdm_result = bdmFindPartition(path, CONFIG_OPL_FILENAME, 0);
+            if (!bdm_result)
+                bdm_result = bdmFindPartition(path, CONFIG_OPL_FILENAME_LEGACY, 0);
             if (bdm_result)
                 is_hdd = 1;
         }
@@ -1183,8 +1191,13 @@ static int checkLoadConfigHDD(int types)
     hddLoadModules();
     hddLoadSupportModules();
 
-    snprintf(path, sizeof(path), "%sconf_opl.cfg", gHDDPrefix);
+    snprintf(path, sizeof(path), "%s%s", gHDDPrefix, CONFIG_OPL_FILENAME);
     value = open(path, O_RDONLY);
+    if (value < 0) {
+        // Legacy fallback so an existing conf_riptopl.cfg install is still found (auto-migrates on save).
+        snprintf(path, sizeof(path), "%s%s", gHDDPrefix, CONFIG_OPL_FILENAME_LEGACY);
+        value = open(path, O_RDONLY);
+    }
     if (value >= 0) {
         close(value);
         configEnd();
@@ -1538,13 +1551,15 @@ static int trySaveConfigBDM(int types)
     char path[64];
     int bdm_result;
 
+    // SAVE path: current filename only -- no legacy probe. Writing under the legacy name would
+    // un-migrate an install that the load path above just migrated forward.
     // check USB
-    bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
+    bdm_result = bdmFindPartition(path, CONFIG_OPL_FILENAME, 1);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
         // wait for up to 5 seconds for the HDD to spin up and become accessible...
         if (hddLoadModules() >= 0 && bdmHDDIsPresent(5000)) {
-            bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
+            bdm_result = bdmFindPartition(path, CONFIG_OPL_FILENAME, 1);
         }
     }
 


### PR DESCRIPTION
On an MC-less install (APA/PFS HDD, or USB with no memory card) OPL **saved settings successfully every boot and booted to defaults every boot**. Silent, permanent, repeating.

The alternate-device discovery probed for a filename this build never writes:

| | |
|---|---|
| `include/config.h:28` | `CONFIG_OPL_FILENAME` = `"settings_riptopl.cfg"` |
| `include/config.h:29` | `CONFIG_OPL_FILENAME_LEGACY` = `"conf_riptopl.cfg"` |
| `src/config.c:26` | writes the file through `CONFIG_OPL_FILENAME` |
| `src/opl.c` | probed the literal **`"conf_opl.cfg"`** at **five** sites |

`grep -c CONFIG_OPL_FILENAME src/opl.c` returned **0**. `trySaveConfigHDD` wrote `pfs0:OPL/settings_riptopl.cfg` while `checkLoadConfigHDD` opened `pfs0:OPL/conf_opl.cfg` — save and load targeted different files.

This is the config-filename rename that was recorded DONE: `config.h` and `config.c` got it, `opl.c` did not. Same defect shape as the rest of this audit — **the data half landed, the code half did not**, and with no `-Wall` the build stayed clean.

### The fix
All five literals now go through the macros.

- The two **load** paths (`checkLoadConfigBDM`, `checkLoadConfigHDD`) additionally probe `CONFIG_OPL_FILENAME_LEGACY` when the current name misses, so an install made by an earlier RiptOPL build is still found and migrates forward on the next save.
- The **save** path (`trySaveConfigBDM`) deliberately does **not** probe legacy: writing under the old name would un-migrate an install the load path just moved forward.

Our `checkLoadConfigBDM` keeps its own HDD spin-up structure (the fork's version of that function is shaped differently) — only the filenames changed, so the 5-second `bdmHDDIsPresent` wait and the `is_hdd` flag behave exactly as before.

### Provenance
Found by the pre-v1.0 multi-lens audit (32 findings, 16 survived adversarial refutation), then **independently re-verified by hand** before committing.

### Verified
- `make -j8` → `MAKE_EXIT=0` in the ps2dev container
- clang-format 12 clean
- zero `conf_opl.cfg` literals remain in `src/` or `include/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)