### PR TITLE
rebuild-57: a refused art request killed that cache slot for the whole session

### DIFF
--- a/src/texcache.c
+++ b/src/texcache.c
@@ -224,7 +224,22 @@ GSTEXTURE *cacheGetTexture(image_cache_t *cache, item_list_t *list, int *cacheId
 
         *UID = cache->nextUID++;
 
-        ioPutRequest(IO_CACHE_LOAD_ART, req);
+        // A REFUSED request never runs, so nothing ever clears qr -- and qr is what marks this slot
+        // "load in flight". Left set, the entry is permanently invisible to BOTH the read path and
+        // the eviction scan above (which only considers entries with !qr), so the slot is dead for
+        // the rest of the session and its art never appears again. Backgrounds and screenshots are
+        // the visible casualties: their caches are ONE slot deep, so a single refusal kills the art
+        // type outright, while a 10-slot cover cache just loses one of ten and shrugs it off.
+        // Roll the slot back instead, leaving it free for the next frame to retry.
+        // (Third instance of this discarded-return shape; see rebuild-38 and rebuild-43.)
+        if (ioPutRequest(IO_CACHE_LOAD_ART, req) != IO_OK) {
+            // Reuse the module's own definition of an empty slot rather than hand-setting fields
+            // (cacheClearItem leaves lastUsed = -1, UID = 0). freeTxt = 0: the texture was already
+            // released by the cacheClearItem(.., 1) above, and the entry has held nothing since.
+            cacheClearItem(oldestEntry, 0);
+            *cacheId = -1; // the cache API's "no entry" sentinel, as used by themes.c
+            free(req);
+        }
     }
 
     return NULL;


### PR DESCRIPTION
`texcache`'s queueing path discarded `ioPutRequest`'s return. A refused request never runs, so nothing ever clears the entry's `qr` — and `qr` is precisely what marks a slot **"load in flight."** Left set, the entry becomes invisible to **both** the read path and the eviction scan (which only considers entries with `!qr`), so the slot is dead for the rest of the session and its art never appears again.

**Backgrounds and screenshots are the visible casualties**: those caches are **one slot deep**, so a single refusal kills the art type outright. A cover cache is 10 slots, so it loses one of ten and shrugs it off.

That means this presents as *"covers work, other art doesn't"* — easily mistaken for the `art.tar` bug fixed in rebuild-56. They're **independent faults with a similar signature**; both had to go.

### The rollback
On failure the slot is rolled back with `cacheClearItem(entry, 0)` rather than by hand-setting fields — that's the module's own definition of an empty slot (`lastUsed = -1`, `UID = 0`), so it can't drift from it. `freeTxt = 0` because the texture was already released by the `cacheClearItem(.., 1)` a few lines above. `*cacheId` goes to `-1`, the sentinel `themes.c` already uses. The next frame simply retries.

### Scope — deliberately not overclaiming
Third instance of this discarded-return shape (rebuild-38 `guiHandleDeferedIO`, rebuild-43 `guiGameHandleDeferedIO`, now here). **This is not a claim that every call site is checked** — ~29 others still discard the return. They're a different shape: `IO_MENU_UPDATE_DEFFERED` / module-load kicks that set no in-flight latch, so a refusal loses one refresh and the next event re-issues it (`opl.c:1102` already checks its return where the result matters). The three fixed are the ones where a refusal leaves a **latch** that blocks all future progress.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)