### PR TITLE
ci: target rebuild/main from Neutrino watch

### DIFF
--- a/.github/workflows/neutrino-watch.yml
+++ b/.github/workflows/neutrino-watch.yml
@@ -68,7 +68,7 @@ jobs:
             echo "Rolling has no recorded bundled Neutrino version; deferring to the next push-to-master rebuild."
           elif [ "$NEU" != "$CUR" ]; then
             echo "Neutrino changed ($CUR -> $NEU): dispatching rolling-release.yml to rebundle."
-            gh workflow run rolling-release.yml --repo "$GITHUB_REPOSITORY" --ref master
+            gh workflow run rolling-release.yml --repo "$GITHUB_REPOSITORY" --ref rebuild/main
           else
             echo "Rolling already bundles the latest Neutrino ($NEU). Nothing to do."
           fi


### PR DESCRIPTION
## Summary
- dispatch Rolling Release from rebuild/main when Neutrino changes
- stop the watcher from rebuilding the legacy master branch

## Verification
- actionlint .github/workflows/neutrino-watch.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Neutrino watcher to use the `rebuild/main` release workflow reference when detecting upstream version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->