### PR TITLE
rebuild-93: settle-time per-game CFG read no longer freezes the GUI

### DIFF
--- a/src/menusys.c
+++ b/src/menusys.c
@@ -177,6 +177,12 @@ static void menuDeleteGame(submenu_list_t **submenu)
         guiMsgBox("NULL Support object. Please report", 0, NULL);
 }
 
+// Waited-on load (the DIALOG path: menuLoadConfig / gameMenuLoadConfig). Deliberately keeps the
+// original shape -- the read runs UNDER menuSemaId -- because a caller is blocked in
+// guiHandleDeferedIO on actionStatus and will hand whatever this publishes straight to
+// itemLaunch()/guiGameLoadConfig(), neither of which tolerates a NULL config_set_t. Publishing
+// unconditionally is what makes that safe, and the caller already shows a "loading settings"
+// overlay, so the brief freeze here is by design and pre-existing.
 static void _menuLoadConfig()
 {
     WaitSema(menuSemaId);
@@ -186,6 +192,50 @@ static void _menuLoadConfig()
     }
     actionStatus = 0;
     SignalSema(menuSemaId);
+}
+
+// Browse-time load (the SETTLE path: menuRenderElements -> _menuRequestConfig each frame). NOBODY
+// waits on this one -- actionStatus is already 0 on that path -- so it can afford to do the read
+// OUTSIDE menuSemaId, which is the whole point: menuRenderElements takes that sema every frame,
+// and itemGetConfig is a per-game CFG open/read on the game's device, so holding it across the read
+// froze rendering and input for the entire read every time the cursor settled on a row (visible on
+// a slow USB stick with art off; worse with art on, when the same device is also serving covers).
+// Snapshot under the sema, read outside it, re-check and publish under it again -- the same shape
+// as _menuResolveInfoSize below.
+static void _menuLoadConfigAsync()
+{
+    item_list_t *list = NULL;
+    config_set_t *loadedConfig = NULL;
+    int configId = -1;
+
+    WaitSema(menuSemaId);
+    if (itemConfig == NULL && selected_item != NULL && selected_item->item != NULL && itemConfigId >= 0) {
+        list = selected_item->item->userdata;
+        configId = itemConfigId;
+    }
+    SignalSema(menuSemaId);
+
+    // Nothing wanted (already cached, or the id was invalidated while this request sat in the
+    // queue). Deliberately does NOT touch actionStatus: this variant is only ever queued when no
+    // waiter exists, and a dialog that armed one in the meantime queues its own _menuLoadConfig.
+    if (list == NULL)
+        return;
+
+    loadedConfig = list->itemGetConfig(list, configId);
+
+    // Publish only if this is still exactly what the menu wants. The id alone is NOT enough: ids are
+    // per-list indices, so a tab switch mid-read yields the same number from a different device --
+    // re-check the owning list too, or device A's per-game config lands on device B's row.
+    WaitSema(menuSemaId);
+    if (loadedConfig != NULL && itemConfig == NULL && itemConfigId == configId &&
+        selected_item != NULL && selected_item->item != NULL && selected_item->item->userdata == list) {
+        itemConfig = loadedConfig;
+        loadedConfig = NULL;
+    }
+    SignalSema(menuSemaId);
+
+    if (loadedConfig != NULL)
+        configFree(loadedConfig); // lost the race -- drop it, never publish another row's config
 }
 
 // Opening the info screen needs #Size, which the scroll-time config load deliberately skips
@@ -268,8 +318,13 @@ static void _menuSaveConfig()
 static void _menuRequestConfig()
 {
     int shouldQueueLoad = 0;
+    int waiterPending;
 
     WaitSema(menuSemaId);
+    // Which load variant to queue. A waiter (dialog path) needs the publish-unconditionally
+    // in-sema load; the browse/settle path has none and gets the async one that keeps the sema
+    // free across the device read. Read under the sema with everything else it decides on.
+    waiterPending = (actionStatus != 0);
     if (selected_item == NULL || selected_item->item == NULL || selected_item->item->current == NULL) {
         // The list can be rebuilt out from under us between the GUI's check and this callback.
         actionStatus = 0;
@@ -291,8 +346,8 @@ static void _menuRequestConfig()
 
     SignalSema(menuSemaId);
 
-    // Queue OUTSIDE the sema: _menuLoadConfig takes it too.
-    if (shouldQueueLoad && ioPutRequest(IO_CUSTOM_SIMPLEACTION, &_menuLoadConfig) != IO_OK) {
+    // Queue OUTSIDE the sema: both load variants take it too.
+    if (shouldQueueLoad && ioPutRequest(IO_CUSTOM_SIMPLEACTION, waiterPending ? (void *)&_menuLoadConfig : (void *)&_menuLoadConfigAsync) != IO_OK) {
         WaitSema(menuSemaId);
         if (itemConfig == NULL)
             itemConfigId = -1; // let the next pass retry rather than caching a row that never loaded

--- a/src/pad.c
+++ b/src/pad.c
@@ -40,7 +40,7 @@ struct pad_data_t
     char actAlign[6];
     int actuators;
     int actAligned; // padSetActAlign confirmed; see padRumbleRealign()
-    int needsInit;  // reconnect-edge re-init pending; runs once the idle gate opens (see readPad)
+    int needsInit;  // reconnect-edge re-init pending; runs once the verified-idle gate opens (see readPads)
 };
 
 /// current time in miliseconds (last update time)
@@ -93,12 +93,21 @@ static int isPadReadyState(int state)
 #define PAD_WAIT_POLLS   25
 #define PAD_WAIT_POLL_US 1000
 
-// Milliseconds without any registered input before a reconnect-edge initializePad() may run
-// (#271/#272). The init is a few hundred ms of polled waits on the GUI thread, and its trigger --
-// freepad dropping the pad under SIO2 contention -- fires exactly while the user is navigating.
-// Maintained in readPads(); resets on any pressed button. A wrap-garbage time_since_last sample
-// only ever makes the counter LARGER (more idle), which opens the gate early -- benign.
-#define PAD_SELF_HEAL_IDLE_MS 1000
+// Milliseconds of continuously VERIFIED idle -- clean, zero-input polls -- before a reconnect-edge
+// initializePad() may run (#271/#272). The init is a few hundred ms of polled waits on the GUI
+// thread, and its trigger -- freepad dropping the pad under IOP/SIO2 load -- fires exactly while
+// the user is navigating. CRITICAL: failed reads and state transitions are UNKNOWN, never evidence
+// of idleness. readPads() zeroes paddata every poll and only a successful read repopulates it, so
+// an idle clock fed by bare `paddata == 0` counts the very read starvation that flapped the pad as
+// a quiet user -- the init then fires over the user's next press, its own pad-bus traffic causes
+// more misses, and the loop self-sustains as a ~1 s cadence of 300-900 ms input blackouts (the USB
+// "one move per second" hardware report; master's f0b039a6/fcb00dd8 measured the same shape). The
+// gate therefore advances only on polls where every attempted read succeeded (readPad's pollClean),
+// and an inter-poll gap above PAD_IDLE_MAX_CLEAN_GAP_MS breaks the run: gap time is unobserved, and
+// this also swallows the once-per-~29 s time_since_last wrap sample, which previously opened the
+// gate in a single step.
+#define PAD_SELF_HEAL_IDLE_MS     1000
+#define PAD_IDLE_MAX_CLEAN_GAP_MS 100
 static u32 padIdleMs = 0;
 
 /*
@@ -298,7 +307,11 @@ static u32 readLeftJoy(struct pad_data_t *pad, u32 pdata)
     return padData;
 }
 
-static int readPad(struct pad_data_t *pad)
+// pollClean is the self-heal gate's evidence stream (see PAD_SELF_HEAL_IDLE_MS): cleared when this
+// pad's tracked state changed this poll, or when its ATTEMPTED native read failed to deliver a
+// sample. A port sitting stably disconnected attempts no read and stays clean, so an unused
+// controller slot can never hold the gate shut.
+static int readPad(struct pad_data_t *pad, int *pollClean)
 {
     int rcode = 0, oldState, newState, ret, padsRead;
     u32 newpdata = 0;
@@ -308,13 +321,14 @@ static int readPad(struct pad_data_t *pad)
     newState = padGetState(pad->port, pad->slot);
     updatePadState(pad, newState);
     if ((oldState == PAD_STATE_DISCONN) && isPadReadyState(pad->state)) {
-        // Pad just connected. DEFER the re-init behind the idle gate below rather than running it
-        // inline: reconnect edges are DRIVEN by the read errors that cluster under SIO2 load
-        // (loading mx4sio_bd, MMCE traffic), so ungated this fired precisely while the user was
-        // navigating, spending the init's polled waits ON THE GUI THREAD mid-input (#271/#272).
-        // A not-yet-initialised pad still reads every d-pad press in digital mode, so deferring
-        // costs nothing the user can feel; a genuinely fresh plug-in is idle by definition and
-        // initialises on the next frame.
+        // Pad just connected. DEFER the re-init behind the verified-idle gate in readPads() rather
+        // than running it inline: reconnect edges are DRIVEN by the read errors that cluster under
+        // IOP/SIO2 load (loading mx4sio_bd, MMCE traffic, USB bulk reads), so ungated this fired
+        // precisely while the user was navigating, spending the init's polled waits ON THE GUI
+        // THREAD mid-input (#271/#272). A not-yet-initialised pad still reads every d-pad press in
+        // digital mode, so deferring costs little the user can feel; a genuinely fresh plug-in
+        // initialises after the next verified-quiet second (analog/rumble return then, not on the
+        // edge poll itself -- the edge is a state transition, which restarts the quiet clock).
         LOG("PAD pad %d,%d connected\n", pad->port, pad->slot);
         pad->needsInit = 1;
     }
@@ -323,10 +337,9 @@ static int readPad(struct pad_data_t *pad)
         LOG("PAD pad %d,%d disconnected\n", pad->port, pad->slot);
     }
 
-    if (pad->needsInit && isPadReadyState(pad->state) && padIdleMs >= PAD_SELF_HEAL_IDLE_MS) {
-        pad->needsInit = 0;
-        initializePad(pad);
-    }
+    // A tracked-state transition proves nothing about the user: the gate must restart its count.
+    if (oldState != pad->state)
+        *pollClean = 0;
 
     if ((pad->state == PAD_STATE_STABLE) || (pad->state == PAD_STATE_FINDCTP1)) {
         // pad is connected. Read pad button information.
@@ -335,6 +348,12 @@ static int readPad(struct pad_data_t *pad)
         if (ret != 0) {
             newpdata = 0xffff ^ pad->buttons.btns;
             padsRead++;
+        } else {
+            // An attempted read that FAILED is unknown, never idle -- these misses are exactly what
+            // clusters with the reconnect flaps under IOP load. Native-only on purpose: the init
+            // this gates is native-pad setup, and a native miss must mark the poll unclean even
+            // when a ds34 source below delivers a valid sample.
+            *pollClean = 0;
         }
     }
 
@@ -537,6 +556,8 @@ void padFreezeEdgeBaseline(int freeze)
 int readPads()
 {
     int i;
+    int pollClean = 1;
+
     if (!edgeBaselineFrozen)
         oldpaddata = paddata;
     paddata = 0;
@@ -549,14 +570,31 @@ int readPads()
     int rslt = 0;
 
     for (i = 0; i < pad_count; ++i) {
-        rslt |= readPad(&pad_data[i]);
+        rslt |= readPad(&pad_data[i], &pollClean);
     }
 
-    // Idle clock for the reconnect-edge self-heal gate (see PAD_SELF_HEAL_IDLE_MS).
-    if (paddata)
+    // Idle clock for the reconnect-edge self-heal gate (see PAD_SELF_HEAL_IDLE_MS). Only a clean,
+    // zero-input, gap-free poll counts: misses and transitions are unknown, and an inter-poll gap
+    // above the bound is unobserved time that must not be credited as a quiet user.
+    if (!pollClean || paddata || time_since_last > PAD_IDLE_MAX_CLEAN_GAP_MS)
         padIdleMs = 0;
-    else
+    else if (padIdleMs < PAD_SELF_HEAL_IDLE_MS)
         padIdleMs += time_since_last;
+
+    // Deferred reconnect re-init, decided AFTER this poll's samples -- the old shape decided before
+    // them, so the press arriving with this very poll could not veto the init that then ate it.
+    // One init per verified-quiet run: the reset makes the next pending pad re-earn a full quiet
+    // second, so multiple reconnects cannot stack their bounded waits into one long blackout.
+    if (pollClean && !paddata && padIdleMs >= PAD_SELF_HEAL_IDLE_MS) {
+        for (i = 0; i < pad_count; ++i) {
+            if (pad_data[i].needsInit && isPadReadyState(pad_data[i].state)) {
+                pad_data[i].needsInit = 0;
+                padIdleMs = 0;
+                initializePad(&pad_data[i]);
+                break;
+            }
+        }
+    }
 
     // Rumble decay + re-send. Unsigned elapsed in RAW ticks -- see the note above padActSet().
     // The re-send is not redundant: freepad drops padSetActDirect outside TASK_UPDATE_PAD and still
@@ -724,6 +762,11 @@ int startPads()
     // scan for pads that exist... at least one has to be present
     pad_count = 0;
 
+    // Fresh pad session -- boot, and again after the NBD server's IOP reset re-enters here
+    // in-process. Stale idle credit or a stale deferred-init flag from the previous session must
+    // not queue work against the new one (startPad() below runs initializePad() itself).
+    padIdleMs = 0;
+
     int maxports = padGetPortMax();
 
     int port; // 0 -> Connector 1, 1 -> Connector 2
@@ -739,6 +782,7 @@ int startPads()
             cpad->port = port;
             cpad->slot = slot;
             cpad->state = PAD_STATE_DISCONN;
+            cpad->needsInit = 0;
 
             if (startPad(cpad))
                 ++pad_count;


### PR DESCRIPTION
Stacks on [#461](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/461) (rebuild-92), so this branch's artifact carries **both** fixes: the verified-idle pad gate and this one.

## What the hardware bisect established

Testing this session went all the way down the rebuild history, and the conclusion inverted the premise we started from:

| Build | Stop-on-title, art off |
|---|---|
| official base (unmodified upstream, our CI toolchain) | hangs — **worst of all** |
| rebuild-34 / rebuild-50 / rebuild-66 | hangs |
| rebuild-92 | hangs (scroll stall fixed) |

So the settle freeze is **not a rebuild regression** — it is inherited upstream behavior, and our rebuild-66 was simply the best-navigating build anyone had. There is no good baseline to return to; it has to be fixed by design. (The earlier "rebuild-66 was clean" report was about scrolling, not settling.)

## Mechanism

`_menuRequestConfig()` queues a per-game config load the instant the cursor settles, and `_menuLoadConfig()` holds `menuSemaId` across `list->itemGetConfig()` — a `CFG/<id>.cfg` open+read on the game's device. The GUI thread takes that same semaphore **every frame** in `menuRenderElements()`, around the whole draw loop. One settle parks rendering and input for the entire device read; on a slow USB stick that is the visible hang, and with art on the same device is also serving covers, stretching the window.

## The change

Split the load by whether anyone is waiting on it, because the two callers have irreconcilable requirements:

- **`_menuLoadConfig`** (dialog path — `menuLoadConfig`/`gameMenuLoadConfig`) keeps the original in-sema shape and unconditional publish. Its caller is blocked in `guiHandleDeferedIO` and hands the result straight to `itemLaunch()`/`guiGameLoadConfig()`, neither of which tolerates a NULL `config_set_t`. It already shows a "loading settings" overlay, so its brief freeze is by design and unchanged.
- **`_menuLoadConfigAsync`** (browse path — the settle load, where `actionStatus` is 0 and nobody waits) snapshots the id under the sema, reads **outside** it, then re-checks and publishes under it — the shape `_menuResolveInfoSize` already uses. Rendering and input keep running through the read.

`_menuRequestConfig` picks the variant by whether a waiter exists at request time.

## Review findings fixed in this cut

An adversarial review caught two defects in the first version of this change; both are resolved by the split:

- **Critical, NULL deref:** making the read async lets the user press X/Triangle mid-read. The single-function version could then release the waiter having dropped its result, handing `itemLaunch()` a NULL config — a crash, not a stall. The async variant now never touches `actionStatus`, so it cannot release anyone.
- **Major, cross-device publish:** the publish re-check compared only the item id. Ids are per-list indices, so a tab switch mid-read yields the same number from a different device and published device A's per-game config onto device B's row. The gate now re-checks the owning list too.

Also verified and **refuted** while investigating: `ioHasPendingRequests()` is lock-free (no GUI-side stall there), and the theme/language device scans run their `listDir` **outside** `guiLock` — only the in-memory name rebuild is locked.

Bounded pad waits (rebuild-90) and the verified-idle gate (rebuild-92) are untouched.

## What to look for on hardware

Stop on a title with art off: plasma should keep animating and input stay live through the settle. Then repeat with art on. Also worth a pass: launching a game immediately after stopping (X), Triangle into game settings, saving per-game settings, and switching device tabs quickly — those exercise the paths the review flagged.

Known remaining settle cost, **not** addressed here so this stays one causal change: background device rescans are deferred out of scrolling and fire as a burst when you go idle (up to 8 BDM slot probes, repeating while parked). That's the next isolated artifact if settle still isn't clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
