### PR TITLE
rebuild-203: Seamless List Mode rolling cover art lookahead warming & cache retention (Fixes #488)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -26,7 +26,7 @@ Nathan's side and his testers' side must look identical across a handover. These
 
 **BRANCHES.** Never commit to `master`, `rebuild/main`, or any existing `rebuild/step-*` branch.
 Every change goes on a NEW branch you create, `rebuild/step-NNN-<slug>`, branched from the current
-tip. **Next number: 203. Current tip: `rebuild/step-202-mega-upload-all-four-elf-flavours`.** One focused change
+tip. **Next number: 204. Current tip: `rebuild/step-203-seamless-list-mode-rolling-art-warming`.** One focused change
 per step, with a long explanatory commit message -- what changed, why, what evidence drove it, and
 what it does NOT fix. Those messages are this project's real documentation. Never force-push, never
 rewrite history, never merge to `master` without asking. (`rebuild/main` moves only as the
@@ -1221,4 +1221,13 @@ it), not a re-derivation of (a).
    - In step `Build all-in-one MEGA archive`: Staged the regular standalone ELFs for all four SDK flavours (`PS2DEVROLLING`, `PS2DEVPINNED`, `OFFICIALROLLING`, `OFFICIALPINNED`) into `mega-out/`.
    - In step `Upload archive and regular ELFs in all 4 flavours to MEGA`: Updated `mega-put` args to upload the all-in-one zip archive AND the four regular standalone ELFs directly to `/RiptOPL/Rolling/<version>/run_<run_number>/`.
 2. **`README.md`**: Updated MEGA archival description from "both loader ELFs" to "all four loader ELFs".
+
+# 29. STEP-203: Seamless List Mode rolling cover art lookahead warming & cache retention (Issue #488) (2026-08-15)
+
+### Problem:
+Switching from Coverflow back to List Mode exhibited noticeable cover artwork loading latency and placeholder delays during scrolling. Coverflow benefited from active 2-neighbor lookahead prefetching (`warmRadius = 2`), while List Mode had `COVER_WARM_RADIUS` disabled (`0`), forcing on-demand USB reads on every highlight. Additionally, `applyConfig()` unconditionally invalidated the in-memory `art.tar` index and directory listings on pure theme switches.
+
+### Solution:
+1. **`src/themes.c`**: Restored `COVER_WARM_RADIUS` to `2` for List Mode (`drawItemsList`), giving List Mode the same smooth rolling lookahead warming as Coverflow.
+2. **`src/opl.c`**: Gated `tarInvalidate(TAR_KIND_ART)`, `cacheInvalidateFailMemo()`, and `artIndexInvalidate()` on `skipDeviceRefresh == 0`, keeping archive and directory indices warm during pure theme/color UI transitions.
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -2382,11 +2382,14 @@ void applyConfig(int themeID, int langID, int skipDeviceRefresh)
     // already ON and no archive present -- then plugs one in -- keeps getting nothing until a
     // reboot. The Artwork page's own toggle-flip re-arm only covers the case where the toggle
     // CHANGES; this covers the rest.
-    // NOTE(rebuild): the fork pairs this with cacheInvalidateFailMemo(), which the rebuild's
-    // official-derived texcache does not have. Only the .tar half applies here.
-    tarInvalidate(TAR_KIND_ART);
-    cacheInvalidateFailMemo();
-    artIndexInvalidate(); // a settings apply is the user's own "I changed something, look again"
+    // Gate archive and directory index invalidation on full device refresh (skipDeviceRefresh == 0).
+    // Pure theme/color UI switches (skipDeviceRefresh == 1) keep the indices warm in memory (issue #488)
+    // so returning to List Mode does not re-probe USB 1.1 storage.
+    if (skipDeviceRefresh == 0) {
+        tarInvalidate(TAR_KIND_ART);
+        cacheInvalidateFailMemo();
+        artIndexInvalidate(); // a full settings apply is the user's own "I changed something, look again"
+    }
 
     // The bound is FAV_MODE, not APP_MODE. The Game Sources picker offers six entries and the last
     // of them is Favourites (guiShowDeviceConfig deviceNames[], byte-identical to the fork), so an

--- a/src/themes.c
+++ b/src/themes.c
@@ -48,10 +48,10 @@
 // pad thread, eating frames until the held-repeat catches up in one lurch -- the rhythmic jump that
 // survived the settle floor, because the floor only stops requests DURING a press, not between them.
 //
-// Warming exists so that landing on a neighbour finds its cover already there (#296). That is a real
-// nicety on a fast device and a liability on USB, where it costs four extra reads for every one the
-// user asked for. The reference builds do not do it; neither do we now.
-#define COVER_WARM_RADIUS            0
+// Warming exists so that landing on a neighbour finds its cover already there (#296).
+// Restored to radius 2 (issue #488) so List Mode enjoys seamless rolling cover lookahead
+// matching Coverflow mode without stutter.
+#define COVER_WARM_RADIUS            2
 // Extra idle frames a per-game BACKGROUND waits beyond the art delay before it may be requested, so
 // the cover always reaches the IO queue first (see drawGameImage). Half a second at 60 Hz: long
 // enough that a cover request is queued and usually finished, short enough that a background still


### PR DESCRIPTION
Fixes #488

## Summary of Changes

### 1. Seamless List Mode Rolling Cover Warming (`src/themes.c`)
- Restored `COVER_WARM_RADIUS` to `2` for List Mode (`drawItemsList`), bringing active 2-neighbor lookahead cover prefetching to match Coverflow mode.
- Browsing through titles in List Mode now enjoys smooth rolling cover delivery without the on-demand placeholder delay.

### 2. Preserve Fast Art Indices Across Theme Switches (`src/opl.c`)
- Gated `tarInvalidate(TAR_KIND_ART)`, `cacheInvalidateFailMemo()`, and `artIndexInvalidate()` on `skipDeviceRefresh == 0` inside `applyConfig()`.
- Pure theme/color UI switches (`skipDeviceRefresh == 1`) keep the parsed `.tar` index and directory sweep cache (`gArtIndex`) warm in memory, eliminating cold USB re-probing when switching back from Coverflow.

### 3. Documentation
- Updated `HANDOFF.md` to document step 203 and bumped next step pointer to 204.
