### PR TITLE
rebuild-59: 1080p is a normal feature now, not an isolated variant

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -105,8 +105,8 @@ jobs:
       # NOTE(rebuild): the fork runs a step here that is not applicable yet --
       #   Install menu-coherent mmceman (#254)
       # It returns with checklist items 1-3 (MMCE), which are still on WAIT. Removed rather than
-      # left to fail/WARN every single run. (GSM 1080p, item 29, has since LANDED -- its build
-      # step is restored in the ps2dev-latest job below.)
+      # left to fail/WARN every single run. (GSM 1080p, item 29, has since LANDED and is now ON in
+      # EVERY build -- it needs no separate step at all.)
 
       - name: Build (make clean release)
         # LOCALVERSION brands the in-ELF version string ("-PS2DEVPINNEDSDK") so hardware reports
@@ -221,8 +221,8 @@ jobs:
       # NOTE(rebuild): the fork runs a step here that is not applicable yet --
       #   Install menu-coherent mmceman (latest-only)
       # It returns with checklist items 1-3 (MMCE), which are still on WAIT. Removed rather than
-      # left to fail/WARN every single run. (GSM 1080p, item 29, has since LANDED -- its build
-      # step is restored in the ps2dev-latest job below.)
+      # left to fail/WARN every single run. (GSM 1080p, item 29, has since LANDED and is now ON in
+      # EVERY build -- it needs no separate step at all.)
 
       - name: Build (make clean release)
         # LOCALVERSION brands the in-ELF version string ("-PS2DEVLATESTSDK") so hardware reports
@@ -276,26 +276,10 @@ jobs:
             echo "WARN: PS2DEVLATESTSDK DUALSENSE=1 build failed; skipping DS5 asset this run" >&2
           fi
 
-      - name: Build + stage experimental 1080p GSM loader (PS2DEVLATESTSDK)
-        # The re-added GSM 1080p mode is a hardware-UNVALIDATED synthetic raster (see ee_core
-        # DTV_1080P). It is compiled ONLY into this dedicated variant, ONLY on the latest-SDK
-        # flavour (like a stricter DS5), and gated behind a triple-confirm in the GUI. Every other
-        # asset -- all flavours' main ELFs, the -ds5 loaders, the VARIANTS zip -- is 1080p-free.
-        # Best-effort: a 1080p build hiccup must not sink the required primary flavour.
-        # LOCALVERSION carries "-PS2DEVLATESTSDK-1080p" so hardware reports self-identify.
-        run: |
-          make --trace clean
-          rm -f RIPTOPL-*.ELF   # drop the main build's leftover named ELF (already staged) so the 1080p output is unambiguous
-          if make --trace LOCALVERSION=PS2DEVLATESTSDK-1080p GSM1080P=1 release; then
-            GSM_ELF="$(ls RIPTOPL-*.ELF 2>/dev/null | head -n1)"
-            if [ -n "${GSM_ELF:-}" ] && [ -f "$GSM_ELF" ]; then
-              cp -f "$GSM_ELF" rolling/RIPTOPL-PS2DEVLATESTSDK-1080p.ELF
-            else
-              echo "WARN: PS2DEVLATESTSDK GSM1080P=1 build produced no ELF; skipping 1080p asset this run" >&2
-            fi
-          else
-            echo "WARN: PS2DEVLATESTSDK GSM1080P=1 build failed; skipping 1080p asset this run" >&2
-          fi
+      # NOTE(rebuild): the fork builds a SEPARATE GSM1080P=1 loader here as its own asset.
+      # No longer needed: 1080p is hardware-confirmed and now ON in every build (Makefile
+      # GSM1080P ?= 1), so the main ELF already carries it. Keeping a second 1080p-only asset
+      # would also REINTRODUCE the raw-index divergence the default flip exists to remove.
 
       - name: Build variant + debug extras (ps2dev:latest = standard)
         # Runs after staging the main ELF so the per-build `make clean` can't wipe it.

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,19 @@ PADEMU ?= 1
 #build that is already hardware-proven. Named DUALSENSE=1 release assets return with item 58.
 DUALSENSE ?= 0
 
-#Enables/disables the experimental, hardware-UNVALIDATED GSM 1080p video mode (a GSM-synthetic
-#progressive raster; see ee_core DTV_1080P). Kept OFF in every default build; the rolling release
-#ships ONE ready-made GSM1080P=1 build as a named RIPTOPL-PS2DEVLATESTSDK-1080p.ELF asset
-#(latest-SDK flavour only), gated behind a triple-confirm in the GUI. When 0, none of the 1080p
-#table/GUI/engine code is compiled in.
-GSM1080P ?= 0
+#GSM 1080p video mode (a GSM-synthetic progressive raster; see ee_core DTV_1080P). ON in every
+#build since it was confirmed working on real hardware (RT4K reported 1080p and displayed it
+#correctly, 2026-08-09) -- it is no longer shipped as an isolated variant.
+#
+#DEFAULTING THIS TO 1 IS LOAD-BEARING, not just convenience: $GSMVMode is stored as a RAW INDEX
+#into gsmvmodeNames[]/predef_vmode[], and the 1080p entry is APPENDED LAST. With the flag
+#optional the list was 29 entries in one build and 30 in another, so a per-game video mode saved
+#by one flavour meant a DIFFERENT mode when read by the other -- and both flavours ship in the
+#same release. One list length everywhere removes that entire class of bug.
+#Kept as an escape hatch (build with GSM1080P=0) if a console ever regresses; nothing we PUBLISH
+#should set it to 0, or the index divergence comes back.
+#The mode itself stays gated behind the triple-confirm in the GUI.
+GSM1080P ?= 1
 
 #Enables/disables building of an edition of OPL that will support the DTL-T10000 (SDK v2.3+)
 DTL_T10000 ?= 0

--- a/src/gsm.c
+++ b/src/gsm.c
@@ -71,7 +71,7 @@ void PrepareGSM(char *cmdline, struct GsmConfig_t *config)
     // Therefore there are many variables involved here that can lead us to success or fail, depending on the already mentioned circumstances.
     //
     // clang-format off
-    // Initializer-sized ([] not a fixed count): the GSM1080P=1 variant appends one row below, and
+    // Initializer-sized ([] not a fixed count): the 1080p row below is #ifdef-gated, and
     // the clamp at the end reads sizeof(predef_vmode) so it tracks 29 or 30 automatically.
     static const predef_vmode_struct predef_vmode[] = {
         //                                                            DH    DW   MAGV MAGH  DY   DX              VS  VDP  VBPE  VBP VFPE  VFP
@@ -104,7 +104,7 @@ void PrepareGSM(char *cmdline, struct GsmConfig_t *config)
         {GS_NONINTERLACED, GS_MODE_VGA_1024_85, GS_FRAME, makeDISPLAY(767,  1023, 0,   0,   30,  290), makeSYNCV(3,  768,  0,    36,  0,   1)},
         {GS_NONINTERLACED, GS_MODE_VGA_1280_60, GS_FRAME, makeDISPLAY(1023, 1279, 1,   1,   40,  350), makeSYNCV(3,  1024, 0,    38,  0,   1)},
         {GS_NONINTERLACED, GS_MODE_VGA_1280_75, GS_FRAME, makeDISPLAY(1023, 1279, 1,   1,   40,  350), makeSYNCV(3,  1024, 0,    38,  0,   1)},
-        // GSM1080P=1 variant only: APPENDED at the LAST index (not inserted after 1080i) because
+        // APPENDED at the LAST index (not inserted after 1080i) because
         // $GSMVMode is a stored raw index -- a mid-list insert would silently remap every existing
         // saved VGA/HDTV config. display/syncv identical to the 1080i row; only the mode (0x54,
         // GSM-synthetic) + NONINTERLACED/FRAME differ. Emitted via the ee_core DTV_1080P handler,

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -415,7 +415,7 @@ void guiGameShowGSConfig(void)
         "VGA 1024x768p @85Hz",
         "VGA 1280x1024p @60Hz",
         "VGA 1280x1024p @75Hz",
-        // GSM1080P=1 variant only: APPENDED last (index 29) to keep every existing $GSMVMode index
+        // APPENDED last (index 29) to keep every existing $GSMVMode index
         // pointing at the same mode; stays 1:1 index-aligned with predef_vmode[] (gsm.c), which
         // guards the matching row under the SAME #ifdef. Selecting it triggers the triple-confirm
         // gate in the save path below.
@@ -996,7 +996,8 @@ static int coreNeverNeutrino = 0;
 #define NEUTRINO_GSMCOMP_DEFAULT_IDX 4
 
 // Index of the appended "HDTV 1080p @60Hz (EXPERIMENTAL)" entry in gsmvmodeNames[] / predef_vmode[]
-// (both 30 long, last index 29) -- only present in the GSM1080P=1 variant. Selecting it must clear
+// (both 30 long, last index 29). GSM1080P now defaults to 1, so every SHIPPED build has this entry
+// and the list length no longer varies between published flavours. Selecting it must clear
 // a triple-confirm before it is saved.
 #ifdef GSM_1080P
 #define GSM_VMODE_1080P_IDX 29
@@ -1193,7 +1194,7 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
     // be committed. X continues / O cancels at each step; any cancel drops the selection back to 0
     // (Auto/off, which removes the per-game key) so 1080p is never persisted without deliberate
     // consent. Only fires when the user actually chose 1080p AND left GSM enabled. (Only compiled
-    // into the GSM1080P=1 variant, the only build where the picker exposes the 1080p entry.)
+    // in when GSM1080P is set, which is now the default for every build.)
     if (EnableGSM != 0 && GSMVMode == GSM_VMODE_1080P_IDX) {
         if (!guiMsgBox(_l(_STR_GSM_1080P_WARNING), 1, NULL) ||
             !guiMsgBox(_l(_STR_GSM_1080P_PROCEED), 1, NULL) ||


### PR DESCRIPTION
> *"stop isolating the 1080p feature and bring it into the regular build since we know it works now"*

It was hardware-confirmed the same day — MonkeyBoyJoey's RT4K reports 1080p and displays it correctly (the BVM that read 720p also calls 800×600 "720p").

`GSM1080P` now defaults to **1**, so every build carries it. The separate `RIPTOPL-PS2DEVLATESTSDK-1080p.ELF` build step is deleted — the main ELF already has the mode, so a second 1080p-only asset is pure duplication.

### This is not only tidying
It removes a real **config-corruption hazard** I hit while designing the global GSM default:

`$GSMVMode` is stored as a **raw index** into `gsmvmodeNames[]`/`predef_vmode[]`, and the 1080p entry is **appended last**. While the flag was optional the list was **29 entries in one build and 30 in another** — and *both flavours ship in the same release*. A per-game video mode saved by one flavour therefore meant a **different mode** when read by the other.

Worse, it blocked the obvious way to add a `Default` entry for the global-inheritance work, since that entry's index would likewise differ per flavour. **One list length everywhere makes the index stable and unblocks that design.**

### The flag is kept, deliberately
`GSM1080P=0` remains as an escape hatch if a console ever regresses — but **nothing we publish should set it**, or the divergence comes straight back. That's stated in the Makefile comment rather than left implied.

The mode is still gated behind the GUI's **triple-confirm**: shipping the code in every build isn't the same as making it easy to switch on by accident.

### Swept the claims this invalidates
Two workflow NOTE blocks still said the 1080p step lived in the ps2dev-latest job; five source comments still called it *"GSM1080P=1 variant only"*.

### Verified — both configurations, from clean
```
make -j8             -> MAKE_EXIT=0, 18 x -DGSM_1080P   (mode present)
make GSM1080P=0 -j8  -> MAKE_EXIT=0,  0 x               (escape hatch intact)
```
clang-format 12 clean; `rolling-release.yml` parses with all 4 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)