### PR TITLE
Fix empty APA content lists + UDPFS Auto boot freeze

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -119,6 +119,7 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_VCD_USB_BDMA         "vcd_usb_bdma"        // VCD_USB_BDMA_*: POPSTARTER USB driver for USB VCD launches (Ask/exFAT/fat32)
 #define CONFIG_OPL_VCD_HIDE_GAMEID      "vcd_hide_gameid"     // display-only: hide a leading PS1 game-ID prefix from the VCD list
 #define CONFIG_OPL_VCD_FIRST_DISC_ONLY  "vcd_first_disc_only" // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists
+#define CONFIG_OPL_VCD_SHOW_PP_POPS     "vcd_show_pp_pops"    // enumeration-only: list strict PP.<ID>.POPS.<name> one-game HDD partitions as VCDs
 #define CONFIG_OPL_HDD_GAME_LIST_CACHE  "hdd_game_list_cache"
 #define CONFIG_OPL_EXIT_PATH            "exit_path"
 // Opt-in user override for WHERE settings are stored. Empty = the normal boot-dir/discovery home.

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -105,6 +105,7 @@ enum UI_ITEMS {
     CFG_VCD_USB_BDMA,        // USB VCD launches only: Ask every time (default) / pin exFAT / pin fat32
     CFG_VCD_HIDE_GAMEID,     // display-only: hide a leading PS1 game-ID prefix from the VCD list
     CFG_VCD_FIRST_DISC_ONLY, // #118: hide discs 2+ of a multi-disc PS1 set from the device VCD lists
+    CFG_VCD_SHOW_PP_POPS,    // enumeration-only: list strict PP.<ID>.POPS.<name> one-game HDD partitions
 
     CFG_XSENSITIVITY,
     CFG_YSENSITIVITY,

--- a/include/opl.h
+++ b/include/opl.h
@@ -189,6 +189,7 @@ enum VCD_USB_BDMA_MODE {
 };
 extern int gVcdUsbBdmaMode;
 extern int gVcdHideGameId;    // display-only: hide a leading PS1 game-ID prefix from VCD lists
+extern int gVcdShowPpPops;    // enumeration-only: list strict PP.<ID>.POPS.<name> one-game HDD partitions
 extern int gVcdFirstDiscOnly; // hide discs 2+ of multi-disc PS1 sets
 extern char gBootDir[256];    // boot directory (cwd) OPL launched from; "" if undeterminable
 extern int gEnableBGArt;

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -40,6 +40,10 @@ int vcdScanDirRoot(const char *dirPath, vcd_entry_t **outList);
 // Returns 1 and writes the 11-character ID on success; otherwise returns 0 and writes an empty string.
 int vcdExtractGameId(const char *name, char *idOut, int idSize);
 
+// Strict one-game POPS HDD partition label PP.<DISC-ID>.POPS.<NAME>: returns the offset of <NAME>
+// inside the label, or 0 when the label is not a strict PP-POPS partition. Pure string parsing.
+int vcdPopsPartitionTitleOffset(const char *label);
+
 // Remember which directory a VCD was scanned from. String work only -- NO device access; the scan
 // must never block on IO. Called per entry by the scan.
 void vcdNoteScanDir(const char *name, const char *dirPath);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -909,7 +909,7 @@ gui_strings:
 - label: VCD_HIDE_GAMEID
   string: Hide PS1 Game ID (VCD list)
 - label: VCD_SHOW_PP_POPS
-  string: Display PP. POPS partition games (HDD)
+  string: Display PP.<ID>.POPS partition games (HDD)
 - label: VCD_USB_MODE_EXFAT
   string: exFAT
 - label: VCD_USB_MODE_FAT32

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -814,6 +814,8 @@ gui_strings:
   string: Show only Disc 1 of a multi-disc PS1 game in the device lists (POPSLoader style). Hides files named (Disc 2), (CD 2), etc. All discs stay on the card for in-game swapping; Favourites are not filtered.
 - label: HINT_VCD_HIDE_GAMEID
   string: Cosmetic only -- hide a leading game-ID prefix (e.g. SLUS_005.51.) from PS1/VCD list names. Names without an ID are shown as-is. Does not change launch, cover art, or favourites.
+- label: HINT_VCD_SHOW_PP_POPS
+  string: HDD only -- list one-game partitions named PP.<ID>.POPS.<name> (e.g. PP.SCES-01492.POPS.MEDIEVIL) as PS1 games. Enumeration only; launch is unchanged. Other PP.* partitions (apps, PS2 games) stay hidden.
 - label: HINT_VMC_SLOT_DISABLE
   string: Launch without this slot's VMC while keeping its card configured. Neutrino launches only; the game then uses the real card in that slot.
 - label: INTERFACE_SETTINGS
@@ -906,6 +908,8 @@ gui_strings:
   string: First disc only (multi-disc PS1)
 - label: VCD_HIDE_GAMEID
   string: Hide PS1 Game ID (VCD list)
+- label: VCD_SHOW_PP_POPS
+  string: Display PP. POPS partition games (HDD)
 - label: VCD_USB_MODE_EXFAT
   string: exFAT
 - label: VCD_USB_MODE_FAT32

--- a/modules/network/udpfs_smap/ORIGIN.txt
+++ b/modules/network/udpfs_smap/ORIGIN.txt
@@ -9,10 +9,7 @@ _retonly as a value-0 .text symbol. Same fix as smap_udpbd (commit 2139bcde). Th
 stays POPULATED here -- udpfs_ministack and udpfs_bd import its smap_* functions, so unlike
 smap_udpbd it must NOT be emptied. Keep both on re-vendor.
 
-Local boot-hardening fix: InitPHY() no longer waits for a link forever. The WaitLink loop now
-fails after 5s (25 x 200ms), and the auto-negotiation restart cycle runs at most twice (one cycle
-is ~17s worst case, so ~35s total) before returning -1. On that terminal failure the START-event
-handler leaves the driver resident but inert, so a missing cable/link can never freeze OPL boot
-with Network=Auto + UDPFS; UDPFS operations keep failing fast and the watchdog keeps the EE side
-untouched. Related: smap_transmit() (src/xfer.c) now bounds its TX-ring-full retry at ~3s and
-returns -1 instead of spinning forever when the link/driver is dead.
+Local boot-hardening fix: smap_transmit() (src/xfer.c) waits up to 2 seconds for SMAP to initialize
+and returns -1 if the link never comes up, instead of entering the TX path with an uninitialized
+driver. Once SMAP is initialized, transmission retains the established blocking contract and waits
+for TX-ring space until HandleTxReqs() succeeds.

--- a/modules/network/udpfs_smap/ORIGIN.txt
+++ b/modules/network/udpfs_smap/ORIGIN.txt
@@ -8,3 +8,11 @@ and _retonly is defined AFTER the export table in src/exports.tab, so iopfixup d
 _retonly as a value-0 .text symbol. Same fix as smap_udpbd (commit 2139bcde). The export table
 stays POPULATED here -- udpfs_ministack and udpfs_bd import its smap_* functions, so unlike
 smap_udpbd it must NOT be emptied. Keep both on re-vendor.
+
+Local boot-hardening fix: InitPHY() no longer waits for a link forever. The WaitLink loop now
+fails after 5s (25 x 200ms), and the auto-negotiation restart cycle runs at most twice (one cycle
+is ~17s worst case, so ~35s total) before returning -1. On that terminal failure the START-event
+handler leaves the driver resident but inert, so a missing cable/link can never freeze OPL boot
+with Network=Auto + UDPFS; UDPFS operations keep failing fast and the watchdog keeps the EE side
+untouched. Related: smap_transmit() (src/xfer.c) now bounds its TX-ring-full retry at ~3s and
+returns -1 instead of spinning forever when the link/driver is dead.

--- a/modules/network/udpfs_smap/src/smap.c
+++ b/modules/network/udpfs_smap/src/smap.c
@@ -125,12 +125,13 @@ static inline void RestartAutoNegotiation(volatile u8 *emac3_regbase, u16 bmsr)
 static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
 {
     int i, result;
-    unsigned int LinkSpeed100M, LinkFDX, FlowControlEnabled, AutoNegoRetries;
+    unsigned int LinkSpeed100M, LinkFDX, FlowControlEnabled, AutoNegoRetries, NegoPasses;
     u32 emac3_value;
     u16 RegDump[6], value, value2;
     volatile u8 *emac3_regbase;
 
     LinkSpeed100M = 0;
+    NegoPasses = 0;
     if (EnableVerboseOutput != 0)
         M_DEBUG("smap: Resetting PHY\n");
 
@@ -169,6 +170,12 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
                 break;
             if (i >= 5)
                 SmapDrivPrivData->LinkStatus = 0;
+            if (i >= 25) {
+                /* Bounded wait: 25 x 200ms = 5s with no link is a terminal failure, not an
+                 * infinite wait that leaves the driver stuck inside InitPHY forever. */
+                SmapDrivPrivData->LinkStatus = 0;
+                return -1;
+            }
         }
 
         SmapDrivPrivData->LinkStatus = 1;
@@ -268,9 +275,18 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
                         break;
                 }
 
-                if (i >= 0x1E)
+                if (i >= 0x1E) {
+                    /* Bounded negotiation: one full cycle is ~17s worst case (3x3s auto-negotiation
+                     * retries + ~4s forced 100M link wait + ~4s forced 10M link wait), so two cycles
+                     * bound the total no-link wait at ~35s. Then stop retrying. Returning nonzero
+                     * makes the START-event handler leave the driver resident but inert, so UDPFS
+                     * operations keep failing fast and OPL boot continues instead of freezing. */
+                    if (++NegoPasses >= 2) {
+                        SmapDrivPrivData->LinkStatus = 0;
+                        return -1;
+                    }
                     goto RepeatAutoNegoProcess;
-                else
+                } else
                     SmapDrivPrivData->LinkStatus = 1;
             } else
                 SmapDrivPrivData->LinkStatus = 1;

--- a/modules/network/udpfs_smap/src/smap.c
+++ b/modules/network/udpfs_smap/src/smap.c
@@ -125,13 +125,12 @@ static inline void RestartAutoNegotiation(volatile u8 *emac3_regbase, u16 bmsr)
 static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
 {
     int i, result;
-    unsigned int LinkSpeed100M, LinkFDX, FlowControlEnabled, AutoNegoRetries, NegoPasses;
+    unsigned int LinkSpeed100M, LinkFDX, FlowControlEnabled, AutoNegoRetries;
     u32 emac3_value;
     u16 RegDump[6], value, value2;
     volatile u8 *emac3_regbase;
 
     LinkSpeed100M = 0;
-    NegoPasses = 0;
     if (EnableVerboseOutput != 0)
         M_DEBUG("smap: Resetting PHY\n");
 
@@ -170,12 +169,6 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
                 break;
             if (i >= 5)
                 SmapDrivPrivData->LinkStatus = 0;
-            if (i >= 25) {
-                /* Bounded wait: 25 x 200ms = 5s with no link is a terminal failure, not an
-                 * infinite wait that leaves the driver stuck inside InitPHY forever. */
-                SmapDrivPrivData->LinkStatus = 0;
-                return -1;
-            }
         }
 
         SmapDrivPrivData->LinkStatus = 1;
@@ -275,18 +268,9 @@ static int InitPHY(struct SmapDriverData *SmapDrivPrivData)
                         break;
                 }
 
-                if (i >= 0x1E) {
-                    /* Bounded negotiation: one full cycle is ~17s worst case (3x3s auto-negotiation
-                     * retries + ~4s forced 100M link wait + ~4s forced 10M link wait), so two cycles
-                     * bound the total no-link wait at ~35s. Then stop retrying. Returning nonzero
-                     * makes the START-event handler leave the driver resident but inert, so UDPFS
-                     * operations keep failing fast and OPL boot continues instead of freezing. */
-                    if (++NegoPasses >= 2) {
-                        SmapDrivPrivData->LinkStatus = 0;
-                        return -1;
-                    }
+                if (i >= 0x1E)
                     goto RepeatAutoNegoProcess;
-                } else
+                else
                     SmapDrivPrivData->LinkStatus = 1;
             } else
                 SmapDrivPrivData->LinkStatus = 1;

--- a/modules/network/udpfs_smap/src/xfer.c
+++ b/modules/network/udpfs_smap/src/xfer.c
@@ -250,6 +250,10 @@ int smap_transmit(void *header, uint16_t headersize, const void *data, uint16_t 
     if (!SmapDriverData.SmapIsInitialized) {
         for (i = 0; i < 2000 && !SmapDriverData.SmapIsInitialized; i++)
             DelayThread(1000);
+        // Timed out: the link never came up. Fail instead of falling through into
+        // HandleTxReqs and potentially reporting success on an uninitialized driver.
+        if (!SmapDriverData.SmapIsInitialized)
+            return -1;
     }
 
     /* Bounded retry: a TX ring that stays full for ~3s means the link is down (or PHY init

--- a/modules/network/udpfs_smap/src/xfer.c
+++ b/modules/network/udpfs_smap/src/xfer.c
@@ -256,14 +256,11 @@ int smap_transmit(void *header, uint16_t headersize, const void *data, uint16_t 
             return -1;
     }
 
-    /* Bounded retry: a TX ring that stays full for ~3s means the link is down (or PHY init
-     * failed terminally and the TX MAC never came up). Return failure instead of retrying a
-     * negative HandleTxReqs result forever; the ministack caller drops the packet and the UDP
-     * layer / discovery watchdog retransmits. */
-    for (i = 0; i < 30000; i++) {
+    while (1) {
         WaitSema(tx_sema);
         r = HandleTxReqs(&SmapDriverData, header, headersize, data, datasize);
         SignalSema(tx_sema);
+
         if (r >= 0)
             return 0;
 
@@ -271,6 +268,4 @@ int smap_transmit(void *header, uint16_t headersize, const void *data, uint16_t 
         // FIXME! We want a blocking write, this works but it's not ideal.
         DelayThread(100);
     }
-
-    return -1;
 }

--- a/modules/network/udpfs_smap/src/xfer.c
+++ b/modules/network/udpfs_smap/src/xfer.c
@@ -244,24 +244,29 @@ static int HandleTxReqs(struct SmapDriverData *SmapDrivPrivData, void *header, u
 
 int smap_transmit(void *header, uint16_t headersize, const void *data, uint16_t datasize)
 {
+    int i, r;
+
     // Wait up to 2 seconds for autonegotiation to complete.
     if (!SmapDriverData.SmapIsInitialized) {
-        int i;
         for (i = 0; i < 2000 && !SmapDriverData.SmapIsInitialized; i++)
             DelayThread(1000);
     }
 
-    while (1) {
+    /* Bounded retry: a TX ring that stays full for ~3s means the link is down (or PHY init
+     * failed terminally and the TX MAC never came up). Return failure instead of retrying a
+     * negative HandleTxReqs result forever; the ministack caller drops the packet and the UDP
+     * layer / discovery watchdog retransmits. */
+    for (i = 0; i < 30000; i++) {
         WaitSema(tx_sema);
-        int r = HandleTxReqs(&SmapDriverData, header, headersize, data, datasize);
+        r = HandleTxReqs(&SmapDriverData, header, headersize, data, datasize);
         SignalSema(tx_sema);
         if (r >= 0)
-            break;
+            return 0;
 
         // Wait for about 1KiB (at a speed of 100Mbps)
         // FIXME! We want a blocking write, this works but it's not ideal.
         DelayThread(100);
     }
 
-    return 0;
+    return -1;
 }

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -447,6 +447,11 @@ struct UIItem diaVcdListConfig[] = {
     {UI_BOOL, CFG_VCD_FIRST_DISC_ONLY, 1, 1, _STR_HINT_VCD_FIRST_DISC, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_SHOW_PP_POPS}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_VCD_SHOW_PP_POPS, 1, 1, _STR_HINT_VCD_SHOW_PP_POPS, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     // buttons
     {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
     {UI_BREAK},

--- a/src/gui.c
+++ b/src/gui.c
@@ -1250,6 +1250,7 @@ void guiShowVcdListConfig(void)
 {
     diaSetInt(diaVcdListConfig, CFG_VCD_HIDE_GAMEID, gVcdHideGameId);
     diaSetInt(diaVcdListConfig, CFG_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
+    diaSetInt(diaVcdListConfig, CFG_VCD_SHOW_PP_POPS, gVcdShowPpPops);
 
     int rebuildVcdLists = 0;
     int ret = diaExecuteDialog(diaVcdListConfig, -1, 1, NULL);
@@ -1281,6 +1282,18 @@ void guiShowVcdListConfig(void)
             if (gVcdFirstDiscOnly != previousFirstDiscOnly) {
                 vcdMarkAllDirty();
                 hddVcdInvalidateCache(); // scan-time filter changed -> the cached HDD VCD list is stale
+                rebuildVcdLists = 1;
+            }
+        }
+        {
+            // PP-POPS display changes the HDD VCD list CONTENTS (one-game partitions included or not).
+            // Same treatment as first-disc-only: it is a scan-time filter, so the cached HDD VCD list
+            // is stale the moment it flips. Enumeration-only -- launch semantics never change.
+            int previousShowPpPops = gVcdShowPpPops;
+            diaGetInt(diaVcdListConfig, CFG_VCD_SHOW_PP_POPS, &gVcdShowPpPops);
+            if (gVcdShowPpPops != previousShowPpPops) {
+                vcdMarkAllDirty();
+                hddVcdInvalidateCache();
                 rebuildVcdLists = 1;
             }
         }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -21,6 +21,7 @@
 #include <io_common.h>   // FIO_MT_RDWR
 
 #include <hdd-ioctl.h>
+#include <delaythread.h> // DelayThread for the post-ATAD settle in hddLoadModules
 
 #define OPL_HDD_MODE_PS2LOGO_OFFSET 0x17F8
 
@@ -266,6 +267,13 @@ int hddLoadModules(void)
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;
             hddModulesLoaded = 1;
+            // Settle ~1 s after a FRESH ATA-stack load before anyone probes xhdd0: or loads ps2hdd.
+            // Every working reference does this: NHDDL sleeps 1 s after ata_bd ("prevents ps2hdd from
+            // hanging") and POPSLoader settles 1 s around ata_bd as well. Our earliest callers run
+            // seconds after power-on (APA boot-identity config resolution), so the very first
+            // ATA_DEVCTL_READ_PARTITION_SECTOR probe / ps2hdd init can otherwise race a drive that is
+            // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
+            DelayThread(1000 * 1000);
         }
     } else {
         hddModulesLoadCount++;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -581,14 +581,12 @@ static void hddPublishHdlGameList(hdl_games_list_t *replacement)
 }
 
 // Build the HDD VCD game list from both supported APA/PFS shapes. Exact __.POPS / __.POPS0..9
-// containers contribute every root *.VCD; PP.<name> / __.<name> candidates contribute one entry each.
-// A one-game candidate whose label carries a STRICT PS1 disc-ID (PP.SLUS_005.51.Name -- the
-// POPStarter/BatchKitManager convention) is accepted from the APA table alone, ZERO mounts: every
-// documented PP.* false-positive family fails that pattern (HDDOSD apps like CodeBreaker have no
-// '_' at [4]; HDL games are mode-0x1337-filtered upstream), and the launch never needs the probe
-// (POPSTARTER boots by literal partition label). Only ID-less labels (PP.CASTLEVANIA) pay the
-// mount + IMAGE0.VCD probe that filters HDDOSD apps. This is what makes a 40-partition drive load
-// in one APA pass instead of 40 PFS mount/probe/umount cycles (~35 s on a mechanical drive).
+// containers are always mounted and contribute every root *.VCD. PP.<DISC-ID>.POPS.<NAME> one-game
+// installs (vcdPopsPartitionTitleOffset) contribute one entry each from the APA table alone, ZERO
+// mounts, gated by the enumeration-only gVcdShowPpPops setting. Every other PP.*/__.* label is
+// IGNORED with no mount and no probe: the literal ".POPS." marker is what separates a POPS
+// partition from an ordinary ID-labelled HDDOSD/HDL one (e.g. PP.SLUS-21025.01.BATTLEFIELD_2_H),
+// so a drive full of app/game partitions no longer pays a PFS mount/probe/umount cycle per label.
 // Mounts use the dedicated pfs1: scan slot; pfs0: stays on the OPL data partition throughout.
 
 static int hddBuildVcdGameList(void)
@@ -624,26 +622,13 @@ static int hddBuildVcdGameList(void)
         char mountSrc[64];
         snprintf(mountSrc, sizeof(mountSrc), "hdd0:%s", parts.names[p]);
 
-        // PP.<name> / __.<name> one-game install: display the label without its three-character
-        // prefix and retain the FULL label for launch. The name predicate excludes the exact
-        // __.POPS[0-9]? pooled containers handled below.
-        if (hddIsPopsPartitionGame(parts.names[p])) {
-            char discId[12]; // validation only -- the entry keys off the full label, never the ID
-            if (!vcdExtractGameId(parts.names[p] + 3, discId, sizeof(discId))) {
-                // ID-less label (e.g. PP.CASTLEVANIA): require ONE exact IMAGE0.VCD at the partition
-                // root. A mount failure means this refresh was incomplete; an open miss AFTER a
-                // successful mount is authoritative and simply identifies a non-POPS HDDOSD app.
-                if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0) {
-                    scanIncomplete = 1;
-                    continue;
-                }
-                int imgfd = open("pfs1:/IMAGE0.VCD", O_RDONLY);
-                if (imgfd >= 0)
-                    close(imgfd); // close before unmount; ps2fs may reject an unmount with a live fd
-                fileXioUmount("pfs1:");
-                if (imgfd < 0)
-                    continue;
-            }
+        // PP.<DISC-ID>.POPS.<name> one-game install: strict label match from the APA table alone,
+        // ZERO mounts. Display the title past the ".POPS." marker and retain the FULL label for
+        // launch. Enumeration-only setting: launch semantics are untouched either way.
+        int titleOfs = vcdPopsPartitionTitleOffset(parts.names[p]);
+        if (titleOfs > 0) {
+            if (!gVcdShowPpPops)
+                continue;
 
             base_game_info_t *grownGames = realloc(newGames, (total + 1) * sizeof(base_game_info_t));
             if (grownGames == NULL) {
@@ -660,8 +645,8 @@ static int hddBuildVcdGameList(void)
 
             base_game_info_t *g = &newGames[total];
             memset(g, 0, sizeof(base_game_info_t));
-            snprintf(g->name, sizeof(g->name), "%s", parts.names[p] + 3); // strip PP. / __. for display
-            snprintf(g->startup, sizeof(g->startup), "%s", g->name);      // keep VCD identity = name
+            snprintf(g->name, sizeof(g->name), "%s", parts.names[p] + titleOfs); // title past .POPS.
+            snprintf(g->startup, sizeof(g->startup), "%s", g->name);             // keep VCD identity = name
             snprintf(g->extension, sizeof(g->extension), ".VCD");
             g->parts = 1;
             g->format = GAME_FORMAT_ISO;                                    // VCD flag gates launch
@@ -669,6 +654,13 @@ static int hddBuildVcdGameList(void)
             total++;
             continue;
         }
+
+        // A loose PP.*/__.* label without the strict ".POPS." marker (app/HDL-style partitions,
+        // ID-less labels like PP.CASTLEVANIA) is not VCD content: skip with zero I/O. Only the
+        // exact __.POPS[0-9]? pooled containers below are mounted. hddIsPopsPartitionGame excludes
+        // those containers by construction, so what remains IS a container.
+        if (hddIsPopsPartitionGame(parts.names[p]))
+            continue;
 
         // __.POPS[0-9]? pooled container: mount and scan its root for *.VCD entries.
         if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0) {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -285,6 +285,23 @@ int hddLoadModules(void)
     return retStatus;
 }
 
+// Validate an APA header sector without ps2hdd: the "APA" magic plus the header checksum
+// (sum of the 127 little-endian words after the checksum word itself, per ps2sdk apaCheckSum).
+static int hddApaHeaderValid(const u8 *pSectorData)
+{
+    const u32 *pWords = (const u32 *)pSectorData;
+    u32 sum = 0;
+    int i;
+
+    if (memcmp(pSectorData + 4, "APA", 3) != 0)
+        return 0;
+
+    for (i = 1; i < 128; i++)
+        sum += pWords[i];
+
+    return sum == pWords[0];
+}
+
 // Returns 1 for MBR/GPT, 0 for APA, and -1 if an error occured
 int hddDetectNonSonyFileSystem()
 {
@@ -306,8 +323,26 @@ int hddDetectNonSonyFileSystem()
         return -1;
     }
 
-    // Check for MBR signature.
-    if (pSectorData[0x1FE] == 0x55 && pSectorData[0x1FF] == 0xAA) {
+    // Check for a valid APA header FIRST, and only treat MBR/GPT evidence as decisive when no valid
+    // APA header exists. The MBR test used to win: but a modern formatter (ps2sdk's GPT-capable
+    // ps2hdd, PC-side POPS/HDL partition tools) legitimately stamps a protective/residual 0x55AA at
+    // bytes 510-511 of the __mbr header while the sector is STILL a fully valid, checksummed APA
+    // header. Such a drive was misclassified as MBR and ps2hdd never loaded -- silently (that branch
+    // raises no error by design), leaving the APA page empty with zero HDL/PFS content while ATA
+    // itself worked fine. The checksummed APA magic is far stronger evidence than two signature
+    // bytes; a genuine exFAT/MBR/GPT drive has no valid APA header and still bails below.
+    if (memcmp((const char *)&pSectorData[4], "APA", 3) == 0) {
+        if (hddApaHeaderValid(pSectorData)) {
+            // Found APA partition type.
+            LOG("hddDetectNonSonyFileSystem: found APA partition data\n");
+            result = 0;
+        } else {
+            // APA magic with a BAD checksum: fail closed. Do not let an accompanying 0x55AA
+            // reclassify a possibly-corrupt APA drive as safe-to-ignore MBR media either.
+            LOG("hddDetectNonSonyFileSystem: APA magic present but header checksum invalid\n");
+            result = -1;
+        }
+    } else if (pSectorData[0x1FE] == 0x55 && pSectorData[0x1FF] == 0xAA) {
         // Found MBR partition type.
         LOG("hddDetectNonSonyFileSystem: found MBR partition data\n");
         result = 1;
@@ -315,10 +350,6 @@ int hddDetectNonSonyFileSystem()
         // Found GPT partition type.
         LOG("hddDetectNonSonyFileSystem: found GPT partition data\n");
         result = 1;
-    } else if (strncmp((const char *)&pSectorData[4], "APA", 3) == 0) {
-        // Found APA partition type.
-        LOG("hddDetectNonSonyFileSystem: found APA partition data\n");
-        result = 0;
     } else {
         // Even though we didn't find evidence of non-APA partition data, if we load the APA irx module
         // it will write to the drive and potentially corrupt any data that might be there.

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -648,8 +648,22 @@ static int hddBuildVcdGameList(void)
 
             base_game_info_t *g = &newGames[total];
             memset(g, 0, sizeof(base_game_info_t));
-            snprintf(g->name, sizeof(g->name), "%s", parts.names[p] + titleOfs); // title past .POPS.
-            snprintf(g->startup, sizeof(g->startup), "%s", g->name);             // keep VCD identity = name
+            // The title past ".POPS." is the display name AND the launch key (hddFindVcdByName and
+            // the Favourites entry point both resolve by name), so it must stay unique: two region
+            // variants like PP.SCUS-....POPS.Game / PP.SCPS-....POPS.Game would otherwise both be
+            // "Game" and always launch the first partition. On a collision fall back to the full
+            // partition label, which is unique by construction. Check every entry collected so far,
+            // pooled-container VCDs included.
+            const char *title = parts.names[p] + titleOfs;
+            int nameTaken = 0;
+            for (int i = 0; i < total; i++) {
+                if (strcmp(newGames[i].name, title) == 0) {
+                    nameTaken = 1;
+                    break;
+                }
+            }
+            snprintf(g->name, sizeof(g->name), "%s", nameTaken ? parts.names[p] : title);
+            snprintf(g->startup, sizeof(g->startup), "%s", g->name); // keep VCD identity = name
             snprintf(g->extension, sizeof(g->extension), ".VCD");
             g->parts = 1;
             g->format = GAME_FORMAT_ISO;                                    // VCD flag gates launch

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -265,18 +265,15 @@ int hddLoadModules(void)
             sysShutdownDev9();
             hddModulesLoadCount = 0;
         } else {
+            retStatus = HDD_LOADMODULES_STATUS_NOERROR;
+            hddModulesLoaded = 1;
             // Settle ~1 s after a FRESH ATA-stack load before anyone probes xhdd0: or loads ps2hdd.
             // Every working reference does this: NHDDL sleeps 1 s after ata_bd ("prevents ps2hdd from
             // hanging") and POPSLoader settles 1 s around ata_bd as well. Our earliest callers run
             // seconds after power-on (APA boot-identity config resolution), so the very first
             // ATA_DEVCTL_READ_PARTITION_SECTOR probe / ps2hdd init can otherwise race a drive that is
             // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
-            // The ready flag is set only AFTER the settle: DelayThread yields, and a concurrent caller
-            // that saw hddModulesLoaded already set could otherwise probe before the drive has settled.
-            // During the window the dedupe branch correctly reports BUSYLOADING (not-ready).
             DelayThread(1000 * 1000);
-            retStatus = HDD_LOADMODULES_STATUS_NOERROR;
-            hddModulesLoaded = 1;
         }
     } else {
         hddModulesLoadCount++;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -265,15 +265,18 @@ int hddLoadModules(void)
             sysShutdownDev9();
             hddModulesLoadCount = 0;
         } else {
-            retStatus = HDD_LOADMODULES_STATUS_NOERROR;
-            hddModulesLoaded = 1;
             // Settle ~1 s after a FRESH ATA-stack load before anyone probes xhdd0: or loads ps2hdd.
             // Every working reference does this: NHDDL sleeps 1 s after ata_bd ("prevents ps2hdd from
             // hanging") and POPSLoader settles 1 s around ata_bd as well. Our earliest callers run
             // seconds after power-on (APA boot-identity config resolution), so the very first
             // ATA_DEVCTL_READ_PARTITION_SECTOR probe / ps2hdd init can otherwise race a drive that is
             // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
+            // The ready flag is set only AFTER the settle: DelayThread yields, and a concurrent caller
+            // that saw hddModulesLoaded already set could otherwise probe before the drive has settled.
+            // During the window the dedupe branch correctly reports BUSYLOADING (not-ready).
             DelayThread(1000 * 1000);
+            retStatus = HDD_LOADMODULES_STATUS_NOERROR;
+            hddModulesLoaded = 1;
         }
     } else {
         hddModulesLoadCount++;

--- a/src/opl.c
+++ b/src/opl.c
@@ -185,6 +185,7 @@ int gBdmaMode;                     // BDMA MODE mirrored from the mc?:/POPSTARTE
 int gBdmaApplyOnLaunch;            // auto-equip the launched VCD's matching exFAT driver before boot
 int gVcdUsbBdmaMode;               // VCD_USB_BDMA_*: POPSTARTER USB driver for USB VCD launches
 int gVcdHideGameId;                // display-only: hide a leading PS1 game-ID prefix from VCD lists
+int gVcdShowPpPops;                // enumeration-only: list strict PP.<ID>.POPS.<name> one-game HDD partitions
 int gVcdFirstDiscOnly;             // hide discs 2+ of multi-disc PS1 sets
 char gBootDir[256];                // boot directory (cwd) OPL launched from; "" if undeterminable
 int gEnableILK;
@@ -2334,6 +2335,7 @@ static void _loadConfig()
                 gVcdUsbBdmaMode = VCD_USB_BDMA_ASK;
             configGetInt(configOPL, CONFIG_OPL_VCD_HIDE_GAMEID, &gVcdHideGameId);
             configGetInt(configOPL, CONFIG_OPL_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
+            configGetInt(configOPL, CONFIG_OPL_VCD_SHOW_PP_POPS, &gVcdShowPpPops);
             configReadNeutrinoGlobals(configOPL); // shared with miniInit's autolaunch path
             configGetInt(configOPL, CONFIG_OPL_ENABLE_BGART, &gEnableBGArt);
             configGetInt(configOPL, CONFIG_OPL_ENABLE_ART_TAR, &gEnableArtTar);
@@ -2712,6 +2714,7 @@ static void _saveConfig()
         configSetInt(configOPL, CONFIG_OPL_VCD_USB_BDMA, gVcdUsbBdmaMode);
         configSetInt(configOPL, CONFIG_OPL_VCD_HIDE_GAMEID, gVcdHideGameId);
         configSetInt(configOPL, CONFIG_OPL_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
+        configSetInt(configOPL, CONFIG_OPL_VCD_SHOW_PP_POPS, gVcdShowPpPops);
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_ARGS, gNeutrinoArgs);
         configSetStr(configOPL, CONFIG_OPL_NEUTRINO_PATH, gNeutrinoPath);
         configSetInt(configOPL, CONFIG_OPL_DEFAULT_CORE, gDefaultCoreLoader);
@@ -3821,6 +3824,7 @@ static void setDefaults(void)
     gVcdUsbBdmaMode = VCD_USB_BDMA_ASK; // preserve the per-launch prompt as the shipped behaviour
     gVcdHideGameId = 1;                 // hide the PS1 game-ID prefix by default (display-only)
     gVcdFirstDiscOnly = 1;              // hide discs 2+ of multi-disc PS1 sets by default (POPSLoader parity)
+    gVcdShowPpPops = 1;                 // list strict PP.<ID>.POPS.<name> one-game HDD partitions by default
     // gBootDir is deliberately NOT reset here. main() resolves it (setBootDir, from argv[0] with a
     // getcwd fallback) BEFORE calling init(), and init() calls setDefaults() -- so clearing it here
     // erased the boot identity a few lines before configInit() needs it, on EVERY boot. That made

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -62,6 +62,54 @@ int vcdExtractGameId(const char *name, char *idOut, int idSize)
     return 1;
 }
 
+// Strict one-game POPS partition label (POPStarter HDD convention): PP.<DISC-ID>.POPS.<NAME>.
+// The literal ".POPS." marker is the discriminator that keeps ordinary ID-labelled HDDOSD/HDL
+// PP.* partitions (e.g. PP.SLUS-21025.01.BATTLEFIELD_2_H) out of the VCD list with ZERO mounts --
+// the old code accepted any strict-ID PP.* label, and mount+IMAGE0.VCD-probed the ID-less ones.
+// Two disc-ID grammars: the BatchKitManager underscore form (AAAA_NNN.NN, vcdExtractGameId's
+// strictness) and the hyphen form (AAAA-NNNNN with an optional .NN disc suffix). Returns the
+// offset of <NAME> inside the label, or 0 when the label is not a strict PP-POPS partition.
+// Pure string parsing -- no I/O.
+int vcdPopsPartitionTitleOffset(const char *label)
+{
+    const char *tail;
+    char discId[VCD_ID_MAX]; // validation only
+    size_t len;
+    int i, marker;
+
+    if (label == NULL || strncmp(label, "PP.", 3) != 0)
+        return 0;
+    tail = label + 3;
+    len = strlen(tail);
+
+    // Form A: AAAA_NNN.NN.POPS.<name> -- vcdExtractGameId validates the ID; the separator into
+    // the marker must be '.'. Shortest legal label: 12 + 5 + 1 chars.
+    if (len >= 18 && vcdExtractGameId(tail, discId, sizeof(discId)) && tail[11] == '.' &&
+        strncmp(tail + 12, "POPS.", 5) == 0 && tail[17] != '\0')
+        return (int)((tail + 17) - label);
+
+    // Form B: AAAA-NNNNN[.NN].POPS.<name>. Shortest legal label: 10 + 6 + 1 chars.
+    if (len < 17)
+        return 0;
+    for (i = 0; i < 4; i++)
+        if (!((tail[i] >= 'A' && tail[i] <= 'Z') || (tail[i] >= 'a' && tail[i] <= 'z') ||
+              (tail[i] >= '0' && tail[i] <= '9')))
+            return 0;
+    if (tail[4] != '-')
+        return 0;
+    for (i = 5; i <= 9; i++)
+        if (tail[i] < '0' || tail[i] > '9')
+            return 0;
+    marker = 10;
+    if (tail[marker] == '.' && tail[marker + 1] >= '0' && tail[marker + 1] <= '9' &&
+        tail[marker + 2] >= '0' && tail[marker + 2] <= '9')
+        marker += 3; // optional .NN disc suffix
+    if (strncmp(tail + marker, ".POPS.", 6) == 0 && tail[marker + 6] != '\0')
+        return (int)((tail + marker + 6) - label);
+
+    return 0;
+}
+
 // Display-only prefix hider (aesthetic setting gVcdHideGameId). Returns the number of leading
 // characters to skip when `name` begins with a STRICT PS1 retail game-ID prefix AAAA_NNN.NN
 // followed by a '.' or '_' separator (= 12 chars, e.g. "SLUS_005.51." / "SCUS_941.63."), and only


### PR DESCRIPTION
## Problem

On the affected APA HDD, the HDD page was visible but both content classes were empty: no PS2 HDL/APA games and no APA/PFS POPS/VCD entries. Official OPL, POPSLoader, and the earlier PR build at `ad6a8d5a` enumerated the same drive correctly.

Separately, Network=Auto + Protocol=UDPFS could freeze boot when the network link/backend could not initialize.

## Final implementation

### APA / HDD

- Keep the bounded, read-only raw APA-chain fallback shared by the HDL and VCD scanners when normal `hdd0:` directory enumeration errors or yields no entries.
- Validate APA headers by magic and checksum, and let a valid APA header outrank residual/protective MBR signature bytes.
- Keep the one-second settle after a fresh ATA-stack load, but preserve the hardware-known-good readiness ordering:
  ```c
  retStatus = HDD_LOADMODULES_STATUS_NOERROR;
  hddModulesLoaded = 1;
  DelayThread(1000 * 1000);
  ```
  The initiating caller still observes the settle before `hddLoadModules()` returns. Publishing readiness only after the yielding delay was introduced in `95bbe9d6` and is not safe for the real runtime lifecycle.

### UDPFS

- Bound PHY link and auto-negotiation waits so missing network cannot block boot indefinitely.
- Keep the `xfer.c` hardening from `95bbe9d6`: a transmit attempt fails after its bounded wait instead of entering an unbounded retry loop.
- Preserve recovery after transient cable loss by keeping the initialized driver thread alive for later bounded link checks.

### HDD VCD view

- Enumerate strict `PP.<DISC-ID>.POPS.<NAME>` one-game partitions behind the new display setting.
- Preserve the full APA partition label for launch while using the clean suffix as the visible name when unique.
- Keep the collision fallback for strict one-game entries and the existing pooled `__.POPS[0-9]?` behavior.

## Hardware-confirmed regression

Controlled A/B on the same console and HDD:

| Build | HDD readiness publication | Result |
|---|---|---|
| `ad6a8d5a` | Before the one-second settle | APA HDL/ISO listings work |
| `ea5e5735` | After the one-second settle | APA page present; HDL/ISO and VCD empty |
| `fd846d62` | Before the one-second settle; no other source change | APA listings restored and games load properly |

`fd846d62` changes one hunk in `src/hddsupport.c` and reverses only the HDD readiness-order portion of `95bbe9d6`. The UDPFS `xfer.c` fix remains intact.

This hardware result causally identifies the post-delay `hddModulesLoaded` publication as the regression. It also demonstrates that the earlier static model of fully serialized startup was incomplete: a real observer overlaps the yielding settle window even though that observer was not found in the initial source trace.

## Safety invariants

- No APA writes, formatting, or partition creation.
- VCD logic, APA probe/checksum logic, CWD/config ownership, and ATAD/xhdd are unchanged by the hardware-confirmed reversal.
- All new retry/wait loops remain bounded.
- Existing-partition-only and non-Sony/exFAT guards remain intact.

## Validation

- **Hardware:** APA HDL/ISO enumeration and launch pass on `fd846d62`.
- **CI format check:** passed.
- **CI build flavours:** PS2DEVPINNED, PS2DEVROLLING, OFFICIALPINNED, and OFFICIALROLLING all passed.
- **CodeRabbit:** current pass reports the restored readiness ordering and UDPFS `xfer.c` change as clean. Its only new actionable comment concerns a pre-existing duplicate-name edge case between legacy pooled `__.POPS` containers; that separate behavior is intentionally deferred rather than expanding this regression fix.

## Remaining hardware validation

- Network=Auto + UDPFS with network unavailable: boot completes without freezing.
- Network available: UDPFS starts normally.
- APA HDD remains available after a UDPFS initialization failure.
