### PR TITLE
rebuild-45: restore two sets of call sites the fork has and we dropped

### DIFF
--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1026,3 +1026,7 @@ gui_strings:
   string: This setting is not used with the Neutrino core.
 - label: DISABLE_ALL
   string: Disable All
+- label: BOOT_LOADING_SOUNDS
+  string: Loading theme sounds...
+- label: BOOT_BUILDING_MENU
+  string: Building menu...

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -943,7 +943,12 @@ void menuSetSelectedItem(menu_item_t *item)
 
 void menuRenderMenu()
 {
-    guiDrawBGPlasma();
+    // Optional themed settings background (use_settings_bg): guiDrawBGSettings draws it and
+    // returns non-zero; 0 means the theme has none, so fall back to the plasma. dia.c already
+    // did this for dialogs -- these three menu screens did not, so a theme that shipped a
+    // settings background got it on its dialogs and the plasma on its menus.
+    if (guiDrawBGSettings() == 0)
+        guiDrawBGPlasma();
 
     if (!mainMenu)
         return;
@@ -1308,7 +1313,12 @@ void menuHandleInputInfo()
 
 void menuRenderGameMenu()
 {
-    guiDrawBGPlasma();
+    // Optional themed settings background (use_settings_bg): guiDrawBGSettings draws it and
+    // returns non-zero; 0 means the theme has none, so fall back to the plasma. dia.c already
+    // did this for dialogs -- these three menu screens did not, so a theme that shipped a
+    // settings background got it on its dialogs and the plasma on its menus.
+    if (guiDrawBGSettings() == 0)
+        guiDrawBGPlasma();
 
     if (!gameMenu)
         return;
@@ -1485,7 +1495,12 @@ void menuHandleInputGameMenu()
 
 void menuRenderAppMenu()
 {
-    guiDrawBGPlasma();
+    // Optional themed settings background (use_settings_bg): guiDrawBGSettings draws it and
+    // returns non-zero; 0 means the theme has none, so fall back to the plasma. dia.c already
+    // did this for dialogs -- these three menu screens did not, so a theme that shipped a
+    // settings background got it on its dialogs and the plasma on its menus.
+    if (guiDrawBGSettings() == 0)
+        guiDrawBGPlasma();
 
     if (!appMenu)
         return;

--- a/src/opl.c
+++ b/src/opl.c
@@ -2603,6 +2603,8 @@ static void init(void)
 
 static void deferredInit(void)
 {
+    guiSetBootStatusSticky(_l(_STR_BOOT_BUILDING_MENU)); // boot-step localizer (IO thread) -- reaching
+                                                         // here means the device init chain cleared; see gui.c
 
     // inform GUI main init part is over
     struct gui_update_t *id = guiOpCreate(GUI_INIT_DONE);
@@ -2619,6 +2621,7 @@ static void deferredAudioInit(void)
 {
     int ret;
 
+    guiSetBootStatusSticky(_l(_STR_BOOT_LOADING_SOUNDS)); // boot-step localizer (IO thread) -- see gui.c
     audioInit();
     ret = sfxInit(1);
     if (ret < 0)


### PR DESCRIPTION
Found by the sweep the pre-v1.0 audit recommended as its closing note: instead of hunting symbols with **zero** callers, compare **call-site counts** against the fork and flag every `N → N-1`. That's the query that finds a half-ported feature, because the symbol still looks "used".

Ran it over **1160 symbols**. Most deltas were explained by deliberately-absent files (`mmcesupport.c`, the threaded `texcache`). These two were not.

### 1. `guiDrawBGSettings` — fork calls it 3× from `menusys.c`, we called it 0× there
`menuRenderMenu` / `menuRenderGameMenu` / `menuRenderAppMenu` each drew `guiDrawBGPlasma()` unconditionally.

`dia.c` **already had** the correct `if (guiDrawBGSettings() == 0) guiDrawBGPlasma();` in all three of its sites — so a theme shipping a settings background (`use_settings_bg` + the `SETTINGS_BG` texture, both already supported here) got that background on its **dialogs** and the plasma on its **menus**. Same feature, two halves, one of them wired.

### 2. `guiSetBootStatusSticky` — fork calls it 2× from `opl.c`, we called it 0× there
The boot-step localizer exists so a boot **hang** is attributable to a step instead of a frozen "Ready." — and the two steps it was missing are the two longest: `deferredInit` (menu build) and `deferredAudioInit` (theme sounds). A hang in either showed a stale earlier label, degrading exactly the diagnostic that was built for the boot-hang reports.

The two labels didn't exist here either (only 7 of the fork's 9 `BOOT_*` are present), so `BOOT_LOADING_SOUNDS` and `BOOT_BUILDING_MENU` are **appended at the end** of `lng_tmpl/_base.yml`.

Verified against the position-consumed `.lng` contract:

| check | result |
|---|---|
| label count | 492 → 494 |
| first 492 identical in order | ✅ |
| duplicates | none |
| new IDs at tail of `lang_autogen.h` | 497 / 498 |

### Verified
`make -j8` → `MAKE_EXIT=0` with languages regenerated; clang-format 12 clean. (It wanted one extra space on a continuation comment — the trailing-comment alignment trap — caught **locally before push** and applied from its own output, scoped to that line.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)