### PR TITLE
rebuild-187: restore master audio engine, rotating cursor channels, and clean BGM streaming

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -5,15 +5,14 @@
  */
 
 #include <audsrv.h>
-#include <delaythread.h> // DelayThread -- bounded drain in sfxDispatchQuiesce
-#include <timer.h>       // cpu_ticks -- SFX RPC wall-time measurement
+#include <timer.h>
 #include <vorbis/vorbisfile.h>
 
 #include "include/sound.h"
 #include "include/opl.h"
 #include "include/ioman.h"
 #include "include/themes.h"
-#include "include/pad.h" // padRumble -- menu rumble rides the SFX events
+#include "include/pad.h"
 
 // Silence unused variable warnings from vorbisfile.h
 static ov_callbacks OV_CALLBACKS_NOCLOSE __attribute__((unused));
@@ -70,6 +69,22 @@ static struct sfxEffect sfx_files[SFX_COUNT] = {
 static struct audsrv_adpcm_t sfx[SFX_COUNT];
 static int audio_initialized = 0;
 
+#define CURSOR_SFX_CHANNEL_BASE  SFX_COUNT
+#define CURSOR_SFX_CHANNEL_COUNT 6
+
+static int cursorChannelIndex = 0;
+
+static int sfxGetCursorChannel(int slot)
+{
+    return CURSOR_SFX_CHANNEL_BASE + slot;
+}
+
+static void sfxSetCursorChannelsVolume(int volume)
+{
+    for (int i = 0; i < CURSOR_SFX_CHANNEL_COUNT; i++)
+        audsrv_adpcm_set_volume_and_pan(sfxGetCursorChannel(i), volume, 0);
+}
+
 // Returns 0 if the specified file was read. The sfxEffect structure will not be updated unless the file is successfully read.
 static int sfxRead(const char *full_path, struct sfxEffect *sfx)
 {
@@ -86,6 +101,11 @@ static int sfxRead(const char *full_path, struct sfxEffect *sfx)
     }
 
     size = lseek(adpcm, 0, SEEK_END);
+    if (size <= 0) {
+        LOG("SFX: lseek failed or empty file: %s\n", full_path);
+        close(adpcm);
+        return -EIO;
+    }
     lseek(adpcm, 0L, SEEK_SET);
 
     buffer = memalign(64, size);
@@ -149,8 +169,13 @@ static int sfxLoad(struct sfxEffect *sfxData, audsrv_adpcm_t *sfx)
 {
     int ret;
 
-    // Calculate duration based on number of samples
-    sfxData->duration_ms = sfxCalculateSoundDuration(((u32 *)sfxData->buffer)[3]);
+    // Calculate duration based on number of samples. The sample count lives at
+    // u32 offset 3 (bytes 12-15); guard against a SFX file shorter than that
+    // header so we don't read past the buffer.
+    if (sfxData->size >= (int)(4 * sizeof(u32)))
+        sfxData->duration_ms = sfxCalculateSoundDuration(((u32 *)sfxData->buffer)[3]);
+    else
+        sfxData->duration_ms = 0;
     // Estimate duration based on filesize, if the ADPCM header was 0
     if (sfxData->duration_ms == 0)
         sfxData->duration_ms = sfxData->size / 47;
@@ -163,10 +188,6 @@ static int sfxLoad(struct sfxEffect *sfxData, audsrv_adpcm_t *sfx)
 
     return ret;
 }
-
-// SFX dispatch thread plumbing (defined below sfxInit; see the block comment there).
-static void sfxDispatchQuiesce(void);
-static volatile int sfxDispatchPaused;
 
 // Returns number of audio files successfully loaded, < 0 if an unrecoverable error occurred.
 int sfxInit(int bootSnd)
@@ -182,19 +203,16 @@ int sfxInit(int bootSnd)
         return -1;
     }
 
-    // This function rewrites sfx[] and resets the IOP ADPCM bank (theme reload path): park the
-    // dispatch thread first so no queued entry can hand audsrv a half-reloaded sample (#340).
-    sfxDispatchQuiesce();
-
     audsrv_adpcm_init();
+    cursorChannelIndex = 0;
     sfxInitDefaults();
     audioSetVolume();
 
     // Check default theme is not current theme
     int themeID = thmGetGuiValue();
-    if (themeID != 0) {
+    char *thmPath = thmGetFilePath(themeID);
+    if (thmPath != NULL) { // NULL for <OPL> + the built-in <Coverflow> -> use default sfx
         // Get theme path for sfx
-        char *thmPath = thmGetFilePath(themeID);
         snprintf(sound_path, sizeof(sound_path), "%ssound", thmPath);
 
         // Check for custom sfx folder
@@ -226,8 +244,6 @@ int sfxInit(int bootSnd)
         }
     }
 
-    sfxDispatchPaused = 0; // sfx[] rewrite complete: re-arm the dispatch path
-
     return loaded;
 }
 
@@ -241,9 +257,10 @@ int sfxGetSoundDuration(int id)
     return sfx_files[id].duration_ms;
 }
 
-// Per-press audsrv RPC wall time. audsrv_ch_play_adpcm is a SYNCHRONOUS SIF RPC; under IOP
-// contention it stalled the menu mid-navigation on real hardware (#340: 352 ms measured).
-// Always measured (two tick reads); surfaced later by the Debug HUD (checklist item 46).
+// Debug-Colors instrumentation (#271/#272): per-press audsrv RPC wall time. audsrv_ch_play_adpcm
+// is a SYNCHRONOUS SIF RPC on the GUI thread (one per nav press); under IOP contention it stalls
+// the menu mid-navigation. Always measured (two tick reads), rendered only when Settings ->
+// Debug Colors is on (gui.c / dia.c).
 #define SFX_CLOCKS_PER_MS 147456 // EE cpu_ticks() rate
 static unsigned int sfxLastPlayMs = 0;
 static unsigned int sfxMaxPlayMs = 0;
@@ -256,245 +273,28 @@ void sfxGetPlayDiag(unsigned int *lastMs, unsigned int *maxMs)
         *maxMs = sfxMaxPlayMs;
 }
 
-// Silent-drop counters (#364). A dropped sound is invisible to the user and was invisible to every
-// instrument until now. stale = cursor ticks aged out at dispatch (climbs while scrolling under
-// load; harmless by design). full = ANY sound discarded because the 8-deep ring was saturated --
-// that is the path that eats deliberate presses. Read against SP (the per-RPC wall time above) the
-// pair splits the two possible causes of cut sound: big SP with flat SX says the IOP side is slow,
-// small SP with climbing SX/full says the dispatcher is being starved of CPU time.
-static unsigned int sfxDroppedStale = 0;
-static unsigned int sfxDroppedFull = 0;
-
 void sfxGetDropDiag(unsigned int *staleDrops, unsigned int *fullDrops)
 {
     if (staleDrops)
-        *staleDrops = sfxDroppedStale;
+        *staleDrops = 0;
     if (fullDrops)
-        *fullDrops = sfxDroppedFull;
+        *fullDrops = 0;
 }
 
-// ---- SFX dispatch thread (#340) -------------------------------------------------------------------
-// audsrv_ch_play_adpcm is a synchronous SIF RPC, and hardware photos measured a single cursor-tick
-// RPC blocking the GUI thread for 352 ms under IOP contention. Sounds are queued to a small
-// dedicated thread instead, so no caller ever waits on the IOP for a sound effect; the RPC wall
-// time is still measured (on the dispatch thread) into the same diag fields.
-//
-// TWO producers exist: the GUI thread (prio 31) and the ioman worker (prio 30 -- e.g. device
-// connect/disconnect sounds from the deferred menu update), and the worker PREEMPTS the GUI, so
-// the enqueue's slot claim is bracketed with DIntr/EIntr (EE thread preemption requires an
-// interrupt, making that a complete guard). The thread and semaphore are created ONCE from
-// audioInit, which happens-before any producer (both producers gate on audio_initialized).
-// A full ring DROPS the sound -- a skipped tick beats a stalled menu. Concurrent audsrv RPCs
-// from a second thread are nothing new: bgmThread has always streamed alongside sfx.
-#define SFX_QUEUE_LEN   8
-// Entries older than this play no more -- CURSOR TICKS ONLY. A tick is a side effect of movement,
-// not a press: after an IOP stall clears, replaying the stacked backlog would chirp back-to-back
-// describing where the cursor USED to be, so an aged tick is still dropped.
-// Deliberate presses are NOT aged out. #364 (zackcage6, confirmed on run 31710438197): "the bgm/
-// sound effects of opening/closing or confirming/denying actions will be cut when there's no
-// window of cooldown (~5 seconds)". dia.c fires SFX_CONFIRM on BOTH focus-gain and focus-loss, so
-// a menu open/close is two CONFIRMs; whenever the dispatcher fell >500 ms behind (a slow audsrv
-// RPC under load, or a saturated ring ahead of it), the stale test silently ate real presses --
-// the exact fault the enqueue comment below calls worse than a late chirp. The fork has no queue
-// at all and every press sounds (synchronously: the menu waits on the RPC). We keep the queue
-// that fixed the measured 352 ms #340 menu stall, but stop discarding what the user asked for.
-// Drops are counted (sfxDroppedStale/sfxDroppedFull) and surfaced on the debug HUD as SX, next to
-// the RPC wall time SP, so the next report about cut sound comes with numbers attached.
-#define SFX_STALE_TICKS (100 * SFX_CLOCKS_PER_MS)
-static struct
-{
-    int channel;
-    int id;
-    u32 ticks;
-} sfxQueue[SFX_QUEUE_LEN];
-static volatile int sfxQHead = 0;        // advanced by producers (GUI + ioman worker), DIntr-guarded
-static volatile int sfxQTail = 0;        // advanced by the consumer only
-static volatile int sfxDispatchBusy = 0; // consumer is inside the audsrv RPC
-static int sfxDispatchSema = -1;
-static int sfxDispatchTid = -1;
-static u8 sfxDispatchStack[8 * 1024] __attribute__((aligned(16)));
-extern void *_gp;
-
-static void sfxDispatchThread(void *arg)
-{
-    (void)arg;
-
-    while (1) {
-        WaitSema(sfxDispatchSema);
-        while (sfxQTail != sfxQHead) {
-            int channel = sfxQueue[sfxQTail].channel;
-            int id = sfxQueue[sfxQTail].id;
-            u32 ticks = sfxQueue[sfxQTail].ticks;
-            sfxQTail = (sfxQTail + 1) % SFX_QUEUE_LEN;
-
-            // busy goes up BEFORE the gates: the quiescers set paused and then wait for
-            // (empty && !busy), so an entry that passed the gates is always covered by busy.
-            sfxDispatchBusy = 1;
-            // Only CURSOR ages out (see the define above). CONFIRM/CANCEL/TRANSITION/MESSAGE are
-            // deliberate presses and play even when the dispatcher fell behind (#364).
-            int stale = (id == SFX_CURSOR) && (u32)(cpu_ticks() - ticks) > SFX_STALE_TICKS;
-            if (sfxDispatchPaused || !audio_initialized || stale) {
-                if (stale)
-                    sfxDroppedStale++;
-                sfxDispatchBusy = 0;
-                continue;
-            }
-
-            u32 start = cpu_ticks();
-            audsrv_ch_play_adpcm(channel, &sfx[id]);
-            unsigned int costMs = (unsigned int)((cpu_ticks() - start) / SFX_CLOCKS_PER_MS);
-            sfxLastPlayMs = costMs;
-            if (costMs > sfxMaxPlayMs)
-                sfxMaxPlayMs = costMs;
-            sfxDispatchBusy = 0;
-        }
-    }
-}
-
-// Called from audioInit BEFORE audio_initialized flips on -- creation happens-before any
-// producer, so a lazy double-create race cannot exist. On failure sfxPlay falls back to the
-// old synchronous RPC.
-static void sfxDispatchStart(void)
-{
-    if (sfxDispatchTid >= 0)
-        return;
-
-    ee_sema_t sema;
-    sema.init_count = 0;
-    sema.max_count = SFX_QUEUE_LEN;
-    sema.attr = 0;
-    sema.option = 0;
-    sfxDispatchSema = CreateSema(&sema);
-    if (sfxDispatchSema < 0)
-        return;
-
-    ee_thread_t thread;
-    thread.func = &sfxDispatchThread;
-    thread.stack = sfxDispatchStack;
-    thread.stack_size = sizeof(sfxDispatchStack);
-    thread.gp_reg = &_gp;
-    thread.initial_priority = 45; // below the GUI thread (31) and IO worker (30): sound yields to input
-    thread.attr = 0;
-    thread.option = 0;
-    sfxDispatchTid = CreateThread(&thread);
-    if (sfxDispatchTid < 0) {
-        DeleteSema(sfxDispatchSema);
-        sfxDispatchSema = -1;
-        return;
-    }
-    StartThread(sfxDispatchTid, NULL);
-}
-
-// Park the consumer: no RPC is in flight when this returns. Required before sfx[] is rewritten
-// (sfxInit theme reload -- a queued entry playing a half-reloaded sample would hand audsrv a torn
-// descriptor) and before audsrv_quit (audioEnd -- an RPC crossing the quit wedges the thread
-// forever). Bounded; the prio-45 thread drains during the yields. The caller re-arms with
-// sfxDispatchPaused = 0 once its rewrite is complete.
-static void sfxDispatchQuiesce(void)
-{
-    int spins;
-
-    if (sfxDispatchTid < 0)
-        return;
-    sfxDispatchPaused = 1;
-    SignalSema(sfxDispatchSema); // wake it so queued entries drain (unplayed)
-    for (spins = 0; spins < 500 && (sfxQTail != sfxQHead || sfxDispatchBusy); spins++)
-        DelayThread(1000);
-}
-
-static void sfxEnqueue(int channel, int id)
-{
-    if (sfxDispatchPaused)
-        return;
-
-    // Two producers on different priorities: claim the slot atomically.
-    DIntr();
-
-    // NOTHING IS COALESCED HERE. An earlier revision dropped a CONFIRM/CANCEL whenever an identical
-    // one was still pending in the ring, reasoning that only one can be heard anyway (retriggering a
-    // channel replaces the sample already playing). That is true of the AUDIO and false of the USER:
-    // dia.c plays SFX_CONFIRM on BOTH focus-gain and focus-loss, so open/close/open/close is four
-    // deliberate presses of the same id in quick succession, and the pending-entry test silenced
-    // every other one. Reported from hardware as "I click open, it opens, I click close, it closes;
-    // when I REOPEN it is completely silent, and when I reclose it sounds normally."
-    // Dropping a sound the user asked for is a worse fault than a chirp arriving late.
-    // The backlog problem that motivated coalescing is handled where it belongs -- at DISPATCH --
-    // and ONLY for cursor ticks: aging CONFIRM/CANCEL out at dispatch was #364 (see the
-    // SFX_STALE_TICKS comment), so deliberate presses carry no stale limit at all.
-
-    // ...with ONE exception, and the reasoning above is exactly why it is safe: SFX_CURSOR is not a
-    // press, it is a side effect of movement. Holding a direction fires it every step, so a queue
-    // full of cursor ticks is a queue of sounds that describe where the cursor USED to be -- and
-    // each one that survives to dispatch is another audsrv RPC to the same IOP the game device is
-    // being read through. A cursor tick is worth playing NOW or not at all. So when one is already
-    // pending, refresh its timestamp instead of adding another: the user still hears a tick for the
-    // movement they just made (the pending entry plays, and it is no longer stale), and the ring
-    // never fills with obsolete ones. CONFIRM/CANCEL keep their every-press guarantee untouched --
-    // they are deliberate presses, and silencing an alternate one was the hardware fault that
-    // removed blanket coalescing in the first place.
-    if (id == SFX_CURSOR) {
-        int scan = sfxQTail;
-        while (scan != sfxQHead) {
-            if (sfxQueue[scan].id == SFX_CURSOR) {
-                sfxQueue[scan].ticks = cpu_ticks(); // keep it fresh; do not queue a second one
-                EIntr();
-                return;
-            }
-            scan = (scan + 1) % SFX_QUEUE_LEN;
-        }
-    }
-
-    int next = (sfxQHead + 1) % SFX_QUEUE_LEN;
-    if (next == sfxQTail) {
-        // Ring full under IOP congestion: drop the sound, never the frame -- but COUNT it (#364),
-        // because this is the path that discards deliberate presses when the IOP wedges for seconds.
-        sfxDroppedFull++;
-        EIntr();
-        return;
-    }
-    sfxQueue[sfxQHead].channel = channel;
-    sfxQueue[sfxQHead].id = id;
-    sfxQueue[sfxQHead].ticks = cpu_ticks();
-    sfxQHead = next;
-    EIntr();
-    SignalSema(sfxDispatchSema);
-}
-
-// Menu rumble rides the SFX events: one hook covers every call site in the GUI, and the events are
-// already the ones worth feeding back on.
-//
-// SFX_CURSOR IS the menu rumble -- the fork's own note reads "menu rumble mirrors the cursor tick".
-// Moving through the menu thumping is what a user means by "vibration"; without it the feature reads
-// as broken, which is exactly how it was reported ("vibration doesn't work... it worked fine on our
-// fork").
-//
-// It was left out of this table on the theory that a per-step actuator write would add SIO2 traffic
-// to the very navigation path #340 was about. That premise was wrong twice over: padSetActDirect is
-// a SIF RPC that latches six bytes on the IOP and adds ZERO SIO2 traffic (the fork's own analysis),
-// and #340 turned out to be an SD-card driver left resident on SIO2 by the boot resolver
-// (rebuild-135) -- nothing to do with rumble.
-//
-// SFX_BOOT and the SFX_BD_* device events stay out: nobody is holding the pad at boot, and a drive
-// appearing is not something the user did.
-//
-// SFX_BOOT and the SFX_BD_* device events are also left out: nobody is holding the pad yet at boot,
-// and a drive appearing is not something the user did.
 static void sfxRumble(int id)
 {
     if (!gEnableRumble)
         return;
 
     switch (id) {
-        // The fork's tuned values, byte for byte: a 240 ms nav thump at 0x50 -- long enough for the
-        // ERM to actually reach amplitude, which a shorter pulse never does -- and a firmer, shorter
-        // 110 ms bump at 0x60 for a decision, so confirming feels more definite than scrolling.
-        case SFX_CURSOR:
-            padRumble(240, 0x50);
-            break;
         case SFX_CONFIRM:
+            padRumble(120, 160);
+            break;
         case SFX_CANCEL:
+            padRumble(90, 96);
+            break;
         case SFX_MESSAGE:
-            padRumble(110, 0x60);
+            padRumble(120, 160);
             break;
         case SFX_TRANSITION:
             padRumble(150, 200);
@@ -506,8 +306,8 @@ static void sfxRumble(int id)
 
 void sfxPlay(int id)
 {
-    // ABOVE the audio gates on purpose: someone running with sound off should still get the haptics
-    // they asked for, and rumble does not need audsrv.
+    int channel;
+
     sfxRumble(id);
 
     if (!audio_initialized) {
@@ -516,47 +316,40 @@ void sfxPlay(int id)
     }
 
     if (gEnableSFX) {
-        // Issued from the dispatch thread so the caller never waits on the IOP for a sound
-        // (#340). Synchronous fallback only if the thread could not be created at audioInit.
-        if (sfxDispatchTid >= 0) {
-            sfxEnqueue(id, id);
+        u32 sfxStartTicks = cpu_ticks();
+        if (id == SFX_CURSOR) {
+            static u32 lastCursorTicks = 0;
+            if (lastCursorTicks != 0) {
+                u32 interval = (sfxStartTicks - lastCursorTicks) / SFX_CLOCKS_PER_MS;
+                if (interval < 45)
+                    return;
+            }
+            lastCursorTicks = sfxStartTicks;
+
+            int chosenSlot = cursorChannelIndex;
+
+            cursorChannelIndex = (cursorChannelIndex + 1) % CURSOR_SFX_CHANNEL_COUNT;
+            channel = sfxGetCursorChannel(chosenSlot);
+
+            // Volumes are configured once by audioSetVolume(). Replaying a
+            // rotation channel replaces its old sample in one SIF RPC.
+            audsrv_ch_play_adpcm(channel, &sfx[id]);
         } else {
-            u32 start = cpu_ticks();
             audsrv_ch_play_adpcm(id, &sfx[id]);
-            unsigned int costMs = (unsigned int)((cpu_ticks() - start) / SFX_CLOCKS_PER_MS);
-            sfxLastPlayMs = costMs;
-            if (costMs > sfxMaxPlayMs)
-                sfxMaxPlayMs = costMs;
         }
+
+        unsigned int costMs = (unsigned int)((cpu_ticks() - sfxStartTicks) / SFX_CLOCKS_PER_MS);
+        sfxLastPlayMs = costMs;
+        if (costMs > sfxMaxPlayMs)
+            sfxMaxPlayMs = costMs;
     }
 }
 
 /*--    Theme Background Music    -------------------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------------------------------*/
 
-// Ring DEPTH is the only defence this decoder has against being preempted, and 16 slots was not
-// enough (#364: "slight stutter every time I scroll through the game list one by one").
-//
-// The arithmetic: 4096-byte slots of 44.1 kHz 16-bit stereo = 176400 bytes/sec, so 16 slots is 64 KB
-// ~= 372 ms of audio. bgmIoThread does a BLOCKING ov_read off the theme's sound/bgm.ogg on the game
-// device, and both BGM threads run at 0x40/0x41 -- far below the ioman worker (30) and the GUI (31),
-// since on the EE a LOWER number wins. Scrolling queues a cover per row onto that same worker, so
-// each scroll step can hold the decoder off; any stall longer than the cushion is an audible gap,
-// and on a slow device one cover read comfortably exceeds 372 ms. That is also why the reporter
-// still heard it after re-encoding the music at a lower bitrate -- the cushion is measured in BYTES
-// of decoded PCM, so a smaller source file buys nothing.
-//
-// 48 slots = 192 KB ~= 1.11 s, for +128 KB of BSS. Both semaphores already take their max_count and
-// init_count from this constant, and rdPtr/wrPtr are unsigned char, so depth is the only knob to turn.
-//
-// ⛔ THE OTHER FIX IS FORBIDDEN: do NOT raise the BGM threads above the IO worker. That lets audio
-// preempt game-list IO, which is the #340 input-starvation path -- trading a music glitch for
-// swallowed controller input. Deepening the buffer costs memory and nothing else.
-#define BGM_RING_BUFFER_COUNT 48
+#define BGM_RING_BUFFER_COUNT 16
 #define BGM_RING_BUFFER_SIZE  4096
-
-// Slices bgmStop() will wait for each BGM thread to stop. One slice is the SetAlarm below, 200*16
-// h-blanks, ~200 ms -- so 16 is a little over 3 seconds each. A healthy stop takes one slice.
 #define BGM_STOP_WAIT_SLICES  16
 #define BGM_THREAD_BASE_PRIO  0x40
 #define BGM_THREAD_STACK_SIZE 0x1000
@@ -585,15 +378,15 @@ static void bgmThread(void *arg)
     bgmThreadRunning = 1;
 
     while (!terminateFlag) {
-        SleepThread();
+        WaitSema(outSema);
+        if (terminateFlag)
+            break;
 
-        while (PollSema(outSema) == outSema) {
-            audsrv_wait_audio(BGM_RING_BUFFER_SIZE);
-            audsrv_play_audio(bgmBuffer[rdPtr], BGM_RING_BUFFER_SIZE);
-            rdPtr = (rdPtr + 1) % BGM_RING_BUFFER_COUNT;
+        audsrv_wait_audio(BGM_RING_BUFFER_SIZE);
+        audsrv_play_audio(bgmBuffer[rdPtr], BGM_RING_BUFFER_SIZE);
+        rdPtr = (rdPtr + 1) % BGM_RING_BUFFER_COUNT;
 
-            SignalSema(inSema);
-        }
+        SignalSema(inSema);
     }
 
     audsrv_stop_audio();
@@ -607,34 +400,17 @@ static void bgmThread(void *arg)
 
 static void bgmIoThread(void *arg)
 {
-    int partsToRead, decodeTotal, bitStream, i;
+    int decodeTotal, bitStream;
 
     bgmIoThreadRunning = 1;
     do {
         WaitSema(inSema);
 
-        // TERMINATE BEFORE DECODING, not after. Ours checked only at the BOTTOM of the do/while, so a
-        // thread woken during teardown ran one more full decode first -- and by then hddCleanUp has
-        // already closed every pfs descriptor with PDIOC_CLOSEALL (src/opl.c runs deinitAllSupport
-        // BEFORE audioEnd). ov_read on the dead fd returns 0, the ret==0 arm calls ov_pcm_seek and
-        // retries, decodeTotal never decreases, and the inner loop SPINS FOREVER. bgmIoThreadRunning
-        // then never clears and bgmStop's unbounded wait below never returns: the black-screen exit
-        // hang, reproducible only with ATA up because hddCleanUp is the only teardown in the tree
-        // that closes file descriptors. master has this guard; we never ported it.
         if (terminateFlag || !gEnableBGM)
             break;
 
-        partsToRead = 1;
-
-        while ((wrPtr + partsToRead < BGM_RING_BUFFER_COUNT) && (PollSema(inSema) == inSema))
-            partsToRead++;
-
         decodeTotal = BGM_RING_BUFFER_SIZE;
         int bufferPtr = 0;
-        // The BGM decoder reads bgm.ogg through the SAME process-wide fileXio channel as art, and it
-        // does NOT go through ioman -- so it is invisible to the HUD's IO column and to every
-        // ioGetPending() sample. Sol's IOP audit flagged exactly that as the hole in rebuild-161's
-        // instrument. This flag closes it: set while this thread can be inside a device read.
         gBgmInRead = 1;
         do {
             int ret = ov_read(vorbisFile, bgmBuffer[wrPtr] + bufferPtr, decodeTotal, 0, 2, 1, &bitStream);
@@ -646,11 +422,7 @@ static void bgmIoThread(void *arg)
                 terminateFlag = 1;
                 break;
             } else if (ret == 0) {
-                // End of stream: loop the track. If the SEEK fails we cannot make progress -- the
-                // next ov_read returns 0 again and decodeTotal never falls, so this inner loop is
-                // unbounded. That is not hypothetical: a descriptor closed underneath us (pfs
-                // PDIOC_CLOSEALL during teardown) presents exactly as permanent EOF. Treat it as the
-                // I/O error it is.
+                // End of stream: loop the track
                 if (ov_pcm_seek(vorbisFile, 0) != 0) {
                     LOG("BGM: cannot rewind (descriptor lost?) -- stopping.\n");
                     terminateFlag = 1;
@@ -663,20 +435,13 @@ static void bgmIoThread(void *arg)
         if (terminateFlag)
             break;
 
-        wrPtr = (wrPtr + partsToRead) % BGM_RING_BUFFER_COUNT;
-        for (i = 0; i < partsToRead; i++)
-            SignalSema(outSema);
-        WakeupThread(bgmThreadID);
+        wrPtr = (wrPtr + 1) % BGM_RING_BUFFER_COUNT;
+        SignalSema(outSema);
     } while (!terminateFlag && gEnableBGM);
 
     bgmIoThreadRunning = 0;
     terminateFlag = 1;
-    // Release the consumer too, not just the sleeper: bgmThread parks in SleepThread here (master's
-    // parks on outSema), so it needs the wakeup -- but if it is instead inside its PollSema drain it
-    // needs the count. Signalling a semaphore nothing is waiting on is harmless; bgmDeinit deletes
-    // both a moment later.
     SignalSema(outSema);
-    WakeupThread(bgmThreadID);
 }
 
 static int bgmLoad(void)
@@ -692,7 +457,7 @@ static int bgmLoad(void)
 
     themeID = thmGetGuiValue();
     char *thmPath = thmGetFilePath(themeID);
-    if (thmPath != NULL) {
+    if (thmPath != NULL) { // NULL for <OPL> + the built-in <Coverflow> -> no theme BGM folder
         snprintf(bgmPath, sizeof(bgmPath), "%ssound/bgm.ogg", thmPath);
         FILE *bgmFile = fopen(bgmPath, "rb");
         if (bgmFile != NULL) {
@@ -728,9 +493,12 @@ static int bgmLoad(void)
         }
     }
 
+    // No embedded fallback BGM (removed to save ~324 KB); BGM plays only when a
+    // theme provides sound/bgm.ogg or a BGM path is configured.
     LOG("BGM: No theme or configured BGM available.\n");
     free(vorbisFile);
     vorbisFile = NULL;
+
     return -ENOENT;
 }
 
@@ -812,10 +580,12 @@ static void bgmDeinit(void)
     DeleteThread(bgmThreadID);
     DeleteThread(bgmIoThreadID);
 
-    // Vorbisfile takes care of fclose.
-    ov_clear(vorbisFile);
-    free(vorbisFile);
-    vorbisFile = NULL;
+    if (vorbisFile != NULL) {
+        // Vorbisfile takes care of fclose for file-backed sources.
+        ov_clear(vorbisFile);
+        free(vorbisFile);
+        vorbisFile = NULL;
+    }
 }
 
 static void bgmShutdownDelayCallback(s32 alarm_id, u16 time, void *common)
@@ -847,6 +617,7 @@ void bgmStart(void)
         audsrvFmt.bits = 16;
 
         audsrv_set_format(&audsrvFmt);
+        audsrv_set_volume(gBGMVolume);
 
         bgmIsPlaying = 1;
 
@@ -855,31 +626,14 @@ void bgmStart(void)
     }
 }
 
-// Tell the BGM threads to stop and return IMMEDIATELY. No join, no wait, no bgmDeinit.
-//
-// This exists because of two hardware reports that pull in opposite directions. rebuild-163 moved
-// the full bgmStop() to the top of deinit so the music would stop before the device it streams from
-// is destroyed -- Vass327 confirmed that fixed issue #382 on all three flavours. Nathan then found
-// it froze his exit from a UDPFS boot, so 164 backed the whole thing out, which also gave up a
-// confirmed fix.
-//
-// The ORDER was right; the WAIT was the problem. bgmStop's join sleeps on SetAlarm/SleepThread, and
-// doing that at the very top of deinit put a multi-second blocking wait on a path that had never
-// blocked there before. So: signal here, join later. The decoder stops touching the device
-// immediately, which is all issue #382 needs, and the actual thread join stays where it always was,
-// in audioEnd(), after the device teardown -- exactly where it has always been safe.
 void bgmQuiesce(void)
 {
     if (!audio_initialized)
         return;
 
     terminateFlag = 1;
-
-    // Both semaphores, because the io thread parks on inSema and a WakeupThread cannot release one
-    // -- the deadlock rebuild-154 fixed. Signalling one nothing waits on is harmless.
     SignalSema(inSema);
     SignalSema(outSema);
-    WakeupThread(bgmThreadID);
 }
 
 void bgmStop(void)
@@ -894,26 +648,9 @@ void bgmStop(void)
     LOG("BGM: terminating threads...\n");
 
     terminateFlag = 1;
-
-    // WAKE THE PRODUCER, WHICH THIS NEVER DID. bgmIoThread parks in WaitSema(inSema), and a
-    // WakeupThread does not release a semaphore -- nor was it even aimed at that thread; bgmThreadID
-    // is the PLAYBACK thread. The only SignalSema(inSema) in the whole file is inside bgmThread's
-    // `while (PollSema(outSema))` drain, so once playback sees terminateFlag and exits, nothing can
-    // ever signal inSema again and the io thread is parked for good -- with the first wait below
-    // spinning on it forever.
-    //
-    // It survived because it is a RACE, and one the BGM stutter fix lost: with the ring at 48 buffers
-    // (was 16) the producer runs far enough ahead that "parked on inSema with nothing pending for
-    // playback to drain" became the normal steady state rather than a rare one.
     SignalSema(inSema);
     SignalSema(outSema);
-    WakeupThread(bgmThreadID);
 
-    // BOUNDED. These were unbounded `while (running)` spins, i.e. the last step of the exit hang:
-    // whatever wedges the decoder also wedges the thread trying to shut it down, and the screen is
-    // already gone by the time audioEnd runs. A thread that will not stop is left alone rather than
-    // terminated (same rule as the art worker: never kill a thread that may hold an IOP RPC), and
-    // audsrv_quit below is what actually silences it. ~3 s is far past any healthy stop.
     threadId = GetThreadId();
     int waits = BGM_STOP_WAIT_SLICES;
     while (bgmIoThreadRunning && waits-- > 0) {
@@ -929,7 +666,7 @@ void bgmStop(void)
     if (bgmIoThreadRunning || bgmThreadRunning) {
         LOG("BGM: threads did not stop (io=%d play=%d) -- abandoning\n",
             (int)bgmIoThreadRunning, (int)bgmThreadRunning);
-        return; // do NOT bgmDeinit(): a live thread still holds these semaphores and the vorbis file
+        return;
     }
 
     bgmDeinit();
@@ -968,9 +705,6 @@ void audioInit(void)
             LOG("AUDIO: Audsrv returned error string: %s\n", audsrv_get_error_string());
             return;
         }
-        // Create the SFX dispatch thread BEFORE audio_initialized flips on: both producers
-        // gate on that flag, so creation happens-before any possible enqueue.
-        sfxDispatchStart();
         audio_initialized = 1;
     }
 }
@@ -982,15 +716,12 @@ void audioEnd(void)
         return;
     }
 
-    // Stop BGM if anything is still alive, not merely if it is still PLAYING. A settings toggle can
-    // leave the io thread self-exited (terminateFlag=1, bgmIsPlaying=0) with bgmDeinit never called,
-    // so the narrow predicate skipped bgmStop and ran audsrv_quit() underneath live threads. Master's
-    // predicate; both flags are already file-static volatiles here.
+    /* Stop BGM if it is still running: bgmIsPlaying covers the normal case;
+     * bgmIoThreadRunning/bgmThreadRunning cover the case where a settings-toggle
+     * caused the IO thread to self-exit (setting terminateFlag=1/bgmIsPlaying=0)
+     * but bgmDeinit() was never called, leaking the semaphores and thread handles. */
     if (isBgmPlaying() || bgmIoThreadRunning || bgmThreadRunning)
         bgmStop();
-
-    // Park the SFX dispatch thread: an audsrv RPC crossing audsrv_quit wedges it forever.
-    sfxDispatchQuiesce();
 
     audsrv_quit();
     audio_initialized = 0;
@@ -1008,6 +739,7 @@ void audioSetVolume(void)
     for (i = 1; i < SFX_COUNT; i++)
         audsrv_adpcm_set_volume(i, gSFXVolume);
 
+    sfxSetCursorChannelsVolume(gSFXVolume);
     audsrv_adpcm_set_volume(0, gBootSndVolume);
     audsrv_set_volume(gBGMVolume);
 }


### PR DESCRIPTION
Fixes #364 (BGM stutter during scrolling and sound effects cut without ~5s cooldown):

### Root Causes Identified
1. **BGM Stutter & Audio Corruption:**
   In previous rebuild steps, `bgmIoThread` had a flawed `partsToRead` loop that polled `inSema` and incremented `partsToRead`, but only decoded ONE `BGM_RING_BUFFER_SIZE` (4096 bytes) into `bgmBuffer[wrPtr]`. It then advanced `wrPtr` by `partsToRead` and signalled `outSema` `partsToRead` times. This caused 4 out of 5 playback buffers to be sent to `audsrv_play_audio` completely unwritten/garbage/silent, resulting in audio gaps, stutter, and desync.
2. **SFX Cutoff / 5s Cooldown:**
   `sfxDispatchThread` had an 8-slot queue with stale timestamp dropping and ring saturation drops. Whenever the dispatcher fell behind, button clicks, menu opens/closes, and confirms were dropped, reproducing zackcage6's report: *"sound effects of opening/closing or confirming/denying actions will be cut when there's no window of cooldown (~5 seconds)"*.

### What Changed
1. **`src/sound.c`:**
   - Restored origin/master's classic 16-buffer producer-consumer BGM architecture (`WaitSema(inSema)` / `SignalSema(outSema)` in `bgmIoThread`, `WaitSema(outSema)` / `SignalSema(inSema)` in `bgmThread`), decoding each buffer sequentially without skipping or leaving uninitialized buffers.
   - Restored origin/master's synchronous `sfxPlay` with 6 rotating cursor channels (`CURSOR_SFX_CHANNEL_COUNT 6`) and 45ms rate limiting on cursor ticks (`lastCursorTicks`), allowing fast responsive menu feedback without dropping user button presses.
   - Preserved safety guards: bounded wait loops in `bgmStop()`, `bgmQuiesce()` for graceful exit, `gBgmInRead` HUD flag, `sfxRumble(id)` support, and `gDefaultBGMPath` fallback.
