### PR TITLE
Step 193: Revert APA pre-init synchronous module loading and restore Coverflow pagination

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 193. Current tip: `rebuild/step-192-honor-pfs-hdd-cwd-and-custom-path`.** One focused change
+tip. **Next number: 194. Current tip: `rebuild/step-193-revert-apa-sync-init-restore-stable-boot`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1202,4 +1202,13 @@ it), not a re-derivation of (a).
    - In `src/opl.c` (`prepareCustomSettingsPath`), automatically translate typed partition targets (`hdd0:+OPL`, `hdd0:/+OPL`, `+OPL`, `+OPL/CFG`) to the mounted PFS filesystem path (`pfs0:` / `pfs0:CFG`), preventing `openFile` from attempting raw I/O on `hdd0:` which caused `ENODEV` (Error 19: "No such device").
 3. **PFS Colon-Slash Normalization**:
    - In `src/config.c`, implemented `configBuildPath` to properly handle trailing colons and slashes across prefixes (e.g., `pfs0:`, `pfs0:OPL/`, `mc0:OPL`), preventing malformed double slashes (`pfs0://conf_opl.cfg`) that caused filesystem errors.
+
+# 23. STEP-193: Revert APA Pre-Init Sync Module Loading & Restore Coverflow Pagination (2026-08-14)
+
+### What was fixed in Step 193:
+1. **Revert Synchronous HDD/PFS Module Loading during `_loadConfig()`**:
+   - In `src/opl.c`, reverted `resolveBootDirToMass()` and `prepareCustomSettingsPath()` back to the proven behavior from v2566 (`bb21e343`) and `master`.
+   - Booting from APA partition (`hdd0:...`) now blanks `gBootDir` and delegates HDD initialization to the safe asynchronous path (`deferredInit()`) after the GUI/GS is initialized, eliminating the early-boot lockup / hard black screen.
+2. **Restore Coverflow Pagination Invariant**:
+   - In `src/menusys.c`, removed early `return;` statements in `menuNextV()` and `menuPrevV()` that prevented `pagestart` from updating during Coverflow scrolling.
 

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -902,10 +902,8 @@ static void menuNextV()
         selected_item->item->current = cur->next;
         sfxPlay(SFX_CURSOR);
         // coverflow slide animation; the wrap branch below stays instant
-        if (gTheme->coverflow) {
+        if (gTheme->coverflow)
             thmTriggerCoverflowAnim(1);
-            return;
-        }
 
         if (gTheme->itemsList && gTheme->itemsList->extended) {
             // if the current item is beyond the page start, move the page start one page down
@@ -935,10 +933,8 @@ static void menuPrevV()
         sfxPlay(SFX_CURSOR);
 
         // coverflow slide animation; the wrap branch below stays instant
-        if (gTheme->coverflow) {
+        if (gTheme->coverflow)
             thmTriggerCoverflowAnim(-1);
-            return;
-        }
 
         if (gTheme->itemsList && gTheme->itemsList->extended) {
             // if the current item is on the page start, move the page start one page up

--- a/src/opl.c
+++ b/src/opl.c
@@ -1464,36 +1464,6 @@ static int prepareCustomSettingsPath(char *path, int pathLen)
     if (path == NULL || path[0] == '\0')
         return 0;
 
-    // APA HDD / PFS paths: translate "hdd0:+OPL", "hdd0:/+OPL", "+OPL", "+OPL/CFG", "pfs0:..." to the mounted PFS path
-    if (!strncmp(path, "hdd", 3) || path[0] == '+' || !strncmp(path, "pfs", 3)) {
-        hddLoadModules();
-        hddLoadSupportModules();
-
-        if (path[0] == '+') {
-            const char *slash = strchr(path, '/');
-            if (slash != NULL && slash[1] != '\0')
-                snprintf(path, pathLen, "pfs0:%s", slash + 1);
-            else
-                snprintf(path, pathLen, "pfs0:");
-        } else if (!strncmp(path, "hdd", 3)) {
-            const char *oplSub = strstr(path, "+OPL");
-            if (oplSub != NULL) {
-                const char *slash = strchr(oplSub, '/');
-                if (slash != NULL && slash[1] != '\0')
-                    snprintf(path, pathLen, "pfs0:%s", slash + 1);
-                else
-                    snprintf(path, pathLen, "pfs0:");
-            } else {
-                const char *pfsSub = strstr(path, ":pfs:/");
-                if (pfsSub != NULL)
-                    snprintf(path, pathLen, "pfs0:%s", pfsSub + 5);
-                else
-                    snprintf(path, pathLen, "%s", gHDDPrefix ? gHDDPrefix : "pfs0:");
-            }
-        }
-        return 0; // ready for configSetMove
-    }
-
     // Not a BDM namespace -> nothing to load; mc?: is ROM-backed and pfs0:/mmce are handled by their
     // own stacks, which are already up by the time a save runs.
     if (strncmp(path, "mass", 4) && strncmp(path, "usb", 3) && strncmp(path, "ata", 3) &&
@@ -1651,33 +1621,14 @@ static void resolveBootDirToMass(void)
     if (gBootDir[0] == '\0')
         return;
 
-    // APA-HDD / PFS boot (FHDB, uLE HDD, or direct PFS boot):
-    // Bring up the HDD/PFS stack so the partition is mounted to pfs0: and settings can load/save to HDD.
-    if (!strncmp(gBootDir, "hdd", 3) || !strncmp(gBootDir, "pfs", 3)) {
-        LOG("BOOT APA/PFS boot dir %s -> initializing HDD/PFS\n", gBootDir);
-        hddLoadModules();
-        hddLoadSupportModules();
-
-        if (!strncmp(gBootDir, "hdd", 3)) {
-            const char *pfsSub = strstr(gBootDir, ":pfs:/");
-            if (pfsSub != NULL) {
-                // e.g. "hdd0:__sysconf:pfs:/FMCB" -> "pfs0:/FMCB"
-                char sub[sizeof(gBootDir)];
-                snprintf(sub, sizeof(sub), "pfs0:%s", pfsSub + 5);
-                snprintf(gBootDir, sizeof(gBootDir), "%s", sub);
-            } else if (strstr(gBootDir, "+OPL") != NULL) {
-                const char *oplSub = strstr(gBootDir, "+OPL");
-                const char *slash = strchr(oplSub, '/');
-                if (slash != NULL && slash[1] != '\0')
-                    snprintf(gBootDir, sizeof(gBootDir), "pfs0:%s", slash + 1);
-                else
-                    snprintf(gBootDir, sizeof(gBootDir), "pfs0:");
-            } else {
-                snprintf(gBootDir, sizeof(gBootDir), "%s", gHDDPrefix ? gHDDPrefix : "pfs0:");
-            }
-        }
+    // uLE hands APA-HDD boots as "hdd0:<partition>:pfs:/..." -- a launch identity OPL can never open
+    // (OPL's own APA mount is pfs0: on the +OPL partition, a different namespace). Unresolvable: drop
+    // to legacy discovery, whose checkLoadConfigHDD probes the APA config location properly.
+    if (!strncmp(gBootDir, "hdd", 3)) {
+        LOG("BOOT unresolvable APA boot dir %s -> legacy discovery\n", gBootDir);
+        gBootDir[0] = '\0';
         configEnd();
-        configInit(gBootDir);
+        configInit(NULL);
         return;
     }
 


### PR DESCRIPTION
## Summary of Changes in Step 193

1. **Revert Synchronous HDD/PFS Module Loading during `_loadConfig()` (`src/opl.c`)**:
   - In `resolveBootDirToMass()` and `prepareCustomSettingsPath()`, reverted synchronous `hddLoadModules()` and `hddLoadSupportModules()` calls back to the proven behavior from v2566 (`bb21e343`) and `master`.
   - Booting from APA partition (`hdd0:...`) now blanks `gBootDir` and delegates HDD initialization to the safe asynchronous path (`deferredInit()`) after the GUI/GS is initialized, eliminating the early-boot lockup / hard black screen.

2. **Restore Coverflow Pagination Invariant (`src/menusys.c`)**:
   - In `menuNextV()` and `menuPrevV()`, removed early `return;` statements that prevented `pagestart` from updating during Coverflow scrolling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vertical Coverflow navigation so page positions update correctly during slide animations.
  * Prevented early HDD/PFS initialization during startup, avoiding potential boot lockups.
  * Improved configuration discovery by falling back to legacy behavior when HDD boot paths cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->