### PR TITLE
rebuild-46: "Settings saved" was shown even when the write failed

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1622,6 +1622,29 @@ static int trySaveAlternateDevice(int types)
     return 0;
 }
 
+// configWriteMulti SUMS per-set results, and configWrite returns 1 for an UNMODIFIED set without
+// touching the disk -- so a failed write of the master settings can hide behind untouched sibling
+// sets and the save reports success ("Settings saved" toast, no retry). Concretely: OPL modified and
+// failing returns 0, NETWORK and GAME untouched return 1 each, the sum is 2, and 2 > 0 reads as
+// success. configWrite clears a set's modified flag only when its write actually succeeded, and
+// _saveConfig configSet*s every set it means to save (marking it modified) -- so any REQUESTED set
+// still marked modified after the write IS a failed write. Returns 0 in that case, the raw sum
+// otherwise.
+static int configWriteChecked(int types)
+{
+    int result = configWriteMulti(types);
+    if (result > 0) {
+        for (int bit = 1; bit < (1 << CONFIG_INDEX_COUNT); bit <<= 1) {
+            if (types & bit) {
+                config_set_t *cfg = configGetByType(bit); // NULL only if a requested set was never allocated
+                if (cfg != NULL && cfg->modified)
+                    return 0;
+            }
+        }
+    }
+    return result;
+}
+
 static void _saveConfig()
 {
     char temp[256];
@@ -1742,8 +1765,10 @@ static void _saveConfig()
         configPrepareNotifications(gBaseMCDir);
     }
 
-    lscret = configWriteMulti(lscstatus);
-    if (lscret == 0)
+    lscret = configWriteChecked(lscstatus);
+    // <= 0, not == 0: configWriteChecked can only return 0 or a positive sum today, but the guard
+    // costs nothing and a negative would otherwise read as success here.
+    if (lscret <= 0)
         lscret = trySaveAlternateDevice(lscstatus);
     lscstatus = 0;
 }


### PR DESCRIPTION
`configWriteMulti` **sums** per-set results, and `configWrite` returns `1` for an **unmodified** set without touching the disk (`src/config.c` — the function ends in a bare `return 1;`).

So the failure arithmetic was:

| set | state | result |
|---|---|---|
| OPL | modified, write **fails** | `0` |
| NETWORK | untouched | `1` |
| GAME | untouched | `1` |
| | **sum** | **`2`** → `2 > 0` reads as success |

The user got the "Settings saved" toast on a failed write — and worse, `trySaveAlternateDevice` was skipped, so the one automatic recovery path never ran. On a flaky HDD, which is exactly when `configWrite`'s own snapshot/restore rescue reports failure, the save silently did nothing.

### The fix
`configWriteChecked` re-checks the contract instead of trusting the sum: `configWrite` clears a set's `modified` flag **only** when its write actually succeeded, and `_saveConfig` `configSet*`s every set it means to save (marking it modified) — so any **requested** set still marked modified after the write **is** a failed write.

Ported from `origin/master:src/opl.c:2113`. Applied only to the top-level save site; the `trySaveConfig*` helpers keep the raw `configWriteMulti`, exactly as the fork does — their result feeds the alternate-device fallback chain, which wants the per-device answer, not the aggregate verdict.

**Not ported** from the fork's surrounding code: the boot-device save retry (`gBootDir` / `gBootDirBdmType` / `bdmResolveBootDir`). That's checklist item 11, on WAIT.

Also tightened `if (lscret == 0)` to `<= 0` before the alternate-device fallback: `configWriteChecked` can only return 0 or a positive sum today, but a negative would otherwise have read as success.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean. Mechanism re-verified by hand (read `configWrite`'s tail to confirm the free `1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)