### PR TITLE
rebuild-58: themes show a PS1 disc ID for VCDs instead of the filename (#380)

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1043,7 +1043,26 @@ config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const
         sbSetDiscAttributes(config, isPS1, isPS1 || game->media == SCECdPS2CD);
     }
 
-    configSetStr(config, CONFIG_ITEM_STARTUP, isVcd ? game->name : game->startup);
+    // #Startup is the GAME ID a theme displays. A PS2 game has a real disc id in game->startup; a
+    // VCD had nothing, so it stamped the whole FILENAME and themes rendered that -- long titles then
+    // overflowed into the cover art (#380). Prefer the PS1 disc id parsed out of the name.
+    //
+    // vcdExtractGameId is PURE STRING PARSING -- no file IO -- so this is free on the config path.
+    // The richer retrogemGetVcdGameID() (which reads SYSTEM.CNF from inside the image) is NOT used
+    // here on purpose: it opens and reads the .VCD, and this runs per selection. That resolver stays
+    // where it is, on the launch path.
+    //
+    // DISPLAY ONLY. The per-game CONFIG KEY above deliberately still uses cfgKey (the filename for a
+    // VCD): the id is absent whenever the file is not named AAAA_NNN.NN*, so keying configs by it
+    // would silently split one game's settings across two files as soon as extraction failed.
+    // Identity and display are separate concerns; only display changes here.
+    if (isVcd) {
+        char vcdId[VCD_ID_MAX];
+        configSetStr(config, CONFIG_ITEM_STARTUP,
+                     vcdExtractGameId(game->name, vcdId, sizeof(vcdId)) ? vcdId : game->name);
+    } else {
+        configSetStr(config, CONFIG_ITEM_STARTUP, game->startup);
+    }
 
     return config;
 }


### PR DESCRIPTION
`#Startup` (`CONFIG_ITEM_STARTUP`) is the **game ID a theme renders**. A PS2 game has a real disc id in `game->startup`; a VCD had nothing, so rebuild-42 stamped the whole **filename** and themes drew that — long PS1 titles then overflowed into the cover art, which is exactly what #380 reports.

Now a VCD stamps the PS1 disc id parsed out of its name (e.g. `SLUS_005.51`), falling back to the filename when there's no id to parse, so nothing regresses for oddly-named files.

### Cost
`vcdExtractGameId` is **pure string parsing — no file IO**, so this is free on the config path.

`retrogemGetVcdGameID()` is deliberately **not** used here: it opens the `.VCD` and reads `SYSTEM.CNF` out of the image, and this code runs per selection. That resolver stays on the launch path where a single read is fine. Same lesson as the `#Size` stat removed from the scroll path in rebuild-37.

### Display only — the config key is untouched
Nathan approved switching the key to the id as well, but his clarification (*"so that when users display the gameID in a theme, there is an ID instead of the filename"*) narrows this to display — and the key should **not** move.

The id is absent whenever a file isn't named `AAAA_NNN.NN*`, so keying configs by it would **silently split one game's settings across two files** the moment extraction failed. The filename key from rebuild-42 is always available and stable. Identity and display are separate concerns.

### The three GameID features stay distinct
None is touched: `gApplyGameID` (PS2 launch barcode), `gPopstarterRetroGemGameID` (VCD launch barcode), and the MMCE game id (deferred). This is the **theme attribute** — and it's deliberately **not** gated on a barcode setting, or turning a barcode off would change what the list displays.

### Memory safety
`vcdId` is a stack buffer; `configSetStr` copies into `config_value_t.val` (`char[256]`, a fixed array) on both the update path and the `addConfigValue` create path. Verified — no pointer is retained.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)