### PR TITLE
ci: mark rolling releases as latest in rolling-release workflow

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -876,9 +876,9 @@ jobs:
           # can never diverge again.
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF_NAME}"; TITLE="${GITHUB_REF_NAME}"; TARGET=""
-            case "${GITHUB_REF}" in *-rc*) PREREL="--prerelease";; *) PREREL="";; esac
+            case "${GITHUB_REF}" in *-rc*) PREREL="--prerelease";; *) PREREL="--latest";; esac
           else
-            TAG="rolling"; TITLE="Rolling"; PREREL="--prerelease"; TARGET="--target $GITHUB_SHA"
+            TAG="rolling"; TITLE="Rolling"; PREREL="--prerelease --latest"; TARGET="--target $GITHUB_SHA"
           fi
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Updating existing release: $TAG"

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1046,10 +1046,8 @@ published) does not. This section is the state of the project now.
 ## The rolling channel is LIVE
 
 - Release: https://github.com/NathanNeurotic/Open-PS2-Loader/releases/tag/rolling —
-  **v1.2.0-Beta-2553-95a138c** (run 31745407636, built from `0127499b`). A prerelease, NOT
-  Latest: `pops-bundle` keeps the Latest badge and `rolling-alpha` (final old-lineage
-  build, archived) sits undisturbed — the "old build is still fine to use" promise made
-  structural.
+  Marked as **Latest** (`--latest`), carrying the rebuild lineage while preserving
+  `rolling-alpha` (final old-lineage build, archived) undisturbed.
 - **How it publishes:** rolling-release.yml fires on push to `rebuild/main` (also master
   and v* tags — master is the old lineage, DO NOT push it; see §0b). `rebuild/main` is the
   PHYSICAL KNOB: Nathan names a step-chain tip, it is fast-forwarded (ff-only; verify


### PR DESCRIPTION
### Summary of Changes

- **Mark Rolling Release as Latest** (`.github/workflows/rolling-release.yml`):
  - Configured `PREREL="--prerelease --latest"` for rolling branch pushes and `PREREL="--latest"` for tagged releases, ensuring rolling releases are explicitly marked with the **Latest** badge on GitHub.
- **Handoff Documentation** (`HANDOFF.md`):
  - Updated rolling channel status and Latest badge documentation.
