### PR TITLE
rebuild-185: eliminate art queue batching, restrict nav-hold to SIO2, and clamp Coverflow warming

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 185. Current tip: `rebuild/step-184-bgm-theme-fallback-restore`.** One focused change
+tip. **Next number: 186. Current tip: `rebuild/step-185-art-queue-batching-and-warming-tame`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1003,6 +1003,17 @@ in an `else` branch of `if (themeID != 0)`, preventing user-configured BGM from 
 themes (miladera22-sketch #380 symptom 4). Restored master's clean fallback chain (theme BGM first,
 then `gDefaultBGMPath`), properly freeing `vorbisFile` on misses to prevent uninitialized memory access
 in `bgmDeinit()`.
+
+**185 — Art queue un-batching, nav-hold SIO2 restriction, and Coverflow warming clamp.**
+Fixed the post-scroll queue surge and batch pop-in effect:
+1. Restricted `navHoldsCache` in `texcache.c` to `isSio2 && gArtNavActive` (matching master), allowing
+   USB, HDD, and SMB to smoothly stream-evict and enqueue incoming covers during active scrolling rather
+   than withholding all eviction and dumping ~20 covers in a single burst upon stopping.
+2. Clamped Coverflow `warmRadius` in `themes.c` to at most 2 items on each side (4 surrounding covers
+   total instead of 18), eliminating the 2-second USB bus flooding storm that starved `bgmIoThread`
+   and caused BGM stutter.
+3. Added `RotateThreadReadyQueue(ART_THREAD_PRIORITY)` in `cacheArtWorkerThread` between consecutive
+   loads to allow BGM audio I/O to be scheduled cleanly.
 
 # 17. CURRENT STATE, 2026-08-13 (late) — SUPERSEDES §14
 

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -881,6 +881,9 @@ static void cacheArtWorkerThread(void *arg)
 
             cacheLoadImage(req);
 
+            // Yield the ready queue so other threads (such as BGM I/O) can process between loads.
+            RotateThreadReadyQueue(ART_THREAD_PRIORITY);
+
             if (gArtTerminate)
                 break;
         }
@@ -1258,19 +1261,9 @@ GSTEXTURE *cacheGetTextureEx(image_cache_t *cache, item_list_t *list, int *cache
     rtime = guiFrameId;
 
     // WHILE A DIRECTION IS HELD, CLAIM ONLY SLOTS THAT COST NOTHING TO TAKE -- free ones and ones
-    // parked as absent. Never evict a decoded texture mid-scroll.
-    //
-    // This is the guard that makes dropping the idle gate above safe rather than a trade. Requesting
-    // art during a scroll means claiming a slot per row passed, and every claim runs
-    // cacheClearItem(entry, 1) -- it FREES whatever cover was in that slot. Most of those requests
-    // are then thrown away 20 frames later by the stale-stamp cancellation, so an unguarded scroll
-    // would spend the cache to buy images it never loads and leave the user watching covers they
-    // already had disappear. That is a worse bug than the one being fixed here.
-    //
-    // With the guard, a cold list (all slots free) starts loading covers the moment the user begins
-    // moving, and a warm one holds what it has and resumes the instant they stop -- with no fixed
-    // delay in front of it any more, which is the actual win over the old gate.
-    int navHoldsCache = gArtNavActive;
+    // parked as absent. Never evict a decoded texture mid-scroll on SIO2/MMCE where bus contention
+    // with pad polling exists. USB, HDD, and SMB stream-evict smoothly without holding.
+    int navHoldsCache = isSio2 && gArtNavActive;
 
     for (i = 0; i < cache->count; i++) {
         currEntry = &cache->content[i];

--- a/src/themes.c
+++ b/src/themes.c
@@ -1235,6 +1235,8 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     */
     mutable_image_t *elemImg = (mutable_image_t *)elem->extended;
     int warmRadius = (elemImg != NULL && elemImg->cache != NULL) ? (elemImg->cache->count - 1) / 2 : 0;
+    if (warmRadius > 2)
+        warmRadius = 2; // Tame lookahead burst: warm at most 2 immediate neighbours on each side
     struct
     {
         image_cache_t *cache;


### PR DESCRIPTION
### Summary of Changes

Fixes post-scroll queue surge, batch pop-in, and BGM stutter on full art collections:

1. **\	excache.c\ (\cacheGetTextureEx\):**
   - Restricted \
avHoldsCache\ from blanket \gArtNavActive\ to \(isSio2 && gArtNavActive)\, matching \origin/master\.
   - On USB, HDD, and SMB, cache slots stream-evict and enqueue during scrolling rather than withholding eviction and dumping ~20 requests in a burst the moment navigation stops.
   - SIO2/MMCE retains pad-bus protection.

2. **\	excache.c\ (\cacheArtWorkerThread\):**
   - Added \RotateThreadReadyQueue(ART_THREAD_PRIORITY)\ between consecutive image loads so BGM I/O audio decoding is never starved by a sequence of back-to-back cover reads.

3. **\	hemes.c\ (\drawCoverFlow\):**
   - Clamped Coverflow lookahead \warmRadius\ to a max of 2 items on each side (4 covers total instead of 18), preventing the 2-second USB bus flooding storm whenever the carousel settles.