### PR TITLE
rebuild-56: art.tar indexed only its FIRST member — ".tar = covers ONLY"

### DIFF
--- a/include/tar.h
+++ b/include/tar.h
@@ -12,7 +12,13 @@
 #define TAR_BLOCK_SIZE 512
 #define MAX_FILE_SIZE  (4 * 1024 * 1024) // 4 MiB
 #define ARC_MAGIC      "ARC\0"
-#define ARC_VERSION    3
+// 4: the v3 indexer STOPPED at the first end-of-archive marker, so a concatenated art.tar was
+// indexed only up to its first member and the sidecar cached that TRUNCATED result. The sidecar
+// is validated against the tar's SIZE alone (tar.c tarReadCache), which does not change, and
+// tarInvalidate only drops the RAM copy -- so without a version bump every affected user would
+// keep their short index forever. Bumping forces a one-time re-scan. Cost: sidecars are no longer
+// interchangeable with wOPL/sOPL's, which is acceptable -- the file is a regenerable cache.
+#define ARC_VERSION    4
 
 typedef struct
 {

--- a/src/tar.c
+++ b/src/tar.c
@@ -269,8 +269,18 @@ static int tarParseFile(TarKind kind, const char *path)
         if (r != TAR_BLOCK_SIZE)
             goto fail;
 
+        // Do NOT stop at the first end-of-archive marker. A tar EOF marker is a run of zero
+        // blocks, and a CONCATENATED art.tar (a covers pack + a BG pack + a SCR pack merged with
+        // cat / copy /b, which is how these packs are actually distributed) carries one MID-FILE.
+        // Breaking here indexed only the FIRST member and silently dropped every entry after it --
+        // in practice every _BG/_SCR/_SCR2, while the covers in the first member kept working.
+        // This is GNU tar's --ignore-zeros semantics. The scan now ends only at a real EOF (the
+        // read()==0 above); trailing padding on a well-formed archive costs a few extra 512-byte
+        // reads. Note the ordering tell: within one game "_BG" sorts BEFORE "_COV", so a single
+        // truncated archive would have lost COVERS first -- covers surviving is only possible if
+        // they sit in an earlier concatenated member.
         if (isZeroBlock(header))
-            break;
+            continue;
 
         char typeflag = (char)header[156];
         u64 rawSize = parseOctal((char *)header + 124, 12);


### PR DESCRIPTION
Zack, on hardware: *".tar = covers ONLY"* / *"they are in my .tar but didnt show em in square menu"* / *"its pulling if the user is using normal arts not .tar arts"*. Same files, same theme, same suffixes — loose art works, tar art gives covers.

**I got this wrong twice before.** I traced `artTarLoadImage`, found it suffix-generic and byte-identical to the fork, and concluded the archive must be at fault. The *loader* is generic. The **indexer** is not.

### Root cause
`tarParseFile` stopped the whole scan at the first end-of-archive marker:

```c
if (isZeroBlock(header))
    break;
```

A tar EOF marker is a run of zero blocks. These art packs are **distributed as separate covers / backgrounds / screenshots archives and merged by the user** with `cat` or `copy /b` — which leaves an EOF marker **mid-file**. Everything after it was never indexed. 7-Zip and Explorer read straight past it, so the files really are "in my .tar".

### The ordering is the proof
Within one game, **`_BG` sorts before `_COV`**. A single well-formed archive truncated at any point would have lost **covers** first. Covers surviving is only possible if they sit in an **earlier concatenated member** — exactly how these packs are built. No other theory explains the direction of the failure.

### Reproduced
Modelling `tarParseFile`'s block walk over a real concatenated archive (covers pack + BG/SCR pack):

```
OLD (break):     2 entries  -- covers only
NEW (continue):  5 entries  -- BG + SCR recovered
```

### The fix
GNU tar's `--ignore-zeros` semantics: skip zero blocks, end the scan only at a real EOF (the `read()==0` the loop already handles). Trailing padding on a well-formed archive costs a few extra 512-byte reads.

**`ARC_VERSION` 3 → 4 is required, not cosmetic.** The truncated index is persisted to `ART/art_cache.bin`, and `tarReadCache` validates it against the tar's **size alone** — which doesn't change. `tarInvalidate` only frees the RAM copy, never the file. Without the bump, every affected user keeps their short index forever and the code fix does nothing for them. Cost: sidecars are no longer interchangeable with wOPL/sOPL's — acceptable, it's a regenerable cache.

**Not a rebuild regression:** `src/tar.c` and `include/tar.h` are byte-identical to `origin/master`, so the fork has this bug too. Inherited with the wOPL port.

### Deliberately not included
`texcache.c` discards `ioPutRequest`'s return when queueing an art load — same discarded-return class as rebuild-38/43. A refused request leaves the entry's `qr` set forever, so a 1-slot BG/SCR cache dies for the session. Real and latent, but a separate change; keeping this one bisectable while Zack is testing.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)