### PR TITLE
rebuild-215: Combined MX4SIO Launch Stall Fix, Single-Shot Config (#500), and Bounded Disc Detect (#465)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1132,6 +1132,51 @@ static int configPathIsRawApa(const char *path)
     return path != NULL && !strncmp(path, "hdd", 3) && path[3] >= '0' && path[3] <= '9' && path[4] == ':';
 }
 
+// Single-shot fast path for small configs (issue #500). Small CFG files (few KB)
+// are common for per-game configs. Reading the whole file in one IOP transaction
+// avoids the 4KB buffered refill loop and the extra BOM probe in openFileBuffer.
+// Falls back to the established 4KB buffered path on any error/OOM/oversize.
+// Keeps the 4096 buffer size; no gratuitous 8KB expansion without measurement.
+static file_buffer_t *configOpenSingleShot(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+
+    int fd = openFile((char *)path, O_RDONLY);
+    if (fd < 0)
+        return NULL;
+
+    int sz = getFileSize(fd);
+    // Only single-shot when size is known, positive and fits in one 4KB buffer.
+    // Zero-byte, malformed (sz<0) and oversized (>4096) fall back to buffered.
+    if (sz <= 0 || sz > 4096) {
+        close(fd);
+        return NULL;
+    }
+
+    char *buf = (char *)malloc(sz);
+    if (buf == NULL) {
+        close(fd);
+        return NULL;
+    }
+
+    int rd = read(fd, buf, sz);
+    close(fd);
+    if (rd != sz) {
+        free(buf);
+        return NULL;
+    }
+
+    // Strip UTF-8 BOM if present (openFileBuffer does the same via 3-byte probe).
+    int off = 0;
+    if (sz >= 3 && (unsigned char)buf[0] == 0xEF && (unsigned char)buf[1] == 0xBB && (unsigned char)buf[2] == 0xBF)
+        off = 3;
+
+    file_buffer_t *fb = openFileBufferBuffer(0, buf + off, sz - off);
+    free(buf);
+    return fb;
+}
+
 int configRead(config_set_t *configSet)
 {
     if (configSet != NULL && configPathIsRawApa(configSet->filename)) {
@@ -1139,13 +1184,17 @@ int configRead(config_set_t *configSet)
         return 0;
     }
     int ret;
-    file_buffer_t *fileBuffer = openFileBuffer(configSet->filename, O_RDONLY, 0, 4096);
+    file_buffer_t *fileBuffer = configOpenSingleShot(configSet->filename);
+    if (fileBuffer == NULL)
+        fileBuffer = openFileBuffer(configSet->filename, O_RDONLY, 0, 4096);
 
     if (fileBuffer == NULL && configSet->filename != NULL) {
         // Our name is absent -- wOPL may have moved this file's data to its own name (see above).
         char woplPath[256];
         if (configBuildWoplPath(configSet->filename, woplPath, sizeof(woplPath))) {
-            fileBuffer = openFileBuffer(woplPath, O_RDONLY, 0, 4096);
+            fileBuffer = configOpenSingleShot(woplPath);
+            if (fileBuffer == NULL)
+                fileBuffer = openFileBuffer(woplPath, O_RDONLY, 0, 4096);
             if (fileBuffer != NULL) {
                 LOG("CONFIG %s absent; reading wOPL's %s instead\n", configSet->filename, woplPath);
                 // Point the set at the file we actually read, so a later save updates THAT file rather
@@ -1162,7 +1211,9 @@ int configRead(config_set_t *configSet)
         // new name. configSet->filename stays the new name, so configWrite migrates transparently.
         char legacyPath[256];
         configBuildLegacyOplPath(configSet->filename, legacyPath, sizeof(legacyPath));
-        fileBuffer = openFileBuffer(legacyPath, O_RDONLY, 0, 4096);
+        fileBuffer = configOpenSingleShot(legacyPath);
+        if (fileBuffer == NULL)
+            fileBuffer = openFileBuffer(legacyPath, O_RDONLY, 0, 4096);
         if (fileBuffer != NULL)
             LOG("CONFIG migrating settings from legacy %s\n", legacyPath);
     }

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -481,16 +481,19 @@ config_set_t *menuLoadConfig()
     actionStatus = 0;
     SignalSema(menuSemaId);
 
-    if (result != NULL || list == NULL || configId < 0)
+    if (list == NULL || configId < 0)
         return result;
 
-    // Launch owns the storage path now. Drop speculative art before the foreground CFG read. A
-    // zero wait requests cancellation but never kills or waits on an in-flight fileXio/SIO2 RPC;
+    // Launch owns the storage path now. Drop speculative art before any launch I/O or cached return.
+    // A zero wait requests cancellation but never kills or waits on an in-flight fileXio/SIO2 RPC;
     // that transaction is allowed to finish cleanly while no new queued art can get in front.
     if (list->mode == MMCE_MODE)
         (void)cacheAbortMmceImageLoadsTimed(0);
     else
         (void)cacheCancelPendingImageLoadsTimed(0);
+
+    if (result != NULL)
+        return result;
 
     loadedConfig = list->itemGetConfig(list, configId);
 

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -189,12 +189,9 @@ static void menuDeleteGame(submenu_list_t **submenu)
         guiMsgBox("NULL Support object. Please report", 0, NULL);
 }
 
-// Waited-on load (the DIALOG path: menuLoadConfig / gameMenuLoadConfig). Deliberately keeps the
-// original shape -- the read runs UNDER menuSemaId -- because a caller is blocked in
-// guiHandleDeferedIO on actionStatus and will hand whatever this publishes straight to
-// itemLaunch()/guiGameLoadConfig(), neither of which tolerates a NULL config_set_t. Publishing
-// unconditionally is what makes that safe, and the caller already shows a "loading settings"
-// overlay, so the brief freeze here is by design and pre-existing.
+// Waited-on load for the game-settings dialog path (gameMenuLoadConfig). Launch-time
+// menuLoadConfig deliberately bypasses ioman below so foreground launch configuration can never
+// sit behind queued device/list work. This queued variant stays for settings UI transitions.
 static void _menuLoadConfig()
 {
     WaitSema(menuSemaId);
@@ -450,13 +447,68 @@ static config_set_t *menuGetCachedCurrentConfig(void)
 
 config_set_t *menuLoadConfig()
 {
-    config_set_t *cached = menuGetCachedCurrentConfig();
-    if (cached != NULL)
-        return cached; // browse-time prefetch already paid the device read
+    item_list_t *list = NULL;
+    config_set_t *loadedConfig = NULL;
+    config_set_t *result = NULL;
+    int configId = -1;
 
-    actionStatus = 1;
-    guiHandleDeferedIO(&actionStatus, _l(_STR_LOADING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_menuRequestConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
-    return itemConfig;
+    // Launch configuration is foreground work. Sending it through the single ioman FIFO makes a
+    // game launch wait behind unrelated device/list rescans and browse-time metadata; on MX4SIO
+    // that can pin the UI at "Loading config..." before the game-side IOP reset is even reached.
+    WaitSema(menuSemaId);
+    if (selected_item != NULL && selected_item->item != NULL && selected_item->item->current != NULL) {
+        list = selected_item->item->userdata;
+        configId = selected_item->item->current->item.id;
+
+        if (itemConfig != NULL && itemConfigId == configId && itemConfigList == list) {
+            result = itemConfig; // browse-time prefetch already paid the device read
+        } else {
+            if (itemConfig != NULL) {
+                configFree(itemConfig);
+                itemConfig = NULL;
+            }
+            itemConfigId = configId;
+            itemConfigList = list;
+        }
+    } else {
+        if (itemConfig != NULL) {
+            configFree(itemConfig);
+            itemConfig = NULL;
+        }
+        itemConfigId = -1;
+        itemConfigList = NULL;
+    }
+    actionStatus = 0;
+    SignalSema(menuSemaId);
+
+    if (result != NULL || list == NULL || configId < 0)
+        return result;
+
+    // Launch owns the storage path now. Drop speculative art before the foreground CFG read. A
+    // zero wait requests cancellation but never kills or waits on an in-flight fileXio/SIO2 RPC;
+    // that transaction is allowed to finish cleanly while no new queued art can get in front.
+    if (list->mode == MMCE_MODE)
+        (void)cacheAbortMmceImageLoadsTimed(0);
+    else
+        (void)cacheCancelPendingImageLoadsTimed(0);
+
+    loadedConfig = list->itemGetConfig(list, configId);
+
+    // A browse-time load may have completed while the direct read was running. Publish only if this
+    // selection still owns the cache; otherwise free the duplicate/stale result.
+    WaitSema(menuSemaId);
+    if (itemConfig == NULL && itemConfigId == configId && itemConfigList == list) {
+        itemConfig = loadedConfig;
+        loadedConfig = NULL;
+    }
+    if (itemConfigId == configId && itemConfigList == list)
+        result = itemConfig;
+    SignalSema(menuSemaId);
+
+    if (loadedConfig != NULL)
+        configFree(loadedConfig);
+
+    return result;
 }
 
 // we don't want a pop up when transitioning to or refreshing Game Menu gui.

--- a/src/system.c
+++ b/src/system.c
@@ -358,8 +358,10 @@ int sysGetDiscID(char *hexDiscID)
     if (sceCdStatus() == SCECdErOPENS) // If tray is open, error
         return -1;
 
-    while (sceCdGetDiskType() == SCECdDETCT) {
-        ;
+    {
+        int detecting = 0;
+        while (sceCdGetDiskType() == SCECdDETCT && detecting++ < 50)
+            DelayThread(20 * 1000); // ~1 s cap, yields (issue #465: bound DETCT, preserve NODISC budget)
     }
     if (sceCdGetDiskType() == SCECdNODISC)
         return -1;
@@ -464,8 +466,11 @@ int sysLaunchDisc(void)
     if (sceCdStatus() == SCECdErOPENS) // tray open
         return -1;
 
-    while (sceCdGetDiskType() == SCECdDETCT) // wait for the drive to identify the disc
-        ;
+    {
+        int detecting = 0;
+        while (sceCdGetDiskType() == SCECdDETCT && detecting++ < 50)
+            DelayThread(20 * 1000); // ~1 s cap, yields (issue #465: bound DETCT, preserve 4 s NODISC re-detect)
+    }
 
     type = sceCdGetDiskType();
     // An idle drive spins the disc DOWN and then reports NODISC even with a game disc loaded.


### PR DESCRIPTION
## Summary
This PR combines and supersedes **#501**, **#502**, and **#505** into a single clean stacked branch on top of \ebuild/main\ (\f8d66d9\).

### 1. MX4SIO Launch Stall Fix (from #502)
- **Problem**: Launching games on MX4SIO could freeze indefinitely on \Loading config...\ because the launch-time \menuLoadConfig()\ was serialized through the single background \ioman\ queue behind pending cover art texture fetches and directory rescans.
- **Fix**: Makes launch-time \menuLoadConfig()\ a synchronous foreground read:
  - Reuses cached \itemConfig\ when available.
  - Drops speculative cover-art requests via \cacheCancelPendingImageLoadsTimed(0)\ without aborting active SIO2 transfers.
  - Safely coordinates with \_menuLoadConfigAsync()\ under \menuSemaId\.

### 2. Single-Shot Small Config Read (#500 / from #505)
- **Problem**: Small per-game config files (typically 200–600 bytes) previously incurred multiple IOP round-trips (BOM check, seek rewind, chunked refills).
- **Fix**: Adds \configOpenSingleShot()\ in \src/config.c\ for files \<= 4096\ bytes to read the whole file in one IOP burst and stream from RAM via \openFileBufferBuffer()\. Automatically detects and strips UTF-8 BOM, with fallback to standard \openFileBuffer()\ on error or oversized files.

### 3. Bounded Disc Detection Loops (#465 / from #505)
- **Problem**: Unbounded \while (sceCdGetDiskType() == SCECdDETCT);\ loops in \sysGetDiscID()\ and \sysLaunchDisc()\ pegged 100% of EE CPU and permanently hung the console if a dirty laser or scratched disc remained in detection state.
- **Fix**: Replaces tight unbounded loops with a bounded 1-second yielding loop (\DelayThread(20 * 1000)\), preserving the ~4s \NODISC\ cold spin-up retry budget while preventing UI freezes on damaged discs.

### Supersedes:
- Supersedes #501 (closed: misdiagnosed root cause in ee_core, base-conflicted)
- Supersedes #502 (closed: incorporated into this combined PR)
- Supersedes #505 (closed: incorporated into this combined PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Faster loading for small, non-empty configuration files.
  - Reduced CPU usage during disc detection by yielding during polling.

- **Bug Fixes**
  - Improved reliability when loading game configurations, including fallback handling for read errors and unsupported files.
  - Prevented stale configuration results from replacing the currently selected game.
  - Limited disc detection waits to approximately one second.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->