### PR TITLE
rebuild-201: APA HDD memory safety hardening and buffer overflow protections

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 201. Current tip: `rebuild/step-200-fix-null-deref-and-apa-pfs-prefix-resolution`.** One focused change
+tip. **Next number: 202. Current tip: `rebuild/step-201-apa-memory-safety-and-bounds-hardening`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1205,4 +1205,12 @@ it), not a re-derivation of (a).
    - In `src/config.c`, added `configBuildPath()` to cleanly format paths with `pfs0:` prefixes without double slashes (`pfs0:conf_opl.cfg` and `pfs0:OPL/conf_opl.cfg`).
 4. **Safe PFS Mount on Save**:
    - In `src/opl.c:trySaveConfigHDD()`, ensured `hddLoadSupportModules()` mounts `pfs0:` before writing.
+
+# 27. STEP-201: APA HDD Memory Safety & Bounds Hardening (2026-08-15)
+
+### What changed:
+1. **`src/hdd.c` Memory Safety & Buffer Overflow Fixes**:
+   - `hddGetFileBlockInfo`: Fixed out-of-bounds heap over-read by replacing `memcpy(blocks, inode->data, max * sizeof(pfs_blockinfo_t))` with `memcpy(blocks, inode->data, inode->number_data * sizeof(pfs_blockinfo_t))`.
+   - `hddGetPartitionInfo`: Added `nsub > APA_MAXSUB` clamping before copying sub-partitions to `parts[APA_MAXSUB + 1]`, preventing stack buffer corruption on invalid or corrupted APA partition headers.
+   - `hddGetHDLGamelist`: Restored `saw_hdl` check to return `-ENOMEM` when partitions exist on disk but all memory allocations fail.
 

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -196,8 +196,10 @@ int hddGetHDLGamelist(hdl_games_list_t *game_list)
     if ((fd = fileXioDopen("hdd0:")) >= 0) {
         head = current = NULL;
         count = 0;
+        int saw_hdl = 0;
         while (fileXioDread(fd, &dirent) > 0) {
             if (dirent.stat.mode == HDL_FS_MAGIC) {
+                saw_hdl = 1;
                 if ((pGameEntry = GetGameListRecord(head, dirent.name)) == NULL) {
                     if (head == NULL) {
                         current = head = malloc(sizeof(struct GameDataEntry));
@@ -227,6 +229,9 @@ int hddGetHDLGamelist(hdl_games_list_t *game_list)
         }
 
         fileXioDclose(fd);
+
+        if (saw_hdl && head == NULL)
+            ret = -ENOMEM;
 
         if (head != NULL) {
             if ((game_list->games = malloc(sizeof(hdl_game_info_t) * count)) != NULL) {
@@ -413,10 +418,16 @@ int hddGetPartitionInfo(const char *name, apa_sub_t *parts)
             parts[0].start = header->start;
             parts[0].length = header->length;
 
-            for (i = 0; i < header->nsub; i++)
+            // Clamp the on-disk sub-partition count to the caller's parts[APA_MAXSUB+1]
+            // array; a corrupt or foreign APA header could otherwise overflow it.
+            int nsub = header->nsub;
+            if (nsub > APA_MAXSUB)
+                nsub = APA_MAXSUB;
+
+            for (i = 0; i < nsub; i++)
                 parts[1 + i] = header->subs[i];
 
-            result = header->nsub + 1;
+            result = nsub + 1;
         } else
             result = -EIO;
     }
@@ -438,7 +449,7 @@ int hddGetFileBlockInfo(const char *name, const apa_sub_t *subs, pfs_blockinfo_t
 
         if (hddReadSectors(lba, sizeof(pfs_inode_t) / 512, inode) == 0) {
             if (inode->number_data < max) {
-                memcpy(blocks, inode->data, max * sizeof(pfs_blockinfo_t));
+                memcpy(blocks, inode->data, inode->number_data * sizeof(pfs_blockinfo_t));
                 result = inode->number_data;
             } else
                 result = -ENOMEM;


### PR DESCRIPTION
## Summary of Changes

### 1. `src/hdd.c` Memory Safety & Buffer Overflow Protections
- **`hddGetFileBlockInfo`**: Fixed out-of-bounds heap over-read by replacing `memcpy(blocks, inode->data, max * sizeof(pfs_blockinfo_t))` with `memcpy(blocks, inode->data, inode->number_data * sizeof(pfs_blockinfo_t))`.
- **`hddGetPartitionInfo`**: Added `nsub > APA_MAXSUB` clamping before copying sub-partitions to `parts[APA_MAXSUB + 1]`, preventing stack buffer corruption when processing invalid or corrupted APA partition headers.
- **`hddGetHDLGamelist`**: Restored `saw_hdl` check to return `-ENOMEM` when partitions exist on disk but all memory allocations fail.

### 2. `HANDOFF.md`
- Documented step-201 and bumped next step pointer to 202.

## CI Validation
All 4 build flavours (OFFICIALPINNED, PS2DEVPINNED, OFFICIALROLLING, PS2DEVROLLING) passed green in CI run 31876505653.
