### PR TITLE
rebuild-73: "Favourites" as the startup page was destroyed before it could be saved

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -2010,7 +2010,22 @@ void applyConfig(int themeID, int langID, int skipDeviceRefresh)
     // official-derived texcache does not have. Only the .tar half applies here.
     tarInvalidate(TAR_KIND_ART);
 
-    if (gDefaultDevice < 0 || gDefaultDevice > APP_MODE)
+    // The bound is FAV_MODE, not APP_MODE. The Game Sources picker offers six entries and the last
+    // of them is Favourites (guiShowDeviceConfig deviceNames[], byte-identical to the fork), so an
+    // APP_MODE bound silently rewrote the two choices ABOVE it -- Favourites and MMCE -- back to
+    // Apps, on every applyConfig AND every boot. Picking "Favourites" as the startup page snapped
+    // the row back to Apps before the value was ever written to the config: the whole feature was
+    // dead with its picker entry, its enum value and its config key all present. Data half without
+    // the code half, again.
+    if (gDefaultDevice < 0 || gDefaultDevice > FAV_MODE)
+        gDefaultDevice = APP_MODE;
+    // Favourites is a valid startup page only while the FAV tab is enabled; otherwise a stale
+    // choice would boot into a hidden tab with no way back to a visible one.
+    if (gDefaultDevice == FAV_MODE && !gFAVStartMode)
+        gDefaultDevice = APP_MODE;
+    // MMCE is checklist item 1 and its support module is a stub here, so it has no page to land on.
+    // The fork falls back TO MMCE_MODE; that target is wrong for this tree until item 1 lands.
+    if (gDefaultDevice == MMCE_MODE)
         gDefaultDevice = APP_MODE;
 
     guiUpdateScrollSpeed();


### PR DESCRIPTION
`applyConfig()` clamped the Default Menu with:

```c
if (gDefaultDevice < 0 || gDefaultDevice > APP_MODE)
    gDefaultDevice = APP_MODE;
```

But **`APP_MODE` is not the top of that picker.** `guiShowDeviceConfig` offers six entries — BDM, Network, HDD, Apps, MMCE, **Favourites** — and its `deviceNames[]` is byte-identical to the fork's. `FAV_MODE` and `MMCE_MODE` both sit **above** `APP_MODE` in the `iosupport.h` enum (also byte-identical to the fork's), so the two choices past Apps were rewritten back to Apps on **every `applyConfig` and every boot**.

Picking "Favourites" as the startup page snapped the row back to Apps *before the value was ever written to the config*. The picker entry, the enum value, the config key and the tab itself all exist and work — only the clamp bound was wrong.

Dead in exactly the shape this rebuild keeps producing: **data half present, code half not**, presenting as a lying settings row.

## Fix

Bound raised to `FAV_MODE`, with the fork's guard that Favourites is only a valid startup page while the FAV tab is enabled — otherwise a stale choice boots into a hidden tab with no visible page to return to.

**The fork falls back to `MMCE_MODE`. Deliberately not copied:** MMCE is checklist item 1 and its support module is a stub here, so it has no page to land on. `MMCE_MODE` is explicitly redirected to `APP_MODE` until item 1 lands.

Found by a tree-wide fork-vs-rebuild contract check (564 items examined, 49 confirmed gaps).

## Verification

- Builds clean in `ps2dev/ps2dev:latest` (`MAKE_EXIT=0`, no new warnings)
- `clang-format` 12 applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)