### PR TITLE
rebuild-70: cover art could starve every other IO request, including exit

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2594,12 +2594,21 @@ int gDeinitTerminal = 0;
 // deinitEx: deinit for the Neutrino keep-IOP handoff -- spares TWO modes' mounts (the game
 // device AND the device holding neutrino.elf), since Neutrino reads its -cwd config/modules
 // and the ISO through OPL's live mounts before performing its own IOP reset.
+// Bound for the teardown drains below. ioBlockOps() waits UNBOUNDED, which is correct only if the
+// queue is guaranteed to finish -- and it is not: cover art is queued one request per visible row on
+// the same single-threaded FIFO, so on a slow device (a network share especially) "Exit to Browser"
+// or a game launch sat waiting for hundreds of art reads with nothing on screen to explain it. The
+// NBD preflight already passes a bound for exactly this reason; the exit and launch paths never got
+// one. Abandoning a pending art read here is safe: every one of these callers is on its way to an
+// IOP reset, and the art request only ever writes into its own cache entry.
+#define TEARDOWN_IO_DRAIN_TICKS 1000
+
 void deinitEx(int exception, int modeSelected, int modeSelected2)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
 
-    // block all io ops, wait for the ones still running to finish
-    ioBlockOps(1);
+    // block all io ops, wait for the ones still running to finish (BOUNDED -- see the note above)
+    ioBlockOpsTimed(1, TEARDOWN_IO_DRAIN_TICKS);
     guiExecDeferredOps();
 
 #ifdef PADEMU
@@ -2629,8 +2638,8 @@ void deinit(int exception, int modeSelected)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
 
-    // block all io ops, wait for the ones still running to finish
-    ioBlockOps(1);
+    // block all io ops, wait for the ones still running to finish (BOUNDED -- see the note above)
+    ioBlockOpsTimed(1, TEARDOWN_IO_DRAIN_TICKS);
     guiExecDeferredOps();
 
 #ifdef PADEMU
@@ -2965,7 +2974,7 @@ static void miniInit(int mode)
 
 void miniDeinit(config_set_t *configSet)
 {
-    ioBlockOps(1);
+    ioBlockOpsTimed(1, TEARDOWN_IO_DRAIN_TICKS);
 #ifdef PADEMU
     ds34usb_reset();
     ds34bt_reset();

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -63,6 +63,12 @@ static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *tex
     return result;
 }
 
+// Most art requests the queue may hold before new ones are refused. Deliberately small: art is
+// re-requested every frame the item stays visible, so a refusal costs one frame of latency on that
+// tile, while a deep queue costs the USER seconds on the next thing they do. Non-art requests are
+// rare, so this doubles as the art cap without a per-type counter.
+#define ART_MAX_QUEUE_DEPTH 4
+
 // Io handled action...
 static void cacheLoadImage(void *data)
 {
@@ -207,6 +213,23 @@ GSTEXTURE *cacheGetTexture(image_cache_t *cache, item_list_t *list, int *cacheId
             rtime = currEntry->lastUsed;
             *cacheId = i;
         }
+    }
+
+    // BACKPRESSURE. Cover art is the only unbounded producer on the single ioman FIFO -- one request
+    // per visible row, refilled on every scroll -- and that FIFO also carries the config save, the
+    // deferred menu rebuild (the L3 VCD view switch among them) and device init. The worker runs
+    // requests strictly one at a time, so on a slow device (network shares especially) a scroll can
+    // park hundreds of art reads ahead of whatever the user does next: the save then blows through
+    // its 30 s bound and reports a failure that never happened, the view toggle appears to do
+    // nothing, and deinit's drain on exit waits behind all of it.
+    //
+    // Art is the one request type that is FREE TO DROP: the slot rolls back to empty below and the
+    // next frame simply asks again. So refuse to deepen an already-deep queue and let the
+    // interactive work through. Non-art requests are rare and short, which is what makes a plain
+    // depth test an effective art cap without needing a per-type counter.
+    if (oldestEntry && ioGetPendingRequestCount() >= ART_MAX_QUEUE_DEPTH) {
+        *cacheId = -1; // nothing queued, nothing to roll back: the slot was never claimed
+        return NULL;
     }
 
     if (oldestEntry) {


### PR DESCRIPTION
Hardware report: scrolling the settings pages left *"art hung up on loading"* before the save could run; the save reported a failure that never happened; device tabs went missing; turning them back on froze then unfroze; **Exit to Browser hung**; *"loading seems stuck — which means lots is queued or something."*

That last guess was exactly right.

## One producer, one queue, no backpressure

`cacheGetTexture` queues one `IO_CACHE_LOAD_ART` **per visible row** and refills on every scroll — onto the **same single-threaded ioman FIFO** that carries the config save, the deferred menu rebuild (the L3 VCD view switch among them), and device init. The worker runs requests strictly one at a time. On a slow device — a network share above all — a scroll parks hundreds of art reads ahead of whatever the user does next.

Everything reported follows from that:

- the **save** waits behind the art, blows through its 30 s bound, and reports a write error against a file nothing touched *(the honest-reporting half landed in #445)*
- the **deferred menu rebuild** waits too, so a view toggle looks like it did nothing
- and **`deinit`'s drain waits for all of it with no bound at all**

## Fix 1 — backpressure at the art enqueue

Art is the one request type that is **free to drop**: the cache slot rolls back to empty and the next frame simply asks again. So refuse to deepen an already-deep queue — `ART_MAX_QUEUE_DEPTH = 4` pending.

A refusal costs one frame of latency on one tile. A deep queue costs the user *seconds* on the next thing they do. Non-art requests are rare and short, so a plain depth test is an effective art cap without needing a per-type counter.

**Deliberately not implemented as a purge:** `ioRemoveRequests()` frees the request *node* but never `req->data`, and an art request also owns a cache entry that must be rolled back or the slot stays marked "load in flight" forever — the exact failure #437 fixed. The safe place to say no is *before the slot is ever claimed*.

## Fix 2 — bound the teardown drains

`deinit()`, `deinitEx()` and `miniDeinit()` called `ioBlockOps(1)`, which waits **unbounded**:

```c
int ioBlockOps(int block) { return ioBlockOpsTimed(block, -1); }
```

That's correct only if the queue is guaranteed to finish — and with an unbounded art producer it isn't. The NBD preflight already passes a bound for precisely this reason (*"so a request stuck on a removed/slow device fails the start instead of freezing after audio and pads have already been dismantled"*); the exit and launch paths never got one.

Abandoning a pending art read here is safe: every one of these callers is on its way to an IOP reset, and an art request only ever writes into its own cache entry.

## Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied
- Needs hardware to confirm the Exit hang and the save starvation are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)