### PR TITLE
rebuild-60: release note — when a language pack must be replaced (and when it must not)

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -711,6 +711,15 @@ jobs:
             if ls rolling/RIPTOPL-LANGS-*.zip >/dev/null 2>&1; then
               printf -- '- RIPTOPL-LANGS-*.zip: extra UI language files (.lng + non-Latin fonts) -- copy into your OPL folder\n'
             fi
+            printf '\n## Using a language other than English?\n'
+            printf 'If you have lang_*.lng files from a PRE-REBUILD RiptOPL build, DELETE them and use the ones\n'
+            printf 'in RIPTOPL-LANGS-*.zip above. That older line numbered its strings differently, and a .lng\n'
+            printf 'is a bare list consumed BY LINE POSITION -- no version, no label names -- so OPL cannot\n'
+            printf 'detect a mismatch: the menus would just show unrelated text instead of failing visibly.\n'
+            printf '\n'
+            printf 'Packs from this rebuild line are safe to keep: strings are only ever APPENDED, so an older\n'
+            printf 'pack still lines up and any strings it predates simply appear in English until you update\n'
+            printf 'it. English itself is always correct -- it is compiled into the ELF, not read from a .lng.\n'
             printf '\nSHA256 (also published as SHA256SUMS.txt):\n'
             printf '```\n'
             cat rolling/SHA256SUMS.txt


### PR DESCRIPTION
A `.lng` is a bare list of strings consumed **by line position** (`src/lang.c:67`) — no version, no label names — so OPL cannot detect a mismatched one. Nothing told users which packs are safe.

### I nearly shipped the wrong advice
My first draft said an older pack *"shifts almost every line"* because this build added strings. **`src/lang.c:75-79` says otherwise** — after reading whatever the file contains, `lngLoadFromFile` **fills the remainder from `internalEnglish`**. So a pack that's merely *shorter* is completely safe: every line it does have still aligns, and the strings it predates fall back to English.

Verified in the code before writing the note rather than after.

### The honest split, which is what the note now says
- **Pre-rebuild (fork-era) packs — replace them.** That line inserted labels mid-list, so its **order** differs and the positions genuinely misalign; menus would show unrelated text rather than fail visibly.
- **Packs from this rebuild line — keep them.** Strings are only ever **appended** (the standing `.lng` rule), so old packs stay aligned and newer strings simply appear in English until updated.
- **English is never affected** — `lang_strs` defaults to `internalEnglish` (`src/lang.c:11`), compiled into the ELF, not read from a `.lng`.

That distinction is the useful part. "Delete everything" would have been both wrong and needlessly destructive for anyone already on a rebuild-line pack.

Notes-only change; no code, no labels. `rolling-release.yml` parses with 4 jobs intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)