### PR TITLE
rebuild-91: UDPFS never had a VCD view -- its whole VCD surface was gated dead

### DIFF
--- a/include/ioman.h
+++ b/include/ioman.h
@@ -10,6 +10,7 @@
 #define IO_ERR_DUPLICIT_HANDLER     -3
 #define IO_ERR_INVALID_HANDLER      -4
 #define IO_ERR_IO_BLOCKED           -5
+#define IO_ERR_TOO_MANY_REQUESTS    -6 // request-node allocation failed (fork parity)
 
 typedef void (*io_request_handler_t)(void *request);
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -1978,6 +1978,11 @@ int guiDeferUpdate(struct gui_update_t *op)
     WaitSema(gSemaId);
 
     struct gui_update_list_t *up = (struct gui_update_list_t *)malloc(sizeof(struct gui_update_list_t));
+    if (!up) {
+        /* OOM: release the semaphore so future callers are not permanently locked out */
+        SignalSema(gSemaId);
+        return -1;
+    }
     up->item = op;
     up->next = NULL;
 

--- a/src/ioman.c
+++ b/src/ioman.c
@@ -62,17 +62,25 @@ int ioRegisterHandler(int type, io_request_handler_t handler)
 {
     WaitSema(gProcSemaId);
 
-    if (handler == NULL)
+    // Every early return below must release gProcSemaId, otherwise a registration
+    // failure leaves the semaphore held and deadlocks the entire I/O subsystem.
+    if (handler == NULL) {
+        SignalSema(gProcSemaId);
         return IO_ERR_INVALID_HANDLER;
+    }
 
-    if (gHandlerCount >= MAX_IO_HANDLERS)
+    if (gHandlerCount >= MAX_IO_HANDLERS) {
+        SignalSema(gProcSemaId);
         return IO_ERR_TOO_MANY_HANDLERS;
+    }
 
     int i;
 
     for (i = 0; i < gHandlerCount; ++i) {
-        if (gRequestHandlers[i].type == type)
+        if (gRequestHandlers[i].type == type) {
+            SignalSema(gProcSemaId);
             return IO_ERR_DUPLICIT_HANDLER;
+        }
     }
 
     gRequestHandlers[gHandlerCount].type = type;
@@ -215,17 +223,20 @@ int ioPutRequest(int type, void *data)
 
     // We don't have to lock the tip of the queue...
     // If it exists, it won't be touched, if it does not exist, it is not being processed
-    struct io_request_t *req = gReqEnd;
-
+    // Allocate FIRST and bail cleanly on OOM (fork parity): the old shape malloc'd straight into
+    // gReqList/gReqEnd->next and then dereferenced the result, so an allocation failure was a NULL
+    // write plus a corrupted queue tail -- with the semaphore held.
+    struct io_request_t *req = (struct io_request_t *)malloc(sizeof(struct io_request_t));
     if (!req) {
-        gReqList = (struct io_request_t *)malloc(sizeof(struct io_request_t));
-        req = gReqList;
-        gReqEnd = gReqList;
-    } else {
-        req->next = (struct io_request_t *)malloc(sizeof(struct io_request_t));
-        req = req->next;
-        gReqEnd = req;
+        SignalSema(gEndSemaId);
+        return IO_ERR_TOO_MANY_REQUESTS;
     }
+
+    if (!gReqEnd)
+        gReqList = req;
+    else
+        gReqEnd->next = req;
+    gReqEnd = req;
 
     req->next = NULL;
     req->type = type;

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -401,7 +401,15 @@ int vcdModeSupported(int mode)
     // FAV_MODE has its own L3 ISO<->VCD view too: the Favourites tab swaps between disc favourites and
     // PS1/.VCD favourites (favsupport filters its list by vcdViewActive(FAV_MODE)). Its vcdView slot is
     // independent of any device's, so toggling Favourites never disturbs a device page's view.
-    return (mode >= BDM_MODE && mode <= BDM_MODE_LAST) || mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE;
+    // UDPFS_MODE was MISSING from this list -- in the fork too (a latent bug there, masked because
+    // VCD was mostly used on BDM/HDD pages). Since this predicate is the FIRST gate in
+    // itemExecToggleView AND the L3 hint condition, its absence made the page's entire shipped VCD
+    // surface unreachable dead code: udpfssupport.c's vcdFillGameList call, the POPS cover
+    // fallback, and the POPSTARTER launch guard (which safely refuses the actual launch with a
+    // toast -- network filesystems cannot host a POPSTARTER handoff, but LISTING the library is
+    // exactly what the code was written to do). First deliberate divergence from the fork's
+    // vcdsupport.c, and it is a fix, not a drift.
+    return (mode >= BDM_MODE && mode <= BDM_MODE_LAST) || mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE || mode == UDPFS_MODE;
 }
 
 int vcdViewActive(int mode)


### PR DESCRIPTION
Hunted by a 5-lens adversarial sweep for the *"L3 shows ISO list"* hardware report. **Eighteen** candidate mechanisms were refuted with the fork open beside each — dirty-flag eating, queue starvation, shared-array republish, OOM paths, memo-wipe churn, all dead on quantified reasoning now on the record. The survivor was hiding in one refutation's evidence:

**`vcdModeSupported()` does not include `UDPFS_MODE`.**

That predicate is the *first* gate in `itemExecToggleView` — before the view flip, before the toast — **and** the condition for showing the L3 hint. So on the UDPFS page L3 is a silent no-op, and the page's entire shipped VCD surface is unreachable dead code: the `vcdFillGameList` call, per-view art keying, POPS cover fallback, and the POPSTARTER launch guard. **Ten call sites dead behind one missing enum check.** The half-landed shape again — except this one is **byte-identical in the fork**: a latent fork bug, masked there because VCD was mostly exercised on BDM/HDD pages. First deliberate divergence from the fork's `vcdsupport.c`, and it's a fix, not drift.

Listing is what that code was written for; *launching* a VCD from a network filesystem is still refused cleanly by the existing `udpfsLaunchVcd` guard.

## Plus three fork-verbatim hardening backports the sweep verified while clearing the queue machinery

- `guiDeferUpdate`: OOM no longer leaves `gSemaId` held forever (permanent GUI-op lockout) or derefs a NULL node
- `ioRegisterHandler`: every early return now releases `gProcSemaId` — a failed registration deadlocked the whole IO subsystem
- `ioPutRequest`: allocate-first with a clean `IO_ERR_TOO_MANY_REQUESTS` bail — the old shape malloc'd straight into the queue tail and dereferenced the result

## Honest scope note

The report says BDM/HDD pages also failed to switch — **this commit cannot account for those** (they pass the gate). Two hardware questions are in flight that split the remaining space: the Default Game View setting's current value, and whether the toast appears on a BDM page at all. No speculative fixes for that half until they answer.

## Verification
- Builds clean before/after formatting; `clang-format` 12; NUL-scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)