### PR TITLE
rebuild-71: one-slot art caches, and four silent .tar failure paths

### DIFF
--- a/src/texcache.c
+++ b/src/texcache.c
@@ -42,23 +42,38 @@ static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *tex
     void *buffer;
     int result;
 
-    if (snprintf(name, sizeof(name), "%s_%s.png", value, suffix) >= (int)sizeof(name))
+    // EVERY failure below returns -1, and the caller then falls through to the loose-file lookup --
+    // which on a .tar-ONLY setup finds nothing and shows no art, with nothing logged to say why.
+    // A tester reported exactly that shape (covers from the archive, backgrounds and screenshots
+    // blank) and there was no way to tell which of these four branches fired. Each one now says so.
+    // Backgrounds and screenshots are several times the size of a cover, so the malloc is the branch
+    // most likely to be the culprit -- and it was the most silent.
+    if (snprintf(name, sizeof(name), "%s_%s.png", value, suffix) >= (int)sizeof(name)) {
+        LOG("ART TAR: key too long for %s_%s.png (max %d)\n", value, suffix, (int)sizeof(name) - 1);
         return -1;
+    }
 
     entry = tarFind(TAR_KIND_ART, name);
-    if (entry == NULL)
+    if (entry == NULL) {
+        LOG("ART TAR: '%s' not in the archive index\n", name);
         return -1;
+    }
 
     buffer = malloc(entry->rawSize);
-    if (buffer == NULL)
+    if (buffer == NULL) {
+        LOG("ART TAR: out of memory for '%s' (%u bytes)\n", name, entry->rawSize);
         return -1;
+    }
 
     if (tarRead(TAR_KIND_ART, entry, buffer, entry->rawSize) != entry->rawSize) {
+        LOG("ART TAR: short read for '%s' (%u bytes expected)\n", name, entry->rawSize);
         free(buffer);
         return -1;
     }
 
     result = texLoadFromMemory(texture, buffer, entry->rawSize);
+    if (result < 0)
+        LOG("ART TAR: '%s' found (%u bytes) but PNG decode failed (%d)\n", name, entry->rawSize, result);
     free(buffer);
     return result;
 }

--- a/src/themes.c
+++ b/src/themes.c
@@ -706,7 +706,17 @@ static mutable_image_t *initMutableImage(const char *themePath, config_set_t *th
         configGetStr(themeConfig, elemProp, &cachePattern);
         snprintf(elemProp, sizeof(elemProp), "%s_count", name);
         configGetInt(themeConfig, elemProp, &cacheCount);
-        if (cachePattern != NULL && strcmp(cachePattern, "COV") == 0 && cacheCount < 2)
+        // Floor EVERY per-game art cache at 2 slots, not just COV.
+        //
+        // A one-slot cache has no redundancy at all: the single slot is claimed, and if that one load
+        // fails for any transient reason the art type shows nothing until something else evicts it.
+        // COV was floored at 2 long ago for exactly this reason -- but BG, SCR and SCR2 are created
+        // with count 1 (the Background/GameImage defaults), which is why a tester with a .tar-only
+        // setup saw covers appear while backgrounds and screenshots stayed blank: covers had ten
+        // slots to absorb a hiccup and the others had one each.
+        // Cheap: an image_cache_t slot is a small struct, and the texture itself is only allocated
+        // when a load actually succeeds.
+        if (cachePattern != NULL && cacheCount < 2)
             cacheCount = 2;
         LOG("THEMES MutableImage %s: type: %s using cache pattern: %s count: %d\n", name, elementsType[type], cachePattern, cacheCount);
     }


### PR DESCRIPTION
Tester report: with all art inside `ART/art.tar` and **no loose files**, game **covers load** and **backgrounds, screenshots and disc art show nothing**. He concluded the `.tar` format was at fault.

It isn't — if the archive were unreadable, covers wouldn't work either.

And it isn't a routing problem either, which is what I assumed first and **was wrong about**: `BG`, `SCR`, `SCR2`, `ICO` *and* `COV` all reach the screen through the same `themes.c:807 cacheGetTexture` → `cacheLoadImage` → `artTarLoadImage` path, with the same key builder (`<startup>_<suffix>.png`). Nothing about the archive lookup is cover-specific.

## What *is* suffix-specific: cache depth

| suffix | slots |
|---|---|
| `COV` | 10 (icons 20) — **hard floor of 2** at `themes.c:709` |
| `BG` | **1** |
| `SCR` | **1** |
| `SCR2` | **1** |

**The three kinds that failed are precisely the three on one-slot caches.** A one-slot cache has no redundancy: the slot is claimed, and one transient failure leaves that art type blank — while a ten-slot cover cache absorbs the identical hiccup without a trace. `COV` was floored at 2 long ago for exactly this reason; nothing else was.

Now every per-game art cache is floored at 2. Cheap: a slot is a small struct, and the texture is only allocated when a load actually succeeds.

## Why I'm not calling that the proven root cause

Because all four failure paths in `artTarLoadImage` were **silent**:

| branch | was |
|---|---|
| key too long for the 64-byte buffer | `return -1` |
| not in the archive index | `return -1` |
| `malloc(rawSize)` failed | `return -1` |
| short read | `return -1` |
| PNG decode failed | returned the error |

Every one returns `-1`, and the caller falls through to the loose-file lookup — which on a tar-only setup finds nothing and shows nothing, with **no log line to say which branch fired**.

All five now log. Backgrounds and screenshots are several times the size of a cover, so the `malloc` is the branch most likely to be responsible — and it was the quietest. One run with a debug build will now *name* the culprit instead of us guessing, which is what this change is really for.

## Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied
- With `gEnableArtTar` off the tar branch is unreachable, exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)