### PR TITLE
rebuild-41: every release shipped with no language pack

### DIFF
--- a/lng_pack.sh
+++ b/lng_pack.sh
@@ -72,9 +72,9 @@ EOF
 
 # Lets pack it!
 cd ${BUILD_DIR}/
-zip -r "${CURRENT_DIR}/OPNPS2LD-LANGS-${OPL_VERSION}.zip" ./*
-if [ -f "${CURRENT_DIR}/OPNPS2LD-LANGS-${OPL_VERSION}.zip" ]
-	then echo "OPL Lang Package Complete: OPNPS2LD-LANGS-${OPL_VERSION}.zip"
+zip -r "${CURRENT_DIR}/RIPTOPL-LANGS-${OPL_VERSION}.zip" ./*
+if [ -f "${CURRENT_DIR}/RIPTOPL-LANGS-${OPL_VERSION}.zip" ]
+	then echo "OPL Lang Package Complete: RIPTOPL-LANGS-${OPL_VERSION}.zip"
 	else echo "OPL Lang Package not found!"
 fi
 


### PR DESCRIPTION
All 31 translations and their non-Latin fonts were absent from **every** rolling and tagged release. English only, silently, with the job staying green.

`lng_pack.sh` emitted `OPNPS2LD-LANGS-<ver>.zip` (upstream naming); the workflow tests `ls RIPTOPL-LANGS-*.zip`. The glob never matched, the step took its soft-fail branch, and printed a WARN nobody reads.

### Proven, not inferred
The pipeline dry run (actions run [31323469795](https://github.com/NathanNeurotic/Open-PS2-Loader/actions/runs/31323469795), `build-rolling-ps2dev-latest`) logged both halves back to back:

```
OPL Lang Package Complete: OPNPS2LD-LANGS-v1.2.0-Beta-2338-c5ce099.zip
WARN: language pack not produced this run
```

### Why the producer side, not the consumer side
The workflow isn't the only thing that names this file — the **release notes advertise `RIPTOPL-LANGS-*.zip` to users** (`rolling-release.yml:696-697`), and the fork's `lng_pack.sh` already emits `RIPTOPL-`. After this change `git diff origin/master -- lng_pack.sh` is **empty**: producer and consumer agree, and we match the fork exactly.

### Blast radius was total, not partial
`rolling-release.yml` deletes every existing asset before upload, so no stale pack survived on the tag either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)