### PR TITLE
rebuild-43: five GUI correctness fixes (one is a likely crash)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -261,7 +261,11 @@ void guiCheckNotifications(int checkTheme, int checkLang)
 {
     if (gEnableNotifications) {
         if (checkTheme) {
-            if (thmGetGuiValue() != 0)
+            // Only DISK themes have a path to announce; the built-ins (<OPL>, <Coverflow>) return NULL
+            // from thmGetFilePath. The old `!= 0` test was correct only while theme IDs ran 0..nThemes;
+            // this tree's themes.c adds a built-in at nThemes+1, so a saved <Coverflow> passed the test
+            // and fed NULL to the "%s" in _STR_THM_NOTIFICATION on EVERY boot. Coverflow is our default.
+            if (thmGetFilePath(thmGetGuiValue()) != NULL)
                 showThmPopup = 1;
         }
 
@@ -859,9 +863,14 @@ void guiShowNetConfig(void)
     diaSetEnum(diaNetConfig, CFG_SMBDIALECT, smbDialects);
 
     // upload current values
-    diaSetInt(diaNetConfig, NETCFG_SHOW_ADVANCED_OPTS, 0);
-    diaSetEnabled(diaNetConfig, NETCFG_ETHOPMODE, 0);
-    diaSetEnabled(diaNetConfig, NETCFG_SHARE_PORT, 0);
+    // Open the Network Config with advanced options ON so SMB Port + ETH op-mode are immediately
+    // editable. Forcing 0 here contradicted the row's own def=1 in dialogs.c AND overwrote it:
+    // diaSetInt writes both `def` and `current`, so even diaResetValue restored the 0. It matters
+    // because this fork defaults the SMB port to 1111 -- anyone pointing at a normal 445 server hit
+    // a greyed field first.
+    diaSetInt(diaNetConfig, NETCFG_SHOW_ADVANCED_OPTS, 1);
+    diaSetEnabled(diaNetConfig, NETCFG_ETHOPMODE, 1);
+    diaSetEnabled(diaNetConfig, NETCFG_SHARE_PORT, 1);
 
     diaSetInt(diaNetConfig, NETCFG_PS2_IP_ADDR_TYPE, ps2_ip_use_dhcp);
     diaSetInt(diaNetConfig, NETCFG_SHARE_ADDR_TYPE, gPCShareAddressIsNetBIOS);
@@ -2059,9 +2068,13 @@ static void guiHandleDeferredOps(void)
 
         gCompletedOps++;
     }
-    SignalSema(gSemaId);
-
+    // Clear the now-dangling tail pointer INSIDE the lock. The drain loop freed every node and emptied
+    // gUpdateList; doing this AFTER SignalSema let an IO-thread guiDeferUpdate slip in (rebuild the list,
+    // set gUpdateEnd) only to have it clobbered here -> the next enqueue's gUpdateEnd->next was a NULL deref.
+    // Not a rare interleaving: the IO worker is prio 30 and the GUI thread prio 31, and lower wins on EE,
+    // so the thread woken by SignalSema preempts us immediately.
     gUpdateEnd = NULL;
+    SignalSema(gSemaId);
 }
 
 void guiExecDeferredOps(void)
@@ -2385,7 +2398,9 @@ int guiAlignMenuHints(menu_hint_item_t *hint, int font, int width)
 
     for (; hint; hint = hint->next) {
         GSTEXTURE *iconTex = thmGetTexture(hint->icon_id);
-        w = (iconTex->Width * 20) / iconTex->Height;
+        // A disk theme with use_default=0 that omits circle.png/cross.png leaves this texture NULL
+        // (thmGetTexture's documented contract); guiDrawIconAndText in this same file already guards.
+        w = iconTex ? (iconTex->Width * 20) / iconTex->Height : 20;
         char *text = _l(hint->text_id);
 
         x -= rmWideScale(w) + 2;
@@ -2407,7 +2422,9 @@ int guiAlignSubMenuHints(int hintCount, int *textID, int *iconID, int font, int 
 
     for (i = 0; i < hintCount; i++) {
         GSTEXTURE *iconTex = thmGetTexture(iconID[i]);
-        w = (iconTex->Width * 20) / iconTex->Height;
+        // A disk theme with use_default=0 that omits circle.png/cross.png leaves this texture NULL
+        // (thmGetTexture's documented contract); guiDrawIconAndText in this same file already guards.
+        w = iconTex ? (iconTex->Width * 20) / iconTex->Height : 20;
         char *text = _l(textID[i]);
 
         x -= rmWideScale(w) + 2;
@@ -2773,7 +2790,12 @@ void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data, int
 
 void guiGameHandleDeferedIO(int *ptr, struct UIItem *ui, int type, void *data)
 {
-    ioPutRequest(type, data);
+    // A rejected request never runs, so nothing will ever clear *ptr and the loop below spins
+    // forever. The sibling guiHandleDeferedIO already checks this; this one did not.
+    if (ioPutRequest(type, data) != IO_OK) {
+        *ptr = 0;
+        return;
+    }
 
     while (*ptr) {
         guiStartFrame();

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -256,10 +256,23 @@ static void _menuSaveConfig()
         setErrorMessagePathCode(_STR_ERROR_SAVING_SETTINGS_TO, itemConfig ? itemConfig->filename : "", gLastSaveErrno);
 }
 
+// Every path out of here MUST either queue a load that will clear actionStatus, or clear it itself.
+// The old version had two paths that did neither: the selection changed but the idle-frame gate was
+// not met, or the row was current with itemConfig still NULL. Both left actionStatus=1 with nothing
+// in flight, so guiHandleDeferedIO span on a load that was never requested -- an outright hang
+// before rebuild-38, and a 30s freeze plus a bogus error toast after it.
+// NOTE(rebuild): the fork also swaps list->delay for MENU_APP_CONFIG_IDLE_FRAMES on APP_MODE. That
+// constant does not exist here and is a separate tuning change, so the idle gate is left exactly as
+// it was; only the completion contract is repaired.
 static void _menuRequestConfig()
 {
+    int shouldQueueLoad = 0;
+
     WaitSema(menuSemaId);
-    if (selected_item->item->current != NULL && itemConfigId != selected_item->item->current->item.id) {
+    if (selected_item == NULL || selected_item->item == NULL || selected_item->item->current == NULL) {
+        // The list can be rebuilt out from under us between the GUI's check and this callback.
+        actionStatus = 0;
+    } else if (itemConfigId != selected_item->item->current->item.id) {
         if (itemConfig) {
             configFree(itemConfig);
             itemConfig = NULL;
@@ -267,12 +280,24 @@ static void _menuRequestConfig()
         item_list_t *list = selected_item->item->userdata;
         if (itemConfigId == -1 || guiInactiveFrames >= list->delay) {
             itemConfigId = selected_item->item->current->item.id;
-            ioPutRequest(IO_CUSTOM_SIMPLEACTION, &_menuLoadConfig);
-        }
-    } else if (itemConfig)
+            shouldQueueLoad = 1;
+        } else
+            actionStatus = 0; // still settling: nothing queued, so release the waiter now
+    } else if (itemConfig == NULL && actionStatus != 0) {
+        shouldQueueLoad = 1; // right row, but its config never landed -- ask again
+    } else
         actionStatus = 0;
 
     SignalSema(menuSemaId);
+
+    // Queue OUTSIDE the sema: _menuLoadConfig takes it too.
+    if (shouldQueueLoad && ioPutRequest(IO_CUSTOM_SIMPLEACTION, &_menuLoadConfig) != IO_OK) {
+        WaitSema(menuSemaId);
+        if (itemConfig == NULL)
+            itemConfigId = -1; // let the next pass retry rather than caching a row that never loaded
+        actionStatus = 0;
+        SignalSema(menuSemaId);
+    }
 }
 
 config_set_t *menuLoadConfig()


### PR DESCRIPTION
All five are places where a fork fix was dropped and upstream's weaker version survived. Grouped because they're all `src/gui.c` plus the one `menusys.c` callback that pairs with the last of them.

### W2 — `gUpdateEnd` cleared outside the lock (likely crash, not a rare race)
`guiHandleDeferredOps` drained the list, released `gSemaId`, and only **then** set `gUpdateEnd = NULL`. An IO-thread `guiDeferUpdate` that slips into that window rebuilds the list and sets `gUpdateEnd` — which we then clobber to NULL, so the next enqueue does `gUpdateEnd->next` on NULL.

This is the **expected** interleaving, not a corner case: the IO worker is prio 30 and the GUI thread prio 31, and **lower wins on EE**, so the thread woken by `SignalSema` preempts immediately. Hot path is `menuDeferredUpdate`, which bursts one `guiDeferUpdate` per game on every device rescan.

### W3 — unguarded `thmGetTexture()` NULL deref in both hint-align helpers
`guiAlignMenuHints` and `guiAlignSubMenuHints` did `iconTex->Width` with no NULL check; `guiDrawIconAndText`, 24 lines above **in the same file**, already guards. A disk theme with `use_default=0` that omits `circle.png`/`cross.png` returns NULL here, and these run every frame.

### W4 — the DEFAULT theme showed a garbled boot toast, every boot
`guiCheckNotifications` gated on `thmGetGuiValue() != 0`, but the consumer feeds `thmGetFilePath(...)` into a `"%s"` — and that returns NULL for the two **built-in** themes. The `!= 0` test was correct only while theme IDs ran `0..nThemes`; this tree's `themes.c` adds a built-in at `nThemes+1`, so a saved `<Coverflow>` — **our default** — passed the test and printed NULL.

### W6 — Network page force-greyed its two advanced rows on every open
`gui.c` set `SHOW_ADVANCED_OPTS`/`ETHOPMODE`/`SHARE_PORT` to `0`, contradicting the row's own `def=1` in `dialogs.c` — and *overwriting* it, since `diaSetInt` writes both `def` and `current`, so even `diaResetValue` restored the 0. Concretely bad here because this fork defaults the SMB port to **1111**: anyone pointing at a normal 445 server met a greyed field first.

### W7 — two paths that could spin the GUI on a load nobody requested
`guiGameHandleDeferedIO` discarded `ioPutRequest`'s return (its sibling `guiHandleDeferedIO` checks it). And `_menuRequestConfig` had two exits that neither queued a load nor cleared `actionStatus`: *selection changed but idle-frame gate unmet*, and *right row but `itemConfig` still NULL*. Both left `actionStatus=1` with nothing in flight — an outright hang before rebuild-38, a 30s freeze plus a bogus error toast after it.

Restructured so every path either queues or clears, with the queue moved outside the sema (`_menuLoadConfig` takes it too) and a failed queue rolling `itemConfigId` back so the next pass retries.

**Deliberately not taken from the fork's version:** `MENU_APP_CONFIG_IDLE_FRAMES` (doesn't exist here, and it's a separate tuning change — the idle gate is untouched) and `padRumbleFlush` (item 43, on WAIT).

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean on both files. Each finding re-verified by hand against `origin/master` before the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)