### PR TITLE
Step 195: APA / PFS __common partition resolution and HDD CWD support

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 195. Current tip: `rebuild/step-194-revert-to-known-good-2566`.** One focused change
+tip. **Next number: 196. Current tip: `rebuild/step-195-apa-pfs-common-partition-cwd`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1219,5 +1219,19 @@ it), not a re-derivation of (a).
    - Restored every source file, header, module, Makefile, script, and documentation asset across the entire repository to the exact bytecode state of commit `bb21e3432e20d00443946b0ec800a7d85bc96f9c`.
    - Confirmed via `git diff --stat bb21e343` that only `HANDOFF.md` differs (for history and pointer tracking).
    - This returns the repository to the exact build that was verified working on hardware.
+
+# 25. STEP-195: APA / PFS `__common` Partition Resolution & HDD CWD Support (2026-08-14)
+
+### What was implemented in Step 195:
+1. **HDD Boot CWD Prioritization in `tryAlternateDevice()` (`src/opl.c`)**:
+   - When booted from internal HDD/APA (`argv[0]` / `gBootDir` / `pwd` contains `hdd` or `pfs`), OPL directly probes the HDD first via `checkLoadConfigHDD()`, resolving the target partition via `hdd0:__common/OPL/conf_hdd.cfg` (or defaulting to `+OPL`) and mounting `pfs0:` without falling back to or touching a Memory Card.
+   - Preserves `gHDDPrefix` (`pfs0:` / `pfs0:OPL/`) as the active config home so memory-card-free users boot straight into their HDD settings.
+2. **HDD Save Mount Support in `trySaveConfigHDD()` (`src/opl.c`)**:
+   - In `trySaveConfigHDD()`, ensured `hddLoadSupportModules()` is called before `configSetMove(gHDDPrefix)` and `configWriteMulti()`, guaranteeing `pfs0:` is mounted before save writes to avoid Error 19 (`ENODEV`).
+3. **Partition Normalization for Custom Settings Path (`src/opl.c`)**:
+   - In `prepareCustomSettingsPath()`, automatically translates typed partition paths (`+OPL`, `hdd0:+OPL`, `__common`, `hdd0:__common`) to the mounted PFS filesystem path (`pfs0:` / `pfs0:OPL/`).
+4. **Colon-Slash Path Normalization (`src/config.c`)**:
+   - Implemented `configBuildPath` to properly handle trailing colons and slashes across prefixes (`pfs0:`, `pfs0:OPL/`, `mc0:OPL`), preventing malformed double slashes (`pfs0://conf_opl.cfg`).
+
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -292,6 +292,18 @@ void configPrepareNotifications(char *prefix)
         *(colpos + 1) = '\0';
 }
 
+static void configBuildPath(char *out, size_t outSize, const char *prefix, const char *filename)
+{
+    size_t len = prefix ? strlen(prefix) : 0;
+    if (len == 0) {
+        snprintf(out, outSize, "%s", filename);
+    } else if (prefix[len - 1] == '/' || prefix[len - 1] == ':') {
+        snprintf(out, outSize, "%s%s", prefix, filename);
+    } else {
+        snprintf(out, outSize, "%s/%s", prefix, filename);
+    }
+}
+
 void configInit(char *prefix)
 {
     char path[256];
@@ -300,10 +312,10 @@ void configInit(char *prefix)
     if (!prefix)
         prefix = gBaseMCDir;
 
-    snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
+    configBuildPath(legacyNetConfigPath, sizeof(legacyNetConfigPath), prefix, "IPCONFIG.DAT");
 
     for (i = 0; i < CONFIG_INDEX_COUNT; i++) {
-        snprintf(path, sizeof(path), "%s/%s", prefix, configFilenames[i]);
+        configBuildPath(path, sizeof(path), prefix, configFilenames[i]);
         configAlloc(1 << i, &configFiles[i], path);
     }
 
@@ -318,10 +330,10 @@ void configSetMove(char *prefix)
     if (!prefix)
         prefix = gBaseMCDir;
 
-    snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
+    configBuildPath(legacyNetConfigPath, sizeof(legacyNetConfigPath), prefix, "IPCONFIG.DAT");
 
     for (i = 0; i < CONFIG_INDEX_COUNT; i++) {
-        snprintf(path, sizeof(path), "%s/%s", prefix, configFilenames[i]);
+        configBuildPath(path, sizeof(path), prefix, configFilenames[i]);
         configMove(&configFiles[i], path);
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1470,6 +1470,43 @@ static int prepareCustomSettingsPath(char *path, int pathLen)
     if (path == NULL || path[0] == '\0')
         return 0;
 
+    // APA HDD / PFS paths: translate "hdd0:+OPL", "hdd0:/+OPL", "+OPL", "+OPL/CFG", "pfs0:...", "hdd0:__common..."
+    // to the mounted PFS path.
+    if (!strncmp(path, "hdd", 3) || path[0] == '+' || !strncmp(path, "pfs", 3) || !strncmp(path, "__common", 8)) {
+        hddLoadModules();
+        hddLoadSupportModules();
+
+        if (path[0] == '+') {
+            const char *slash = strchr(path, '/');
+            if (slash != NULL && slash[1] != '\0')
+                snprintf(path, pathLen, "pfs0:%s", slash + 1);
+            else
+                snprintf(path, pathLen, "pfs0:");
+        } else if (!strncmp(path, "__common", 8)) {
+            const char *slash = strchr(path, '/');
+            if (slash != NULL && slash[1] != '\0')
+                snprintf(path, pathLen, "pfs0:%s", slash + 1);
+            else
+                snprintf(path, pathLen, "pfs0:OPL/");
+        } else if (!strncmp(path, "hdd", 3)) {
+            const char *oplSub = strstr(path, "+OPL");
+            if (oplSub != NULL) {
+                const char *slash = strchr(oplSub, '/');
+                if (slash != NULL && slash[1] != '\0')
+                    snprintf(path, pathLen, "pfs0:%s", slash + 1);
+                else
+                    snprintf(path, pathLen, "pfs0:");
+            } else {
+                const char *pfsSub = strstr(path, ":pfs:/");
+                if (pfsSub != NULL)
+                    snprintf(path, pathLen, "pfs0:%s", pfsSub + 5);
+                else
+                    snprintf(path, pathLen, "%s", gHDDPrefix ? gHDDPrefix : "pfs0:");
+            }
+        }
+        return 0; // ready for configSetMove / configInit
+    }
+
     // Not a BDM namespace -> nothing to load; mc?: is ROM-backed and pfs0:/mmce are handled by their
     // own stacks, which are already up by the time a save runs.
     if (strncmp(path, "mass", 4) && strncmp(path, "usb", 3) && strncmp(path, "ata", 3) &&
@@ -1508,6 +1545,22 @@ static int tryAlternateDevice(int types)
     // settings are strictly homed to gBootDir. Never probe alternate devices (mass0:/hdd0:) or hijack
     // the save location away from CWD/Memory Card.
     if (gBootDir[0] != '\0') {
+        // If booted from HDD/APA/PFS (e.g. "hdd0:__sysconf:pfs:/FMCB", "hdd0:+OPL", "hdd0:__common", "pfs0:"):
+        // Check HDD first via checkLoadConfigHDD (mounts __common, reads conf_hdd.cfg, mounts target partition).
+        if (!strncmp(gBootDir, "hdd", 3) || !strncmp(gBootDir, "pfs", 3)) {
+            value = checkLoadConfigHDD(types);
+            if (value & CONFIG_OPL)
+                return value;
+            // Even if no config existed yet, keep HDD partition as the config home
+            if (gHDDPrefix != NULL) {
+                configEnd();
+                configInit(gHDDPrefix);
+                configPrepareNotifications(gHDDPrefix);
+                showCfgPopup = 0;
+                return 0;
+            }
+        }
+
         // LEGACY READ-ONLY FALLBACK. Every build before the CWD doctrine -- ours and official alike
         // -- homed settings at mc?:OPL, so every existing install's config lives THERE, not beside
         // the ELF. Without this, upgrading silently reset every user to defaults (reported from
@@ -1556,7 +1609,21 @@ static int tryAlternateDevice(int types)
         return 0;
     }
 
-    // Bare ELF launch without boot directory context: try Memory Card first.
+    // Bare ELF launch without boot directory context: check HDD first if pwd is hdd, else MC first.
+    char pwd[64] = {0};
+    if (getcwd(pwd, sizeof(pwd)) != NULL && (!strncmp(pwd, "hdd", 3) || !strncmp(pwd, "pfs", 3))) {
+        value = checkLoadConfigHDD(types);
+        if (value & CONFIG_OPL)
+            return value;
+        if (gHDDPrefix != NULL) {
+            configEnd();
+            configInit(gHDDPrefix);
+            configPrepareNotifications(gHDDPrefix);
+            showCfgPopup = 0;
+            return 0;
+        }
+    }
+
     if (sysCheckMC() >= 0) {
         configPrepareNotifications(gBaseMCDir);
         showCfgPopup = 0;
@@ -1570,9 +1637,10 @@ static int tryAlternateDevice(int types)
         configEnd();
         configInit("mass0:");
     } else {
-        dir = opendir(gHDDPrefix);
-        if (dir != NULL) {
-            closedir(dir);
+        value = checkLoadConfigHDD(types);
+        if (value & CONFIG_OPL)
+            return value;
+        if (gHDDPrefix != NULL) {
             configEnd();
             configInit(gHDDPrefix);
         }
@@ -1628,14 +1696,11 @@ static void resolveBootDirToMass(void)
     if (gBootDir[0] == '\0')
         return;
 
-    // uLE hands APA-HDD boots as "hdd0:<partition>:pfs:/..." -- a launch identity OPL can never open
-    // (OPL's own APA mount is pfs0: on the +OPL partition, a different namespace). Unresolvable: drop
-    // to legacy discovery, whose checkLoadConfigHDD probes the APA config location properly.
-    if (!strncmp(gBootDir, "hdd", 3)) {
-        LOG("BOOT unresolvable APA boot dir %s -> legacy discovery\n", gBootDir);
-        gBootDir[0] = '\0';
-        configEnd();
-        configInit(NULL);
+    // APA-HDD / PFS boots (FHDB, uLE HDD, __common, etc.):
+    // Leave gBootDir intact so tryAlternateDevice knows OPL booted from HDD and probes
+    // hdd0:__common/OPL/conf_hdd.cfg first without blocking early boot.
+    if (!strncmp(gBootDir, "hdd", 3) || !strncmp(gBootDir, "pfs", 3)) {
+        LOG("BOOT APA/PFS boot dir %s -> HDD discovery\n", gBootDir);
         return;
     }
 
@@ -2090,8 +2155,9 @@ static int trySaveConfigBDM(int types)
 static int trySaveConfigHDD(int types)
 {
     hddLoadModules();
+    hddLoadSupportModules();
     // Check that the formatted & usable HDD is connected.
-    if (hddCheck() == 0) {
+    if (hddCheck() == 0 && gHDDPrefix != NULL) {
         configSetMove(gHDDPrefix);
         return configWriteMulti(types);
     }
@@ -2107,23 +2173,20 @@ static int trySaveConfigMC(int types)
 
 static int trySaveAlternateDevice(int types)
 {
-    // Big enough for a real device prefix and ZEROED first: getcwd() into a bare char[8] left the
-    // buffer as stack garbage when it failed (this function is only reachable when the boot
-    // identity could not be determined -- exactly when getcwd is most likely to fail), and the
-    // strncmp probes below then read uninitialised bytes. A "mass"-shaped garbage match steered
-    // the save at a device that was never the cwd.
-    char pwd[16] = {0};
+    char pwd[64] = {0};
     int value;
 
-    if (getcwd(pwd, sizeof(pwd)) == NULL)
+    if (gBootDir[0] != '\0')
+        snprintf(pwd, sizeof(pwd), "%s", gBootDir);
+    else if (getcwd(pwd, sizeof(pwd)) == NULL)
         pwd[0] = '\0';
 
     // First, try the device that OPL booted from.
-    if (!strncmp(pwd, "mass", 4) && (pwd[4] == ':' || pwd[5] == ':')) {
-        if ((value = trySaveConfigBDM(types)) > 0)
-            return value;
-    } else if (!strncmp(pwd, "hdd", 3) && (pwd[3] == ':' || pwd[4] == ':')) {
+    if (!strncmp(pwd, "hdd", 3) || !strncmp(pwd, "pfs", 3)) {
         if ((value = trySaveConfigHDD(types)) > 0)
+            return value;
+    } else if (!strncmp(pwd, "mass", 4) && (pwd[4] == ':' || pwd[5] == ':')) {
+        if ((value = trySaveConfigBDM(types)) > 0)
             return value;
     }
 


### PR DESCRIPTION
## Summary of Changes in Step 195

1. **HDD Boot CWD Prioritization in `tryAlternateDevice()` (`src/opl.c`)**:
   - When booted from internal HDD/APA (`argv[0]` / `gBootDir` / `pwd` contains `hdd` or `pfs`), OPL directly probes the HDD first via `checkLoadConfigHDD()`, resolving the target partition via `hdd0:__common/OPL/conf_hdd.cfg` (or defaulting to `+OPL`) and mounting `pfs0:` without falling back to or touching a Memory Card.
   - Preserves `gHDDPrefix` (`pfs0:` / `pfs0:OPL/`) as the active config home so memory-card-free users boot straight into their HDD settings.

2. **HDD Save Mount Support in `trySaveConfigHDD()` (`src/opl.c`)**:
   - In `trySaveConfigHDD()`, ensured `hddLoadSupportModules()` is called before `configSetMove(gHDDPrefix)` and `configWriteMulti()`, guaranteeing `pfs0:` is mounted before save writes to avoid Error 19 (`ENODEV`).

3. **Partition Normalization for Custom Settings Path (`src/opl.c`)**:
   - In `prepareCustomSettingsPath()`, automatically translates typed partition paths (`+OPL`, `hdd0:+OPL`, `__common`, `hdd0:__common`) to the mounted PFS filesystem path (`pfs0:` / `pfs0:OPL/`).

4. **Colon-Slash Path Normalization (`src/config.c`)**:
   - Implemented `configBuildPath` to properly handle trailing colons and slashes across prefixes (`pfs0:`, `pfs0:OPL/`, `mc0:OPL`), preventing malformed double slashes (`pfs0://conf_opl.cfg`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved configuration discovery and saving for HDD/APA/PFS environments.
  * Added support for normalized `pfs0:` paths and HDD boot directories.
  * Improved handling of alternate save locations and bare launches.

* **Bug Fixes**
  * Prevented malformed configuration paths when prefixes already contain separators.
  * Preserved HDD boot directories during configuration loading.
  * Improved compatibility with paths using colon or slash separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->