### PR TITLE
Step 192: Honor PFS / APA HDD boot CWD and custom settings path

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 192. Current tip: `rebuild/step-191-fix-bgm-freeze-artindex-deinit`.** One focused change
+tip. **Next number: 193. Current tip: `rebuild/step-192-honor-pfs-hdd-cwd-and-custom-path`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1191,4 +1191,15 @@ it), not a re-derivation of (a).
    - In `src/opl.c`, restored `audioEnd()` execution order to run *after* `deinitAllSupport()` in `deinit()` and `moduleCleanup()` in `deinitEx()`, matching `bb21e343` and `master`.
 4. **CI Format Parity**:
    - In `src/themes.c`, formatted macro definitions (lines 19–65) with `clang-format 12` column alignment to pass `CI-format-check`.
+
+# 22. STEP-192: Honor PFS / APA HDD Boot CWD & Custom Settings Path (2026-08-14)
+
+### What was fixed in Step 192:
+1. **Preserve PFS and APA HDD Boot Directory (`gBootDir`)**:
+   - In `src/opl.c`, stopped wiping `gBootDir` to empty when booted from HDD/FHDB (`hdd0:...` or `pfs0:...`).
+   - Brought up the HDD/PFS driver stack (`hddLoadModules()`, `hddLoadSupportModules()`) on APA/PFS boot so `pfs0:` is mounted before config loading, and translated raw launch paths (e.g. `hdd0:__sysconf:pfs:/FMCB` $\rightarrow$ `pfs0:/FMCB`, `hdd0:+OPL` $\rightarrow$ `pfs0:`) so settings are saved and loaded directly beside the ELF on HDD without requiring a Memory Card.
+2. **Translate Typed APA Partition Paths in Custom Settings Path**:
+   - In `src/opl.c` (`prepareCustomSettingsPath`), automatically translate typed partition targets (`hdd0:+OPL`, `hdd0:/+OPL`, `+OPL`, `+OPL/CFG`) to the mounted PFS filesystem path (`pfs0:` / `pfs0:CFG`), preventing `openFile` from attempting raw I/O on `hdd0:` which caused `ENODEV` (Error 19: "No such device").
+3. **PFS Colon-Slash Normalization**:
+   - In `src/config.c`, implemented `configBuildPath` to properly handle trailing colons and slashes across prefixes (e.g., `pfs0:`, `pfs0:OPL/`, `mc0:OPL`), preventing malformed double slashes (`pfs0://conf_opl.cfg`) that caused filesystem errors.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 191. Current tip: `rebuild/step-190-bg-art-speed-bgm-priority`.** One focused change
+tip. **Next number: 192. Current tip: `rebuild/step-191-fix-bgm-freeze-artindex-deinit`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1177,4 +1177,18 @@ it), not a re-derivation of (a).
    - In `src/sound.c`, updated `BGM_THREAD_BASE_PRIO` from `0x40` (64) to `0x38` (56).
    - `bgmThread` now runs at priority 56 and `bgmIoThread` (Vorbis stream reader/decoder) at priority 57, ensuring time-critical audio buffer feeding outranks background texture decoding (`ART_THREAD_PRIORITY 64`) on the Sony EE kernel scheduler.
    - Prevents audio ring buffer starvation and stuttering when scrolling games on USB.
+
+# 21. STEP-191: Fix BGM SleepThread Freeze, Restore Safe Art Path Splitting, & Deinit Teardown Order (2026-08-14)
+
+### What was fixed in Step 191:
+1. **BGM `bgmStop()` Bounded Wait Recovery**:
+   - In `src/sound.c`, restored `BGM_STOP_WAIT_SLICES` (16 slices) loop bounds and timeout handling when waiting for `bgmIoThreadRunning` and `bgmThreadRunning` to terminate.
+   - Prevents the GUI thread from hanging in an infinite `SleepThread()` loop on boot/screen transitions when BGM is stopped or restarted.
+2. **`artIndexSplit()` Safe Path Splitting**:
+   - In `src/artindex.c`, restored simple, bounds-safe path splitting (`memcpy(dirOut, fullPath, dirLen)`) without fragile prefix subtraction.
+   - Prevents root paths (e.g. `mass0:/SLUS_200.01_COV.png`) from generating negative `tailLen` calculations and truncating colons into invalid device names (`mass0`).
+3. **Deinit Teardown Order Alignment**:
+   - In `src/opl.c`, restored `audioEnd()` execution order to run *after* `deinitAllSupport()` in `deinit()` and `moduleCleanup()` in `deinitEx()`, matching `bb21e343` and `master`.
+4. **CI Format Parity**:
+   - In `src/themes.c`, formatted macro definitions (lines 19–65) with `clang-format 12` column alignment to pass `CI-format-check`.
 

--- a/src/artindex.c
+++ b/src/artindex.c
@@ -124,21 +124,8 @@ static int artIndexSplit(const char *fullPath, char *dirOut, int dirMax, const c
     if (dirLen <= 0 || dirLen >= dirMax)
         return 0;
 
-    // Canonicalize "mass0:/ART" -> "mass0:ART" so both forms match the same slot
-    const char *colon = strchr(fullPath, ':');
-    if (colon != NULL && colon < cut && colon[1] == '/') {
-        int headLen = (int)(colon - fullPath) + 1;
-        int tailLen = (int)(cut - (colon + 2));
-        if (headLen + tailLen >= dirMax)
-            return 0;
-        memcpy(dirOut, fullPath, headLen);
-        if (tailLen > 0)
-            memcpy(dirOut + headLen, colon + 2, tailLen);
-        dirOut[headLen + tailLen] = '\0';
-    } else {
-        memcpy(dirOut, fullPath, dirLen);
-        dirOut[dirLen] = '\0';
-    }
+    memcpy(dirOut, fullPath, dirLen);
+    dirOut[dirLen] = '\0';
 
     *baseOut = (slash != NULL) ? slash + 1 : cut;
     if ((*baseOut)[0] == '\0')

--- a/src/config.c
+++ b/src/config.c
@@ -292,6 +292,18 @@ void configPrepareNotifications(char *prefix)
         *(colpos + 1) = '\0';
 }
 
+static void configBuildPath(char *out, size_t outSize, const char *prefix, const char *filename)
+{
+    size_t len = strlen(prefix);
+    if (len == 0) {
+        snprintf(out, outSize, "%s", filename);
+    } else if (prefix[len - 1] == '/' || prefix[len - 1] == ':') {
+        snprintf(out, outSize, "%s%s", prefix, filename);
+    } else {
+        snprintf(out, outSize, "%s/%s", prefix, filename);
+    }
+}
+
 void configInit(char *prefix)
 {
     char path[256];
@@ -300,10 +312,10 @@ void configInit(char *prefix)
     if (!prefix)
         prefix = gBaseMCDir;
 
-    snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
+    configBuildPath(legacyNetConfigPath, sizeof(legacyNetConfigPath), prefix, "IPCONFIG.DAT");
 
     for (i = 0; i < CONFIG_INDEX_COUNT; i++) {
-        snprintf(path, sizeof(path), "%s/%s", prefix, configFilenames[i]);
+        configBuildPath(path, sizeof(path), prefix, configFilenames[i]);
         configAlloc(1 << i, &configFiles[i], path);
     }
 
@@ -318,10 +330,10 @@ void configSetMove(char *prefix)
     if (!prefix)
         prefix = gBaseMCDir;
 
-    snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
+    configBuildPath(legacyNetConfigPath, sizeof(legacyNetConfigPath), prefix, "IPCONFIG.DAT");
 
     for (i = 0; i < CONFIG_INDEX_COUNT; i++) {
-        snprintf(path, sizeof(path), "%s/%s", prefix, configFilenames[i]);
+        configBuildPath(path, sizeof(path), prefix, configFilenames[i]);
         configMove(&configFiles[i], path);
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -3059,8 +3059,6 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 #endif
     unloadPads();
 
-    audioEnd();
-
     for (int i = 0; i < MODE_COUNT; i++) {
         if (list_support[i].support != NULL) {
             int spared = (modeSelected2 >= 0 && list_support[i].support->mode == modeSelected2);
@@ -3068,6 +3066,7 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
         }
     }
 
+    audioEnd();
     ioEnd();
     guiEnd();
     menuEnd();
@@ -3118,10 +3117,9 @@ void deinit(int exception, int modeSelected)
 #endif
     unloadPads();
 
-    audioEnd();
-
     deinitAllSupport(exception, modeSelected);
 
+    audioEnd();
     ioEnd();
     guiEnd();
     menuEnd();

--- a/src/opl.c
+++ b/src/opl.c
@@ -1457,18 +1457,42 @@ static void writeConfigPathRedirect(const char *path)
 // Make a typed settings path usable: the user may name a device that is not mounted yet (that is the
 // whole point of typing it rather than picking from a list), so force-load its transport and rewrite
 // the prefix to the massN: OPL can actually read. Returns 1 when `path` is ready to hand to
-// configInit(), 0 when it is not a BDM path at all (mc?:/pfs0:/mmce -- usable as typed), and -1 when
-// it names a BDM device that never mounted.
-//
-// A -1 MUST NOT silently fall back to mc: an unreachable path is a user error to surface, and
-// re-homing onto whatever memory card happens to be inserted is exactly the incident item 11 exists
-// to prevent (a stray mc?:OPL folder stamped onto an unrelated card).
 static int prepareCustomSettingsPath(char *path, int pathLen)
 {
     int bdmType = BDM_TYPE_UNKNOWN;
 
     if (path == NULL || path[0] == '\0')
         return 0;
+
+    // APA HDD / PFS paths: translate "hdd0:+OPL", "hdd0:/+OPL", "+OPL", "+OPL/CFG", "pfs0:..." to the mounted PFS path
+    if (!strncmp(path, "hdd", 3) || path[0] == '+' || !strncmp(path, "pfs", 3)) {
+        hddLoadModules();
+        hddLoadSupportModules();
+
+        if (path[0] == '+') {
+            const char *slash = strchr(path, '/');
+            if (slash != NULL && slash[1] != '\0')
+                snprintf(path, pathLen, "pfs0:%s", slash + 1);
+            else
+                snprintf(path, pathLen, "pfs0:");
+        } else if (!strncmp(path, "hdd", 3)) {
+            const char *oplSub = strstr(path, "+OPL");
+            if (oplSub != NULL) {
+                const char *slash = strchr(oplSub, '/');
+                if (slash != NULL && slash[1] != '\0')
+                    snprintf(path, pathLen, "pfs0:%s", slash + 1);
+                else
+                    snprintf(path, pathLen, "pfs0:");
+            } else {
+                const char *pfsSub = strstr(path, ":pfs:/");
+                if (pfsSub != NULL)
+                    snprintf(path, pathLen, "pfs0:%s", pfsSub + 5);
+                else
+                    snprintf(path, pathLen, "%s", gHDDPrefix ? gHDDPrefix : "pfs0:");
+            }
+        }
+        return 0; // ready for configSetMove
+    }
 
     // Not a BDM namespace -> nothing to load; mc?: is ROM-backed and pfs0:/mmce are handled by their
     // own stacks, which are already up by the time a save runs.
@@ -1615,8 +1639,7 @@ static void configReadNeutrinoGlobals(config_set_t *configOPL)
 }
 
 // Basename of the ELF OPL was booted as (argv[0]); pairs with gBootDir. resolveBootDirToMass uses
-// it to verify WHICH mounted massN: slot is the boot device (launcher slot numbering need not
-// match OPL's). Empty when the boot dir came from getcwd() or argv[0] had no filename part.
+// this to verify the BDM slot actually holds the boot binary before claiming a match.
 static char gBootElfName[64];
 // BDM_TYPE_* of the resolved boot device, BDM_TYPE_UNKNOWN for non-BDM boots. Set by
 // resolveBootDirToMass(); consumed by the _saveConfig re-resolve retry.
@@ -1628,14 +1651,33 @@ static void resolveBootDirToMass(void)
     if (gBootDir[0] == '\0')
         return;
 
-    // uLE hands APA-HDD boots as "hdd0:<partition>:pfs:/..." -- a launch identity OPL can never open
-    // (OPL's own APA mount is pfs0: on the +OPL partition, a different namespace). Unresolvable: drop
-    // to legacy discovery, whose checkLoadConfigHDD probes the APA config location properly.
-    if (!strncmp(gBootDir, "hdd", 3)) {
-        LOG("BOOT unresolvable APA boot dir %s -> legacy discovery\n", gBootDir);
-        gBootDir[0] = '\0';
+    // APA-HDD / PFS boot (FHDB, uLE HDD, or direct PFS boot):
+    // Bring up the HDD/PFS stack so the partition is mounted to pfs0: and settings can load/save to HDD.
+    if (!strncmp(gBootDir, "hdd", 3) || !strncmp(gBootDir, "pfs", 3)) {
+        LOG("BOOT APA/PFS boot dir %s -> initializing HDD/PFS\n", gBootDir);
+        hddLoadModules();
+        hddLoadSupportModules();
+
+        if (!strncmp(gBootDir, "hdd", 3)) {
+            const char *pfsSub = strstr(gBootDir, ":pfs:/");
+            if (pfsSub != NULL) {
+                // e.g. "hdd0:__sysconf:pfs:/FMCB" -> "pfs0:/FMCB"
+                char sub[sizeof(gBootDir)];
+                snprintf(sub, sizeof(sub), "pfs0:%s", pfsSub + 5);
+                snprintf(gBootDir, sizeof(gBootDir), "%s", sub);
+            } else if (strstr(gBootDir, "+OPL") != NULL) {
+                const char *oplSub = strstr(gBootDir, "+OPL");
+                const char *slash = strchr(oplSub, '/');
+                if (slash != NULL && slash[1] != '\0')
+                    snprintf(gBootDir, sizeof(gBootDir), "pfs0:%s", slash + 1);
+                else
+                    snprintf(gBootDir, sizeof(gBootDir), "pfs0:");
+            } else {
+                snprintf(gBootDir, sizeof(gBootDir), "%s", gHDDPrefix ? gHDDPrefix : "pfs0:");
+            }
+        }
         configEnd();
-        configInit(NULL);
+        configInit(gBootDir);
         return;
     }
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -682,13 +682,21 @@ void bgmStop(void)
         SignalSema(outSema);
 
     threadId = GetThreadId();
-    while (bgmIoThreadRunning) {
+    int waits = BGM_STOP_WAIT_SLICES;
+    while (bgmIoThreadRunning && waits-- > 0) {
         SetAlarm(200 * 16, &bgmShutdownDelayCallback, (void *)threadId);
         SleepThread();
     }
-    while (bgmThreadRunning) {
+    waits = BGM_STOP_WAIT_SLICES;
+    while (bgmThreadRunning && waits-- > 0) {
         SetAlarm(200 * 16, &bgmShutdownDelayCallback, (void *)threadId);
         SleepThread();
+    }
+
+    if (bgmIoThreadRunning || bgmThreadRunning) {
+        LOG("BGM: threads did not stop (io=%d play=%d) -- abandoning\n",
+            (int)bgmIoThreadRunning, (int)bgmThreadRunning);
+        return;
     }
 
     bgmDeinit();

--- a/src/themes.c
+++ b/src/themes.c
@@ -16,9 +16,9 @@
 #include <time.h>
 #include <math.h>
 
-#define MENU_POS_V                   50
-#define HINT_HEIGHT                  32
-#define DECORATOR_SIZE               20
+#define MENU_POS_V             50
+#define HINT_HEIGHT            32
+#define DECORATOR_SIZE         20
 // Cover cache depth. Hardware (debug HUD, art delay 0, one USB device, BG off): 73 ms per cover
 // load -- the load path is fine -- but D climbing past 100 COMPLETED loads in a single browse, far
 // more covers than the library shows. That is the same files being read again and again: the
@@ -27,7 +27,7 @@
 // is the "drag" that survived removing the throttles. Sized so the visible set and its warmed
 // neighbours fit together; at the size themes actually ship (140x200 in that capture) a decoded
 // cover is well under 100 KB, so this trades ~1 MB of EE RAM for not re-reading USB.
-#define COVER_CACHE_SLOTS            20
+#define COVER_CACHE_SLOTS      20
 // How many rows either side of the SELECTED row may be warmed. Measured: the warm loop asked for
 // every visible row -- 18 on the shipped theme -- where uOPL asks for exactly one (its
 // decorator-less list branch requests nothing at all; only the cover panel does). At 73 ms per load
@@ -51,7 +51,7 @@
 // Warming exists so that landing on a neighbour finds its cover already there (#296). That is a real
 // nicety on a fast device and a liability on USB, where it costs four extra reads for every one the
 // user asked for. The reference builds do not do it; neither do we now.
-#define COVER_WARM_RADIUS            0
+#define COVER_WARM_RADIUS      0
 // Cache slots per AttributeImage element. An AttributeImage is NOT a per-game image -- it is a small FIXED
 // SET of glyphs keyed by the attribute's value, so the cache only ever needs to hold that attribute's whole
 // value set to be thrash-free. Our built-in attributes are tiny (#Format = ISO/ZSO/VCD/UL/ELF/HDL = 6,
@@ -60,7 +60,7 @@
 // 32 covers any realistic custom attribute with headroom. Genuinely cheap -- cacheInitCache allocates only
 // `count` empty cache_entry_t structs (no texture memory until a glyph is actually loaded into a slot), so
 // 32 slots is ~2-3 KB of EE RAM and a #DiscType cache still only ever HOLDS its 3.
-#define ATTR_IMAGE_CACHE_SLOTS       32
+#define ATTR_IMAGE_CACHE_SLOTS 32
 
 extern const char conf_theme_OPL_cfg;
 extern u16 size_conf_theme_OPL_cfg;


### PR DESCRIPTION
## Summary of Changes in Step 192

1. **Preserve PFS and APA HDD Boot Directory (`gBootDir`)**:
   - In `src/opl.c`, stopped blanking `gBootDir` to empty when booted from HDD/FHDB (`hdd0:...` or `pfs0:...`).
   - Bring up the HDD/PFS driver stack (`hddLoadModules()`, `hddLoadSupportModules()`) on APA/PFS boot so `pfs0:` is mounted before config loading, and translate launch paths (e.g. `hdd0:__sysconf:pfs:/FMCB` -> `pfs0:/FMCB`, `hdd0:+OPL` -> `pfs0:`) so settings are saved and loaded directly beside the ELF on HDD without requiring a Memory Card.

2. **Translate Typed APA Partition Paths in Custom Settings Path**:
   - In `src/opl.c` (`prepareCustomSettingsPath`), automatically translate typed partition targets (`hdd0:+OPL`, `hdd0:/+OPL`, `+OPL`, `+OPL/CFG`) to the mounted PFS filesystem path (`pfs0:` / `pfs0:CFG`), preventing `openFile` from attempting raw I/O on `hdd0:` which caused `ENODEV` (Error 19: "No such device").

3. **PFS Colon-Slash Normalization**:
   - In `src/config.c`, implemented `configBuildPath` to properly handle trailing colons and slashes across prefixes (`pfs0:`, `pfs0:OPL/`, `mc0:OPL`), preventing malformed double slashes (`pfs0://conf_opl.cfg`) that caused filesystem errors.
