### PR TITLE
rebuild-69: menu sounds went silent on every other press -- rebuild-55 coalescing was wrong

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -269,10 +269,15 @@ void sfxGetPlayDiag(unsigned int *lastMs, unsigned int *maxMs)
 // audioInit, which happens-before any producer (both producers gate on audio_initialized).
 // A full ring DROPS the sound -- a skipped tick beats a stalled menu. Concurrent audsrv RPCs
 // from a second thread are nothing new: bgmThread has always streamed alongside sfx.
-#define SFX_QUEUE_LEN   8
+#define SFX_QUEUE_LEN        8
 // Entries older than this play no more: after an IOP stall clears, replaying the backlog of
 // stacked cursor ticks would chirp back-to-back.
-#define SFX_STALE_TICKS (100 * SFX_CLOCKS_PER_MS)
+#define SFX_STALE_TICKS      (100 * SFX_CLOCKS_PER_MS)
+// Confirm (847 ms) and cancel (522 ms) are far longer than a cursor tick and are fired by deliberate
+// presses, not by scrolling, so they get a much looser bound: long enough that a real press always
+// sounds even when the dispatcher is briefly behind, short enough that a backlog which surfaces
+// after an IOP stall is still discarded instead of chirping long after the fact.
+#define SFX_STALE_TICKS_LONG (500 * SFX_CLOCKS_PER_MS)
 static struct
 {
     int channel;
@@ -302,8 +307,10 @@ static void sfxDispatchThread(void *arg)
             // busy goes up BEFORE the gates: the quiescers set paused and then wait for
             // (empty && !busy), so an entry that passed the gates is always covered by busy.
             sfxDispatchBusy = 1;
-            if (sfxDispatchPaused || !audio_initialized ||
-                (id == SFX_CURSOR && (u32)(cpu_ticks() - ticks) > SFX_STALE_TICKS)) {
+            u32 staleLimit = (id == SFX_CONFIRM || id == SFX_CANCEL) ? SFX_STALE_TICKS_LONG : SFX_STALE_TICKS;
+            int stale = (id == SFX_CURSOR || id == SFX_CONFIRM || id == SFX_CANCEL) &&
+                        (u32)(cpu_ticks() - ticks) > staleLimit;
+            if (sfxDispatchPaused || !audio_initialized || stale) {
                 sfxDispatchBusy = 0;
                 continue;
             }
@@ -378,35 +385,16 @@ static void sfxEnqueue(int channel, int id)
     // Two producers on different priorities: claim the slot atomically.
     DIntr();
 
-    // Coalesce repeats of the LONG confirm/cancel samples (hardware report: the open/close chirp
-    // trails the button by a growing margin when the user mashes it).
-    //
-    // Measured from the ADPCM headers with this file's own sfxCalculateSoundDuration():
-    //     cursor  3528 samples =  80 ms      confirm 37376 samples = 847 ms
-    //     cancel 23040 samples = 522 ms
-    // and BOTH the focus-gain and focus-loss paths in dia.c play SFX_CONFIRM -- so opening and
-    // closing an option each fire a 847 ms sample on ONE channel. Mash it and up to 7 stack in the
-    // ring and replay serially long after the last press, because the staleness drop below is
-    // gated on SFX_CURSOR only. One pending entry per id is all that can ever be HEARD anyway:
-    // retriggering a channel replaces the sample already playing on it, so the extra copies only
-    // ever bought latency.
-    //
-    // If the ring is EMPTY there is nothing to match, so an isolated press is never dropped -- only
-    // a repeat that arrives while an identical sound is still pending. We do NOT touch the queued
-    // entry (no ticks refresh): producers must never mutate a slot, because the consumer copies its
-    // three fields and advances sfxQTail OUTSIDE this interrupt guard. Same sample either way.
-    //
-    // SFX_CURSOR is deliberately NOT coalesced: it is 80 ms, it already has the staleness drop, and
-    // it is the scroll path -- the #340 surface this whole rebuild exists to protect.
-    if (id == SFX_CONFIRM || id == SFX_CANCEL) {
-        int i;
-        for (i = sfxQTail; i != sfxQHead; i = (i + 1) % SFX_QUEUE_LEN) {
-            if (sfxQueue[i].id == id) {
-                EIntr();
-                return; // identical sound already pending: this repeat would only add latency
-            }
-        }
-    }
+    // NOTHING IS COALESCED HERE. An earlier revision dropped a CONFIRM/CANCEL whenever an identical
+    // one was still pending in the ring, reasoning that only one can be heard anyway (retriggering a
+    // channel replaces the sample already playing). That is true of the AUDIO and false of the USER:
+    // dia.c plays SFX_CONFIRM on BOTH focus-gain and focus-loss, so open/close/open/close is four
+    // deliberate presses of the same id in quick succession, and the pending-entry test silenced
+    // every other one. Reported from hardware as "I click open, it opens, I click close, it closes;
+    // when I REOPEN it is completely silent, and when I reclose it sounds normally."
+    // Dropping a sound the user asked for is a worse fault than a chirp arriving late.
+    // The backlog problem that motivated it is handled where it belongs -- at DISPATCH, by the
+    // staleness test, which now covers these ids too (see sfxDispatchThread).
 
     int next = (sfxQHead + 1) % SFX_QUEUE_LEN;
     if (next == sfxQTail) {


### PR DESCRIPTION
Hardware report (Zack):

> "I click open an option, it opens, I click close, it closes. **WHEN I REOPEN IT** the sound doesn't trigger, it is **COMPLETELY SILENT**, and when I reclose it recloses normally."
> "it goes like `tiit...... tiiit` instead of the right way `tiit tiit tiit tiit`"

That is rebuild-55, exactly as written.

### What it did, and why the reasoning was wrong

rebuild-55 dropped a `SFX_CONFIRM`/`SFX_CANCEL` whenever an identical one was still pending in the ring, on the reasoning that *only one can be heard anyway* — retriggering a channel replaces the sample already playing on it.

**That reasoning is true of the audio and false of the user.** `dia.c` plays `SFX_CONFIRM` on **both** focus-gain and focus-loss, so open/close/open/close is four *deliberate* presses of the same id in quick succession. The confirm sample is 847 ms, so while the dispatch thread is still working through one entry, the next press lands on a non-empty ring and is silently discarded.

Every other press lost its sound. I optimised away the user's feedback and called it latency.

**Dropping a sound the user asked for is a worse fault than a chirp arriving late.**

### The fix

The coalescing is gone. The backlog problem it was actually aimed at — entries surfacing long after an IOP stall and chirping back-to-back — is handled where it belongs: at **dispatch**, by the staleness test that already existed for `SFX_CURSOR`.

That test now covers `CONFIRM` and `CANCEL` too, with their own looser bound:

| id | sample | stale bound |
|---|---|---|
| `SFX_CURSOR` | 80 ms | 100 ms *(unchanged)* |
| `SFX_CANCEL` | 522 ms | 500 ms |
| `SFX_CONFIRM` | 847 ms | 500 ms |

Loose enough that a real press always sounds even when the dispatcher is briefly behind; tight enough that a post-stall backlog is still discarded.

`SFX_CURSOR` is untouched — it's the scroll path this whole rebuild exists to protect, and its 100 ms bound is unchanged.

### Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)