### PR TITLE
rebuild-68: settings never went to the boot device -- setDefaults erased the boot dir before configInit read it

### DIFF
--- a/include/diag.h
+++ b/include/diag.h
@@ -3,5 +3,6 @@
 
 // Captured at the settings-write failure site for the later user-facing error.
 extern volatile int gLastSaveErrno;
+extern volatile int gLastDeferredTimedOut;
 
 #endif

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1044,3 +1044,5 @@ gui_strings:
   string: Per Game + Global
 - label: GSM_DEFAULTS
   string: GSM Defaults (All Games)
+- label: ERR_DEVICE_BUSY_TIMEOUT
+  string: "Device busy: the settings write never started. Try again once loading finishes."

--- a/src/gui.c
+++ b/src/gui.c
@@ -6,6 +6,7 @@
 
 #include "include/opl.h"
 #include "include/gui.h"
+#include "include/diag.h" // gLastDeferredTimedOut -- a bounded wait that expired means the handler never ran
 #include "include/renderman.h"
 #include "include/menusys.h"
 #include "include/fntsys.h"
@@ -2895,10 +2896,14 @@ void guiHandleDeferedIO(int *ptr, const char *message, int type, void *data, int
     // is single-wrap-safe, unlike an absolute clock()+limit deadline.
     clock_t startTick = clock();
     clock_t limitTicks = (clock_t)timeoutMs * (CLOCKS_PER_SEC / 1000);
+    gLastDeferredTimedOut = 0;
     while (*ptr) {
         if (timeoutMs > 0 && (clock() - startTick) >= limitTicks) {
             LOG("guiHandleDeferedIO: deferred IO unfinished after %d ms; storage stuck, abandoning wait\n", timeoutMs);
             *ptr = 0;
+            // The handler never ran. Callers must not report a device error against their target
+            // path on the strength of this -- nothing touched it.
+            gLastDeferredTimedOut = 1;
             break;
         }
         guiRenderTextScreen(message);

--- a/src/opl.c
+++ b/src/opl.c
@@ -183,6 +183,9 @@ int gArtDelay;                           // inactivity frames before art loads; 
 int gEnableFolderNav;                    // folder browsing in game lists (item 34)
 unsigned char gDefaultPlasBlendColor[3]; // plasma gradient low end; black = historical look
 volatile int gLastSaveErrno = 0;
+// Set by guiHandleDeferedIO when it abandons a bounded wait: the request never ran, so any
+// error the caller would otherwise report against the target path is meaningless.
+volatile int gLastDeferredTimedOut = 0;
 int gEnableMX4SIO;
 int gEnableBdmHDD;
 int gEnableUDPBD;
@@ -2073,6 +2076,11 @@ int saveConfig(int types, int showUI)
     char notification[128];
     lscstatus = types;
     lscret = 0;
+    // Reset before the attempt. gLastSaveErrno is only ever ASSIGNED at the three real failure sites
+    // in configWrite, never cleared -- so a stale value from an earlier save could be reported for a
+    // later one, and (worse) a save that never reached configWrite at all reported whatever was left,
+    // usually the 0 that produced the nonsensical "(error 0)".
+    gLastSaveErrno = 0;
 
     guiHandleDeferedIO(&lscstatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_saveConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
 
@@ -2084,7 +2092,15 @@ int saveConfig(int types, int showUI)
 
             guiMsgBox(notification, 0, NULL);
         } else {
-            snprintf(notification, sizeof(notification), _l(_STR_ERROR_SAVING_SETTINGS_TO), configGetDir(), gLastSaveErrno);
+            // Distinguish "the write failed" from "the write never ran". guiHandleDeferedIO abandons
+            // its wait after OPL_DEFERRED_IO_TIMEOUT_MS and clears the status WITHOUT _saveConfig
+            // having executed -- the IO worker is single-threaded and shared with cover-art loads, so
+            // a queue full of slow art can starve the save past the bound. In that case nothing ever
+            // touched the config, so reporting a write error against the config path is a lie.
+            if (gLastDeferredTimedOut)
+                snprintf(notification, sizeof(notification), "%s", _l(_STR_ERR_DEVICE_BUSY_TIMEOUT));
+            else
+                snprintf(notification, sizeof(notification), _l(_STR_ERROR_SAVING_SETTINGS_TO), configGetDir(), gLastSaveErrno);
             guiMsgBox(notification, 0, NULL);
         }
     }
@@ -2762,7 +2778,12 @@ static void setDefaults(void)
     gBdmaApplyOnLaunch = 1; // auto-equip on launch by default
     gVcdHideGameId = 1;     // hide the PS1 game-ID prefix by default (display-only)
     gVcdFirstDiscOnly = 1;  // hide discs 2+ of multi-disc PS1 sets by default (POPSLoader parity)
-    gBootDir[0] = '\0';
+    // gBootDir is deliberately NOT reset here. main() resolves it (setBootDir, from argv[0] with a
+    // getcwd fallback) BEFORE calling init(), and init() calls setDefaults() -- so clearing it here
+    // erased the boot identity a few lines before configInit() needs it, on EVERY boot. That made
+    // resolveBootDirToMass() early-return at its `gBootDir[0] == '\0'` guard every time, and homed
+    // every config set on the mc?:OPL default regardless of what OPL actually booted from.
+    // setBootDir() already zeroes the buffer at its own entry, so nothing needs a reset here.
     gEnableBGArt = 1; // fork parity; gEnableArt is 1 above, so this is live
     gEnableArtTar = 0;
     gArtDelay = 8; // official-like settle (the fork's aggressive 2-frame default is a gate-D decision, item 45)
@@ -2808,7 +2829,7 @@ static void init(void)
 
     padInit(0);
     int padStatus = 0;
-    configInit(NULL);
+    configInit(gBootDir[0] ? gBootDir : NULL); // settings live in the boot dir (cwd), not a fixed MC default
 
     rmInit();
     lngInit();
@@ -2892,7 +2913,7 @@ static void miniInit(int mode)
     int ret;
 
     setDefaults();
-    configInit(NULL);
+    configInit(gBootDir[0] ? gBootDir : NULL); // settings live in the boot dir (cwd)
 
     ioInit();
     LOG_ENABLE();


### PR DESCRIPTION
Hardware report: booted from UDPFS, got **"could not write settings to mc0: (error 0)"**. Both halves of that message were wrong, for two unrelated reasons.

## 1. The `mc0:` half — the settings-to-boot-dir doctrine has been dead on *every* boot

`main()` resolves the boot directory into `gBootDir` at `opl.c:3118`, with a comment saying it does so deliberately *"before any config init"*. It then calls `init()` at `:3146`. `init()` calls `setDefaults()` **first** — and `setDefaults` contained:

```c
gBootDir[0] = '\0';
```

The boot identity was erased four lines before `configInit()` needed it. `configInit(NULL)` then substitutes `gBaseMCDir` = `"mc?:OPL"`, and `configGetDir()` renders that as `mc0:` once a card is detected.

**This was never a UDPFS bug.** `gBootDir` was empty on *every* boot, so:

- `resolveBootDirToMass()` early-returned at its own `gBootDir[0] == '\0'` guard **every single time**. All of its device handling — the MMCE settle poll, the APA and cdrom redirects, `bdmResolveBootDir` — has never run.
- The `configInit(gBootDir)` re-home at `opl.c:1494` was unreachable.
- The `gBootDir` consumers in `vcdsupport.c` were reading an empty string.
- The comment at `opl.c:1484` asserting *"the config sets were already homed there by init()'s configInit"* described the **fork's** code, not ours.

The fork's `setDefaults` has **zero** `gBootDir` references, and homes both config inits on the boot dir:

```c
configInit(gBootDir[0] ? gBootDir : NULL); // settings live in the boot dir (cwd)
```

The rebuild ported `setBootDir()` and `main()`'s resolution but left `init()` on upstream's `configInit(NULL)` — then added a wipe that made the leftover unfixable from outside. **Restoring only the `configInit` line would have been inert while the wipe stood**; both edits are required, which is why this survived earlier inspection.

Minimal fix: delete the wipe (`setBootDir` already zeroes the buffer at its own entry) and home both `configInit` sites on `gBootDir`, as the fork does.

## 2. The `(error 0)` half — the save never ran

`gLastSaveErrno` is assigned **only** at the three real failure sites in `configWrite` and is never cleared, so "error 0" means *no write ever reported anything*.

`guiHandleDeferedIO` abandons its wait after `OPL_DEFERRED_IO_TIMEOUT_MS`, clears the status, and returns **without the handler having executed**. `lscret` stays 0, so `saveConfig` printed a write-failure toast against a path nothing had touched.

Cover-art loads and `_saveConfig` share the single prio-30 IO worker, so a queue full of slow network art starves the save past the bound — precisely the reported *"art got us hung up on loading before the save could save settings"*.

Now `gLastSaveErrno` is reset at the start of every save, and an expired bounded wait is reported as what it is (device busy, nothing written) rather than as a write error with a meaningless errno.

## Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied
- New label `ERR_DEVICE_BUSY_TIMEOUT` appended at the **END** of `lng_tmpl/_base.yml`; prefix order unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)