### PR TITLE
rebuild-51: resolve the boot dir to its massN: mount (item 11)

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -33,6 +33,7 @@
 #include "include/appsupport.h"
 #include "include/favsupport.h"
 #include "include/folderbrowse.h" // folderDepth -- favourites suppression inside subfolders
+#include "include/mmcesupport.h"  // mmceLoadModules() -- MMCE boot branch of resolveBootDirToMass
 #include "include/tar.h"          // tarInvalidate -- re-arm the .tar probe on a settings apply
 #include "include/vcdsupport.h"   // vcdViewActive stub -- isVcd stays 0 until item 12 lands
 
@@ -1305,10 +1306,110 @@ static void configReadNeutrinoGlobals(config_set_t *configOPL)
     }
 }
 
+// Basename of the ELF OPL was booted as (argv[0]); pairs with gBootDir. resolveBootDirToMass uses
+// it to verify WHICH mounted massN: slot is the boot device (launcher slot numbering need not
+// match OPL's). Empty when the boot dir came from getcwd() or argv[0] had no filename part.
+static char gBootElfName[64];
+// BDM_TYPE_* of the resolved boot device, BDM_TYPE_UNKNOWN for non-BDM boots. Set by
+// resolveBootDirToMass(); consumed by the _saveConfig re-resolve retry.
+static int gBootDirBdmType = BDM_TYPE_UNKNOWN;
+
+static void resolveBootDirToMass(void)
+{
+    if (gBootDir[0] == '\0')
+        return;
+
+    // uLE hands APA-HDD boots as "hdd0:<partition>:pfs:/..." -- a launch identity OPL can never open
+    // (OPL's own APA mount is pfs0: on the +OPL partition, a different namespace). Unresolvable: drop
+    // to legacy discovery, whose checkLoadConfigHDD probes the APA config location properly.
+    if (!strncmp(gBootDir, "hdd", 3)) {
+        LOG("BOOT unresolvable APA boot dir %s -> legacy discovery\n", gBootDir);
+        gBootDir[0] = '\0';
+        configEnd();
+        configInit(NULL);
+        return;
+    }
+
+    // CD-ROM / ISO boot (PS3 PS2-Classic ISO or PS2 disc boot): cdrom0: is read-only hardware.
+    // Re-home the config to the Memory Card (mc?:OPL) so saves land on Memory Card Slot 1/2 (#353).
+    if (!strncmp(gBootDir, "cdrom", 5)) {
+        LOG("BOOT read-only cdrom boot dir %s -> redirecting config home to MC\n", gBootDir);
+        gBootDir[0] = '\0';
+        configEnd();
+        configInit(NULL);
+        return;
+    }
+
+    // MMCE boot: the mmceman driver is likewise not loaded at boot time (sysReset loads none of the
+    // device stacks), so mmceN: is unreadable exactly when settings must load. Load it (idempotent)
+    // and give the card a moment to register its filesystem. mmceN: IS the readable namespace, so no
+    // prefix rewrite is needed.
+    if (!strncmp(gBootDir, "mmce", 4)) {
+        // NOTE(rebuild): mmceLoadModules() is still the no-op stub here (MMCE is checklist items 1-3,
+        // on WAIT), so the driver never loads and the opendir poll below always times out. That lands
+        // on the "keep as config home" fallback -- which is the CORRECT feature-off behaviour, and the
+        // one that matters: it is precisely the branch that keeps mc untouched. An MMCE boot therefore
+        // reads defaults for now and its first successful save lands on mmce once item 1 makes the
+        // driver real. Cost is the ~10 x delay(1) poll on an MMCE boot only.
+        mmceLoadModules();
+        char devRoot[8];
+        const char *colon = strchr(gBootDir, ':');
+        size_t rootLen = colon ? (size_t)(colon - gBootDir) + 1 : 0;
+        if (rootLen > 0 && rootLen < sizeof(devRoot)) {
+            memcpy(devRoot, gBootDir, rootLen);
+            devRoot[rootLen] = '\0';
+            for (int tries = 0; tries < 10; tries++) { // ~2 s total: the driver detects a present card in ms
+                DIR *dir = opendir(devRoot);
+                if (dir != NULL) {
+                    closedir(dir);
+                    return; // mounted -- the boot dir is readable as-is
+                }
+                delay(1);
+            }
+        }
+        // Card still settling after the wait. It served this very ELF milliseconds ago, so it IS present
+        // -- it just has not re-registered its mmceman filesystem yet. Do NOT blank gBootDir and re-home
+        // the config to a plain memory card here (the old configInit(NULL) fallback): with an empty boot
+        // dir, configGetDir() returns the legacy mc?: default, so _saveConfig's checkMCFolder() + the
+        // per-file O_CREAT stamped an unwanted mc?:OPL folder and settings onto a SEPARATE plain mc card
+        // (FifthFox, HW 2026-07-16). mc is never an MMCE user's config home. Keep mmce as the home: this
+        // boot falls back to defaults if the card is still settling, and the first save lands on mmce
+        // once it has mounted (a truly dead card fails the save visibly -- the same contract the BDM boot
+        // device honours below). mc stays untouched.
+        LOG("BOOT MMCE boot device %s not mounted after wait -> keep as config home (mc untouched)\n", gBootDir);
+        return;
+    }
+
+    char before[sizeof(gBootDir)];
+    snprintf(before, sizeof(before), "%s", gBootDir);
+    gBootDirBdmType = BDM_TYPE_UNKNOWN; // classify fresh from the prefix
+    int ret = bdmResolveBootDir(gBootDir, sizeof(gBootDir), gBootElfName, &gBootDirBdmType);
+    if (ret < 0) {
+        // The boot device's BDM stack did not mount within the resolve budget. It served this ELF, so it
+        // IS present -- do NOT blank gBootDir and re-home the config to a plain mc here (the old
+        // configInit(NULL)). An empty boot dir makes configGetDir() fall to the legacy mc?: default, and
+        // _saveConfig's checkMCFolder() + the per-file O_CREAT then stamp an mc?:OPL folder + settings
+        // onto a plain memory card (FifthFox, HW 2026-07-16 -- extended from the MMCE case above at
+        // NathanNeurotic's request). mc is never the boot device's config home. Keep the boot identity as
+        // the home (the config sets were already homed there by init()'s configInit): this boot reads
+        // defaults if the stack is still coming up, and a save targets the boot device -- failing visibly
+        // if it is genuinely gone -- never a plain mc. bdmResolveBootDir leaves gBootDir UNCHANGED on a
+        // failed resolve (it only rewrites on success), so the identity here is intact.
+        LOG("BOOT boot device %s not mounted after resolve -> keep as config home (mc untouched)\n", before);
+        return;
+    }
+    if (ret > 0 && strcmp(before, gBootDir) != 0) {
+        LOG("BOOT resolved boot dir %s -> %s\n", before, gBootDir);
+        configEnd();
+        configInit(gBootDir); // re-point the config sets from the unreadable prefix to the massN: path
+    }
+}
+
 static void _loadConfig()
 {
     int value, themeID = -1, langID = -1;
     const char *temp;
+    resolveBootDirToMass(); // usb0:/ata0:/mx4sio0:/APPS -> mass0:/APPS (boot-device massN:) before the first read
     int result = configReadMulti(lscstatus);
 
     if (lscstatus & CONFIG_OPL) {
@@ -2845,10 +2946,6 @@ static void autoLaunchBDMGame(char *argv[])
 }
 
 // --------------------- Main --------------------
-// Basename of the ELF OPL was booted as (argv[0]); pairs with gBootDir. Static: consumers
-// outside this file go through gBootDir only.
-static char gBootElfName[64];
-
 static void setBootDir(const char *bootPath)
 {
     gBootDir[0] = '\0';


### PR DESCRIPTION
Rebased from the long-stale `rebuild/step-26-bootdev` (48 commits behind) onto current `rebuild/main`. The work is unchanged; the conflict resolution is described below.

### The gap
`setBootDir()` already populated `gBootDir` from `argv[0]`, but **nothing resolved it**. A launcher hands OPL its boot path in whatever namespace it used — `usb0:`, `mx4sio0:`, `ata0:`, or a bare `mass0:` — and OPL can only **read** `massN:`. So an unresolved `usb0:/APPS` reached the consumers as a path none of them can open.

`bdmResolveBootDir()` has been sitting in the tree **built and uncalled** since rebuild-12. This is the caller.

### The dispatcher
`resolveBootDirToMass()`, ported byte-identical from fork master, called at the top of `_loadConfig` before the first read:

| prefix | behaviour |
|---|---|
| `hdd*` | uLE hands `hdd0:<part>:pfs:/…` — an identity OPL can never open (OPL's APA mount is `pfs0:` on +OPL) → blank, fall back to legacy discovery |
| `cdrom*` | read-only hardware → re-home config to `mc?:OPL` (#353) |
| `mmce*` | load the driver, poll for the mount, then **keep** `mmce` as home |
| else | `bdmResolveBootDir()` maps the prefix to the mounted `massN:` |

### Why this is bounded, not a boot hazard
`bdmResolveBootDir` is **lazy** — `bdmEnsureTransportLoaded()` brings up only the transport the prefix implies, and an untyped `massN:` tries the cheap USB/MX4SIO pair first, escalating to iLink+ATA only if nothing holds the boot folder. The wait is budgeted: **10 s** for ATA (dev9 power-up + platter spin-up), **3 s** otherwise.

### The failure paths are the point
On a failed resolve this does **not** blank `gBootDir`. An empty boot dir makes `configGetDir()` fall back to the legacy `mc?:` default, and `_saveConfig`'s `checkMCFolder()` + per-file `O_CREAT` then stamp an unwanted `mc?:OPL` folder onto a **separate plain memory card** — a real hardware incident (FifthFox, 2026-07-16). Keeping the boot identity means this boot reads defaults and a later save targets the boot device, failing visibly if it's genuinely gone. **`mc` is never a BDM/MMCE user's config home.**

**MMCE branch note:** `mmceLoadModules()` is still the no-op stub (items 1–3 on WAIT), so the driver never loads and the poll always times out, landing on the "keep as config home" fallback. That's the correct feature-off behaviour — and it's precisely the branch that keeps `mc` untouched.

### Rebase conflict — resolved by keeping BOTH sides
The stale branch and rebuild-32 both inserted at the same point in `opl.c`. `configReadNeutrinoGlobals()` and `gBootElfName`/`gBootDirBdmType`/`resolveBootDirToMass` are independent, so both are kept. The branch also **moves** `gBootElfName`'s declaration up beside `gBootDirBdmType` (matching the fork's layout) — verified exactly **one** declaration survives, and the first build caught the two closing braces the three-way merge had eaten (`invalid storage class for function`).

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean; `bdmResolveBootDir` now has a live caller (`opl.c:1386`) and `resolveBootDirToMass` is invoked from `_loadConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)