### PR TITLE
rebuild-206: Fix APA boot directory resolution infinite recursion and support PFS paths

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1216,7 +1216,6 @@ it), not a re-derivation of (a).
 
 # 28. STEP-202: Include regular ELFs in all 4 flavours in MEGA uploads (2026-08-15)
 
-<<<<<<< HEAD
 ### What changed:
 1. **`.github/workflows/rolling-release.yml`**:
    - In step `Build all-in-one MEGA archive`: Staged the regular standalone ELFs for all four SDK flavours (`PS2DEVROLLING`, `PS2DEVPINNED`, `OFFICIALROLLING`, `OFFICIALPINNED`) into `mega-out/`.
@@ -1253,4 +1252,16 @@ wLaunchELF-R3Z supports dual HDDs (`hdd0:` and `hdd1:`) and passes `argv[0]` as 
    - Extracts any nested subfolder (e.g. `OPL`, `FMCB`, `APPS/OPL`), resolving `gBootDir` to `pfs0:<subfolder>` (or `pfs0:` for root) and stripping any terminal ELF binary name.
    - Validates the mount via `opendir()`, homes configuration sets directly there, and sets `gHDDStartMode = START_MODE_AUTO` using `hddLoadModulesReady()`.
 
+# 32. STEP-206: Fix APA Boot Directory Resolution Infinite Recursion (2026-08-15)
 
+## Problem
+
+When booting from an APA HDD path (such as `hdd0:/__common/OPL/OPNPSX.ELF` or `hdd0:__common:pfs:/OPL/OPNPSX.ELF` from wLaunchELF-R3Z / uLE / FHDB), `configInit()` called `_loadConfig()`, which called `resolveBootDirToMass()`. Inside `resolveBootDirToMass()`, `gBootDir` was resolved to `pfs0:OPL` and re-homed by calling `configEnd(); configInit(gBootDir);`. In that second `configInit()` call, `_loadConfig()` ran again, triggered `resolveBootDirToMass()` on `pfs0:OPL`, and unconditionally re-homed `configInit(gBootDir)` in an infinite recursive loop. This blew the EE call stack within milliseconds, hanging the PlayStation 2 in a permanent black screen prior to graphics initialization.
+
+## Solution
+
+1. **`src/opl.c:resolveBootDirToMass()`**:
+   - Recorded `before` boot directory buffer before APA path parsing.
+   - Gated the `configEnd(); configInit(gBootDir);` re-homing call on `if (strcmp(before, gBootDir) != 0)`. On the re-homed pass (`before == "pfs0:OPL"`), execution terminates cleanly without re-entering `configInit()`.
+2. **`src/opl.c:apaParseBootPath()`**:
+   - Added direct support for already-mounted PFS paths (`pfs0:OPL`, `pfs0:`), populating `outBootDir` and `outHddPrefix` cleanly and returning success without rejecting `pfs` prefixes.

--- a/src/opl.c
+++ b/src/opl.c
@@ -1634,8 +1634,9 @@ static int apaParseBootPath(const char *bootPath, char *outPart, size_t partSize
     if (bootPath == NULL)
         return -1;
 
-    // Direct PFS mount paths (e.g. "pfs0:OPL", "pfs0:")
-    if (!strncmp(bootPath, "pfs", 3)) {
+    // Direct PFS mount paths (e.g. "pfs0:OPL", "pfs0:", "pfs:OPL")
+    if (bootPath[0] == 'p' && bootPath[1] == 'f' && bootPath[2] == 's' &&
+        ((isdigit((unsigned char)bootPath[3]) && bootPath[4] == ':') || bootPath[3] == ':')) {
         if (outBootDir != NULL && bootDirSize > 0)
             snprintf(outBootDir, bootDirSize, "%s", bootPath);
         if (outHddPrefix != NULL && prefixSize > 0) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -1631,7 +1631,27 @@ static int gBootDirBdmType = BDM_TYPE_UNKNOWN;
 // "hdd0:__sysconf:pfs:/FMCB", "hdd0:/__sysconf/FMCB", "hdd0:/__contents/APPS", etc.
 static int apaParseBootPath(const char *bootPath, char *outPart, size_t partSize, char *outBootDir, size_t bootDirSize, char *outHddPrefix, size_t prefixSize)
 {
-    if (bootPath == NULL || strncmp(bootPath, "hdd", 3) != 0)
+    if (bootPath == NULL)
+        return -1;
+
+    // Direct PFS mount paths (e.g. "pfs0:OPL", "pfs0:")
+    if (!strncmp(bootPath, "pfs", 3)) {
+        if (outBootDir != NULL && bootDirSize > 0)
+            snprintf(outBootDir, bootDirSize, "%s", bootPath);
+        if (outHddPrefix != NULL && prefixSize > 0) {
+            snprintf(outHddPrefix, prefixSize, "%s", bootPath);
+            size_t len = strlen(outHddPrefix);
+            if (len > 0 && outHddPrefix[len - 1] != '/') {
+                if (len + 1 < prefixSize) {
+                    outHddPrefix[len] = '/';
+                    outHddPrefix[len + 1] = '\0';
+                }
+            }
+        }
+        return 0;
+    }
+
+    if (strncmp(bootPath, "hdd", 3) != 0)
         return -1;
     // Strictly accept only unit numbers 0 and 1 followed by ':' or '/'
     if (bootPath[3] != '0' && bootPath[3] != '1')
@@ -1715,13 +1735,17 @@ static void resolveBootDirToMass(void)
     // so config and CWD live on the APA partition beside the ELF with no multi-device probe discovery.
     if (!strncmp(gBootDir, "hdd", 3) || !strncmp(gBootDir, "pfs", 3)) {
         if (hddLoadModulesReady()) {
+            char before[sizeof(gBootDir)];
+            snprintf(before, sizeof(before), "%s", gBootDir);
             char targetPart[64] = {0};
             char resolvedBootDir[sizeof(gBootDir)] = {0};
             char resolvedHddPrefix[64] = {0};
 
             if (apaParseBootPath(gBootDir, targetPart, sizeof(targetPart), resolvedBootDir, sizeof(resolvedBootDir), resolvedHddPrefix, sizeof(resolvedHddPrefix)) == 0) {
-                // Set gOPLPart to the exact partition where the ELF was launched from
-                snprintf(gOPLPart, sizeof(gOPLPart), "%s", targetPart);
+                if (targetPart[0] != '\0') {
+                    // Set gOPLPart to the exact partition where the ELF was launched from
+                    snprintf(gOPLPart, sizeof(gOPLPart), "%s", targetPart);
+                }
             }
 
             hddLoadSupportModules();
@@ -1739,11 +1763,15 @@ static void resolveBootDirToMass(void)
                         while (rlen > 0 && gBootDir[rlen - 1] == '/')
                             gBootDir[--rlen] = '\0';
                     }
-                    LOG("BOOT resolved APA boot dir -> %s (part %s)\n", gBootDir, gOPLPart);
-                    configEnd();
-                    configInit(gBootDir);
                     if (gHDDStartMode == START_MODE_DISABLED)
                         gHDDStartMode = START_MODE_AUTO;
+
+                    // Only re-home configInit if gBootDir actually changed (prevents infinite recursion)
+                    if (strcmp(before, gBootDir) != 0) {
+                        LOG("BOOT resolved APA boot dir %s -> %s (part %s)\n", before, gBootDir, gOPLPart);
+                        configEnd();
+                        configInit(gBootDir);
+                    }
                     return;
                 }
             }


### PR DESCRIPTION
## Problem

When booting from an APA HDD path (such as `hdd0:/__common/OPL/OPNPSX.ELF` or `hdd0:__common:pfs:/OPL/OPNPSX.ELF` from wLaunchELF-R3Z / uLE / FHDB), `configInit()` called `_loadConfig()`, which called `resolveBootDirToMass()`. Inside `resolveBootDirToMass()`, `gBootDir` was resolved to `pfs0:OPL` and re-homed by calling `configEnd(); configInit(gBootDir);`. In that second `configInit()` call, `_loadConfig()` ran again, triggered `resolveBootDirToMass()` on `pfs0:OPL`, and unconditionally re-homed `configInit(gBootDir)` in an infinite recursive loop. This blew the EE call stack within milliseconds, hanging the PlayStation 2 in a permanent black screen prior to graphics initialization.

Furthermore, direct PFS boot paths (`pfs0:OPL`, `pfs0:`) were rejected by `apaParseBootPath()`, causing fallback to `+OPL` and MC.

## Solution

1. **`src/opl.c:resolveBootDirToMass()`**:
   - Recorded `before` boot directory buffer before APA path parsing.
   - Gated the `configEnd(); configInit(gBootDir);` re-homing call on `if (strcmp(before, gBootDir) != 0)`. On the re-homed pass (`before == "pfs0:OPL"`), execution terminates cleanly without re-entering `configInit()`.
2. **`src/opl.c:apaParseBootPath()`**:
   - Added direct support for already-mounted PFS paths (`pfs0:OPL`, `pfs0:`), populating `outBootDir` and `outHddPrefix` cleanly and returning success without rejecting `pfs` prefixes.
3. **`HANDOFF.md`**:
   - Documented Step 206 with markdownlint H2 formatting and updated next step pointer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for booting directly from already-mounted `pfs0:` paths.
  * Improved boot path handling to preserve the selected boot directory and storage location.

* **Bug Fixes**
  * Prevented repeated APA boot configuration initialization when the boot directory has not changed.
  * Improved boot setup behavior when HDD start mode is disabled.

* **Documentation**
  * Documented the updated boot configuration behavior and corrected a formatting issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->