### PR TITLE
rebuild-47: restore guiLock serialization at the three sites that lost it

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -5,6 +5,7 @@
 #include "include/ioman.h"
 #include "include/themes.h"
 #include "include/sound.h"
+#include "include/gui.h" // guiLock/guiUnlock -- serialize the language name-list rebuild
 
 static int guiLangID = 0;
 static char **lang_strs = internalEnglish;
@@ -156,7 +157,13 @@ int lngAddLanguages(char *path, const char *separator, int mode)
 
     result = listDir(path, separator, MAX_LANGUAGE_FILES - nLanguages, &lngReadEntry);
     nLanguages += result;
+    // Serialize the name-list free+swap against the GUI's readers (see thmRebuildGuiNames, which is
+    // already locked this way in themes.c): this runs on the IO worker for device-triggered language
+    // discovery, and guiShowUIConfig hands the very same list to its dialog. The lock is a
+    // not-ready no-op during pre-GUI init.
+    guiLock();
     lngRebuildLangNames();
+    guiUnlock();
 
     const char *temp;
     if (configGetStr(configGetByType(CONFIG_OPL), "language_text", &temp)) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -301,8 +301,16 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
 
     // refresh Cache
     if (themeChanged) {
-        if (mod->subMenu)
+        if (mod->subMenu) {
+            // Serialize the per-item cache_id/cache_uid array reallocation with rendering: this runs
+            // on the IO thread during a mid-session theme reload while the GUI thread draws the
+            // carousel THROUGH those arrays (read + write on enqueue). Unserialized, a draw racing
+            // the free()+malloc() wrote a fresh (index, uid) pair through a freed pointer into a
+            // NEIGHBOUR's reallocated array -- the permanent wrong-cover mapping.
+            guiLock();
             submenuRebuildCache(mod->subMenu);
+            guiUnlock();
+        }
         guiCheckNotifications(themeChanged, 0);
     }
 }
@@ -1818,10 +1826,14 @@ void applyConfig(int themeID, int langID, int skipDeviceRefresh)
         }
     } else {
         if (changed) {
+            // Same serialization as moduleUpdateMenuInternal: never realloc the per-item art-pair
+            // arrays while the GUI thread may be drawing through them.
+            guiLock();
             for (int i = 0; i < MODE_COUNT; i++) {
                 if (list_support[i].support && list_support[i].subMenu)
                     submenuRebuildCache(list_support[i].subMenu);
             }
+            guiUnlock();
         }
     }
 


### PR DESCRIPTION
Same `N → N-1` sweep as rebuild-45. `guiLock`: the fork calls it **4×** across `opl.c` and `lang.c`, we called it **1×**. All three missing sites guard a `free()`+`realloc()` of an array the GUI thread reads while rendering.

### 1. `src/opl.c` `moduleUpdateMenuInternal` — the wrong-cover bug
`submenuRebuildCache(mod->subMenu)` ran unguarded on a mid-session theme reload.

This is not a theoretical race — the fork's comment records the observed symptom, and it's a bug this project has already chased. The rebuild runs on the **IO thread** while the **GUI thread** draws the carousel *through* the per-item `cache_id`/`cache_uid` arrays (it reads them **and** writes them on enqueue). A draw racing the `free()`+`malloc()` wrote a fresh `(index, uid)` pair through a freed pointer into a **neighbour's** reallocated array — the permanent **wrong-cover mapping**.

### 2. `src/opl.c` `moduleUpdateMenu`
The same rebuild, looped over every `MODE_COUNT` support, equally unguarded.

### 3. `src/lang.c` `lngAddLanguages`
`lngRebuildLangNames()` free+swaps the language name list on the IO worker during device-triggered discovery, while `guiShowUIConfig` hands that same list to its dialog.

**Item 3 is the clearest instance of the pattern this audit keeps turning up.** The *theme* half is already correct here — `themes.c` is byte-identical to the fork and locks `thmRebuildGuiNames` at both of its sites. Only the *language* half lost its lock. And `gui.c:659-660`'s own comment states that **both** lists are "freed+rebuilt under guiLock on the IO worker", which was simply untrue for `lngRebuildLangNames`. Another comment asserting behaviour the code didn't implement.

### Safety
`guiLock` is a not-ready no-op during pre-GUI single-threaded init, so none of these change boot ordering. Lock/unlock pairs verified balanced (`opl.c` 3/3, `lang.c` 1/1). `lang.c` needed a new `gui.h` include.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)