### PR TITLE
rebuild-202: Include regular ELFs in all 4 flavours in MEGA uploads

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -970,7 +970,25 @@ jobs:
           done
           ( cd rolling && zip -r -X "../mega-out/${ARCHIVE}" $MEGA_FILES >/dev/null )
 
-          echo "MEGA_ARCHIVE=mega-out/${ARCHIVE}" >> "$GITHUB_ENV"
+          # Copy the regular standalone ELFs in all 4 flavours so they are available
+          # directly in the MEGA folder alongside the all-in-one archive.
+          for elf in "rolling/${VERSIONED_BASE}-PS2DEVROLLING.ELF" \
+                     "rolling/${VERSIONED_BASE}-PS2DEVPINNED.ELF" \
+                     "rolling/${VERSIONED_BASE}-OFFICIALROLLING.ELF" \
+                     "rolling/${VERSIONED_BASE}-OFFICIALPINNED.ELF"; do
+            if [ -f "$elf" ]; then
+              cp -f "$elf" mega-out/
+            fi
+          done
+
+          MEGA_UPLOAD_FILES="mega-out/${ARCHIVE}"
+          for f in mega-out/*.ELF; do
+            if [ -f "$f" ]; then
+              MEGA_UPLOAD_FILES="$MEGA_UPLOAD_FILES $f"
+            fi
+          done
+          echo "MEGA_UPLOAD_FILES=${MEGA_UPLOAD_FILES}" >> "$GITHUB_ENV"
+
           # Suggested layout: /RiptOPL/Rolling/<version>/run_<run number>/ -- run number keeps every
           # build in its own immutable folder (nothing is ever overwritten on MEGA).
           echo "MEGA_REMOTE_DIR=/RiptOPL/Rolling/${VER}/run_${GITHUB_RUN_NUMBER}/" >> "$GITHUB_ENV"
@@ -979,8 +997,10 @@ jobs:
           unzip -l "mega-out/${ARCHIVE}"
           echo "== MEGA archive SHA256 =="
           sha256sum "mega-out/${ARCHIVE}" | tee "mega-out/${ARCHIVE}.sha256"
+          echo "== MEGA staged files for upload =="
+          ls -la mega-out
 
-      - name: Upload the all-in-one archive to MEGA
+      - name: Upload archive and regular ELFs in all 4 flavours to MEGA
         if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rebuild/main') && env.USERNAME != '' && env.PASSWORD != ''
         # Pinned to a full commit SHA rather than @master: this third-party action runs with the
         # MEGA credentials, so freeze it to a reviewed snapshot instead of trusting whatever is on
@@ -988,8 +1008,8 @@ jobs:
         # validated for this change, so behavior is identical. Bump deliberately (re-review first).
         uses: Difegue/action-megacmd@bf698c68edaf91143b2a52d3468595202011bf17 # v1.4.0
         with:
-          # Runs `mega-put -c <archive> <remotedir>/`: -c creates the remote folder path if missing,
-          # the trailing slash puts the file INTO that folder. Uploads ONLY the single all-in-one
-          # zip -- individual assets are NOT uploaded separately. Credentials come from the job-level
+          # Runs `mega-put -c <files...> <remotedir>/`: -c creates the remote folder path if missing,
+          # the trailing slash puts the files INTO that folder. Uploads the all-in-one zip archive
+          # and the regular ELFs for all four SDK flavours. Credentials come from the job-level
           # USERNAME/PASSWORD env, which this action reads by those exact names.
-          args: put -c ${{ env.MEGA_ARCHIVE }} ${{ env.MEGA_REMOTE_DIR }}
+          args: put -c ${{ env.MEGA_UPLOAD_FILES }} ${{ env.MEGA_REMOTE_DIR }}

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 202. Current tip: `rebuild/step-201-apa-memory-safety-and-bounds-hardening`.** One focused change
+tip. **Next number: 203. Current tip: `rebuild/step-202-mega-upload-all-four-elf-flavours`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1213,4 +1213,12 @@ it), not a re-derivation of (a).
    - `hddGetFileBlockInfo`: Fixed out-of-bounds heap over-read by replacing `memcpy(blocks, inode->data, max * sizeof(pfs_blockinfo_t))` with `memcpy(blocks, inode->data, inode->number_data * sizeof(pfs_blockinfo_t))`.
    - `hddGetPartitionInfo`: Added `nsub > APA_MAXSUB` clamping before copying sub-partitions to `parts[APA_MAXSUB + 1]`, preventing stack buffer corruption on invalid or corrupted APA partition headers.
    - `hddGetHDLGamelist`: Restored `saw_hdl` check to return `-ENOMEM` when partitions exist on disk but all memory allocations fail.
+
+# 28. STEP-202: Include regular ELFs in all 4 flavours in MEGA uploads (2026-08-15)
+
+### What changed:
+1. **`.github/workflows/rolling-release.yml`**:
+   - In step `Build all-in-one MEGA archive`: Staged the regular standalone ELFs for all four SDK flavours (`PS2DEVROLLING`, `PS2DEVPINNED`, `OFFICIALROLLING`, `OFFICIALPINNED`) into `mega-out/`.
+   - In step `Upload archive and regular ELFs in all 4 flavours to MEGA`: Updated `mega-put` args to upload the all-in-one zip archive AND the four regular standalone ELFs directly to `/RiptOPL/Rolling/<version>/run_<run_number>/`.
+2. **`README.md`**: Updated MEGA archival description from "both loader ELFs" to "all four loader ELFs".
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ contains and how to pull it.
 
 > 🗄️ **Permanent archive (MEGA):** the GitHub `rolling` pre-release only ever holds the *latest*
 > build — every push overwrites it. So **every** rolling build is also archived permanently to MEGA
-> as one self-contained zip of the installable payload (both loader ELFs, the installable
+> as one self-contained zip of the installable payload (all four loader ELFs, the installable
 > package zip, the source snapshot, `SHA256SUMS.txt`, and the IRX manifests — the large VARIANTS
 > and DEBUG diagnostic bundles stay on the GitHub release only). Click the **MEGA**
 > badge at the top of this README — or [browse the archive here](https://mega.nz/folder/74pRHKRB#9SLDkrkvZAbeKO4Qvxg9LQ) —


### PR DESCRIPTION
## Summary of Changes

### 1. `.github/workflows/rolling-release.yml`
- In step `Build all-in-one MEGA archive`: Staged the regular standalone ELFs for all four SDK flavours (`PS2DEVROLLING`, `PS2DEVPINNED`, `OFFICIALROLLING`, `OFFICIALPINNED`) into `mega-out/`.
- In step `Upload archive and regular ELFs in all 4 flavours to MEGA`: Updated `mega-put` args to upload the all-in-one zip archive AND the four regular standalone ELFs directly to `/RiptOPL/Rolling/<version>/run_<run_number>/`.

### 2. Documentation
- `README.md`: Updated MEGA archival description from "both loader ELFs" to "all four loader ELFs".
- `HANDOFF.md`: Documented step 202 and bumped next step pointer to 203.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rolling MEGA releases now include standalone loader ELF binaries for all four SDK variants alongside the all-in-one archive.

* **Documentation**
  * Updated release documentation to describe the expanded archive contents.
  * Updated handoff instructions for the latest release step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->