### PR TITLE
Step 191: Fix BGM SleepThread freeze, restore safe art path splitting, and deinit teardown order

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 191. Current tip: `rebuild/step-190-bg-art-speed-bgm-priority`.** One focused change
+tip. **Next number: 192. Current tip: `rebuild/step-191-fix-bgm-freeze-artindex-deinit`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1177,4 +1177,18 @@ it), not a re-derivation of (a).
    - In `src/sound.c`, updated `BGM_THREAD_BASE_PRIO` from `0x40` (64) to `0x38` (56).
    - `bgmThread` now runs at priority 56 and `bgmIoThread` (Vorbis stream reader/decoder) at priority 57, ensuring time-critical audio buffer feeding outranks background texture decoding (`ART_THREAD_PRIORITY 64`) on the Sony EE kernel scheduler.
    - Prevents audio ring buffer starvation and stuttering when scrolling games on USB.
+
+# 21. STEP-191: Fix BGM SleepThread Freeze, Restore Safe Art Path Splitting, & Deinit Teardown Order (2026-08-14)
+
+### What was fixed in Step 191:
+1. **BGM `bgmStop()` Bounded Wait Recovery**:
+   - In `src/sound.c`, restored `BGM_STOP_WAIT_SLICES` (16 slices) loop bounds and timeout handling when waiting for `bgmIoThreadRunning` and `bgmThreadRunning` to terminate.
+   - Prevents the GUI thread from hanging in an infinite `SleepThread()` loop on boot/screen transitions when BGM is stopped or restarted.
+2. **`artIndexSplit()` Safe Path Splitting**:
+   - In `src/artindex.c`, restored simple, bounds-safe path splitting (`memcpy(dirOut, fullPath, dirLen)`) without fragile prefix subtraction.
+   - Prevents root paths (e.g. `mass0:/SLUS_200.01_COV.png`) from generating negative `tailLen` calculations and truncating colons into invalid device names (`mass0`).
+3. **Deinit Teardown Order Alignment**:
+   - In `src/opl.c`, restored `audioEnd()` execution order to run *after* `deinitAllSupport()` in `deinit()` and `moduleCleanup()` in `deinitEx()`, matching `bb21e343` and `master`.
+4. **CI Format Parity**:
+   - In `src/themes.c`, formatted macro definitions (lines 19–65) with `clang-format 12` column alignment to pass `CI-format-check`.
 

--- a/src/artindex.c
+++ b/src/artindex.c
@@ -124,21 +124,8 @@ static int artIndexSplit(const char *fullPath, char *dirOut, int dirMax, const c
     if (dirLen <= 0 || dirLen >= dirMax)
         return 0;
 
-    // Canonicalize "mass0:/ART" -> "mass0:ART" so both forms match the same slot
-    const char *colon = strchr(fullPath, ':');
-    if (colon != NULL && colon < cut && colon[1] == '/') {
-        int headLen = (int)(colon - fullPath) + 1;
-        int tailLen = (int)(cut - (colon + 2));
-        if (headLen + tailLen >= dirMax)
-            return 0;
-        memcpy(dirOut, fullPath, headLen);
-        if (tailLen > 0)
-            memcpy(dirOut + headLen, colon + 2, tailLen);
-        dirOut[headLen + tailLen] = '\0';
-    } else {
-        memcpy(dirOut, fullPath, dirLen);
-        dirOut[dirLen] = '\0';
-    }
+    memcpy(dirOut, fullPath, dirLen);
+    dirOut[dirLen] = '\0';
 
     *baseOut = (slash != NULL) ? slash + 1 : cut;
     if ((*baseOut)[0] == '\0')

--- a/src/opl.c
+++ b/src/opl.c
@@ -3059,8 +3059,6 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 #endif
     unloadPads();
 
-    audioEnd();
-
     for (int i = 0; i < MODE_COUNT; i++) {
         if (list_support[i].support != NULL) {
             int spared = (modeSelected2 >= 0 && list_support[i].support->mode == modeSelected2);
@@ -3068,6 +3066,7 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
         }
     }
 
+    audioEnd();
     ioEnd();
     guiEnd();
     menuEnd();
@@ -3118,10 +3117,9 @@ void deinit(int exception, int modeSelected)
 #endif
     unloadPads();
 
-    audioEnd();
-
     deinitAllSupport(exception, modeSelected);
 
+    audioEnd();
     ioEnd();
     guiEnd();
     menuEnd();

--- a/src/sound.c
+++ b/src/sound.c
@@ -682,13 +682,21 @@ void bgmStop(void)
         SignalSema(outSema);
 
     threadId = GetThreadId();
-    while (bgmIoThreadRunning) {
+    int waits = BGM_STOP_WAIT_SLICES;
+    while (bgmIoThreadRunning && waits-- > 0) {
         SetAlarm(200 * 16, &bgmShutdownDelayCallback, (void *)threadId);
         SleepThread();
     }
-    while (bgmThreadRunning) {
+    waits = BGM_STOP_WAIT_SLICES;
+    while (bgmThreadRunning && waits-- > 0) {
         SetAlarm(200 * 16, &bgmShutdownDelayCallback, (void *)threadId);
         SleepThread();
+    }
+
+    if (bgmIoThreadRunning || bgmThreadRunning) {
+        LOG("BGM: threads did not stop (io=%d play=%d) -- abandoning\n",
+            (int)bgmIoThreadRunning, (int)bgmThreadRunning);
+        return;
     }
 
     bgmDeinit();

--- a/src/themes.c
+++ b/src/themes.c
@@ -16,9 +16,9 @@
 #include <time.h>
 #include <math.h>
 
-#define MENU_POS_V                   50
-#define HINT_HEIGHT                  32
-#define DECORATOR_SIZE               20
+#define MENU_POS_V             50
+#define HINT_HEIGHT            32
+#define DECORATOR_SIZE         20
 // Cover cache depth. Hardware (debug HUD, art delay 0, one USB device, BG off): 73 ms per cover
 // load -- the load path is fine -- but D climbing past 100 COMPLETED loads in a single browse, far
 // more covers than the library shows. That is the same files being read again and again: the
@@ -27,7 +27,7 @@
 // is the "drag" that survived removing the throttles. Sized so the visible set and its warmed
 // neighbours fit together; at the size themes actually ship (140x200 in that capture) a decoded
 // cover is well under 100 KB, so this trades ~1 MB of EE RAM for not re-reading USB.
-#define COVER_CACHE_SLOTS            20
+#define COVER_CACHE_SLOTS      20
 // How many rows either side of the SELECTED row may be warmed. Measured: the warm loop asked for
 // every visible row -- 18 on the shipped theme -- where uOPL asks for exactly one (its
 // decorator-less list branch requests nothing at all; only the cover panel does). At 73 ms per load
@@ -51,7 +51,7 @@
 // Warming exists so that landing on a neighbour finds its cover already there (#296). That is a real
 // nicety on a fast device and a liability on USB, where it costs four extra reads for every one the
 // user asked for. The reference builds do not do it; neither do we now.
-#define COVER_WARM_RADIUS            0
+#define COVER_WARM_RADIUS      0
 // Cache slots per AttributeImage element. An AttributeImage is NOT a per-game image -- it is a small FIXED
 // SET of glyphs keyed by the attribute's value, so the cache only ever needs to hold that attribute's whole
 // value set to be thrash-free. Our built-in attributes are tiny (#Format = ISO/ZSO/VCD/UL/ELF/HDL = 6,
@@ -60,7 +60,7 @@
 // 32 covers any realistic custom attribute with headroom. Genuinely cheap -- cacheInitCache allocates only
 // `count` empty cache_entry_t structs (no texture memory until a glyph is actually loaded into a slot), so
 // 32 slots is ~2-3 KB of EE RAM and a #DiscType cache still only ever HOLDS its 3.
-#define ATTR_IMAGE_CACHE_SLOTS       32
+#define ATTR_IMAGE_CACHE_SLOTS 32
 
 extern const char conf_theme_OPL_cfg;
 extern u16 size_conf_theme_OPL_cfg;


### PR DESCRIPTION
## Summary of Changes in Step 191

1. **BGM Thread Wait Recovery (`src/sound.c`)**:
   - Restored `BGM_STOP_WAIT_SLICES` (16 slices) bounded wait loop in `bgmStop()` when waiting for `bgmIoThreadRunning` and `bgmThreadRunning` to exit.
   - If audio threads fail to terminate within the timeout budget, the operation logs and abandons gracefully rather than hanging the main GUI thread indefinitely in `SleepThread()`.

2. **Art Index Path Splitting Safety (`src/artindex.c`)**:
   - Restored bounds-safe path splitting in `artIndexSplit()` without prefix arithmetic subtraction that caused negative `tailLen` calculations on root paths (e.g. `mass0:/SLUS_200.01_COV.png`).
   - Prevents path truncation that omitted the trailing colon and caused directory opens (`fioDopen`) to fail.

3. **Deinit Teardown Ordering (`src/opl.c`)**:
   - Restored `audioEnd()` invocation order to execute after `deinitAllSupport()` in `deinit()` and after `moduleCleanup()` in `deinitEx()`, matching `bb21e343` and `master` parity.

4. **Format Parity (`src/themes.c`)**:
   - Aligned macro definitions on lines 19-65 with `clang-format 12` column standards to satisfy `CI-format-check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BGM shutdown reliability by bounding wait times and preventing unsafe resource cleanup when playback threads remain active.
  * Preserved original artwork directory paths during matching.
  * Corrected shutdown ordering so support modules and audio devices are cleaned up safely.

* **Style**
  * Aligned cache and layout definitions for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->