### PR TITLE
rebuild-220: fix #508 VCD art identity, prefix-aware GameID, and resolve throttle

### DIFF
--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -36,9 +36,14 @@ int vcdScanDir(const char *devPrefix, vcd_entry_t **outList);
 // Like vcdScanDir but scans `dirPath` DIRECTLY (no POPS/ subfolder) -- for the APA/PFS HDD where each
 // __.POPS* partition holds its .VCD at the mounted root (e.g. dirPath = "pfs1:/").
 int vcdScanDirRoot(const char *dirPath, vcd_entry_t **outList);
-// Extract a strict leading PS1 ID from "SXXX_NNN.NN.Title" for same-folder CFG/art fallback.
+
+// Extract a strict leading PS1 ID from "SXXX_NNN.NN.Title" or "XX.SXXX_NNN.NN.Title" for same-folder CFG/art fallback.
 // Returns 1 and writes the 11-character ID on success; otherwise returns 0 and writes an empty string.
 int vcdExtractGameId(const char *name, char *idOut, int idSize);
+
+// Centralized helper for VCD artwork lookup: extracts ID from filename (zero IO) or returns the
+// cached disc ID (zero IO). Returns 1 with outId filled if a disc ID is known, 0 otherwise.
+int vcdGetArtGameId(const char *name, char *outId, int outSize);
 
 // Remember which directory a VCD was scanned from. String work only -- NO device access; the scan
 // must never block on IO. Called per entry by the scan.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1511,20 +1511,26 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    // OPL's own ART/<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
-    // with a strict PS1 ID).
+    // 1. Primary lookup: ART/<name>_<suffix>.png
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", pDeviceData->bdmPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD --
-    // ROOT-anchored (bdmBuildVcdPrefix), the SAME prefix the VCD scan uses, since the POPS layout lives at
-    // the device root, outside gBDMPrefix. Cover/icon only, VCD view only.
+
+    // 2. VCD secondary lookup: ART/<discID>_<suffix>.png (extracted from filename or cached disc ID)
     if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList)) {
-        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
-        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
-        r = vcdLoadPopsCover(vcdPrefix, value, suffix, resultTex);
+        char discId[VCD_ID_MAX];
+        if (vcdGetArtGameId(value, discId, sizeof(discId)) && strcmp(discId, value) != 0) {
+            snprintf(path, sizeof(path), "%s%s/%s_%s", pDeviceData->bdmPrefix, folder, discId, suffix);
+            r = texDiscoverLoad(resultTex, path, -1);
+        }
+        // 3. Fallback: POPSLoader-style suffixless cover next to .VCD
+        if (r == ERR_BAD_FILE) {
+            char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
+            bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
+            r = vcdLoadPopsCover(vcdPrefix, value, suffix, resultTex);
+        }
     }
     return r;
 }

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -986,17 +986,24 @@ static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char
 {
     char path[256];
 
-    // OPL's own ART\<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
-    // with a strict PS1 ID).
+    // 1. Primary lookup: ART\<name>_<suffix>.png
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s\\%s_%s", ethPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD.
-    // ethPrefix ends in '\\', so vcdLoadPopsCover auto-detects the SMB separator. Cover/icon, VCD view only.
-    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList))
-        r = vcdLoadPopsCover(ethPrefix, value, suffix, resultTex);
+
+    // 2. VCD secondary lookup: ART\<discID>_<suffix>.png (extracted from filename or cached disc ID)
+    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList)) {
+        char discId[VCD_ID_MAX];
+        if (vcdGetArtGameId(value, discId, sizeof(discId)) && strcmp(discId, value) != 0) {
+            snprintf(path, sizeof(path), "%s%s\\%s_%s", ethPrefix, folder, discId, suffix);
+            r = texDiscoverLoad(resultTex, path, -1);
+        }
+        // 3. Fallback: POPSLoader-style suffixless cover next to .VCD
+        if (r == ERR_BAD_FILE)
+            r = vcdLoadPopsCover(ethPrefix, value, suffix, resultTex);
+    }
     return r;
 }
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1367,13 +1367,22 @@ static int hddGetImage(item_list_t *itemList, char *folder, int isRelative, char
     if (isRelative && gHDDPrefix == NULL)
         return ERR_BAD_FILE;
 
-    // PS1 (VCD) art uses this same ART path as PS2. The cache supplies the filename first and may retry
-    // once with a strict PS1 ID after a genuine miss; pfs0: remains the current OPL data mount.
+    // 1. Primary lookup: ART/<name>_<suffix>.png
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", gHDDPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1);
+    int r = texDiscoverLoad(resultTex, path, -1);
+
+    // 2. VCD secondary lookup: ART/<discID>_<suffix>.png (extracted from filename or cached disc ID)
+    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList)) {
+        char discId[VCD_ID_MAX];
+        if (vcdGetArtGameId(value, discId, sizeof(discId)) && strcmp(discId, value) != 0) {
+            snprintf(path, sizeof(path), "%s%s/%s_%s", gHDDPrefix, folder, discId, suffix);
+            r = texDiscoverLoad(resultTex, path, -1);
+        }
+    }
+    return r;
 }
 
 static int hddGetTextId(item_list_t *itemList)

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -1080,13 +1080,19 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
-    // OPL's own ART/<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
-    // with a strict PS1 ID). On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless
-    // cover named exactly like the .VCD, next to it in the POPS/ folder (mmceArtPrimary IS the VCD scan
-    // prefix). Cover/icon only, VCD view only -- a PS2 list and any hit never pay the extra probe.
+    // 1. Primary lookup: ART/<name>_<suffix>.png
     int r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
-    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode))
-        r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
+
+    // 2. VCD secondary lookup: ART/<discID>_<suffix>.png (extracted from filename or cached disc ID)
+    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode)) {
+        char discId[VCD_ID_MAX];
+        if (vcdGetArtGameId(value, discId, sizeof(discId)) && strcmp(discId, value) != 0)
+            r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, discId, suffix, resultTex);
+
+        // 3. Fallback: POPSLoader-style suffixless cover next to .VCD
+        if (r == ERR_BAD_FILE)
+            r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
+    }
     return r;
 }
 

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -360,17 +360,24 @@ static int udpfsGetImage(item_list_t *itemList, char *folder, int isRelative, ch
 {
     char path[256];
 
-    // OPL's own ART/<name>_COV.png is the PRIMARY lookup (same path PS2 uses; the cache also retries once
-    // with a strict PS1 ID).
+    // 1. Primary lookup: ART/<name>_<suffix>.png
     if (isRelative)
         snprintf(path, sizeof(path), "%s%s/%s_%s", udpfsPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    // On a VCD (PS1) genuine miss, fall back to the POPSLoader-style suffixless cover next to the .VCD.
-    // Cover/icon only, VCD view only.
-    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList))
-        r = vcdLoadPopsCover(udpfsPrefix, value, suffix, resultTex);
+
+    // 2. VCD secondary lookup: ART/<discID>_<suffix>.png (extracted from filename or cached disc ID)
+    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList)) {
+        char discId[VCD_ID_MAX];
+        if (vcdGetArtGameId(value, discId, sizeof(discId)) && strcmp(discId, value) != 0) {
+            snprintf(path, sizeof(path), "%s%s/%s_%s", udpfsPrefix, folder, discId, suffix);
+            r = texDiscoverLoad(resultTex, path, -1);
+        }
+        // 3. Fallback: POPSLoader-style suffixless cover next to .VCD
+        if (r == ERR_BAD_FILE)
+            r = vcdLoadPopsCover(udpfsPrefix, value, suffix, resultTex);
+    }
     return r;
 }
 

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -37,41 +37,87 @@
 int vcdExtractGameId(const char *name, char *idOut, int idSize)
 {
     int i;
+    const char *p = name;
 
     if (idOut == NULL || idSize <= 11)
         return 0;
     idOut[0] = '\0';
-    if (name == NULL || strlen(name) < 13)
-        return 0; // require AAAA_NNN.NN plus a separator and non-empty title
-    for (i = 0; i < 4; i++)
-        if (!((name[i] >= 'A' && name[i] <= 'Z') || (name[i] >= 'a' && name[i] <= 'z') ||
-              (name[i] >= '0' && name[i] <= '9')))
-            return 0;
-    if (name[4] != '_')
-        return 0;
-    for (i = 5; i <= 7; i++)
-        if (name[i] < '0' || name[i] > '9')
-            return 0;
-    if (name[8] != '.' || name[9] < '0' || name[9] > '9' || name[10] < '0' || name[10] > '9')
-        return 0;
-    if ((name[11] != '.' && name[11] != '_') || name[12] == '\0')
+    if (name == NULL)
         return 0;
 
-    memcpy(idOut, name, 11);
+    // Skip POPSTARTER 3-character prefixes (e.g. "XX.", "SB.", "EL.", "SM.", or any "??.")
+    if (p[0] != '\0' && p[1] != '\0' && p[2] == '.') {
+        p += 3;
+    }
+
+    if (strlen(p) < 11)
+        return 0;
+
+    // Check strict AAAA_NNN.NN shape (e.g. SLUS_005.51, SLES_012.58)
+    for (i = 0; i < 4; i++) {
+        if (!((p[i] >= 'A' && p[i] <= 'Z') || (p[i] >= 'a' && p[i] <= 'z') ||
+              (p[i] >= '0' && p[i] <= '9')))
+            return 0;
+    }
+    if (p[4] != '_')
+        return 0;
+    for (i = 5; i <= 7; i++) {
+        if (p[i] < '0' || p[i] > '9')
+            return 0;
+    }
+    if (p[8] != '.' || p[9] < '0' || p[9] > '9' || p[10] < '0' || p[10] > '9')
+        return 0;
+
+    // If there is a trailing character, ensure it is a delimiter or title separator
+    if (p[11] != '\0' && p[11] != '.' && p[11] != '_' && p[11] != ' ' && p[11] != '-')
+        return 0;
+
+    for (i = 0; i < 11; i++) {
+        char c = p[i];
+        if (c >= 'a' && c <= 'z')
+            c -= ('a' - 'A'); // normalize uppercase
+        idOut[i] = c;
+    }
     idOut[11] = '\0';
     return 1;
 }
 
+// Centralized helper for VCD artwork lookup: extracts ID from filename (zero IO) or returns the
+// cached disc ID (zero IO). Returns 1 with outId filled if a disc ID is known, 0 otherwise.
+int vcdGetArtGameId(const char *name, char *outId, int outSize)
+{
+    if (name == NULL || outId == NULL || outSize <= 0)
+        return 0;
+    outId[0] = '\0';
+
+    // 1. Cheap filename parse first (zero IO)
+    if (vcdExtractGameId(name, outId, outSize))
+        return 1;
+
+    // 2. Fallback to cached disc ID from background resolver (zero IO)
+    return vcdDisplayIdCached(name, outId, outSize);
+}
+
 // Display-only prefix hider (aesthetic setting gVcdHideGameId). Returns the number of leading
 // characters to skip when `name` begins with a STRICT PS1 retail game-ID prefix AAAA_NNN.NN
-// followed by a '.' or '_' separator (= 12 chars, e.g. "SLUS_005.51." / "SCUS_941.63."), and only
-// when there is a non-empty title after it. Returns 0 otherwise, so clean titles are never cut.
-// The strict character checks prevent a false positive from eating a real title and short-circuit
-// safely on names shorter than 12 characters.
+// (optionally preceded by a POPSTARTER prefix like "XX.") followed by a '.' or '_' separator.
 static int vcdGameIdPrefixLen(const char *name)
 {
+    const char *p = name;
+    int prefixLen = 0;
+    if (name == NULL)
+        return 0;
+    if (p[0] != '\0' && p[1] != '\0' && p[2] == '.') {
+        p += 3;
+        prefixLen += 3;
+    }
     char gameId[VCD_ID_MAX];
-    return vcdExtractGameId(name, gameId, sizeof(gameId)) ? 12 : 0;
+    if (vcdExtractGameId(p, gameId, sizeof(gameId))) {
+        if (p[11] == '.' || p[11] == '_' || p[11] == ' ' || p[11] == '-')
+            return prefixLen + 12;
+        return prefixLen + 11;
+    }
+    return 0;
 }
 
 // Render-time display name for the VCD list. PURELY COSMETIC: returns a pointer PAST a leading
@@ -146,13 +192,22 @@ static int vcdEntryCmp(const void *a, const void *b)
 #define VCD_ID_PROBE_BUDGET 8   // discs opened per scan
 #define VCD_ID_MEMO_MAX     512 // ids remembered for the session
 
+typedef enum {
+    VCD_ID_UNREQUESTED = 0,
+    VCD_ID_QUEUED,
+    VCD_ID_DEFERRED,
+    VCD_ID_RESOLVED,
+    VCD_ID_ABSENT
+} vcd_id_state_t;
+
 typedef struct vcd_id_memo
 {
     struct vcd_id_memo *next;
-    char id[VCD_ID_MAX]; // resolved disc id; empty once `asked` is set means the disc carries none
-    char *dir;           // directory this VCD was scanned from -- the ONLY correct path source
-    unsigned char asked; // 1 once the disc has been read, so a "no id" answer is not re-read
-    char name[];         // flexible: VCD basenames run long, most are far short of the cap
+    char id[VCD_ID_MAX];     // resolved disc id; empty once absent
+    char *dir;               // directory this VCD was scanned from -- the ONLY correct path source
+    unsigned char state;     // vcd_id_state_t
+    unsigned int retryFrame; // guiFrameId when deferred retry is next permitted
+    char name[];             // flexible: VCD basenames run long, most are far short of the cap
 } vcd_id_memo_t;
 
 static vcd_id_memo_t *gVcdIdMemo = NULL;
@@ -183,7 +238,8 @@ void vcdNoteScanDir(const char *name, const char *dirPath)
         if (m->dir == NULL || strcmp(m->dir, dirPath) != 0) {
             free(m->dir); // same name on a different device: re-point, and re-ask the disc
             m->dir = strdup(dirPath);
-            m->asked = 0;
+            m->state = VCD_ID_UNREQUESTED;
+            m->retryFrame = 0;
             m->id[0] = '\0';
         }
         return;
@@ -198,7 +254,8 @@ void vcdNoteScanDir(const char *name, const char *dirPath)
         return;
     memcpy(m->name, name, len + 1);
     m->id[0] = '\0';
-    m->asked = 0;
+    m->state = VCD_ID_UNREQUESTED;
+    m->retryFrame = 0;
     m->dir = strdup(dirPath);
     m->next = gVcdIdMemo;
     gVcdIdMemo = m;
@@ -277,10 +334,6 @@ static int vcdCanonDisplayId(const char *idIn, char *idOut, int idSize)
 // shows the id pays one disc read per game per session, and a theme that does not pays nothing --
 // exactly how #Size behaves, and exactly what Nathan asked for: it may arrive late, it must never
 // hold anything up.
-//
-// It is emphatically NOT identity. Art, per-game CFG and the launch all key off the VCD FILENAME
-// (bdmGetGameStartup returns g->name for the VCD view). Feeding a disc-derived id into those would
-// point art lookups at a name the files on disk are not called.
 int vcdResolveDisplayId(const char *name, char *idOut, int idSize)
 {
     if (name == NULL || idOut == NULL || idSize <= 0)
@@ -291,21 +344,22 @@ int vcdResolveDisplayId(const char *name, char *idOut, int idSize)
     if (m == NULL || m->dir == NULL)
         return 0; // never scanned (or the table was full): caller falls back to the filename
 
-    if (m->asked) {
-        if (m->id[0] == '\0')
-            return 0; // asked already, this disc carries no id
+    if (m->state == VCD_ID_RESOLVED) {
         snprintf(idOut, idSize, "%s", m->id);
         return 1;
     }
+    if (m->state == VCD_ID_ABSENT)
+        return 0;
 
     char vcdPath[256];
     char discId[RETROGEM_GAMEID_MAX];
     size_t dl = strlen(m->dir);
     const char *sep = (dl > 0 && m->dir[dl - 1] == '/') ? "" : "/";
 
-    m->asked = 1; // one attempt per game per session, success or not
-    if (snprintf(vcdPath, sizeof(vcdPath), "%s%s%s.VCD", m->dir, sep, name) >= (int)sizeof(vcdPath))
+    if (snprintf(vcdPath, sizeof(vcdPath), "%s%s%s.VCD", m->dir, sep, name) >= (int)sizeof(vcdPath)) {
+        m->state = VCD_ID_ABSENT;
         return 0;
+    }
 
     // The image is ground truth, and this is the SAME resolver the RetroGEM barcode uses at launch,
     // so a game reports one id to the theme and to the scanner.
@@ -317,8 +371,12 @@ int vcdResolveDisplayId(const char *name, char *idOut, int idSize)
         const char *store = vcdCanonDisplayId(discId, canon, sizeof(canon)) ? canon : discId;
         snprintf(m->id, sizeof(m->id), "%s", store);
         snprintf(idOut, idSize, "%s", store);
+        m->state = VCD_ID_RESOLVED;
         return 1;
     }
+
+    m->state = VCD_ID_ABSENT;
+    m->id[0] = '\0';
     return 0;
 }
 
@@ -338,8 +396,7 @@ int vcdResolveDisplayId(const char *name, char *idOut, int idSize)
 // config-consuming elements (rebuild-155's CFG-storm gate, menusys.c), which stays exactly as it
 // is -- and on the reporter's themes the VCD main page has none, so a resolve riding the config
 // path would never fire for him. One queued resolve per settled VCD row per session; the memo's
-// `asked` flag dedupes everything after, so merely holding a direction costs one strcmp walk per
-// frame and nothing else.
+// state dedupes everything after, so merely holding a direction costs one strcmp walk per frame.
 
 // Memo-read half for the render thread: returns the id ONLY if it is already resolved. Never
 // touches the device, never queues anything -- a miss means "not yet", and the caller falls back.
@@ -350,7 +407,7 @@ int vcdDisplayIdCached(const char *name, char *idOut, int idSize)
     idOut[0] = '\0';
 
     vcd_id_memo_t *m = vcdIdMemoFind(name);
-    if (m == NULL || !m->asked || m->id[0] == '\0')
+    if (m == NULL || m->state != VCD_ID_RESOLVED || m->id[0] == '\0')
         return 0;
     snprintf(idOut, idSize, "%s", m->id);
     return 1;
@@ -358,8 +415,7 @@ int vcdDisplayIdCached(const char *name, char *idOut, int idSize)
 
 // One outstanding resolve request: the GUI writes it, the io worker reads and clears it. Both
 // bracket with DIntr/EIntr -- EE thread preemption requires an interrupt, so that is a complete
-// guard (same pattern as the SFX dispatch ring). A settle while one is in flight is dropped; the
-// next frame re-asks, so the row the user is ON is queued within a frame of the worker freeing.
+// guard (same pattern as the SFX dispatch ring).
 static char gVcdIdReqName[256];
 static volatile int gVcdIdReqPending = 0;
 
@@ -377,11 +433,18 @@ static void vcdResolveQueuedDisplayId(void)
     gVcdIdReqPending = 0;
     EIntr();
 
+    vcd_id_memo_t *m = vcdIdMemoFind(name);
+
     // Async is not enough by itself: a device read can still starve the same USB/PFS channel
-    // used by artwork and BGM. This metadata has zero authority over those assets, so if either
-    // pipeline is busy simply abandon this attempt; the still-selected row asks again next frame.
-    if (cacheHasPendingArt() || !bgmDiscretionaryIoAllowed())
+    // used by artwork and BGM. If either pipeline is busy, transition to DEFERRED with a throttled
+    // retry frame (~1.5 s backoff) so the GUI thread does not flood the IO queue at 60 Hz.
+    if (cacheHasPendingArt() || !bgmDiscretionaryIoAllowed()) {
+        if (m != NULL && m->state == VCD_ID_QUEUED) {
+            m->state = VCD_ID_DEFERRED;
+            m->retryFrame = guiFrameId + 90;
+        }
         return;
+    }
 
     vcdResolveDisplayId(name, id, sizeof(id));
 }
@@ -393,21 +456,24 @@ void vcdRequestDisplayId(const char *name)
     if (name == NULL || name[0] == '\0')
         return;
 
-    // Filename already supplies exactly what ItemText needs: display it immediately and never pay
-    // for a deep image read merely to rediscover the same cosmetic ID.
+    // Filename already supplies exactly what ItemText needs: zero IO
     if (vcdExtractGameId(name, parsed, sizeof(parsed)))
         return;
 
     vcd_id_memo_t *m = vcdIdMemoFind(name);
-    if (m == NULL || m->asked || m->dir == NULL)
-        return; // memo full / never scanned, already resolved/attempted this session, or the dir
-                // strdup OOM'd at scan time. ALL THREE fail closed: vcdResolveDisplayId returns
-                // before setting `asked` when dir is NULL, so without this guard every settle
-                // would re-queue a request that can never succeed -- the CFG-storm shape (#155)
-                // in miniature. Recoverable: a later rescan re-points dir and re-arms the row.
+    if (m == NULL || m->dir == NULL)
+        return;
+
+    // If already resolved, marked absent, or already queued in ioman, no-op
+    if (m->state == VCD_ID_RESOLVED || m->state == VCD_ID_ABSENT || m->state == VCD_ID_QUEUED)
+        return;
+
+    // If deferred due to art/BGM activity, throttle retry attempts
+    if (m->state == VCD_ID_DEFERRED && guiFrameId < m->retryFrame)
+        return;
 
     if (strlen(name) >= sizeof(gVcdIdReqName))
-        return; // pathological basename: the resolver's own path buffer rejects it too -- leave the title
+        return; // pathological basename: leave the title
 
     DIntr();
     if (gVcdIdReqPending) {
@@ -416,13 +482,15 @@ void vcdRequestDisplayId(const char *name)
     }
     snprintf(gVcdIdReqName, sizeof(gVcdIdReqName), "%s", name);
     gVcdIdReqPending = 1;
+    m->state = VCD_ID_QUEUED;
     EIntr();
 
     if (ioPutRequest(IO_CUSTOM_SIMPLEACTION, &vcdResolveQueuedDisplayId) != IO_OK) {
-        // No worker owns the one-slot request when enqueue fails. Release the latch immediately or
-        // every future cosmetic ID request is suppressed for the rest of the session.
+        // Enqueue failed: throttle retry so we don't spam
         DIntr();
         gVcdIdReqPending = 0;
+        m->state = VCD_ID_DEFERRED;
+        m->retryFrame = guiFrameId + 60;
         EIntr();
     }
 }

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -34,6 +34,25 @@
 #include "include/retrogem.h"
 
 
+// Recognized documented POPSTARTER prefixes:
+// XX. = USB / MX4SIO / iLink (local block devices)
+// SB. = SMB / ETH (network shares)
+// EL. = ELF launcher prefix (embedded / custom launcher)
+// SM. = SMB alternate prefix
+static int vcdSkipPopstarterPrefix(const char *name)
+{
+    if (name == NULL || strlen(name) < 3)
+        return 0;
+
+    if ((!strncasecmp(name, "XX.", 3)) ||
+        (!strncasecmp(name, "SB.", 3)) ||
+        (!strncasecmp(name, "EL.", 3)) ||
+        (!strncasecmp(name, "SM.", 3)))
+        return 3;
+
+    return 0;
+}
+
 int vcdExtractGameId(const char *name, char *idOut, int idSize)
 {
     int i;
@@ -45,10 +64,8 @@ int vcdExtractGameId(const char *name, char *idOut, int idSize)
     if (name == NULL)
         return 0;
 
-    // Skip POPSTARTER 3-character prefixes (e.g. "XX.", "SB.", "EL.", "SM.", or any "??.")
-    if (p[0] != '\0' && p[1] != '\0' && p[2] == '.') {
-        p += 3;
-    }
+    // Skip documented POPSTARTER prefixes (XX., SB., EL., SM.)
+    p += vcdSkipPopstarterPrefix(p);
 
     if (strlen(p) < 11)
         return 0;
@@ -103,14 +120,10 @@ int vcdGetArtGameId(const char *name, char *outId, int outSize)
 // (optionally preceded by a POPSTARTER prefix like "XX.") followed by a '.' or '_' separator.
 static int vcdGameIdPrefixLen(const char *name)
 {
-    const char *p = name;
-    int prefixLen = 0;
     if (name == NULL)
         return 0;
-    if (p[0] != '\0' && p[1] != '\0' && p[2] == '.') {
-        p += 3;
-        prefixLen += 3;
-    }
+    int prefixLen = vcdSkipPopstarterPrefix(name);
+    const char *p = name + prefixLen;
     char gameId[VCD_ID_MAX];
     if (vcdExtractGameId(p, gameId, sizeof(gameId))) {
         if (p[11] == '.' || p[11] == '_' || p[11] == ' ' || p[11] == '-')
@@ -191,6 +204,7 @@ static int vcdEntryCmp(const void *a, const void *b)
 //      The remainder resolve on later builds, a few at a time.
 #define VCD_ID_PROBE_BUDGET 8   // discs opened per scan
 #define VCD_ID_MEMO_MAX     512 // ids remembered for the session
+#define VCD_ID_MAX_RETRIES  3   // transient read attempts before marking absent
 
 typedef enum {
     VCD_ID_UNREQUESTED = 0,
@@ -206,6 +220,7 @@ typedef struct vcd_id_memo
     char id[VCD_ID_MAX];     // resolved disc id; empty once absent
     char *dir;               // directory this VCD was scanned from -- the ONLY correct path source
     unsigned char state;     // vcd_id_state_t
+    unsigned char retries;   // count of failed read attempts before transitioning to ABSENT
     unsigned int retryFrame; // guiFrameId when deferred retry is next permitted
     char name[];             // flexible: VCD basenames run long, most are far short of the cap
 } vcd_id_memo_t;
@@ -239,6 +254,7 @@ void vcdNoteScanDir(const char *name, const char *dirPath)
             free(m->dir); // same name on a different device: re-point, and re-ask the disc
             m->dir = strdup(dirPath);
             m->state = VCD_ID_UNREQUESTED;
+            m->retries = 0;
             m->retryFrame = 0;
             m->id[0] = '\0';
         }
@@ -255,6 +271,7 @@ void vcdNoteScanDir(const char *name, const char *dirPath)
     memcpy(m->name, name, len + 1);
     m->id[0] = '\0';
     m->state = VCD_ID_UNREQUESTED;
+    m->retries = 0;
     m->retryFrame = 0;
     m->dir = strdup(dirPath);
     m->next = gVcdIdMemo;
@@ -372,11 +389,20 @@ int vcdResolveDisplayId(const char *name, char *idOut, int idSize)
         snprintf(m->id, sizeof(m->id), "%s", store);
         snprintf(idOut, idSize, "%s", store);
         m->state = VCD_ID_RESOLVED;
+        m->retries = 0;
         return 1;
     }
 
-    m->state = VCD_ID_ABSENT;
-    m->id[0] = '\0';
+    // Distinguish transient device-read / contention failures from genuine absence:
+    // allow bounded retries with backoff before marking the disc ID permanently absent.
+    if (m->retries < VCD_ID_MAX_RETRIES) {
+        m->retries++;
+        m->state = VCD_ID_DEFERRED;
+        m->retryFrame = guiFrameId + 120; // 2s backoff on read failure
+    } else {
+        m->state = VCD_ID_ABSENT;
+        m->id[0] = '\0';
+    }
     return 0;
 }
 


### PR DESCRIPTION
### Summary of Changes

Fixes #508 (PS1/VCD cover art failing and navigation latency regression with artwork enabled).

#### 1. VCD Request State Machine, 60 Hz Enqueue Throttle, & Bounded Retries (`src/vcdsupport.c`)
- **Problem**: When artwork was missing or loading, `vcdResolveQueuedDisplayId()` bailed on the `cacheHasPendingArt()` gate before `vcdResolveDisplayId()` could establish `m->asked`. As a result, `menusys.c` saw `!m->asked` and `!gVcdIdReqPending` every frame (60 Hz), continually flooding `ioman` with `IO_CUSTOM_SIMPLEACTION` requests and saturating the USB bus. Furthermore, transient device read/contention failures could permanently mark the game as `ABSENT`.
- **Fix**: Replaced the binary `asked` flag with a 5-state lifecycle (`UNREQUESTED`, `QUEUED`, `DEFERRED`, `RESOLVED`, `ABSENT`), frame throttle (`retryFrame`), and bounded read retry budget (`retries`, `VCD_ID_MAX_RETRIES = 3`).
  - Deferred requests back off by ~1.5 seconds without re-hammering `ioman` every frame.
  - Transient I/O read failures transition to `DEFERRED` with backoff (~2.0 seconds) and retry up to 3 times before quiescing to `ABSENT`.

#### 2. Documented POPSTARTER-Prefix Parser (`vcdExtractGameId`, `vcdGetArtGameId`)
- **Problem**: `vcdExtractGameId()` assumed games started strictly at character 0 and failed immediately on filenames with standard POPSTARTER prefixes (`XX.`, `SB.`, `EL.`, `SM.`).
- **Fix**: Added explicit `vcdSkipPopstarterPrefix()` to skip only documented prefixes (`XX.`, `SB.`, `EL.`, `SM.`) before extracting canonical `AAAA_NNN.NN` Game IDs with zero I/O. Added `vcdGetArtGameId()` as the single shared helper for all device handlers to query filename-extracted ID first, falling back to cached disc ID with zero synchronous I/O.

#### 3. Two-Tiered VCD Artwork Lookup Across Device Handlers (`bdmsupport.c`, `ethsupport.c`, `mmcesupport.c`, `udpfssupport.c`, `hddsupport.c`)
- **Problem**: Device `itemGetImage` handlers looked only for `ART/<filename>_COV.png` and `POPS/<filename>.png`, ignoring standard OPL Manager Disc-ID named covers (`ART/<GAMEID>_COV.png`).
- **Fix**: Updated all device `itemGetImage` implementations to follow the structured resolution order:
  1. `ART/<filename>_<suffix>.png` (primary filename key)
  2. `ART/<discID>_<suffix>.png` (secondary Disc ID key via `vcdGetArtGameId()`)
  3. `POPS/<filename>.png` (legacy POPSLoader suffixless cover next to `.VCD`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved VCD artwork matching across supported storage sources.
  * Added support for additional POPSTARTER filename formats, including lowercase and title-less IDs.
  * Artwork lookup now retries using the extracted disc ID before using fallback artwork.

* **Bug Fixes**
  * Improved display-ID resolution reliability with better retry handling and caching.
  * Reduced unnecessary background requests during artwork and music activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->