### PR TITLE
rebuild-84: Favourites re-sync, plasma blend colour, vmc_groups counts

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2372,14 +2372,26 @@ void guiDrawBGPlasma()
     if (ymax > PLASMA_H)
         ymax = PLASMA_H;
 
+    // plasma_blend_color (parity-audit #15): the gradient's LOW end, historically hardcoded black
+    // (the old expression fper*curbgColor>>8 lerps black->bgColor). Lerp blend->bgColor instead;
+    // the default black collapses to the exact old bytes (all terms non-negative there, and /256 of
+    // a non-negative int is exactly >>8). Signed intermediates: the delta goes negative when the
+    // blend is brighter than the tint -- divide instead of shifting (right-shift of a negative int
+    // is implementation-defined); the result stays in [0,255] without clamping (fper<=256,
+    // |delta|<=255: endpoints land exactly on blend / curbgColor). Every OTHER half of this feature
+    // -- the Colors-page picker, the theme key, the default, the struct field -- was already here;
+    // this loop was the one consumer that never read it, so the picker stored a colour the plasma
+    // never used.
+    const unsigned char *blend = gTheme->plasBlendColor;
+
     for (y = pery; y < ymax; y++) {
         for (x = 0; x < PLASMA_W; x++) {
             u32 fper = guiCalcPerlin((float)(2 * x) / PLASMA_W, (float)(2 * y) / PLASMA_H, perz) * 0x80 + 0x80;
 
             *buf = GS_SETREG_RGBA(
-                (u32)(fper * curbgColor[0]) >> 8,
-                (u32)(fper * curbgColor[1]) >> 8,
-                (u32)(fper * curbgColor[2]) >> 8,
+                (u32)(blend[0] + (((int)fper * ((int)curbgColor[0] - (int)blend[0])) / 256)),
+                (u32)(blend[1] + (((int)fper * ((int)curbgColor[1] - (int)blend[1])) / 256)),
+                (u32)(blend[2] + (((int)fper * ((int)curbgColor[2] - (int)blend[2])) / 256)),
                 0x80);
 
             ++buf;

--- a/src/opl.c
+++ b/src/opl.c
@@ -1051,8 +1051,15 @@ void menuDeferredUpdate(void *data)
         updateMenuFromGameList(mod);
 
         // If other modes have been updated, then the apps list should be updated too.
-        if (mod->support->mode != APP_MODE)
+        // Exclude FAV: a FAV rebuild marking apps dirty would re-trigger the FAV resync below
+        // (an apps refresh calls loadFavourites), looping forever once favNeedsUpdate fires.
+        if (mod->support->mode != APP_MODE && mod->support->mode != FAV_MODE)
             shouldAppsUpdate = 1;
+
+        // A source-list refresh may expose newly-loaded items to validate favourites
+        // against. Re-sync the FAV tab (cheap/idempotent; skipped when FAV is disabled).
+        if (gFAVStartMode && mod->support->mode != FAV_MODE)
+            loadFavourites();
     }
 }
 

--- a/src/vmc_groups.c
+++ b/src/vmc_groups.c
@@ -1150,12 +1150,12 @@ static const char *titles_XEBP_100_72[] = {
     "SLPM_625.25",
     "SLKA_150.45",
     "SLPM_626.38"};
-static const size_t count_XEBP_100_72 = sizeof(titles_XEBP_100_71) / sizeof(titles_XEBP_100_72[0]);
+static const size_t count_XEBP_100_72 = sizeof(titles_XEBP_100_72) / sizeof(titles_XEBP_100_72[0]); // was sizeof(titles_XEBP_100_71): copy-paste numerator overstated the count and walked past the array
 
 static const char *titles_XEBP_100_73[] = {
     "SLPM_651.76",
     "SLPM_652.06"};
-static const size_t count_XEBP_100_73 = sizeof(titles_XEBP_100_71) / sizeof(titles_XEBP_100_73[0]);
+static const size_t count_XEBP_100_73 = sizeof(titles_XEBP_100_73) / sizeof(titles_XEBP_100_73[0]); // was sizeof(titles_XEBP_100_71): copy-paste numerator overstated the count and walked past the array
 
 static const char *titles_XEBP_100_74[] = {
     "SLUS_206.36",
@@ -1169,7 +1169,7 @@ static const char *titles_XEBP_100_74[] = {
     "SLES_535.27",
     "SLED_536.27",
     "SLES_536.26"};
-static const size_t count_XEBP_100_74 = sizeof(titles_XEBP_100_71) / sizeof(titles_XEBP_100_74[0]);
+static const size_t count_XEBP_100_74 = sizeof(titles_XEBP_100_74) / sizeof(titles_XEBP_100_74[0]); // was sizeof(titles_XEBP_100_71): copy-paste numerator overstated the count and walked past the array
 
 static const char *titles_XEBP_100_75[] = {
     "SLUS_205.65",
@@ -1177,7 +1177,7 @@ static const char *titles_XEBP_100_75[] = {
     "SLES_523.25",
     "SLUS_209.73",
     "SLES_530.39"};
-static const size_t count_XEBP_100_75 = sizeof(titles_XEBP_100_71) / sizeof(titles_XEBP_100_75[0]);
+static const size_t count_XEBP_100_75 = sizeof(titles_XEBP_100_75) / sizeof(titles_XEBP_100_75[0]); // was sizeof(titles_XEBP_100_71): copy-paste numerator overstated the count and walked past the array
 
 static const char *titles_XEBP_000_01[] = {
     "SLES_820.36",


### PR DESCRIPTION
Three more from the verified BRING ledger.

1. **Favourites re-sync** (fork parity) — `menuDeferredUpdate` never re-validated the FAV tab after a source device's list refreshed. Ported with the fork's loop guard intact: FAV must not mark apps dirty, because an apps refresh itself calls `loadFavourites` — without the guard the pair re-trigger each other forever once `favNeedsUpdate` fires.
2. **Plasma blend colour** (parity-audit #15) — every half existed (picker, theme key, struct field, default) except the one consumer: `guiDrawBGPlasma` still lerped black→bgColor, so the picker stored a colour the renderer never read. Fork's lerp ported verbatim: signed intermediates with `/256` (right-shifting a negative is implementation-defined), exact endpoints, default black collapses to the historical bytes so untouched themes render identically.
3. **`vmc_groups` counts** — four copy-paste numerators divided `sizeof(titles_XEBP_100_71)` by other arrays' element sizes; where the 71 table is byte-larger (73: 2 real entries, count claimed ~15) the group walk read past the array. Each numerator now names its own array.

## Verification
- Builds clean before and after formatting (`MAKE_EXIT=0`); `clang-format` 12; NUL-scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)