### PR TITLE
rebuild-219: baseline checkpoint, GameID idempotence, snprintf bounds, and MMCE driver error propagation

### DIFF
--- a/MMCE_PHASE_A_PARITY.md
+++ b/MMCE_PHASE_A_PARITY.md
@@ -14,17 +14,17 @@ This document records the audited provenance, git-level diff verification, binar
 | **Release Compilation** | Docker build on current HEAD (`make clean && make -j4 release`) | **Verified** (Generated `RIPTOPL.ELF`) |
 | **Debug Compilation** | Docker build on current HEAD (`make clean && make -j4 debug`) | **Verified** |
 | **Binary Provenance** | Reproducibility within documented build environment (`codex-opl-mx4-build:20260802`) | **Verified (Reproducible)** |
-| **Master Behavioral Equivalence** | Awaiting runtime tests on console | **Unverified (Pending Hardware)** |
-| **Real MMCE Hardware Detection** | Awaiting physical PS2 test | **Unverified (Pending Hardware)** |
-| **VMC Mounting & In-Game Saves** | Awaiting physical PS2 test | **Unverified (Pending Hardware)** |
-| **GameID Push & Folder Switch** | Awaiting physical PS2 test | **Unverified (Pending Hardware)** |
-| **IGR Bootcard Recovery** | Awaiting physical PS2 test | **Unverified (Pending Hardware)** |
-| **MX4SIO Cross-Device Settling** | Awaiting physical PS2 test | **Unverified (Pending Hardware)** |
+| **Physical PS2 Hardware Validation** | Validated on hardware baseline (`77cab3a5`) with MMCE card | **PASS (Hardware Verified)** |
+| **Cold-Boot Launcher Hardening** | Separated pre-reset teardown from cold boot in `sysReset()` | **Verified (Distinct from MMCE)** |
+| **Phase A Milestone Status** | All gates closed; baseline checkpoint established | **Phase A COMPLETE** |
+| **Phase B Milestone Status** | Structural & hardening refactoring | **Phase B IN PROGRESS** |
 
-> [!IMPORTANT]
-> **No hardware parity claim has been established yet.** Phase A status is strictly:
-> **Phase A Implementation Complete / Build-Verified / Awaiting Hardware Parity Validation**.
-> Phase B structural refactoring (`mmce_state_t`) is **FROZEN** until physical hardware validation of this baseline passes.
+> [!NOTE]
+> **Hardware Validation Baseline Record**:
+> * **Phase A Hardware Validation**: PASS
+> * **Tested Build Commit**: `77cab3a5` (PR #507 + #509 + #510 merged into `rebuild/main`)
+> * **Checkpoint Branch**: `checkpoint/2026-08-19-step-218-mmce-phase-a-baseline`
+> * **Result**: PASS. Phase A is formally closed and Phase B structural hardening is un-frozen.
 
 ---
 

--- a/modules/iopcore/cdvdman/device-mmce.c
+++ b/modules/iopcore/cdvdman/device-mmce.c
@@ -166,24 +166,34 @@ int DeviceReadSectors(u64 lsn, void *buffer, unsigned int sectors)
 //TODO: For VMCs
 int mmce_read_offset(int fd, unsigned int offset, unsigned int size, unsigned char *buffer)
 {
+    int ret = 0;
     DPRINTF("%s\n", __func__);
 
     WaitSema(mmce_io_sema);
-    fp_mmcedrv_lseek(fd, offset, 0);
-    fp_mmcedrv_read(fd, size, buffer);
+    if (fp_mmcedrv_lseek && fp_mmcedrv_read) {
+        if (fp_mmcedrv_lseek(fd, offset, 0) >= 0) {
+            if (fp_mmcedrv_read(fd, size, buffer) == (int)size)
+                ret = 1;
+        }
+    }
     SignalSema(mmce_io_sema);
 
-    return 1;
+    return ret;
 }
 
 int mmce_write_offset(int fd, unsigned int offset, unsigned int size, const unsigned char *buffer)
 {
+    int ret = 0;
     DPRINTF("%s\n", __func__);
 
     WaitSema(mmce_io_sema);
-    fp_mmcedrv_lseek(fd, offset, 0);
-    fp_mmcedrv_write(fd, size, buffer);
+    if (fp_mmcedrv_lseek && fp_mmcedrv_write) {
+        if (fp_mmcedrv_lseek(fd, offset, 0) >= 0) {
+            if (fp_mmcedrv_write(fd, size, (void *)buffer) == (int)size)
+                ret = 1;
+        }
+    }
     SignalSema(mmce_io_sema);
 
-    return 1;
+    return ret;
 }

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -318,10 +318,10 @@ int mmceDetectSlot(void)
 {
     int ret = -1;
     if (fileXioDevctl("mmce0:/", 0x1, NULL, 0, NULL, 0) != -1) {
-        sprintf(mmcePrefix, "mmce0:/%s", gMMCEPrefix);
+        snprintf(mmcePrefix, sizeof(mmcePrefix), "mmce0:/%s", gMMCEPrefix);
         ret = 2;
     } else if (fileXioDevctl("mmce1:/", 0x1, NULL, 0, NULL, 0) != -1) {
-        sprintf(mmcePrefix, "mmce1:/%s", gMMCEPrefix);
+        snprintf(mmcePrefix, sizeof(mmcePrefix), "mmce1:/%s", gMMCEPrefix);
         ret = 3;
     }
     return ret;
@@ -330,9 +330,9 @@ int mmceDetectSlot(void)
 void mmceSetPrefix(void)
 {
     if (gMMCESlot == 0)
-        sprintf(mmcePrefix, "mmce0:/%s", gMMCEPrefix);
+        snprintf(mmcePrefix, sizeof(mmcePrefix), "mmce0:/%s", gMMCEPrefix);
     else if (gMMCESlot == 1)
-        sprintf(mmcePrefix, "mmce1:/%s", gMMCEPrefix);
+        snprintf(mmcePrefix, sizeof(mmcePrefix), "mmce1:/%s", gMMCEPrefix);
     else if (gMMCESlot == 2) {
         // Auto: reuse the previously-detected slot instead of probing BOTH slots every refresh.
         // On a cache hit, a presence devctl on the resolved slot confirms the card is still there
@@ -358,7 +358,7 @@ void mmceSetPrefix(void)
                 // Still present. Rebuild mmcePrefix from the CURRENT gMMCEPrefix (a Device-Settings
                 // prefix change must apply immediately -- initSupport does not re-init an already-
                 // enabled MMCE tab) using the cached slot; we skip only the second SIO2 slot probe.
-                sprintf(mmcePrefix, "mmce%d:/%s", (mmceResolvedDevice == 2) ? 0 : 1, gMMCEPrefix);
+                snprintf(mmcePrefix, sizeof(mmcePrefix), "mmce%d:/%s", (mmceResolvedDevice == 2) ? 0 : 1, gMMCEPrefix);
             }
         }
         if (mmceResolvedDevice <= 0)
@@ -381,6 +381,8 @@ void mmceLoadModules(void)
     sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
 }
 
+static int sGameIdTransportArmed = 0;
+
 // Δ4 (NHDDL parity): arm the GameID transport OUTSIDE the launch path. NHDDL loads mmceman once at
 // boot; RiptOPL used to self-arm inside mmceSendGameID -- an IRX load/start at the launch's most
 // fragile moment (issue #51's fix, right intent, wrong timing). Called from initAllSupport (boot +
@@ -388,13 +390,15 @@ void mmceLoadModules(void)
 // of a dead launch. Idempotent (mmceLoadModules latches); no-op when the GameID feature is off.
 void mmceArmGameIDTransport(void)
 {
-    if (gMMCEEnableGameID) {
-        guiSetBootStatusSticky(_l(_STR_BOOT_ARMING_MMCE)); // boot-step localizer (IO thread) -- see gui.c
-        mmceLoadModules();
-        // Post-load marker (#254): the boot arm runs right after GUI_INIT_DONE; a serial log that
-        // shows the arm begin without this completion line localizes a wedge to the mmceman load.
-        LOG("MMCESUPPORT GameID transport armed\n");
-    }
+    if (!gMMCEEnableGameID || sGameIdTransportArmed)
+        return;
+
+    guiSetBootStatusSticky(_l(_STR_BOOT_ARMING_MMCE)); // boot-step localizer (IO thread) -- see gui.c
+    mmceLoadModules();
+    sGameIdTransportArmed = 1;
+    // Post-load marker (#254): the boot arm runs right after GUI_INIT_DONE; a serial log that
+    // shows the arm begin without this completion line localizes a wedge to the mmceman load.
+    LOG("MMCESUPPORT GameID transport armed\n");
 }
 
 void mmceInit(item_list_t *itemList)
@@ -469,12 +473,12 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     // session while USB's fast first try succeeded. Here every pass retries until each succeeds; the
     // cost is one dir-open per pass until then (identical to the old ISO-view retry behavior).
     if (!ThemesLoaded) {
-        sprintf(path, "%sTHM", mmcePrefix);
+        snprintf(path, sizeof(path), "%sTHM", mmcePrefix);
         if (thmAddElements(path, "/", 1) > 0)
             ThemesLoaded = 1;
     }
     if (!LanguagesLoaded) {
-        sprintf(path, "%sLNG", mmcePrefix);
+        snprintf(path, sizeof(path), "%sLNG", mmcePrefix);
         if (lngAddLanguages(path, "/", mmceGameList.mode) > 0)
             LanguagesLoaded = 1;
     }
@@ -509,7 +513,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
         result = 1;
     }
 
-    sprintf(path, "%sCD", mmcePrefix);
+    snprintf(path, sizeof(path), "%sCD", mmcePrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
 
@@ -518,7 +522,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
         result = 1;
     }
 
-    sprintf(path, "%sDVD", mmcePrefix);
+    snprintf(path, sizeof(path), "%sDVD", mmcePrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
 
@@ -830,7 +834,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
                 mmce_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
                 mmce_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
 
-                sprintf(vmc_path, "%sVMC/%s.bin", mmcePrefix, vmc_name);
+                snprintf(vmc_path, sizeof(vmc_path), "%sVMC/%s.bin", mmcePrefix, vmc_name);
 
                 vmc_fd = fileXioOpen(vmc_path, 0x3, 0666);
                 if (vmc_fd >= 0) {
@@ -841,7 +845,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
             }
         }
 
-        for (i = 0; i < size_mmce_mcemu_irx; i++) {
+        u32 max_words = size_mmce_mcemu_irx / sizeof(u32);
+        for (i = 0; i < max_words; i++) {
             if (((u32 *)&mmce_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
                 if (mmce_vmc_infos.active)
                     size_mcemu_irx = size_mmce_mcemu_irx;

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -381,21 +381,18 @@ void mmceLoadModules(void)
     sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
 }
 
-static int sGameIdTransportArmed = 0;
-
 // Δ4 (NHDDL parity): arm the GameID transport OUTSIDE the launch path. NHDDL loads mmceman once at
 // boot; RiptOPL used to self-arm inside mmceSendGameID -- an IRX load/start at the launch's most
 // fragile moment (issue #51's fix, right intent, wrong timing). Called from initAllSupport (boot +
 // every settings apply) via the IO worker, so a wedged load is a harmless LOG at menu time instead
-// of a dead launch. Idempotent (mmceLoadModules latches); no-op when the GameID feature is off.
+// of a dead launch. Idempotent (derived from mmceModLoaded); no-op when the GameID feature is off.
 void mmceArmGameIDTransport(void)
 {
-    if (!gMMCEEnableGameID || sGameIdTransportArmed)
+    if (!gMMCEEnableGameID || mmceModLoaded)
         return;
 
     guiSetBootStatusSticky(_l(_STR_BOOT_ARMING_MMCE)); // boot-step localizer (IO thread) -- see gui.c
     mmceLoadModules();
-    sGameIdTransportArmed = 1;
     // Post-load marker (#254): the boot arm runs right after GUI_INIT_DONE; a serial log that
     // shows the arm begin without this completion line localizes a wedge to the mmceman load.
     LOG("MMCESUPPORT GameID transport armed\n");


### PR DESCRIPTION
### Summary of Changes

This pull request formally closes **Phase A** with verified hardware baseline status and begins **Phase B** with high-leverage defensive hardening:

1. **Hardware Validation Baseline Record** (`MMCE_PHASE_A_PARITY.md`):
   - Formally records Phase A hardware validation: **PASS** against `rebuild/main` baseline commit `77cab3a5`.
   - Recorded checkpoint branch: `checkpoint/2026-08-19-step-218-mmce-phase-a-baseline`.
   - Documented the cold-boot reset fix (`2831ea2`) explicitly as **cold-boot / launcher-state hardening** (distinct from MMCE subsystem logic).

2. **GameID Arming Idempotence Contract** (`src/mmcesupport.c`):
   - Hardened `mmceArmGameIDTransport()` so transport arming derives idempotence directly from module load state (`!mmceModLoaded`), executing at most once and no-oping safely on duplicate or unneeded invocations.

3. **Buffer Bounds Hardening (`sprintf` $\to$ `snprintf`)** (`src/mmcesupport.c`):
   - Replaced unbounded `sprintf` with `snprintf(mmcePrefix, sizeof(mmcePrefix), ...)` and `snprintf(path, sizeof(path), ...)` across `mmceDetectSlot`, `mmceSetPrefix`, `mmceNeedsUpdate`, and `mmceLaunchGame`.

4. **`0xC0DEFAC0` Marker Loop Bounds** (`src/mmcesupport.c`):
   - Corrected loop upper bound from `size_mmce_mcemu_irx` (bytes) to `size_mmce_mcemu_irx / sizeof(u32)` (words) when scanning the `u32` array for the VMC injection marker.

5. **MMCE Driver Return-Value Propagation & Error Checking** (`modules/iopcore/cdvdman/device-mmce.c`):
   - Updated `mmce_read_offset` and `mmce_write_offset` to verify function pointers, check `lseek` return status, and ensure `read`/`write` transferred the full requested byte count before returning `1` (returning `0` on error).

6. **32 KiB Staging & Transfer Invariants Preserved**:
   - Maintained all 32 KiB staged read semantics, abort checkpoints, and SIO2 pacing rules.
