### PR TITLE
rebuild-87: existing installs keep their settings -- legacy mc?:OPL read fallback

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1363,6 +1363,26 @@ static int tryAlternateDevice(int types)
     // settings are strictly homed to gBootDir. Never probe alternate devices (mass0:/hdd0:) or hijack
     // the save location away from CWD/Memory Card.
     if (gBootDir[0] != '\0') {
+        // LEGACY READ-ONLY FALLBACK. Every build before the CWD doctrine -- ours and official alike
+        // -- homed settings at mc?:OPL, so every existing install's config lives THERE, not beside
+        // the ELF. Without this, upgrading silently reset every user to defaults (reported from
+        // hardware as "it didn't read my settings" and "everything is slow like it used to be" --
+        // stock art delay and scroll speed are literally the old feel). The user's setup did not
+        // change; we moved where we look, so we keep looking in the old place too.
+        //
+        // READ ONLY, and only the mc?:OPL home -- never other devices (that hijack is what the
+        // strict homing exists to prevent). The home is moved straight back to the boot dir, so
+        // the very first save writes the config BESIDE THE ELF and this fallback goes quiet for
+        // good: read-old, write-new, self-migrating. The load toast names the boot device rather
+        // than the card on the one boot that reads legacy -- the save-location toast telling the
+        // truth matters more, and after the first save the two agree anyway.
+        if (sysCheckMC() >= 0) {
+            configSetMove(NULL); // point the config files at the legacy mc?:OPL home
+            value = configReadMulti(types);
+            configSetMove(gBootDir); // home (and notifications) back on the boot dir: saves self-migrate
+            if (value & CONFIG_OPL)
+                return value;
+        }
         configPrepareNotifications(gBootDir);
         showCfgPopup = 0;
         return 0;


### PR DESCRIPTION
The CWD settings doctrine (rebuild-68) orphaned every existing install: all prior builds — ours and official alike — homed settings at `mc?:/OPL/`, so that's where every user's config actually lives. Moving the home without a read fallback silently reset everyone to defaults on upgrade. The hardware reports said it twice: *"it didn't read my settings in mc0"*, then *"everything is slow and delay-y like it used to be"* — which is exactly what stock art delay + stock scroll speed feel like when your tuning stops loading.

**The user's setup never changed; the build changed. Our regression, fixed in code — not by asking users to move files.**

## The fix: read old, write new

- Boot dir has no config → read the legacy `mc?:/OPL/` home. **Only** that home — never other devices (the `mass0:` hijack is what strict homing exists to prevent)
- The home moves straight back to the boot dir before returning, so the **first save writes the config beside the ELF** — the fallback then never fires again. Self-migrating, one boot
- Custom Settings Path still takes precedence (unchanged, runs first)
- Booting *from* `mc?:/OPL/` is naturally a no-op
- The `?` wildcard resolves through the same `checkFile` digit substitution every legacy build read with

One honest wrinkle, documented in place: on the single boot that reads legacy, the load toast names the boot device rather than the card — the save-location toast telling the truth matters more, and after the first save they agree.

## Verification
- Builds clean before/after formatting (`MAKE_EXIT=0`); `clang-format` 12; NUL-scan clean
- Hardware test is the real one: an untouched existing install should boot with its own settings and feel identical to rebuild-66

🤖 Generated with [Claude Code](https://claude.com/claude-code)