### PR TITLE
rebuild-214: keep MX4SIO launch config off the background I/O queue

### DIFF
--- a/src/menusys.c
+++ b/src/menusys.c
@@ -189,12 +189,9 @@ static void menuDeleteGame(submenu_list_t **submenu)
         guiMsgBox("NULL Support object. Please report", 0, NULL);
 }
 
-// Waited-on load (the DIALOG path: menuLoadConfig / gameMenuLoadConfig). Deliberately keeps the
-// original shape -- the read runs UNDER menuSemaId -- because a caller is blocked in
-// guiHandleDeferedIO on actionStatus and will hand whatever this publishes straight to
-// itemLaunch()/guiGameLoadConfig(), neither of which tolerates a NULL config_set_t. Publishing
-// unconditionally is what makes that safe, and the caller already shows a "loading settings"
-// overlay, so the brief freeze here is by design and pre-existing.
+// Waited-on load for the game-settings dialog path (gameMenuLoadConfig). Launch-time
+// menuLoadConfig deliberately bypasses ioman below so foreground launch configuration can never
+// sit behind queued device/list work. This queued variant stays for settings UI transitions.
 static void _menuLoadConfig()
 {
     WaitSema(menuSemaId);
@@ -450,13 +447,68 @@ static config_set_t *menuGetCachedCurrentConfig(void)
 
 config_set_t *menuLoadConfig()
 {
-    config_set_t *cached = menuGetCachedCurrentConfig();
-    if (cached != NULL)
-        return cached; // browse-time prefetch already paid the device read
+    item_list_t *list = NULL;
+    config_set_t *loadedConfig = NULL;
+    config_set_t *result = NULL;
+    int configId = -1;
 
-    actionStatus = 1;
-    guiHandleDeferedIO(&actionStatus, _l(_STR_LOADING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuRequestConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
-    return itemConfig;
+    // Launch configuration is foreground work. Sending it through the single ioman FIFO makes a
+    // game launch wait behind unrelated device/list rescans and browse-time metadata; on MX4SIO
+    // that can pin the UI at "Loading config..." before the game-side IOP reset is even reached.
+    WaitSema(menuSemaId);
+    if (selected_item != NULL && selected_item->item != NULL && selected_item->item->current != NULL) {
+        list = selected_item->item->userdata;
+        configId = selected_item->item->current->item.id;
+
+        if (itemConfig != NULL && itemConfigId == configId && itemConfigList == list) {
+            result = itemConfig; // browse-time prefetch already paid the device read
+        } else {
+            if (itemConfig != NULL) {
+                configFree(itemConfig);
+                itemConfig = NULL;
+            }
+            itemConfigId = configId;
+            itemConfigList = list;
+        }
+    } else {
+        if (itemConfig != NULL) {
+            configFree(itemConfig);
+            itemConfig = NULL;
+        }
+        itemConfigId = -1;
+        itemConfigList = NULL;
+    }
+    actionStatus = 0;
+    SignalSema(menuSemaId);
+
+    if (result != NULL || list == NULL || configId < 0)
+        return result;
+
+    // Launch owns the storage path now. Drop speculative art before the foreground CFG read. A
+    // zero wait requests cancellation but never kills or waits on an in-flight fileXio/SIO2 RPC;
+    // that transaction is allowed to finish cleanly while no new queued art can get in front.
+    if (list->mode == MMCE_MODE)
+        (void)cacheAbortMmceImageLoadsTimed(0);
+    else
+        (void)cacheCancelPendingImageLoadsTimed(0);
+
+    loadedConfig = list->itemGetConfig(list, configId);
+
+    // A browse-time load may have completed while the direct read was running. Publish only if this
+    // selection still owns the cache; otherwise free the duplicate/stale result.
+    WaitSema(menuSemaId);
+    if (itemConfig == NULL && itemConfigId == configId && itemConfigList == list) {
+        itemConfig = loadedConfig;
+        loadedConfig = NULL;
+    }
+    if (itemConfigId == configId && itemConfigList == list)
+        result = itemConfig;
+    SignalSema(menuSemaId);
+
+    if (loadedConfig != NULL)
+        configFree(loadedConfig);
+
+    return result;
 }
 
 // we don't want a pop up when transitioning to or refreshing Game Menu gui.


### PR DESCRIPTION
## What this fixes

On the current rebuild, launching a game can sit on `Loading config...` while the foreground per-game CFG read is serialized behind the same single ioman FIFO used by device/list rescans and browse-time metadata. MX4SIO makes that especially visible because SD access is comparatively slow and also shares the SIO2 path.

This step makes the launch-facing `menuLoadConfig()` a foreground read:

- reuses the already-prefetched config when available;
- otherwise snapshots the selected list/id and reads the selected game's config directly instead of enqueueing `_menuRequestConfig` behind background work;
- requests cancellation of speculative cover-art work before the read, without waiting on or terminating an active fileXio/SIO2 transaction;
- preserves the Step-212 list+id config ownership checks so an async browse read cannot publish another row's config over the launch selection.

`gameMenuLoadConfig()` remains deferred, so ordinary game-settings transitions keep their existing asynchronous UI behavior.

## What this deliberately does not change

This does **not** remove the positive-module-id guard in the game-side MX4SIO IOP reset path. The current `SIO2MAN -> MX4SIOBD` ordering/guard is the hardware-proven coherent PS2SDK stack from #337. The module-result premise used by #501 is not used here.

This PR targets the failure stage actually being reported now: the frontend launch path stopping at `Loading config...` before the game-side IOP reset is reached.

## Tester focus

Please test from an MX4SIO game page:

1. Launch while covers/background page work are still active.
2. Launch again after the page has been idle.
3. Test a game with no per-game CFG and one with a saved per-game CFG.
4. Confirm launch gets past config loading and reaches the normal game-side handoff/game boot.
5. Sanity-check a non-MX4SIO source to make sure foreground config loading did not regress normal launches.

No APA-listing changes are included in this step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading during application launch.
  * Prevented stale or mismatched configurations from being displayed.
  * Improved handling of cached configurations and pending artwork loads.
  * Added safeguards to ensure configuration results are loaded and applied reliably.

* **Documentation**
  * Clarified configuration loading behavior for dialog-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->