### PR TITLE
ci: update rolling release notes, workflows for MMCE support, and mark as latest

### DIFF
--- a/.github/rolling-release-notes-block.md
+++ b/.github/rolling-release-notes-block.md
@@ -24,10 +24,6 @@ else. New features come after parity, not before.
 what a rolling channel is for: it exists so testing can happen. If you want the most
 trustworthy RiptOPL today, that is still the old build below.
 
-**MMCE is still awaiting reimplementation.** If your games are on MMCE, this build will
-not see them yet. This line stays in every release until MMCE lands, so nobody downloads
-expecting it.
-
 **The old build is still available and still fine to use.** The final release of that
 lineage is on the releases page (*Rolling Alpha*) for exactly this reason, and the archive
 is on MEGA. If you are happy on it, stay on it — it is not going anywhere.

--- a/.github/workflows/flavours.yml
+++ b/.github/workflows/flavours.yml
@@ -91,6 +91,9 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow || true
 
+      - name: Install menu-coherent mmceman (#254)
+        run: sh .github/scripts/install_coherent_mmce.sh
+
       - name: Compile -> make clean release (${{ matrix.flavour }})
         run: make --trace clean && make --trace LOCALVERSION=${{ matrix.flavour }} release
 

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -105,13 +105,8 @@ jobs:
       - name: Mark workspace safe and fetch history
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git fetch --prune --unshallow || true
-
-      # NOTE(rebuild): the fork runs a step here that is not applicable yet --
-      #   Install menu-coherent mmceman (#254)
-      # It returns with checklist items 1-3 (MMCE), which are still on WAIT. Removed rather than
-      # left to fail/WARN every single run. (GSM 1080p, item 29, has since LANDED and is now ON in
-      # EVERY build -- it needs no separate step at all.)
+      - name: Install menu-coherent mmceman (#254)
+        run: sh .github/scripts/install_coherent_mmce.sh
 
       - name: Build (make clean release)
         # LOCALVERSION brands the in-ELF version string ("-PS2DEVPINNED") so hardware reports
@@ -223,11 +218,8 @@ jobs:
         id: ver
         run: echo "version=$(make oplversion)" >> "$GITHUB_OUTPUT"
 
-      # NOTE(rebuild): the fork runs a step here that is not applicable yet --
-      #   Install menu-coherent mmceman (latest-only)
-      # It returns with checklist items 1-3 (MMCE), which are still on WAIT. Removed rather than
-      # left to fail/WARN every single run. (GSM 1080p, item 29, has since LANDED and is now ON in
-      # EVERY build -- it needs no separate step at all.)
+      - name: Install menu-coherent mmceman (#254)
+        run: sh .github/scripts/install_coherent_mmce.sh
 
       - name: Build (make clean release)
         # LOCALVERSION brands the in-ELF version string ("-PS2DEVROLLING") so hardware reports
@@ -327,9 +319,8 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow || true
 
-      # NOTE(rebuild): the fork runs a menu-coherent mmceman install here. MMCE is checklist
-      # items 1-3, on WAIT, and this tree embeds no mmceman at all -- so the step would rebuild a
-      # driver nothing loads. It returns with item 1.
+      - name: Install menu-coherent mmceman (#254)
+        run: sh .github/scripts/install_coherent_mmce.sh
 
       - name: Build (make clean release)
         # LOCALVERSION brands the in-ELF version string ("-OFFICIALROLLING") so hardware
@@ -410,6 +401,9 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --prune --unshallow || true
+
+      - name: Install menu-coherent mmceman (#254)
+        run: sh .github/scripts/install_coherent_mmce.sh
 
       - name: Build (make clean release)
         run: make --trace clean && make --trace LOCALVERSION=OFFICIALPINNED release

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1059,11 +1059,10 @@ published) does not. This section is the state of the project now.
   rewrite notes, and — since step-180 — RE-TARGET the tag), then MEGA archives one
   immutable zip to `/RiptOPL/Rolling/<version>/run_<n>/` (VARIANTS/DEBUG excluded).
 - **The notes are carried, not drafted:** `.github/rolling-release-notes-block.md` is
-  cat'd into every body after the header (new-lineage statement: parity goal, MMCE
-  awaiting reimplementation, old build still fine, report rules, the OrbitOPL Toolbox
-  metadata section). The flavour guidance lives ONLY in the workflow's "Get started"
-  section (all four flavours, pinned-first, Settings → About names the running one).
-  Do not re-add it to the block — one home, one copy.
+  cat'd into every body after the header (new-lineage statement: parity goal, old build
+  still fine, report rules, the OrbitOPL Toolbox metadata section). The flavour guidance
+  lives ONLY in the workflow's "Get started" section (all four flavours, pinned-first,
+  Settings → About names the running one). Do not re-add it to the block — one home, one copy.
 - **Publish procedure (every time):** ff rebuild/main → push → watch the run to green →
   INSPECT (prerelease flag, tag SHA == pushed SHA, notes rendered, four APP_RIPTOPL-*
   folders in the package zip, four ds5 assets, the ACTUAL version value from the body,


### PR DESCRIPTION
### Summary of Changes

- **Mark Rolling Release as Latest** (`.github/workflows/rolling-release.yml`):
  - Configured `PREREL="--prerelease --latest"` so rolling release publishes are explicitly marked as the **Latest** release on GitHub.
- **Rolling Release Notes Block** (`.github/rolling-release-notes-block.md`):
  - Removed the outdated statement stating that *"MMCE is still awaiting reimplementation"* now that MMCE support has landed on `rebuild/main`.
- **Workflow Coherent MMCE IRX Installation** (`.github/workflows/rolling-release.yml` & `.github/workflows/flavours.yml`):
  - Enabled `sh .github/scripts/install_coherent_mmce.sh` across all build jobs so all release flavours embed the menu-coherent `mmceman.irx` with the file descriptor leak and `-ENOENT` patches.
- **Handoff Documentation** (`HANDOFF.md`):
  - Updated rolling release description summary and Latest badge status accordingly.
