### PR TITLE
rebuild-40: folder browsing could list games but never launch them

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -859,15 +859,30 @@ void sbRebuildULCfg(base_game_info_t **list, const char *prefix, int gamecount, 
 
 static void sbCreatePath_name(const base_game_info_t *game, char *path, const char *prefix, const char *sep, int part, const char *game_name)
 {
+    // Folder browsing: a game inside a subfolder sits at <prefix>CD|DVD/<sub>/<name>. sbBrowseSub is
+    // "" for the normal device-root case, so subseg collapses to nothing and the path is unchanged.
+    // WITHOUT this, every consumer of sbCreatePath composed a DEVICE-ROOT path for a game the user
+    // opened from a subfolder: launch open()s a file that is not there, and sbDelete unlink()s the
+    // root path -- which, if a same-named ISO exists at the root, silently deletes the WRONG game.
+    // ul.cfg (USBLD) is a device-root-only concept and is deliberately left unprefixed.
+    char subseg[FOLDER_SUB_MAX + 2];
+    if (sbBrowseSub[0] != '\0')
+        snprintf(subseg, sizeof(subseg), "%s%s", sbBrowseSub, sep);
+    else
+        subseg[0] = '\0';
+
     switch (game->format) {
         case GAME_FORMAT_USBLD:
             snprintf(path, 256, "%sul.%08X.%s.%02x", prefix, USBA_crc32(game_name), game->startup, part);
             break;
         case GAME_FORMAT_ISO:
-            snprintf(path, 256, "%s%s%s%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, game_name, game->extension);
+            snprintf(path, 256, "%s%s%s%s%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, subseg, game_name, game->extension);
             break;
         case GAME_FORMAT_OLD_ISO:
-            snprintf(path, 256, "%s%s%s%s.%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, game->startup, game_name, game->extension);
+            snprintf(path, 256, "%s%s%s%s%s.%s%s", prefix, (game->media == SCECdPS2CD) ? "CD" : "DVD", sep, subseg, game->startup, game_name, game->extension);
+            break;
+        case GAME_FORMAT_FOLDER:
+            path[0] = '\0'; // a folder is never launched / deleted / renamed / pathed
             break;
     }
 }


### PR DESCRIPTION
With Folder Navigation on (`gEnableFolderNav`, default OFF), descending into `mass0:/DVD/RPGs` listed the games correctly and then launched **nothing** — every consumer of `sbCreatePath` composed a **device-root** path, so `open()` missed and the user got `_STR_ERR_FILE_INVALID`. 100% failure rate on every folder-capable device (BDM/UDPFS), both loader cores.

**Worse than a failed launch:** `sbDelete` `unlink()`s that same root path. If a game with the same filename exists at the device root, deleting a game from inside a subfolder **silently deletes the wrong file** — and `sbDelete` ignores the return, so nothing is reported. Rename was a no-op for the same reason.

### Root cause
`sbCreatePath_name` simply never consumed `sbBrowseSub`. Everything else was present: the producers (`sbSetBrowseSub`, called from `bdmsupport.c` and `udpfssupport.c`), the state variable, and — critically — the file's own comment at `src/supportbase.c:426` claiming *"a game inside a subfolder resolves correctly even when the launch does not go through a fresh scan."*

That comment asserts behaviour that did not happen. It is exactly why this survived review.

### I own part of this
rebuild-37 added the **identical** `subseg` block to `sbPopulateConfig`, 85 lines below, and I did not check the sibling composer. I wrote in that commit that leaving half a contract wrong *"would have been worse than the wider diff"* — and then left the launch path wrong. Porting one half of a two-part contract is the failure mode this rebuild keeps repeating; this is the audit's headline finding and I contributed to it.

### Scope
- `subseg` collapses to `""` at the device root, so **non-folder-nav behaviour is byte-identical**.
- `ul.cfg` (USBLD) stays unprefixed — it's a device-root-only concept.
- Adds the fork's `GAME_FORMAT_FOLDER` arm (`path[0] = '\0'`). Folder rows are currently blocked from every consumer, so it's defensive only, but it costs one line and makes the switch total.

### Verified
- `make -j8` → `MAKE_EXIT=0`; clang-format 12 clean.
- Re-verified by hand against `origin/master` — the fork's `sbCreatePath_name` carries this block verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)