### PR TITLE
rebuild-85: presses during a screen fade no longer vanish (fork's edge-baseline freeze)

### DIFF
--- a/include/pad.h
+++ b/include/pad.h
@@ -45,6 +45,11 @@ void padStoreSettings(int *buffer);
 /** Restore's the button delay from specified integer array (has to have 16 items) */
 void padRestoreSettings(int *buffer);
 
+/** During a screen transition, seed and freeze the key-on baseline with the triggering sample.
+ * This prevents the trigger from replaying on the destination while preserving a different button
+ * that is still held when the destination appears. */
+void padFreezeEdgeBaseline(int freeze);
+
 /** Starts a menu rumble pulse on every connected pad that has actuators.
  * @param durationMs pulse length in ms (clamped internally)
  * @param large large-engine strength 0..255; the small engine runs for the whole pulse */

--- a/src/gui.c
+++ b/src/gui.c
@@ -2571,6 +2571,11 @@ static void guiDrawOverlays()
 
 static void guiReadPads()
 {
+    // A transition polls without dispatching input. Freeze against the triggering sample so that
+    // button cannot replay on the destination, while a different button held through the fade can
+    // still register there (see padFreezeEdgeBaseline in pad.c -- deliberately NOT a poll pause).
+    padFreezeEdgeBaseline(screenHandlerTarget != NULL);
+
     if (readPads())
         guiInactiveFrames = 0;
     else

--- a/src/pad.c
+++ b/src/pad.c
@@ -469,11 +469,34 @@ void padRumble(int durationMs, int large)
         padActSet(&pad_data[i], 1, large);
 }
 
+/* Screen-transition edge freeze. During the fade the main loop polls pads but dispatches no input,
+ * so every key-on edge that fires inside the fade is consumed unseen: a button pressed during the
+ * ~26-frame transition simply vanished, and one HELD across it never registered on the destination
+ * (its edge was already burned). Freezing the key-on BASELINE for the fade's duration fixes the
+ * held case -- the destination's first dispatched frame still sees old=0 for that button -- while
+ * seeding the baseline from the transition-TRIGGERING sample on entry keeps that button from
+ * replaying on the destination. A tap pressed and released entirely inside the fade remains
+ * intentionally ignored. Polling itself continues (rumble timing, pad state, reconnects).
+ * NOT a poll pause: pausing readPads() outright was tried and latches the pre-transition sample,
+ * which re-triggers handlers in a loop on arrival. */
+static int edgeBaselineFrozen = 0;
+
+void padFreezeEdgeBaseline(int freeze)
+{
+    int next = freeze ? 1 : 0;
+
+    if (next && !edgeBaselineFrozen)
+        oldpaddata = paddata; // seed with the triggering sample so it cannot replay
+
+    edgeBaselineFrozen = next;
+}
+
 /** polling method. Call every frame. */
 int readPads()
 {
     int i;
-    oldpaddata = paddata;
+    if (!edgeBaselineFrozen)
+        oldpaddata = paddata;
     paddata = 0;
 
     // in ms.


### PR DESCRIPTION
During the ~26-frame screen transition the main loop polls pads but dispatches no input, so every key-on edge fired inside the fade was consumed unseen: a press during the fade vanished, and a button **held** across it never registered on the destination (its edge was already burned). Direct contributor to the "dropped inputs" family under #340.

This is the fork's `padFreezeEdgeBaseline`, ported faithfully:

- `guiReadPads()` freezes the key-on **baseline** while a transition is in flight; `readPads()` stops advancing `oldpaddata` while frozen — a button held through the fade still reads as newly-pressed on the destination's first dispatched frame
- entering the freeze **seeds** the baseline from the transition-*triggering* sample, so the trigger can't replay on the destination
- a tap fully inside the fade stays intentionally ignored; **polling itself continues** (rumble timing, pad state, reconnects)

Explicitly **not** the naive version: pausing `guiReadPads()` outright was tried in the broken run and latches the pre-transition sample, re-triggering handlers in a loop on arrival — the games-list freeze that forced its same-day revert. Freeze the *baseline*, keep *polling* — that distinction is the entire fix, which is why this lands as its own isolated, hardware-testable step.

## Verification
- Builds clean before/after formatting (`MAKE_EXIT=0`); `clang-format` 12
- Needs hardware: press-during-fade and hold-across-fade both want a real pad

🤖 Generated with [Claude Code](https://claude.com/claude-code)