### PR TITLE
rebuild-61: per-key GSM inheritance — global mode + this game's own offsets

### DIFF
--- a/include/guigame.h
+++ b/include/guigame.h
@@ -1,8 +1,16 @@
 #ifndef __GUIGAME_H
 #define __GUIGAME_H
 
-#define SETTINGS_GLOBAL  0
-#define SETTINGS_PERGAME 1
+#define SETTINGS_GLOBAL        0
+#define SETTINGS_PERGAME       1
+// Per-key GSM inheritance: a key PRESENT in the game's own config wins, a key ABSENT follows the
+// global block. Deliberately a NEW value: only 0 and 1 have ever been written (by this fork, by the
+// upstream fork, and by every build in the field), so a 2 cannot appear in any config that already
+// exists -- which is what lets the two legacy branches in gsm.c InitGSMConfig stay bit-identical.
+// Do NOT retrofit this meaning onto SETTINGS_PERGAME: that would silently change games whose keys
+// were stripped for being zero (the per-game save leg removes zero-valued keys, so "absent" there
+// means BOTH "unset" and "explicitly 0").
+#define SETTINGS_PERGAME_MIXED 2
 
 int guiGameAltStartupNameHandler(char *text, int maxLen);
 

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1040,3 +1040,5 @@ gui_strings:
   string: Custom Settings Path
 - label: HINT_CUSTOM_SETTINGS_PATH
   string: "Save settings to a folder you choose, e.g. mass0:/OPL. Leave blank to use the folder OPL booted from. The device is loaded on demand, so it need not be mounted when you type it."
+- label: PERGAME_MIXED_SETTINGS
+  string: Per Game + Global

--- a/src/gsm.c
+++ b/src/gsm.c
@@ -20,6 +20,7 @@
 #include "../ee_core/include/coreconfig.h"
 
 #include "include/pggsm.h"
+#include "include/guigame.h" // SETTINGS_* -- $GSMSource values shared with the GS settings page
 
 static int gEnableGSM;   // Enables GSM - 0 for Off, 1 for On
 static int gGSMVMode;    // See the related predef_vmode
@@ -40,8 +41,37 @@ void InitGSMConfig(config_set_t *configSet)
     gGSMFIELDFix = 0;
 
     if (configGetInt(configSet, CONFIG_ITEM_GSMSOURCE, &gGSMSource)) {
-        // Load the rest of the per-game GSM configuration, only if GSM is enabled.
-        if (configGetInt(configSet, CONFIG_ITEM_ENABLEGSM, &gEnableGSM) && gEnableGSM) {
+        if (gGSMSource == SETTINGS_PERGAME_MIXED) {
+            // Per-key inheritance: a key present in the GAME's config wins, a key absent follows the
+            // GLOBAL block. Only reachable from $GSMSource == 2, which no config written by any
+            // existing build can contain -- so every config in the field still resolves through the
+            // two untouched branches below, bit for bit. That is the whole point of a new value:
+            // the half of this behaviour nobody can test on hardware yet is also the half nothing
+            // can reach by accident.
+            //
+            // Why NOT simply retrofit this onto SETTINGS_PERGAME: the per-game save leg removes
+            // zero-valued keys, so an absent key there means BOTH "never set" AND "explicitly 0",
+            // and 0 is a real choice in every one of these (mode 0 = NTSC, offsets 0 = centred,
+            // absent $EnableGSM is the GUI's only way to say "GSM off for this game"). Inheriting on
+            // absence would therefore have changed games that work today -- including pulling a
+            // global 1080p into a game that had deliberately chosen NTSC, bypassing the GUI's
+            // triple-confirm.
+            if (!configGetInt(configSet, CONFIG_ITEM_ENABLEGSM, &gEnableGSM))
+                if (!configGetInt(configGame, CONFIG_ITEM_ENABLEGSM, &gEnableGSM))
+                    gEnableGSM = 0;
+
+            if (gEnableGSM) {
+                if (!configGetInt(configSet, CONFIG_ITEM_GSMVMODE, &gGSMVMode))
+                    configGetInt(configGame, CONFIG_ITEM_GSMVMODE, &gGSMVMode);
+                if (!configGetInt(configSet, CONFIG_ITEM_GSMXOFFSET, &gGSMXOffset))
+                    configGetInt(configGame, CONFIG_ITEM_GSMXOFFSET, &gGSMXOffset);
+                if (!configGetInt(configSet, CONFIG_ITEM_GSMYOFFSET, &gGSMYOffset))
+                    configGetInt(configGame, CONFIG_ITEM_GSMYOFFSET, &gGSMYOffset);
+                if (!configGetInt(configSet, CONFIG_ITEM_GSMFIELDFIX, &gGSMFIELDFix))
+                    configGetInt(configGame, CONFIG_ITEM_GSMFIELDFIX, &gGSMFIELDFix);
+            }
+        } else if (configGetInt(configSet, CONFIG_ITEM_ENABLEGSM, &gEnableGSM) && gEnableGSM) {
+            // LEGACY per-game ($GSMSource == 1): section-level, no inheritance. Unchanged.
             configGetInt(configSet, CONFIG_ITEM_GSMVMODE, &gGSMVMode);
             configGetInt(configSet, CONFIG_ITEM_GSMXOFFSET, &gGSMXOffset);
             configGetInt(configSet, CONFIG_ITEM_GSMYOFFSET, &gGSMYOffset);

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -357,7 +357,20 @@ static void guiGameSetGSMSettingsState(void)
     if (previousSource != gGSMSource && gGSMSource == SETTINGS_GLOBAL) {
         config_set_t *configSet = gameMenuLoadConfig(diaGSConfig);
         configRemoveKey(configSet, CONFIG_ITEM_GSMSOURCE);
+        // Also drop the game's own GSM keys. They were inert before only because the old resolver
+        // never looked at them once $GSMSource was gone -- but per-key inheritance DOES look, so a
+        // leftover key would silently keep overriding the global the user just switched to.
+        configRemoveKey(configSet, CONFIG_ITEM_ENABLEGSM);
+        configRemoveKey(configSet, CONFIG_ITEM_GSMVMODE);
+        configRemoveKey(configSet, CONFIG_ITEM_GSMXOFFSET);
+        configRemoveKey(configSet, CONFIG_ITEM_GSMYOFFSET);
+        configRemoveKey(configSet, CONFIG_ITEM_GSMFIELDFIX);
         guiGameLoadGSMConfig(configSet, configGetByType(CONFIG_GAME));
+    } else if (previousSource != gGSMSource && gGSMSource == SETTINGS_PERGAME_MIXED) {
+        // 1 -> 2 must NOT reload: the rows already hold the resolved values and saving pins them
+        // all explicitly, so switching is a behavioural no-op until a row is set to Default.
+        config_set_t *configSet = gameMenuLoadConfig(diaGSConfig);
+        configSetInt(configSet, CONFIG_ITEM_GSMSOURCE, gGSMSource);
     } else if (previousSource != gGSMSource && gGSMSource == SETTINGS_PERGAME) {
         config_set_t *configSet = gameMenuLoadConfig(diaGSConfig);
         configSetInt(configSet, CONFIG_ITEM_GSMSOURCE, gGSMSource);
@@ -380,10 +393,24 @@ static int guiGameGSMUpdater(int modified)
     return 0;
 }
 
+// UI-only sentinel for "this row follows the global". Appended LAST to gsmvmodeNames below, so it
+// sits one past the final real mode. It is NEVER written to disk -- picking it REMOVES $GSMVMode --
+// so unlike the real modes its index does not have to stay stable across builds.
+// Index of the last REAL mode in gsmvmodeNames[] / predef_vmode[]: 28 for the 29 base modes, 29 when
+// the 1080p row is compiled in (which is every shipped build -- Makefile GSM1080P ?= 1).
+#ifdef GSM_1080P
+#define GSM_VMODE_LAST_REAL_IDX 29
+#else
+#define GSM_VMODE_LAST_REAL_IDX 28
+#endif
+#define GSM_VMODE_DEFAULT_IDX (GSM_VMODE_LAST_REAL_IDX + 1)
+
 void guiGameShowGSConfig(void)
 {
     // configure the enumerations
-    const char *settingsSource[] = {_l(_STR_GLOBAL_SETTINGS), _l(_STR_PERGAME_SETTINGS), NULL};
+    // Third source: per-KEY inheritance. Only offered here (the GSM page); the cheats/VMC/etc
+    // pages keep the original two-way choice.
+    const char *settingsSource[] = {_l(_STR_GLOBAL_SETTINGS), _l(_STR_PERGAME_SETTINGS), _l(_STR_PERGAME_MIXED_SETTINGS), NULL};
     // clang-format off
     const char *gsmvmodeNames[] = {
         "NTSC",
@@ -422,6 +449,9 @@ void guiGameShowGSConfig(void)
 #ifdef GSM_1080P
         "HDTV 1080p @60Hz (EXPERIMENTAL)",
 #endif
+        // "Default" = follow the global $GSMVMode. LAST, after every real mode, and never stored
+        // (the save leg removes the key instead), so it cannot disturb the raw indices above.
+        _l(_STR_DEFAULT),
         NULL};
     // clang-format on
 
@@ -1205,7 +1235,21 @@ int guiGameSaveConfig(config_set_t *configSet, item_list_t *support)
     }
 #endif
 
-    if (gGSMSource == SETTINGS_PERGAME) {
+    if (gGSMSource == SETTINGS_PERGAME_MIXED) {
+        // Per-key: write EVERY value explicitly, INCLUDING 0, so an explicit per-game choice
+        // always beats the global. The legacy arm below strips zeros, which is exactly why its
+        // absent keys are ambiguous and cannot support inheritance. Only the video mode has a
+        // Default state today; picking it REMOVES the key, and gsm.c then falls back to global.
+        result = configSetInt(configSet, CONFIG_ITEM_GSMSOURCE, gGSMSource);
+        result = configSetInt(configSet, CONFIG_ITEM_ENABLEGSM, EnableGSM);
+        if (GSMVMode == GSM_VMODE_DEFAULT_IDX)
+            configRemoveKey(configSet, CONFIG_ITEM_GSMVMODE);
+        else
+            result = configSetInt(configSet, CONFIG_ITEM_GSMVMODE, GSMVMode);
+        result = configSetInt(configSet, CONFIG_ITEM_GSMXOFFSET, GSMXOffset);
+        result = configSetInt(configSet, CONFIG_ITEM_GSMYOFFSET, GSMYOffset);
+        result = configSetInt(configSet, CONFIG_ITEM_GSMFIELDFIX, GSMFIELDFix);
+    } else if (gGSMSource == SETTINGS_PERGAME) {
         result = configSetInt(configSet, CONFIG_ITEM_GSMSOURCE, gGSMSource);
         if (EnableGSM != 0)
             result = configSetInt(configSet, CONFIG_ITEM_ENABLEGSM, EnableGSM);
@@ -1460,7 +1504,18 @@ static void guiGameLoadGSMConfig(config_set_t *configSet, config_set_t *configGa
 
     // override global with per-game settings if available and selected.
     configGetInt(configSet, CONFIG_ITEM_GSMSOURCE, &gGSMSource);
-    if (gGSMSource == SETTINGS_PERGAME) {
+    if (gGSMSource == SETTINGS_PERGAME_MIXED) {
+        // Per-key: the globals were already loaded above, so only OVERRIDE where the game has its
+        // own key. An absent $GSMVMode is a deliberate Default (the save leg removed it), so show
+        // the Default row rather than the inherited value -- otherwise the user could not tell
+        // "following global" from "pinned to the same mode".
+        configGetInt(configSet, CONFIG_ITEM_ENABLEGSM, &EnableGSM);
+        if (!configGetInt(configSet, CONFIG_ITEM_GSMVMODE, &GSMVMode))
+            GSMVMode = GSM_VMODE_DEFAULT_IDX;
+        configGetInt(configSet, CONFIG_ITEM_GSMXOFFSET, &GSMXOffset);
+        configGetInt(configSet, CONFIG_ITEM_GSMYOFFSET, &GSMYOffset);
+        configGetInt(configSet, CONFIG_ITEM_GSMFIELDFIX, &GSMFIELDFix);
+    } else if (gGSMSource == SETTINGS_PERGAME) {
         if (!configGetInt(configSet, CONFIG_ITEM_ENABLEGSM, &EnableGSM))
             EnableGSM = 0;
         if (!configGetInt(configSet, CONFIG_ITEM_GSMVMODE, &GSMVMode))


### PR DESCRIPTION
Until now GSM was all-or-nothing: `$GSMSource` present meant the global block was never consulted for **any** of the five keys. Now a game can take some settings from global and set others itself.

### ⭐ Gated behind a new `$GSMSource` value (2 = `SETTINGS_PERGAME_MIXED`)
That's what makes it safe. Only **0 and 1** have ever been written — verified across this tree *and* `origin/master`, whose `include/guigame.h` defines exactly the same two values and whose `InitGSMConfig` is the same section-level if/else.

A `2` therefore cannot appear in any config in the field, so **both legacy branches stay bit-identical and no existing config changes behaviour** — including the 1080p ones Zack just validated on hardware.

### Why not simply retrofit it onto `$GSMSource=1` (my first instinct)
The per-game save leg writes each key only when **non-zero** and `configRemoveKey`s it otherwise. So on every card already out there, **key-absence means both "never set" and "explicitly 0"** — and 0 is a real choice in all five (`$GSMVMode` 0 = NTSC, offsets 0 = centred, an absent `$EnableGSM` is the GUI's *only* way to say "GSM off for this game").

Inheriting on absence would have changed **7 real config shapes**, the worst being a game that deliberately chose NTSC silently inheriting a global **1080p — bypassing the triple-confirm**. No migration can fix that: explicit-0 and unset are byte-identical on disk.

Under source 2 the save leg writes every value **explicitly, including 0**, so a per-game choice always beats the global. That's the same fix the fork already applied twice — to `$CoreLoader` and `$NeutrinoVideo` — each time so an explicit per-game value would survive a non-Off global. GSM is the third instance of that shape.

### Option A, as chosen
Video mode gets a **"Default"** row. Picking it removes `$GSMVMode` and `gsm.c` falls back to the global. Because Default is **never stored**, its index doesn't need to be stable across builds — unlike the real modes, which is why it can be appended safely at all.

Enable/FIELD-fix stay plain toggles and the offsets stay plain numbers, always written explicitly. Giving those a Default means turning two bools into tri-state enums, and a sentinel **cannot survive a `UI_INT`** — `dia.c` wraps at min/max on every press. Documented as a later option (B).

### Latent leak plugged
Flipping Settings source to Global removed **only** `$GSMSource`, leaving the game's five GSM keys behind. Inert under the old resolver, which stopped looking at them — but per-key **does** look, so a leftover key would have silently kept overriding the global the user just switched to.

### Deliberately not included
The `gsm.c:122` clamp hardening (a bad index silently becomes NTSC with GSM still on). Fixing it needs the mode-array size at the read boundary, and the array is local to `PrepareGSM` — duplicating the count is exactly the two-halves drift this project keeps finding. Needs the array hoisted first.

### Verified
`make -j8` → `MAKE_EXIT=0`; clang-format 12 clean; labels 499 → 500 with prefix order verified **identical** (append-only `.lng` contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)