### PR TITLE
rebuild-183 & 184: art absence FatFs mapping, VCD fallback restore, and BGM theme fallback

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 184. Current tip: `rebuild/step-183-art-absence-fatfs-mapping`.** One focused change
+tip. **Next number: 185. Current tip: `rebuild/step-184-bgm-theme-fallback-restore`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -996,6 +996,13 @@ clearing the cache slot instead of parking it, retrying the 4.3s USB directory w
 every scroll, and breaking the `if (r == ERR_BAD_FILE)` condition in `bdmsupport.c` so the VCD POPS
 cover fallback was completely bypassed. Step 183 maps errno 4/5/6 on `mass*` to genuine absence, guards
 `artindex` against backslash SMB paths, and streamlines the HUD formatting.
+
+**184 — BGM theme-to-default fallback restore & vorbis clean-up.**
+In `sound.c:bgmLoad()`, custom themes without bundled `sound/bgm.ogg` were trapping `gDefaultBGMPath`
+in an `else` branch of `if (themeID != 0)`, preventing user-configured BGM from ever playing on custom
+themes (miladera22-sketch #380 symptom 4). Restored master's clean fallback chain (theme BGM first,
+then `gDefaultBGMPath`), properly freeing `vorbisFile` on misses to prevent uninitialized memory access
+in `bgmDeinit()`.
 
 # 17. CURRENT STATE, 2026-08-13 (late) — SUPERSEDES §14
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 182. Current tip: `rebuild/step-181-handoff-refresh`.** One focused change
+tip. **Next number: 184. Current tip: `rebuild/step-183-art-absence-fatfs-mapping`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -983,9 +983,19 @@ rolling = v1.2.0-Beta-2553-95a138c (run 31745407636): REVISION HEAD-based and mo
 IS a build input, correctly not excluded), all four ds5 ELFs present and listed,
 four-flavour Get started, stale-tag paragraph gone (removed in 175 as designed), tag =
 0127499b, MEGA run_463. Claude's review loop caught 178 pre-publish; log it as the model
-for anything user-visible that can move backwards.
+**182 — art queue priority lane + dual-port ACT HUD.** Focused selection art pushes to the front
+of the worker FIFO (`artPushFront`/`artPromote`) so the cursor cover pops in instantly without waiting
+for queued surrounding covers. Added dual-port `ACT<p0>/<p1>` (`padGetActuatorDiag`) to the debug HUD
+to diagnose rumble alignment and actuator detection without needing an EE serial cable.
 
----
+**183 — FatFs FR_NO_FILE absence mapping + artindex SMB guard + VCD fallback restore.**
+On FatFs-backed BDM (`mass*`), `bdmfs_fatfs` returns `-FR_NO_FILE` (-4) or `-FR_NO_PATH` (-5), which
+EE `libcglue` turns into `open() == -1` with `errno == 4` / `5`. Testing strictly `ENOENT` (2) caused
+every USB missing cover to be treated as a transient I/O error (`OE`/`TF` climbing in lockstep),
+clearing the cache slot instead of parking it, retrying the 4.3s USB directory walk endlessly on
+every scroll, and breaking the `if (r == ERR_BAD_FILE)` condition in `bdmsupport.c` so the VCD POPS
+cover fallback was completely bypassed. Step 183 maps errno 4/5/6 on `mass*` to genuine absence, guards
+`artindex` against backslash SMB paths, and streamlines the HUD formatting.
 
 # 17. CURRENT STATE, 2026-08-13 (late) — SUPERSEDES §14
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -182,6 +182,14 @@ These are not general advice. Each one names a specific build that went out wron
 8. **Say when something is unproven.** Two 16-agent adversarial investigations this session ended
    with *nothing surviving refutation*. That is a real and useful result — it eliminated four
    hypotheses — and it is more valuable to Nathan than a confident guess would have been.
+9. **Never quote a version string you haven't read off a built artifact.** `git rev-list --count`
+   in a shallow/local worktree returns a partial local count (e.g. ~313) while CI unshallows to the
+   full 2555+ history. Quoting locally computed revisions causes false alarms or downgrades; always
+   read the actual `OPL_VERSION` string directly from CI build logs or packaged artifact filenames.
+10. **SDK structs have external readers in compiled SDK binaries.** When running dead-contract or
+    unused-field sweeps, distinguish internal OPL structs from SDK structs (`gsKit`, `ps2sdk`).
+    Fields like `GSTEXTURE.VramClut` may be initialized in OPL and consumed inside external
+    pre-compiled SDK functions (`gsKit_TexManager_bind`) with zero readers in OPL's source tree.
 
 # 1. Ground truth: repo, branches, where to work
 

--- a/src/artindex.c
+++ b/src/artindex.c
@@ -253,6 +253,11 @@ int artIndexMayExist(const char *fullPath)
     if (fullPath == NULL || fullPath[0] == '\0')
         return 1;
 
+    // Reject SMB / backslash paths: artIndexSplit expects '/' directory separators.
+    // Returning 1 ("uncertain; perform real open") guarantees SMB art is never falsely declared absent.
+    if (strchr(fullPath, '\\') != NULL || !strncmp(fullPath, "smb", 3))
+        return 1;
+
     // Not the owner thread: never touch the slots at all. See gArtIndexOwnerThread.
     if (gArtIndexOwnerThread < 0 || GetThreadId() != gArtIndexOwnerThread) {
         gArtIndexWrongThread++; // HUD: if this climbs, confinement is rejecting the art worker itself

--- a/src/gui.c
+++ b/src/gui.c
@@ -2739,13 +2739,12 @@ static void guiDrawOverlays()
         snprintf(actBuf, sizeof(actBuf), "ACT%d%s/%d%s",
                  padAct0, (padAct0 > 0 ? (padAln0 ? "a" : "u") : ""),
                  padAct1, (padAct1 > 0 ? (padAln1 ? "a" : "u") : ""));
-        snprintf(artdbg, sizeof(artdbg), "Q%d A%d D%d X%d %dms(ok %dms %dx%d) O:%d/%d W%d@%d/%d/%d%c OE%u IX%d/%u/%u KL%u TF%u SX%u/%u SP%u/%u  F%u/%u OV%u  NR%u MT%u %s  IO %d/%d T%u/%u",
+        snprintf(artdbg, sizeof(artdbg), "Q%d A%d D%d X%d %dms(ok %dms %dx%d) O:%d/%d W%d@%d/%d/%d%c OE%u IX%d/%u/%u KL%u TF%u SX%u/%u SP%u/%u F%u/%u %s NR%u MT%u IO%d/%d",
                  q, a, d, cacheDebugDropped(), lastMs, okMs, w, h,
                  gTexLastOpenMs, gTexLastMissOpenMs, wOpen, wPend, wMenu, wBgm, wMiss ? 'm' : 'h', gTexStagedOpenNonEnoent, ixDirs, ixAbsent, ixFailed, cacheDebugKeyTooLong(), cacheDebugTransientFail(), sxStale, sxFull, spLastMs, spMaxMs,
-                 (unsigned)(fLast / 1000), (unsigned)(fWorst / 1000), (unsigned)fOver,
-                 (unsigned)padNR, (unsigned)padEmpty, actBuf,
-                 ioGetPending(IO_CUSTOM_SIMPLEACTION), ioGetPending(IO_MENU_UPDATE_DEFFERED),
-                 ioGetTotal(IO_CUSTOM_SIMPLEACTION), ioGetTotal(IO_MENU_UPDATE_DEFFERED));
+                 (unsigned)(fLast / 1000), (unsigned)(fWorst / 1000),
+                 actBuf, (unsigned)padNR, (unsigned)padEmpty,
+                 ioGetPending(IO_CUSTOM_SIMPLEACTION), ioGetPending(IO_MENU_UPDATE_DEFFERED));
         fntRenderString(gTheme->fonts[0], 8, screenHeight - 24, ALIGN_NONE, 0, 0, artdbg, GS_SETREG_RGBA(255, 255, 0, 128));
     }
 }

--- a/src/sound.c
+++ b/src/sound.c
@@ -681,31 +681,57 @@ static void bgmIoThread(void *arg)
 
 static int bgmLoad(void)
 {
-    FILE *bgmFile;
     char bgmPath[256];
+    int themeID;
 
     vorbisFile = malloc(sizeof(OggVorbis_File));
+    if (vorbisFile == NULL)
+        return -ENOMEM;
+
     memset(vorbisFile, 0, sizeof(OggVorbis_File));
 
-    int themeID = thmGetGuiValue();
-    if (themeID != 0) {
-        char *thmPath = thmGetFilePath(themeID);
+    themeID = thmGetGuiValue();
+    char *thmPath = thmGetFilePath(themeID);
+    if (thmPath != NULL) {
         snprintf(bgmPath, sizeof(bgmPath), "%ssound/bgm.ogg", thmPath);
-    } else
-        snprintf(bgmPath, sizeof(bgmPath), gDefaultBGMPath);
+        FILE *bgmFile = fopen(bgmPath, "rb");
+        if (bgmFile != NULL) {
+            if (ov_open_callbacks(bgmFile, vorbisFile, NULL, 0, OV_CALLBACKS_DEFAULT) == 0) {
+                LOG("BGM: Loaded theme BGM %s\n", bgmPath);
+                return 0;
+            }
 
-    bgmFile = fopen(bgmPath, "rb");
-    if (bgmFile == NULL) {
-        LOG("BGM: Failed to open Ogg file %s\n", bgmPath);
-        return -ENOENT;
+            LOG("BGM: Theme BGM is not a valid Ogg bitstream: %s\n", bgmPath);
+            fclose(bgmFile);
+            memset(vorbisFile, 0, sizeof(OggVorbis_File));
+        } else {
+            LOG("BGM: Theme BGM not found: %s\n", bgmPath);
+        }
     }
 
-    if (ov_open_callbacks(bgmFile, vorbisFile, NULL, 0, OV_CALLBACKS_DEFAULT) < 0) {
-        LOG("BGM: Input does not appear to be an Ogg bitstream.\n");
-        return -ENOENT;
+    if (gDefaultBGMPath[0] != '\0') {
+        FILE *bgmFile;
+
+        snprintf(bgmPath, sizeof(bgmPath), "%s", gDefaultBGMPath);
+        bgmFile = fopen(bgmPath, "rb");
+        if (bgmFile != NULL) {
+            if (ov_open_callbacks(bgmFile, vorbisFile, NULL, 0, OV_CALLBACKS_DEFAULT) == 0) {
+                LOG("BGM: Loaded configured BGM %s\n", bgmPath);
+                return 0;
+            }
+
+            LOG("BGM: Configured BGM is not a valid Ogg bitstream: %s\n", bgmPath);
+            fclose(bgmFile);
+            memset(vorbisFile, 0, sizeof(OggVorbis_File));
+        } else {
+            LOG("BGM: Configured BGM not found: %s\n", bgmPath);
+        }
     }
 
-    return 0;
+    LOG("BGM: No theme or configured BGM available.\n");
+    free(vorbisFile);
+    vorbisFile = NULL;
+    return -ENOENT;
 }
 
 static int bgmInit(void)

--- a/src/textures.c
+++ b/src/textures.c
@@ -520,26 +520,24 @@ static int texStagedOpenIsAbsence(const char *filePath, int err)
 
     // ONLY A REAL "no such file" MEANS ABSENT. Anything else is transient and must be retried.
     //
-    // This used to return 1 unconditionally for every non-MMCE device, so ANY open failure --
-    // a contended bus, a network blip, an SMB share mid-reconnect -- branded that cover permanently
-    // missing. It was survivable while the memo was thrown away on the next list rebuild. rebuild-155
-    // made the memo persist until a device generation bump, and that turned a momentary failure into
-    // a cover that never comes back.
+    // On BDM/USB ("mass*"), ps2sdk's bdmfs_fatfs returns the negated FatFs result (fs_driver.c: `ret = -ret;`),
+    // which libcglue converts to open() == -1 with errno == +result. For missing files, FatFs returns
+    // FR_NO_FILE (4) or FR_NO_PATH (5) (ff.h). Checking ONLY ENOENT (2) caused every genuine USB miss to be
+    // branded a transient failure (OE/TF lockstep), skipping the VCD POPS fallback in bdmsupport.c and
+    // continuously re-probing the 4.3 s USB directory walk on every scroll.
     //
-    // Reported by L10N37 on issue #388, over SMB, and his description is exactly this: art worked
-    // when he first connected, then "it dropping artwork altogether for a bunch of games",
-    // reconnecting did not fix it, and two reboots ended with no artwork at all. He also notes it is
-    // absent from the older builds -- correct, because the memo did not survive a rebuild there.
-    // My regression, and the counter I added to catch it could not see it: OE only ever incremented
-    // on the staged arm (mmce/mass), and SMB does not take that arm.
-    //
-    // The trade I was worried about when I left this alone -- if errno is not faithful, a genuine
-    // miss retries forever and browsing gets slow -- is the RIGHT way round to be wrong. Slow art is
-    // a complaint; art that silently never returns is a broken loader.
-    if (err != ENOENT)
+    // On MMCE ("mmce*"), mmceman returns -ENOENT specifically for card not-found, so err == ENOENT applies.
+    int isAbsence = (err == ENOENT);
+    if (filePath != NULL && !strncmp(filePath, "mass", 4)) {
+        // FatFs codes: FR_NO_FILE (4), FR_NO_PATH (5), FR_INVALID_NAME (6)
+        if (err == 4 || err == 5 || err == 6)
+            isAbsence = 1;
+    }
+
+    if (!isAbsence)
         gTexStagedOpenNonEnoent++;
 
-    return err == ENOENT;
+    return isAbsence;
 }
 
 static int texShouldUseMemoryReader(const char *filePath)


### PR DESCRIPTION
### Summary of Changes

- **rebuild-183 (b38d8dd):**
  - Map FatFs absence error codes (4: FR_NO_FILE, 5: FR_NO_PATH, 6: FR_INVALID_NAME) on BDM \mass*\ paths to \ERR_BAD_FILE\.
  - Fixes 4.3 s USB missing art retry loop, unblocking the FIFO art worker queue.
  - Restores \cdLoadPopsCover\ fallback in \src/bdmsupport.c\ so VCD covers load beside the \.VCD\.
  - SMB guard in \src/artindex.c\ to prevent false absences on backslash paths.
  - Streamlines \ACT\ HUD overlay line formatting.

- **rebuild-184 (5e742ea):**
  - Restore master's clean fallback chain in \src/sound.c:bgmLoad()\ (theme BGM first, then \gDefaultBGMPath\) so user-configured BGM plays on custom themes (e.g. Coverflow).
  - Properly free \orbisFile\ on load failures to prevent uninitialized memory issues in \gmDeinit()\.