### PR TITLE
rebuild-50: analog nav — "Off" didn't turn it off, "High" was worse than "Medium"

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -193,6 +193,12 @@ static void updatePadState(struct pad_data_t *pad, int state)
         pad->state = state;
 }
 
+// Left-stick navigation: the stick is MERGED into the d-pad bits, so analog nav is always available
+// and the X/Y Sensitivity rows are its control. Those rows offer FOUR options (Off/Low/Medium/High)
+// -- this switch must have four cases to match. It previously had three (upstream's), so index 3
+// ("High") fell into `default` and came out LESS sensitive than "Medium", and index 0 ("Off") mapped
+// to a 100 deadzone that still navigated. A 128 deadzone cannot be exceeded by a 0..255 axis centred
+// at 127, and the explicit `< 128` guards below make that intent unmistakable: Off really is off.
 static u32 readLeftJoy(struct pad_data_t *pad, u32 pdata)
 {
     u32 padData = pdata;
@@ -201,41 +207,51 @@ static u32 readLeftJoy(struct pad_data_t *pad, u32 pdata)
     if ((pad->buttons.mode >> 4) == 0x07) {
         switch (gXSensitivity) {
             case 0:
-                xDeadzone = 100;
+                xDeadzone = 128;
                 break;
             case 1:
-                xDeadzone = 80;
+                xDeadzone = 100;
                 break;
             case 2:
+                xDeadzone = 80;
+                break;
+            case 3:
                 xDeadzone = 60;
                 break;
             default:
-                xDeadzone = 80;
+                xDeadzone = 100;
         }
 
         switch (gYSensitivity) {
             case 0:
-                yDeadzone = 100;
+                yDeadzone = 128;
                 break;
             case 1:
-                yDeadzone = 80;
+                yDeadzone = 100;
                 break;
             case 2:
+                yDeadzone = 80;
+                break;
+            case 3:
                 yDeadzone = 60;
                 break;
             default:
-                yDeadzone = 80;
+                yDeadzone = 100;
         }
 
-        if (pad->buttons.ljoy_h < 127 - xDeadzone)
-            padData |= PAD_LEFT;
-        else if (pad->buttons.ljoy_h > 127 + xDeadzone)
-            padData |= PAD_RIGHT;
+        if (xDeadzone < 128) {
+            if (pad->buttons.ljoy_h < 127 - xDeadzone)
+                padData |= PAD_LEFT;
+            else if (pad->buttons.ljoy_h > 127 + xDeadzone)
+                padData |= PAD_RIGHT;
+        }
 
-        if (pad->buttons.ljoy_v < 127 - yDeadzone)
-            padData |= PAD_UP;
-        else if (pad->buttons.ljoy_v > 127 + yDeadzone)
-            padData |= PAD_DOWN;
+        if (yDeadzone < 128) {
+            if (pad->buttons.ljoy_v < 127 - yDeadzone)
+                padData |= PAD_UP;
+            else if (pad->buttons.ljoy_v > 127 + yDeadzone)
+                padData |= PAD_DOWN;
+        }
     }
 
     return padData;


### PR DESCRIPTION
Analog-stick navigation and a deadzone setting were both **already there** — `readLeftJoy` merges the left stick into the d-pad bits, and the X/Y Sensitivity rows in Controller Settings *are* the deadzone control. What was broken is the mapping between them.

The UI offers **four** options (`Off / Low / Medium / High`, `gui.c:1893`) but the switch had only **three** cases — upstream's:

| UI option | index | deadzone we used | result |
|---|---|---|---|
| Off | 0 | 100 | **still navigated — Off wasn't off** |
| Low | 1 | 80 | |
| Medium | 2 | 60 | |
| High | 3 | *fell to `default`* = 80 | **less sensitive than Medium** |

So the top setting was worse than the middle one, and the disable setting didn't disable.

Classic data-half/code-half split: the 4-entry enum came across in the settings-layout step, the 4-case switch didn't.

### Fix
Ported the fork's `readLeftJoy` verbatim — `128 / 100 / 80 / 60` for Off / Low / Medium / High, with explicit `if (xDeadzone < 128)` / `if (yDeadzone < 128)` guards around the axis tests. 128 is unreachable by a 0..255 axis centred at 127, so the guard is belt-and-braces on top of an already-unreachable threshold — kept because it states the intent that **Off means off**.

This is a **rebuild regression, not a fork gap**: `origin/master` has all four cases and both guards.

### Note on item 44
The "Left Stick Navigation" **boolean** stays removed. It was dead in the fork too (no reader for `gEnableAnalogNav`), and it's redundant now that Off works — the deadzone row is the real control.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)