### PR TITLE
rebuild-55: stop open/close chirps stacking up when the button is mashed

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -376,6 +376,37 @@ static void sfxEnqueue(int channel, int id)
 
     // Two producers on different priorities: claim the slot atomically.
     DIntr();
+
+    // Coalesce repeats of the LONG confirm/cancel samples (hardware report: the open/close chirp
+    // trails the button by a growing margin when the user mashes it).
+    //
+    // Measured from the ADPCM headers with this file's own sfxCalculateSoundDuration():
+    //     cursor  3528 samples =  80 ms      confirm 37376 samples = 847 ms
+    //     cancel 23040 samples = 522 ms
+    // and BOTH the focus-gain and focus-loss paths in dia.c play SFX_CONFIRM -- so opening and
+    // closing an option each fire a 847 ms sample on ONE channel. Mash it and up to 7 stack in the
+    // ring and replay serially long after the last press, because the staleness drop below is
+    // gated on SFX_CURSOR only. One pending entry per id is all that can ever be HEARD anyway:
+    // retriggering a channel replaces the sample already playing on it, so the extra copies only
+    // ever bought latency.
+    //
+    // If the ring is EMPTY there is nothing to match, so an isolated press is never dropped -- only
+    // a repeat that arrives while an identical sound is still pending. We do NOT touch the queued
+    // entry (no ticks refresh): producers must never mutate a slot, because the consumer copies its
+    // three fields and advances sfxQTail OUTSIDE this interrupt guard. Same sample either way.
+    //
+    // SFX_CURSOR is deliberately NOT coalesced: it is 80 ms, it already has the staleness drop, and
+    // it is the scroll path -- the #340 surface this whole rebuild exists to protect.
+    if (id == SFX_CONFIRM || id == SFX_CANCEL) {
+        int i;
+        for (i = sfxQTail; i != sfxQHead; i = (i + 1) % SFX_QUEUE_LEN) {
+            if (sfxQueue[i].id == id) {
+                EIntr();
+                return; // identical sound already pending: this repeat would only add latency
+            }
+        }
+    }
+
     int next = (sfxQHead + 1) % SFX_QUEUE_LEN;
     if (next == sfxQTail) {
         EIntr();


### PR DESCRIPTION
Hardware report (Zack): *"the bgm still lacks behind when the user keeps o[p]pressing the open/close button on an option"* — clarified to the open/close **sound effects**, not the music. Crucially he added: **"occurs on all opls btw."**

That last part is the important half, and it is **not** fixed here, because it can't be.

### Measurement first
Using this file's own `sfxCalculateSoundDuration()` (nSamples = word 3 of the ADPCM header):

| sample | samples | duration |
|---|---|---|
| cursor | 3528 | **80 ms** |
| confirm | 37376 | **847 ms** |
| cancel | 23040 | 522 ms |
| transition | 48128 | 1091 ms |

And **both** the focus-gain and focus-loss paths in `dia.c` play `SFX_CONFIRM` (`:828`, `:834`, `:1157`). So opening *and* closing an option each fire a **847 ms** sample — 10.6× longer than the cursor tick he says is clean — on a single channel, behind a blocking audsrv SIF RPC.

That floor exists in official OPL too, which is exactly why he sees it everywhere.

### What IS ours
The dispatch ring's staleness drop is gated on `SFX_CURSOR` **alone**, so `CONFIRM`/`CANCEL` are never aged out. Mashing the button stacks up to 7 and they replay serially after the presses stop — turning a fixed latency into a **growing** one. That's the part this fixes.

`sfxEnqueue` now coalesces `SFX_CONFIRM`/`SFX_CANCEL`: if an identical sound is already pending, the repeat is dropped rather than appended. Nothing audible is lost — retriggering a channel replaces the sample already playing on it, so the extra copies only ever bought latency. It also stops a CONFIRM burst evicting `SFX_BD_CONNECT`/`SFX_MESSAGE` from the shared ring.

### Three deliberate narrowings, against an analysis that proposed more
- **`SFX_CURSOR` is not coalesced.** It's 80 ms, it already has the staleness drop, and it's the **scroll path** — the #340 surface this rebuild exists to protect. Not worth touching for a symptom nobody reported there.
- **The queued entry is not mutated** (no ticks refresh). The consumer copies its three fields and advances `sfxQTail` *outside* the interrupt guard, so letting producers write into queued slots would introduce a real race. Dropping the repeat instead is audibly identical — same sample.
- **An empty ring matches nothing**, so an isolated press is never dropped; only a repeat arriving while an identical sound is still pending.

### Rejected
Extending the staleness drop past `SFX_CURSOR` — it would silence legitimate isolated presses, and would specifically silence `SFX_BD_CONNECT`/`DISCONNECT`, which are enqueued by the prio-30 ioman worker that then blocks the prio-45 consumer for the whole device scan, making those entries *always* "stale" on slow devices. Also rejected: raising the dispatch thread priority, which inverts the documented sound-yields-to-input contract.

### Be honest with the tester
**First-press latency is unchanged**, and a 847 ms confirm still runs on past the last press. What goes away is the **accumulation**.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean. Found by a 4-lens adversarial investigation; the durations, the dual `SFX_CONFIRM` paths and the CURSOR-only gate were each re-verified by hand before the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)