### PR TITLE
rebuild-88: the render fast path pays for the fail memo no more

### DIFF
--- a/src/texcache.c
+++ b/src/texcache.c
@@ -257,10 +257,12 @@ GSTEXTURE *cacheGetTexture(image_cache_t *cache, item_list_t *list, int *cacheId
     if (cache == NULL || list == NULL || cacheId == NULL || UID == NULL || value == NULL || value[0] == '\0')
         return NULL;
 
-    if (cacheIsFailMemo(value, cache->suffix)) {
-        *cacheId = -2;
-        return NULL;
-    }
+    // NO memo lookup here. This function runs for EVERY art element on screen EVERY frame --
+    // including covers that are already loaded and rendering -- and the memo check costs a
+    // snprintf + hash + strcmp. Placed here it taxed every cached frame (dozens of format-string
+    // calls per frame on a 294 MHz CPU); the fast path below must stay a couple of integer
+    // compares, exactly what the hardware-validated builds did. The memo is consulted at the
+    // ENQUEUE decision instead -- the only place it saves anything real (an IO attempt).
 
     if (*cacheId == -2) {
         return NULL;
@@ -283,6 +285,14 @@ GSTEXTURE *cacheGetTexture(image_cache_t *cache, item_list_t *list, int *cacheId
 
     // under the cache pre-delay (to avoid filling cache while moving around)
     if (guiInactiveFrames < list->delay)
+        return NULL;
+
+    // Known-missing art: skip the slot claim and the IO attempt entirely. Reached only for rows
+    // with no live cache entry, after the idle delay -- i.e. exactly where the old code would have
+    // issued a doomed open(); the memo is strictly cheaper than the IO it replaces. The row's
+    // cacheId stays -1, so once the memo is cleared (applyConfig / list rebuild) it retries
+    // naturally.
+    if (cacheIsFailMemo(value, cache->suffix))
         return NULL;
 
     cache_entry_t *currEntry, *oldestEntry = NULL;


### PR DESCRIPTION
Steelmanning the maintainer's doubt about the "slow and delay-y" hardware report produced exactly **one** engine-side candidate in the good-build→judged-build delta, and it's real.

The missing-art memo check sat at the **top** of `cacheGetTexture` — which runs for **every art element on screen, every frame**, including covers already loaded and rendering. Each call: a `snprintf` (format-string parsing), a hash walk, a `strcmp`. With coverflow covers + background + icons on screen, that's dozens of format-string calls per frame on a 294 MHz CPU — taxing precisely the frames that used to cost **two integer compares** on the hardware-validated builds.

## Fix

The memo moves to the **enqueue decision**: after the idle-delay gate, only for rows with no live cache entry — exactly where the old code would have issued a doomed `open()`. There it's strictly *cheaper* than the IO it replaces, and the fast path is bit-equivalent to the good build again.

Bonus: rows skipped by the memo keep `cacheId == -1`, so they retry naturally once the memo clears (applyConfig / list rebuild) — mildly better than the old form, which `-2`-latched them until a full rebuild.

With this + the legacy settings read (#456) in one build, **both credible explanations for the hardware report are eliminated at once**. If hardware still says slow, the good→current differential contains nothing but pointer-guard checks — and the next step is instrumentation, not theory.

## Verification
- Builds clean before/after formatting (`MAKE_EXIT=0`); `clang-format` 12; NUL-scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)