### PR TITLE
rebuild-66: the OPL menu itself at 1080p (#163) -- the third of the three

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1762,6 +1762,9 @@ void guiShowDisplayConfig(void)
         , "HDTV 1920x1080i @60Hz 16bit (HIRES)"
         , "PAL 640x256p @50Hz 24bit"
         , "NTSC 640x224p @60Hz 24bit"
+        // Appended LAST to keep every stored $VMode index pointing at the same mode. Index 14 must
+        // stay 1:1 with rm_mode_table[] (renderman.c), which carries the same warning.
+        , "HDTV 1920x1080p @60Hz 16bit (EXPERIMENTAL)"
         , NULL};
     // clang-format on
     int previousVMode;

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -23,7 +23,7 @@ static u8 hires = 0;
 static u8 guiWakeupCount;
 static int vsync_id = -1;
 
-#define NUM_RM_VMODES 14
+#define NUM_RM_VMODES 15
 #define RM_VMODE_AUTO 0
 
 // RM Vmode -> GS Vmode conversion table
@@ -62,6 +62,27 @@ static struct rm_mode rm_mode_table[NUM_RM_VMODES] = {
     // 24 bit color mode for older systems (non-interlaced, low resolution)
     {GS_MODE_PAL,        16,  640,  256,  1, 4, GS_NONINTERLACED, GS_FRAME, RM_ARATIO_4_3,  8, 15}, // PAL@50Hz
     {GS_MODE_NTSC,       16,  640,  224,  1, 4, GS_NONINTERLACED, GS_FRAME, RM_ARATIO_4_3,  7, 15}, // NTSC@60Hz
+    // 1080p for the OPL MENU ITSELF (issue #163). EXPERIMENTAL.
+    //
+    // APPENDED LAST, never inserted: $VMode is a stored RAW INDEX, so a mid-list insert would
+    // silently remap every existing saved config onto a different mode.
+    //
+    // It is the 1080i row above with the interlace turned OFF, and that is the whole trick. The GS
+    // has no native 1080p, but the ROM's SetGsCrt takes interlace as a separate argument from the
+    // mode, so asking it for GS_MODE_DTV_1080I NON-interlaced gets a real, ROM-programmed 1080-line
+    // progressive raster with no custom register writes at all. That matters here: the multi-pass
+    // hires renderer rewrites DISPLAY every vblank, so anything we patched in by hand would be
+    // overwritten a frame later. GSM needs its own synthetic 0x54 mode for games only because it
+    // hooks SetGsCrt and must tell "the game asked for 1080i" apart from "we are synthesising
+    // 1080p" -- a mode WE select for our own screen has no such ambiguity. The GSM 1080p row's
+    // DISPLAY/SYNCV are byte-identical to its 1080i row (gsm.c), which is the evidence that
+    // interlace really is the only delta.
+    //
+    // Unlike the 1080i row this does NOT get Height/=2 in rmSetMode (that halving only applies to
+    // INTERLACED+FRAME), so the buffer really is 1080 lines. 1920x1080 at 16bit will not fit in
+    // 4MB of VRAM twice over, which is why passes stays 3: the hires path renders and DMAs one
+    // ~360-line band at a time rather than allocating the whole frame.
+    {GS_MODE_DTV_1080I,  31, 1920, 1080,  3, 1, GS_NONINTERLACED, GS_FRAME, RM_ARATIO_16_9, 1,  1}, // HDTV1080P@60Hz
 };
 // clang-format on
 


### PR DESCRIPTION
Completes the **global / per-game / the GUI itself** set. The first two landed in rebuild-61 and rebuild-62; this is the OPL menu's own video mode.

### The whole change is one table row — and why that's the surprise

The GS has no native 1080p and gsKit has no `GS_MODE_DTV_1080P`, so the obvious reading is that the menu needs the same synthetic `0x54` raster GSM programs for games. **It doesn't.**

The ROM's `SetGsCrt` takes **interlace as a separate argument from the mode**, so asking it for `GS_MODE_DTV_1080I` *non*-interlaced yields a real, ROM-programmed 1080-line progressive raster with **no custom register writes at all**.

That distinction is load-bearing, not stylistic: **the multi-pass hires renderer rewrites `DISPLAY` every vblank**, so any `SMODE2`/`DISPLAY`/`SYNCV` values poked in by hand would be overwritten a frame later. Going through the ROM is the only version of this that can hold.

GSM needs its own synthetic mode id for a reason that doesn't apply here: it **hooks** `SetGsCrt`, so it must distinguish "the game asked for 1080i" from "we're synthesising 1080p". A mode *we* select for *our own* screen has no such ambiguity.

The evidence that interlace really is the only delta is in `gsm.c` itself — its 1080p row's `DISPLAY` and `SYNCV` are **byte-identical** to its 1080i row; only mode + `NONINTERLACED`/`FRAME` differ. And that raster is **HW-confirmed** (MonkeyBoyJoey: RT4K reports 1080p and displays correctly).

### VRAM

Unlike the 1080i row this does **not** get `Height /= 2` in `rmSetMode` — that halving only applies to `INTERLACED`+`FRAME` — so the buffer really is 1080 lines. 1920×1080 at 16-bit doesn't fit in 4 MB of VRAM twice over, which is why `passes` stays **3**: the hires path renders and DMAs one ~360-line band at a time instead of allocating the whole frame.

### Index stability

Appended **last** in both `rm_mode_table[]` and `vmodeNames[]`, never inserted: `$VMode` is a stored **raw index**, so a mid-list insert would silently remap every existing saved config onto a different mode. Both lists carry the warning; both are now 15 entries and stay 1:1.

### Why this is safe to ship as opt-in EXPERIMENTAL

Two independent escape hatches already cover a display that can't sync:
1. `guiConfirmVideoMode()`'s 10 s **auto-revert** — made wrap-safe in #442, and that's exactly why that step came first; it was *not* sound before.
2. **Triangle+Cross at boot** forces 480p progressive.

### Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied
- No new language labels — mode names are literals like every other entry
- Needs hardware: an emulator says nothing about GS raster timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)