### PR TITLE
rebuild-222: wLE startup detachment, Coverflow palette, network protocol retention, and BDM visibility synchronization

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -103,6 +103,7 @@ int bdmIsUDPBDLoaded(void); // 1 if the UDPBD NIC stack is loaded (the SMB stack
 // reboot while the loaded IRX cannot.
 int bdmGetLoadedNetProtocol(void);
 int bdmSupportIsUDPBD(item_list_t *support); // 1 if this support is the UDPBD block device (its games are Neutrino-only)
+int bdmModeIsUDPBD(int mode);                // 1 if this BDM mode slot is the UDPBD block device
 
 // Re-evaluate every BDM device's presence + page visibility on the next refresh (bumps the latch
 // generation). Call after a device-enable toggle so a latched-hidden tab re-shows without a replug.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -612,8 +612,10 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     opl_io_module_t *pOwner = (opl_io_module_t *)itemList->owner;
     if (pOwner != NULL && pOwner->menuItem.visible == 1) {
         // If the device page is visible but the device support is not enabled, hide the device page.
-        if (bdmTransportEnabled(pDeviceData->bdmDeviceType) == 0)
+        if (bdmTransportEnabled(pDeviceData->bdmDeviceType) == 0) {
             pOwner->menuItem.visible = 0;
+            moduleUpdateMenu(itemList->mode, 0, 0);
+        }
     }
 
     // VCD view: an L3 toggle marks the mode dirty but does NOT bump BdmGeneration or reset
@@ -1851,10 +1853,12 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     // So: if this slot already knows what it is and has published a list, a reappearance restores
     // the page and nothing else. Nothing about the device changed, so there is nothing to re-read.
     if (dir >= 0 && visible == 0 &&
-        pDeviceData->bdmDeviceRoot[0] != ' ' && pDeviceData->bdmDriver[0] != ' ' &&
+        pDeviceData->bdmDeviceRoot[0] != '\0' && pDeviceData->bdmDriver[0] != '\0' &&
         pDeviceData->bdmDeviceType != BDM_TYPE_UNKNOWN && pDeviceData->bdmULSizePrev != -2) {
-        if (itemList->owner != NULL)
+        if (itemList->owner != NULL) {
             ((opl_io_module_t *)itemList->owner)->menuItem.visible = 1;
+            moduleUpdateMenu(itemList->mode, 0, 0);
+        }
         pDeviceData->bdmMissCount = 0;
         LOG("bdmUpdateDeviceData: device %d reappeared intact -- restoring page, no rescan\n", itemList->mode);
         fileXioDclose(dir);
@@ -1930,6 +1934,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         if (itemList->owner != NULL) {
             LOG("bdmUpdateDeviceData: setting device %d visible\n", itemList->mode);
             ((opl_io_module_t *)itemList->owner)->menuItem.visible = 1;
+            moduleUpdateMenu(itemList->mode, 0, 0);
         }
 
         // Close the device handle.
@@ -1961,6 +1966,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         if (itemList->owner != NULL) {
             LOG("bdmUpdateDeviceData: setting device %d invisible\n", itemList->mode);
             ((opl_io_module_t *)itemList->owner)->menuItem.visible = 0;
+            moduleUpdateMenu(itemList->mode, 0, 0);
         }
 
         pDeviceData->FoldersCreated = 0;

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -299,6 +299,16 @@ int bdmSupportIsUDPBD(item_list_t *support)
     return ((bdm_device_data_t *)support->priv)->bdmDeviceType == BDM_TYPE_UDPBD;
 }
 
+// True when this BDM mode slot is the UDPBD block device.
+int bdmModeIsUDPBD(int mode)
+{
+    if (mode < BDM_MODE || mode > BDM_MODE_LAST)
+        return 0;
+    if (bdmDeviceList[mode - BDM_MODE].priv == NULL)
+        return 0;
+    return ((bdm_device_data_t *)bdmDeviceList[mode - BDM_MODE].priv)->bdmDeviceType == BDM_TYPE_UDPBD;
+}
+
 static void bdmEventHandler(void *packet, void *opt)
 {
     BdmGeneration++;

--- a/src/gui.c
+++ b/src/gui.c
@@ -700,13 +700,10 @@ void guiShowDeviceConfig(void)
         diaGetInt(diaDeviceConfig, CFG_ENABLEMX4SIO, &gEnableMX4SIO);
         diaGetInt(diaDeviceConfig, CFG_ENABLEBDMHDD, &gEnableBdmHDD);
 
-        // Network Start Mode read-back: Start=Off forces the protocol OFF; switching Start back on
-        // with no protocol memory (was OFF) lands on SMB, the common default. The protocol itself is
-        // picked on the Network page. Then re-derive the legacy shadows downstream consumers read.
+        // Network Start Mode read-back: Start=Off disables network start;
+        // preserve the user's configured gNetworkProtocol (defaulting to SMB only if uninitialized).
         diaGetInt(diaDeviceConfig, CFG_NETSTART, &gNetStartMode);
-        if (gNetStartMode == START_MODE_DISABLED)
-            gNetworkProtocol = NET_PROTO_OFF;
-        else if (gNetworkProtocol == NET_PROTO_OFF)
+        if (gNetworkProtocol == NET_PROTO_OFF)
             gNetworkProtocol = NET_PROTO_SMB;
         gEnableUDPBD = (gNetworkProtocol == NET_PROTO_UDPBD || gNetworkProtocol == NET_PROTO_UDPFSBD);
         gNetBootProtocol = (gNetworkProtocol == NET_PROTO_UDPFSBD) ? NET_BOOT_UDPFS : NET_BOOT_UDPBD;
@@ -1119,11 +1116,10 @@ void guiShowNetConfig(void)
         int netProtoVal2, netAccessVal2;
         diaGetInt(diaNetConfig, CFG_NETPROTOCOL, &netProtoVal2);
         diaGetInt(diaNetConfig, CFG_UDPFSMODE, &netAccessVal2);
-        gNetworkProtocol = (gNetStartMode == START_MODE_DISABLED) ? NET_PROTO_OFF :
-                           (netProtoVal2 == 0)                    ? NET_PROTO_SMB :
-                           (netProtoVal2 == 2)                    ? NET_PROTO_UDPBD :
-                           (netAccessVal2 == 1)                   ? NET_PROTO_UDPFSBD :
-                                                                    NET_PROTO_UDPFS; // UDPFS + Files
+        gNetworkProtocol = (netProtoVal2 == 0)  ? NET_PROTO_SMB :
+                           (netProtoVal2 == 2)  ? NET_PROTO_UDPBD :
+                           (netAccessVal2 == 1) ? NET_PROTO_UDPFSBD :
+                                                  NET_PROTO_UDPFS; // UDPFS + Files
         gEnableUDPBD = (gNetworkProtocol == NET_PROTO_UDPBD || gNetworkProtocol == NET_PROTO_UDPFSBD);
         gNetBootProtocol = (gNetworkProtocol == NET_PROTO_UDPFSBD) ? NET_BOOT_UDPFS : NET_BOOT_UDPBD;
         // SMB's start mode IS the network start row (Auto = boot connect, Manual = on-entry);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1386,7 +1386,8 @@ void menuHandleInputMenu()
         // gFAVStartMode was missing, so a Favourites-only setup could not escape at all.
         // bdmEffectiveStartMode() rather than raw gBDMStartMode: UDPBD floors the BDM start mode, so
         // a UDPBD-only rig has rows while gBDMStartMode itself is still disabled.
-        if (gAPPStartMode || gETHStartMode || bdmEffectiveStartMode() || gHDDStartMode || gFAVStartMode || gMMCEStartMode) {
+        int netActive = (gNetworkProtocol == NET_PROTO_SMB) ? gETHStartMode : (gNetworkProtocol == NET_PROTO_UDPFS ? gNetStartMode : 0);
+        if (gAPPStartMode || gETHStartMode || netActive || bdmEffectiveStartMode() || gHDDStartMode || gFAVStartMode || gMMCEStartMode) {
             guiSwitchScreen(GUI_SCREEN_MAIN);
             refreshMenuPosition();
         }

--- a/src/pad.c
+++ b/src/pad.c
@@ -654,7 +654,7 @@ int readPads()
                 // which is exactly why it does not do it. The mode read is EE-local and cheap; the
                 // init behind it is the expensive part, and now it runs only when it has something
                 // to fix.
-                if (padInfoMode(pad_data[i].port, pad_data[i].slot, PAD_MODECURID, 0) == PAD_TYPE_DUALSHOCK) {
+                if (pad_data[i].actuators > 0 && padInfoMode(pad_data[i].port, pad_data[i].slot, PAD_MODECURID, 0) == PAD_TYPE_DUALSHOCK) {
                     LOG("PAD port %d reconnect: already DualShock, skipping re-init\n", pad_data[i].port);
                     break;
                 }

--- a/src/system.c
+++ b/src/system.c
@@ -198,6 +198,10 @@ void sysReset(int modload_mask)
         SifExitIopHeap();
         SifLoadFileExit();
         SifExitRpc();
+    } else {
+        // Initial boot: detach inherited parent-launcher RPC/fileXio state before rebooting the IOP
+        fileXioExit();
+        SifExitRpc();
     }
     sInitialBoot = 0;
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -3049,7 +3049,7 @@ int thmSetGuiValue(int themeID, int reload)
 
             guiThemeID = themeID;
             return 1;
-        } else if (guiThemeID == 0 || guiThemeID == nThemes + 1)
+        } else if (guiThemeID == 0)
             thmSetColors(gTheme);
     }
     return 0;

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -821,15 +821,16 @@ int vcdModeSupported(int mode)
     // FAV_MODE has its own L3 ISO<->VCD view too: the Favourites tab swaps between disc favourites and
     // PS1/.VCD favourites (favsupport filters its list by vcdViewActive(FAV_MODE)). Its vcdView slot is
     // independent of any device's, so toggling Favourites never disturbs a device page's view.
-    // UDPFS_MODE was MISSING from this list -- in the fork too (a latent bug there, masked because
-    // VCD was mostly used on BDM/HDD pages). Since this predicate is the FIRST gate in
-    // itemExecToggleView AND the L3 hint condition, its absence made the page's entire shipped VCD
-    // surface unreachable dead code: udpfssupport.c's vcdFillGameList call, the POPS cover
-    // fallback, and the POPSTARTER launch guard (which safely refuses the actual launch with a
-    // toast -- network filesystems cannot host a POPSTARTER handoff, but LISTING the library is
-    // exactly what the code was written to do). First deliberate divergence from the fork's
-    // vcdsupport.c, and it is a fix, not a drift.
-    return (mode >= BDM_MODE && mode <= BDM_MODE_LAST) || mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE || mode == UDPFS_MODE;
+    //
+    // Supported L3 VCD pages:
+    // - USB / exFAT, MMCE, MX4SIO, SMB, ATA (BDM HDD), APA / PFS HDD, FAV_MODE
+    //
+    // Unsupported:
+    // - UDPBD, UDPFS, APPS
+    if (mode >= BDM_MODE && mode <= BDM_MODE_LAST)
+        return !bdmModeIsUDPBD(mode);
+
+    return mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE;
 }
 
 int vcdViewActive(int mode)


### PR DESCRIPTION
## Summary of Changes

- **Track 1 (wLaunchELF Startup Detachment)**: Detach inherited EE-side RPC and fileXio state on initial boot before SIF IOP reset in \src/system.c\, resolving launch freezes under wLaunchELF_R3Z when IOP Reset is OFF.
- **Track 2A (Coverflow Palette Preservation)**: Restrict \	hmSetColors()\ default palette overwrite in \src/themes.c\ to theme 0 only, preserving Coverflow's custom dark navy (\#182580\) background across settings apply.
- **Track 2B (Network Protocol Retention)**: Decouple \gNetworkProtocol\ from \gNetStartMode\ in \src/gui.c\ so disabling network start mode does not clobber UDPFS selection back to SMB.
- **Track 2B (UDPFS Start Menu Gate)**: Include UDPFS in active device check in \src/menusys.c\ when returning from the Start menu to the main carousel.
- **Track 2B (BDM Visibility Synchronization)**: Emit \moduleUpdateMenu()\ on BDM visibility transitions (\

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Network protocol settings are now preserved when automatic network startup is disabled.
  - Network menu options now accurately reflect the active protocol and available start modes.
  - Menu visibility updates refresh immediately after pages are hidden, restored, published, or removed.
  - Improved system reset handling during startup for more reliable device initialization.
  - Custom Coverflow theme colors are no longer unexpectedly replaced with default theme colors.

- **Compatibility**
  - Updated virtual CD support for block-device modes, excluding UDPBD and UDPFS where unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->