### PR TITLE
rebuild-63: menu rumble (item 43) -- unblocked without the pad-clock rework

### DIFF
--- a/include/opl.h
+++ b/include/opl.h
@@ -228,6 +228,7 @@ extern int gSelectButton;
 extern int gHDDGameListCache;
 
 extern int gEnableSFX;
+extern int gEnableRumble;
 extern int gEnableBootSND;
 extern int gEnableBGM;
 extern int gSFXVolume;

--- a/include/pad.h
+++ b/include/pad.h
@@ -45,4 +45,13 @@ void padStoreSettings(int *buffer);
 /** Restore's the button delay from specified integer array (has to have 16 items) */
 void padRestoreSettings(int *buffer);
 
+/** Starts a menu rumble pulse on every connected pad that has actuators.
+ * @param durationMs pulse length in ms (clamped internally)
+ * @param large large-engine strength 0..255; the small engine runs for the whole pulse */
+void padRumble(int durationMs, int large);
+
+/** Stops any rumble pulse in flight. Call before blocking the GUI thread -- the decay only runs
+ * from readPads(), so a pulse started just before a blocking read would outlast it. */
+void padRumbleFlush(void);
+
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -1916,22 +1916,16 @@ void guiShowControllerConfig(void)
     diaSetInt(diaControllerConfig, CFG_SELECTBUTTON, gSelectButton == KEY_CIRCLE ? 0 : 1);
     diaSetInt(diaControllerConfig, CFG_XSENSITIVITY, gXSensitivity);
     diaSetInt(diaControllerConfig, CFG_YSENSITIVITY, gYSensitivity);
-    // NOTE(rebuild): Menu Rumble returns with checklist item 43 -- show its row greyed at Off until
-    // then. The row, its config key (CONFIG_OPL_RUMBLE) and its labels were all pre-staged by the
-    // settings-layout step, but gEnableRumble and the whole padRumble* engine are absent, so the
-    // toggle was rendering as an interactive control wired to nothing.
-    // Greyed rather than hidden ON PURPOSE: diaSetVisible targets the CONTROL id, and the caption is
-    // a separate {UI_LABEL, 0, ...} row, so hiding leaves an orphan label with nothing beside it
-    // (the defect rebuild-17 had to clean up on the Artwork page). Greying keeps the pair together,
-    // matching the MMCE Start Mode row.
-    diaSetInt(diaControllerConfig, CFG_RUMBLE, 0);
-    diaSetEnabled(diaControllerConfig, CFG_RUMBLE, 0);
+    diaSetInt(diaControllerConfig, CFG_RUMBLE, gEnableRumble);
 
     int result = diaExecuteDialog(diaControllerConfig, -1, 1, NULL);
     if (result) {
         diaGetInt(diaControllerConfig, UICFG_SCROLL, &gScrollSpeed);
         diaGetInt(diaControllerConfig, CFG_XSENSITIVITY, &gXSensitivity);
         diaGetInt(diaControllerConfig, CFG_YSENSITIVITY, &gYSensitivity);
+        diaGetInt(diaControllerConfig, CFG_RUMBLE, &gEnableRumble);
+        if (!gEnableRumble)
+            padRumbleFlush(); // turned off mid-pulse -> do not leave a motor running
 
         if (diaGetInt(diaControllerConfig, CFG_SELECTBUTTON, &value))
             gSelectButton = value == 0 ? KEY_CIRCLE : KEY_CROSS;

--- a/src/opl.c
+++ b/src/opl.c
@@ -201,6 +201,7 @@ int gOverscan;
 int gSelectButton;
 int gHDDGameListCache;
 int gEnableSFX;
+int gEnableRumble;
 int gEnableBootSND;
 int gEnableBGM;
 int gSFXVolume;
@@ -1685,6 +1686,7 @@ static void _loadConfig()
             if (gNetworkProtocol == NET_PROTO_SMB)
                 gETHStartMode = gNetStartMode;
             configGetInt(configOPL, CONFIG_OPL_SFX, &gEnableSFX);
+            configGetInt(configOPL, CONFIG_OPL_RUMBLE, &gEnableRumble);
             configGetInt(configOPL, CONFIG_OPL_BOOT_SND, &gEnableBootSND);
             configGetInt(configOPL, CONFIG_OPL_BGM, &gEnableBGM);
             configGetInt(configOPL, CONFIG_OPL_SFX_VOLUME, &gSFXVolume);
@@ -1923,6 +1925,7 @@ static void _saveConfig()
         configSetInt(configOPL, CONFIG_OPL_NETWORK_PROTOCOL, gNetworkProtocol);
         configSetInt(configOPL, CONFIG_OPL_NET_START_MODE, gNetStartMode);
         configSetInt(configOPL, CONFIG_OPL_SFX, gEnableSFX);
+        configSetInt(configOPL, CONFIG_OPL_RUMBLE, gEnableRumble);
         configSetInt(configOPL, CONFIG_OPL_BOOT_SND, gEnableBootSND);
         configSetInt(configOPL, CONFIG_OPL_BGM, gEnableBGM);
         configSetInt(configOPL, CONFIG_OPL_SFX_VOLUME, gSFXVolume);
@@ -2722,7 +2725,8 @@ static void setDefaults(void)
     gEnableNotifications = 1;
     gEnableArt = 1;
     gWideScreen = 1;
-    gEnableSFX = 1; // safe now: sfxPlay dispatches asynchronously (#340)
+    gEnableSFX = 1;    // safe now: sfxPlay dispatches asynchronously (#340)
+    gEnableRumble = 0; // opt-in: haptics are a taste thing, and a worn motor is loud
     gEnableBootSND = 1;
     gEnableBGM = 1; // inert without a bgm.ogg on the card
     gSFXVolume = 80;

--- a/src/pad.c
+++ b/src/pad.c
@@ -97,6 +97,11 @@ static int initializePad(struct pad_data_t *pad)
 
     LOG("PAD initializing pad %d,%d\n", pad->port, pad->slot);
 
+    // Cleared up front because every path below can return before padInfoAct() is reached. Without
+    // this, unplugging a DualShock and plugging a digital pad into the same port would leave the
+    // old actuator count behind, and the rumble engine would drive engines that are not there.
+    pad->actuators = 0;
+
     // is there any device connected to that port?
     if (waitPadReady(pad) == PAD_STATE_DISCONN) {
         LOG("PAD pad %d,%d not connected.\n", pad->port, pad->slot);
@@ -339,6 +344,80 @@ static int getKeyDelay(int id, int repeat)
     return delay;
 }
 
+/*--    Menu rumble    ------------------------------------------------------------------------------
+Opt-in (gEnableRumble). The pulse is timed against RAW cpu_ticks() elapsed since it started, and
+NOT against time_since_last below -- that value is the difference of two ALREADY divided cpu_ticks()
+readings, so it goes wild once every ~29.1 s when the 32-bit tick counter wraps. On a decrementing
+"milliseconds left" counter a single bad sample adds ~29 s to the pulse: a motor latched on. An
+elapsed comparison in raw ticks is correct across one wrap by ordinary unsigned arithmetic, and a
+pulse is capped below at a fraction of a second, so one wrap is the most that can occur inside it.
+This is why the feature needs none of the pad-clock rework it was originally blocked on.
+----------------------------------------------------------------------------------------------------*/
+static u32 rumbleStartTicks = 0;
+static u32 rumbleDurTicks = 0;
+static int rumbleActive = 0;
+
+// Longest pulse we will ever hold a motor on for. Menu feedback, not a sustained buzz.
+#define RUMBLE_MAX_MS 500
+
+static void padActSet(struct pad_data_t *pad, int small, int large)
+{
+    char act[6];
+
+    if (pad->actuators == 0)
+        return;
+
+    memset(act, 0, sizeof(act));
+    act[0] = small ? 1 : 0;        // small engine: on/off only
+    act[1] = (char)(large & 0xff); // large engine: 0..255
+    // Fire-and-forget: padSetActDirect queues a SIO2 request and returns. Deliberately NOT preceded
+    // by waitPadReady() -- that is a busy wait, and this runs on the GUI thread.
+    padSetActDirect(pad->port, pad->slot, act);
+}
+
+/** Stops any pulse in flight, on every pad.
+ * The decay only runs from readPads(), so anything that can block the GUI thread for longer than a
+ * pulse has to stop the motor on the way in or it buzzes for the whole operation.
+ */
+void padRumbleFlush(void)
+{
+    int i;
+
+    if (!rumbleActive)
+        return;
+
+    rumbleActive = 0;
+    rumbleDurTicks = 0;
+    for (i = 0; i < pad_count; ++i)
+        padActSet(&pad_data[i], 0, 0);
+}
+
+/** Starts a rumble pulse on every connected pad that has actuators.
+ * @param durationMs pulse length, clamped to RUMBLE_MAX_MS
+ * @param large      large (variable-speed) engine strength, 0..255; the small engine runs for the
+ *                   whole pulse regardless, since it is the one that gives a crisp click
+ */
+void padRumble(int durationMs, int large)
+{
+    int i;
+
+    if (durationMs <= 0)
+        return;
+    if (durationMs > RUMBLE_MAX_MS)
+        durationMs = RUMBLE_MAX_MS;
+    if (large < 0)
+        large = 0;
+    if (large > 255)
+        large = 255;
+
+    rumbleStartTicks = cpu_ticks();
+    rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
+    rumbleActive = 1;
+
+    for (i = 0; i < pad_count; ++i)
+        padActSet(&pad_data[i], 1, large);
+}
+
 /** polling method. Call every frame. */
 int readPads()
 {
@@ -356,6 +435,10 @@ int readPads()
     for (i = 0; i < pad_count; ++i) {
         rslt |= readPad(&pad_data[i]);
     }
+
+    // Rumble decay. Unsigned elapsed in RAW ticks -- see the note above padActSet().
+    if (rumbleActive && (u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks)
+        padRumbleFlush();
 
     for (i = 0; i < 16; ++i) {
         if (getKeyPressed(i + 1))
@@ -473,6 +556,10 @@ static void unloadPad(struct pad_data_t *pad)
 void unloadPads()
 {
     int i;
+
+    // Last chance to stop a motor. Closing the port does not clear the actuators, and OPL is on its
+    // way out here -- a pulse still in flight would keep buzzing into whatever we hand off to.
+    padRumbleFlush();
 
     for (i = 0; i < pad_count; ++i)
         unloadPad(&pad_data[i]);

--- a/src/sound.c
+++ b/src/sound.c
@@ -13,6 +13,7 @@
 #include "include/opl.h"
 #include "include/ioman.h"
 #include "include/themes.h"
+#include "include/pad.h" // padRumble -- menu rumble rides the SFX events
 
 // Silence unused variable warnings from vorbisfile.h
 static ov_callbacks OV_CALLBACKS_NOCLOSE __attribute__((unused));
@@ -420,8 +421,45 @@ static void sfxEnqueue(int channel, int id)
     SignalSema(sfxDispatchSema);
 }
 
+// Menu rumble rides the SFX events: one hook covers every call site in the GUI, and the events are
+// already the ones worth feeding back on.
+//
+// SFX_CURSOR is deliberately NOT in this table. It fires on every single cursor step, so haptics
+// there would be a continuous buzz while scrolling -- and, more to the point, it would put a SIO2
+// request on the GUI thread inside the one path #340 is about. The discrete events below fire at
+// human speed and cannot pile up.
+//
+// SFX_BOOT and the SFX_BD_* device events are also left out: nobody is holding the pad yet at boot,
+// and a drive appearing is not something the user did.
+static void sfxRumble(int id)
+{
+    if (!gEnableRumble)
+        return;
+
+    switch (id) {
+        case SFX_CONFIRM:
+            padRumble(120, 160);
+            break;
+        case SFX_CANCEL:
+            padRumble(90, 96);
+            break;
+        case SFX_MESSAGE:
+            padRumble(120, 160);
+            break;
+        case SFX_TRANSITION:
+            padRumble(150, 200);
+            break;
+        default:
+            break;
+    }
+}
+
 void sfxPlay(int id)
 {
+    // ABOVE the audio gates on purpose: someone running with sound off should still get the haptics
+    // they asked for, and rumble does not need audsrv.
+    sfxRumble(id);
+
     if (!audio_initialized) {
         LOG("SFX: %s: ERROR: not initialized!\n", __FUNCTION__);
         return;


### PR DESCRIPTION
Closes the last lying row on the Controller page. `rebuild-22` had to pin **Menu Rumble** to Off and grey it out because the engine appeared to depend on a pad-clock rework first.

### Why it was blocked, and why it isn't

The fork decays a pulse with `rumbleMsLeft -= time_since_last`. `time_since_last` is the difference of two **already divided** `cpu_ticks()` readings, so it goes wild once every ~29.1 s when the 32-bit counter wraps. One bad sample on a decrementing counter adds ~29 s to the pulse — a motor latched on. Fixing that clock also moves `delaycnt[]`, the key-repeat path the validated scrolling feel runs on.

None of it is needed. Compare **raw ticks elapsed since the pulse started** instead of accumulating differences:

```c
if (rumbleActive && (u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks)
    padRumbleFlush();
```

Unsigned subtraction is correct across one wrap, and a pulse is capped at 500 ms, so one wrap is the most that can occur inside it. **`time_since_last` and `delaycnt[]` are untouched.**

The rest was already here: `initializePad()` has always done the full actuator bring-up (`padSetMainMode` DUALSHOCK+LOCK, `padInfoAct`, `padSetActAlign`). Only `padSetActDirect` and the timing were missing.

### Scope decisions

- **No rumble on `SFX_CURSOR`.** It fires on every cursor step — haptics there would be a continuous buzz while scrolling, and it would put a SIO2 request on the GUI thread inside the exact path #340 is about. Only `CONFIRM` / `CANCEL` / `MESSAGE` / `TRANSITION` rumble; those fire at human speed and cannot pile up.
- **Hook sits above the audio gates** in `sfxPlay()`. Rumble doesn't need audsrv, and someone running with sound off should still get haptics they turned on.
- **`padRumbleFlush()` from `unloadPads()`**, which every exit and launch path goes through. Closing the pad port does *not* clear the actuators — without this a pulse in flight at launch would buzz on into the game.
- **`initializePad()` now clears `pad->actuators` up front.** Every early return below it (disconnected / digital pad / no DualShock mode) skipped the assignment, so swapping a DualShock for a digital pad on the same port left the stale count behind and the engine would drive actuators that aren't there. Pre-existing latent bug, surfaced by this feature.

Default **OFF**. No pad-clock rework, no debug HUD, no freepad — as requested.

### Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied
- No new language labels (`RUMBLE` / `HINT_RUMBLE` were pre-staged by the settings-layout step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)