### PR TITLE
rebuild-67: revert the 1080p GUI mode (cannot fit VRAM) + fix a boot hang I shipped in 65

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1762,9 +1762,6 @@ void guiShowDisplayConfig(void)
         , "HDTV 1920x1080i @60Hz 16bit (HIRES)"
         , "PAL 640x256p @50Hz 24bit"
         , "NTSC 640x224p @60Hz 24bit"
-        // Appended LAST to keep every stored $VMode index pointing at the same mode. Index 14 must
-        // stay 1:1 with rm_mode_table[] (renderman.c), which carries the same warning.
-        , "HDTV 1920x1080p @60Hz 16bit (EXPERIMENTAL)"
         , NULL};
     // clang-format on
     int previousVMode;
@@ -2622,7 +2619,16 @@ void guiIntroLoop(void)
             sfxPlay(SFX_BOOT);
             // Calculate transition delay
             tFadeStart = clock();
-            tFadeDelay = (clock_t)(sfxGetSoundDuration(SFX_BOOT) - fadeDuration) * (CLOCKS_PER_SEC / 1000);
+            // CLAMP AT ZERO. sfxGetSoundDuration returns 0 when audsrv failed to initialise, and a
+            // custom theme's boot sound can legitimately be shorter than the fade -- either way this
+            // subtraction goes negative, and clock_t is UNSIGNED LONG, so the cast turns ~-1163 into
+            // ~4.29 billion and the wait below becomes ~71 minutes on the boot splash with no exit.
+            // The absolute-deadline form this replaced was accidentally immune (a deadline in the
+            // past reads as already elapsed); converting it to the elapsed form is what exposed it.
+            int fadeDelayMs = sfxGetSoundDuration(SFX_BOOT) - fadeDuration;
+            if (fadeDelayMs < 0)
+                fadeDelayMs = 0;
+            tFadeDelay = (clock_t)fadeDelayMs * (CLOCKS_PER_SEC / 1000);
             tFadeArmed = 1;
         }
 

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -23,7 +23,7 @@ static u8 hires = 0;
 static u8 guiWakeupCount;
 static int vsync_id = -1;
 
-#define NUM_RM_VMODES 15
+#define NUM_RM_VMODES 14
 #define RM_VMODE_AUTO 0
 
 // RM Vmode -> GS Vmode conversion table
@@ -62,27 +62,6 @@ static struct rm_mode rm_mode_table[NUM_RM_VMODES] = {
     // 24 bit color mode for older systems (non-interlaced, low resolution)
     {GS_MODE_PAL,        16,  640,  256,  1, 4, GS_NONINTERLACED, GS_FRAME, RM_ARATIO_4_3,  8, 15}, // PAL@50Hz
     {GS_MODE_NTSC,       16,  640,  224,  1, 4, GS_NONINTERLACED, GS_FRAME, RM_ARATIO_4_3,  7, 15}, // NTSC@60Hz
-    // 1080p for the OPL MENU ITSELF (issue #163). EXPERIMENTAL.
-    //
-    // APPENDED LAST, never inserted: $VMode is a stored RAW INDEX, so a mid-list insert would
-    // silently remap every existing saved config onto a different mode.
-    //
-    // It is the 1080i row above with the interlace turned OFF, and that is the whole trick. The GS
-    // has no native 1080p, but the ROM's SetGsCrt takes interlace as a separate argument from the
-    // mode, so asking it for GS_MODE_DTV_1080I NON-interlaced gets a real, ROM-programmed 1080-line
-    // progressive raster with no custom register writes at all. That matters here: the multi-pass
-    // hires renderer rewrites DISPLAY every vblank, so anything we patched in by hand would be
-    // overwritten a frame later. GSM needs its own synthetic 0x54 mode for games only because it
-    // hooks SetGsCrt and must tell "the game asked for 1080i" apart from "we are synthesising
-    // 1080p" -- a mode WE select for our own screen has no such ambiguity. The GSM 1080p row's
-    // DISPLAY/SYNCV are byte-identical to its 1080i row (gsm.c), which is the evidence that
-    // interlace really is the only delta.
-    //
-    // Unlike the 1080i row this does NOT get Height/=2 in rmSetMode (that halving only applies to
-    // INTERLACED+FRAME), so the buffer really is 1080 lines. 1920x1080 at 16bit will not fit in
-    // 4MB of VRAM twice over, which is why passes stays 3: the hires path renders and DMAs one
-    // ~360-line band at a time rather than allocating the whole frame.
-    {GS_MODE_DTV_1080I,  31, 1920, 1080,  3, 1, GS_NONINTERLACED, GS_FRAME, RM_ARATIO_16_9, 1,  1}, // HDTV1080P@60Hz
 };
 // clang-format on
 


### PR DESCRIPTION
Two corrections to my own last two steps. Both confirmed with arithmetic, not argument.

### 1. The 1080p GUI mode cannot work — reverted

The PS2 has **4,194,304 bytes** of VRAM (`renderman.c:15` states it). A 1920×1080 CT16S framebuffer is `1920*1080*2` = **4,147,200 bytes — 98.9%**, leaving ~47 KB for every texture the GUI draws. The font atlas alone doesn't fit, never mind cover art.

| mode | buffer | % of VRAM |
|---|---|---|
| 720p | 1280×720×2 | 43.9% |
| 1080i | 1920×**540**×2 | 49.4% |
| 1080p (reverted) | 1920×**1080**×2 | **98.9%** |

My rebuild-66 reasoning was wrong in a specific way worth recording. I claimed `passes=3` meant the hires path renders one ~360-line band instead of allocating the whole frame. **That is not what makes the existing HD modes fit.** What makes 1080i fit is `rmSetMode`'s `if (Interlace == GS_INTERLACED && Field == GS_FRAME) Height /= 2` — the *table* says 1080 but the buffer is really 540. My row was `NONINTERLACED`, so it skipped that halving and asked for the full 1080 lines.

**The halving I relied on the absence of was the entire reason the neighbouring row fits.**

Whether `SetGsCrt(0x51, non-interlaced)` can even produce a 1080-line progressive raster is now moot, and stays unanswered.

### 2. A boot hang in rebuild-65 — my regression, not pre-existing

`guiIntroLoop` computes the fade delay as `sfxGetSoundDuration(SFX_BOOT) - fadeDuration`, where `fadeDuration` is 1163 ms.

**`sfxGetSoundDuration` returns 0 when audsrv failed to initialise** (`sound.c:236-239`), and a custom theme's boot sound can legitimately be shorter than the fade. Either way the subtraction goes negative — and `clock_t` is **`unsigned long`** (`sys/_types.h:179`), so the cast turns `-1163` into `4294966133`; times `CLOCKS_PER_SEC/1000` that's a **~4294 second wait on the boot splash**, and this comparison is the loop's *only* exit.

rebuild-65 introduced this. The absolute-deadline form it replaced was **accidentally immune**: a deadline computed in the *past* reads as already elapsed, so a short sound just started the fade at once. Converting to the elapsed form removed that accident. `gEnableBootSND` defaults to **1**, so any console where audio init fails would have hung at the logo.

Clamped at zero. The wrap-safety rebuild-65 was actually for is unaffected.

> **Lesson:** converting an absolute deadline to an elapsed comparison is not a mechanical rewrite. The absolute form tolerates a negative duration; the elapsed form does not, because the duration becomes an unsigned operand. Check the sign of every duration before converting.

### Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied
- `NUM_RM_VMODES` back to 14; `rm_mode_table[]` and `vmodeNames[]` both back to 14 entries and 1:1

🤖 Generated with [Claude Code](https://claude.com/claude-code)