### PR TITLE
Auto-provision POPSTARTER SMB network config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ GFX_OBJS = $(PNG_ASSETS:%=%_png.o) poeveticanew.o icon_sys.o icon_icn.o
 # NOTE: audio/bgm.ogg is intentionally NOT compiled into the ELF (saves ~324 KB).
 # It is kept in the repo only as a reference/default track. BGM is loaded at
 # runtime from a theme's sound/bgm.ogg, a configured BGM path, or the built-in
-# theme's conventional <OPL home>/bgm.ogg (see sound.c bgmLoad), never embedded
+# theme's <OPL boot/CWD home>/bgm.ogg on non-APA boots and <gHDDPrefix>THM/bgm.ogg
+# on APA boots (see sound.c bgmLoad), never embedded
 # -- do not add bgm.o back here.
 AUDIO_OBJS =	boot.o cancel.o confirm.o cursor.o message.o transition.o bd_connect.o bd_disconnect.o
 

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,9 @@ GFX_OBJS = $(PNG_ASSETS:%=%_png.o) poeveticanew.o icon_sys.o icon_icn.o
 
 # NOTE: audio/bgm.ogg is intentionally NOT compiled into the ELF (saves ~324 KB).
 # It is kept in the repo only as a reference/default track. BGM is loaded at
-# runtime from a theme's sound/bgm.ogg or a configured BGM path (see sound.c
-# bgmLoad), never embedded -- do not add bgm.o back here.
+# runtime from a theme's sound/bgm.ogg, a configured BGM path, or the built-in
+# theme's conventional <OPL home>/bgm.ogg (see sound.c bgmLoad), never embedded
+# -- do not add bgm.o back here.
 AUDIO_OBJS =	boot.o cancel.o confirm.o cursor.o message.o transition.o bd_connect.o bd_disconnect.o
 
 MISC_OBJS =	icon_sys_A.o icon_sys_J.o icon_sys_C.o conf_theme_OPL.o theme_coverflow.o bdma_usbd_usb.o bdma_usbhdfsd_usbexfat.o bdma_usbhdfsd_mx4sio.o bdma_usbd_mmce.o bdma_usbhdfsd_mmce.o bdma_usbd_ata.o bdma_usbhdfsd_ata.o

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -92,9 +92,16 @@ int bdmEnsureSourceModules(int bdmType, u32 timeoutMs);
 // basename; may be empty) verifies the slot: the device holding <bootdir>/<elfName> IS the boot device.
 // *ioBdmType: pass the known boot-device BDM_TYPE_* to pin the search (save-path re-resolve) or
 // BDM_TYPE_UNKNOWN to classify from the prefix; on success it returns the resolved device's type.
-// Returns 1 with bootDir rewritten in place, 0 when bootDir is not a BDM path (untouched), -1 when the
-// boot device never mounted in time (untouched -- caller drops it so legacy discovery re-arms).
+// Returns 1 with bootDir rewritten in place (or confirmed unchanged for an explicit massN: slot),
+// 0 when bootDir is not a BDM path (untouched), -1 when the boot device never mounted in time
+// (untouched; callers keep that explicit identity and can fall back to defaults).
 int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType);
+// Bootstrap variant for the first config read. An explicit massN: is identified only by opening
+// that exact slot and reading its driver/device ioctls; it never probes other mass slots. Its
+// bounded USB -> MX4SIO -> iLink/ATA transport bring-up prevents a normal first-run boot from
+// spending the full recovery budget before defaults are shown. Explicit custom paths and save-time
+// re-resolution use bdmResolveBootDir() above.
+int bdmResolveBootDirBootstrap(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType);
 
 int bdmFindPartition(char *target, const char *name, int write);
 int bdmIsUDPBDLoaded(void); // 1 if the UDPBD NIC stack is loaded (the SMB stack must not load on top)

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -254,6 +254,9 @@ enum UI_ITEMS {
     VCDUSB_BTN_FAT32,
     VCDUSB_BTN_EXFAT,
 
+    POPS_OVERWRITE_KEEP,
+    POPS_OVERWRITE_REPLACE,
+
     // Settings-layout restructure: sub-page buttons (chained dialogs, goto-reshow pattern)
     UICFG_ARTWORK_BUTTON,
     UICFG_COLORS_BUTTON,
@@ -365,6 +368,7 @@ extern struct UIItem diaNeutrinoDefaults[];
 extern struct UIItem diaBdmaConfig[];
 extern struct UIItem diaVcdListConfig[];
 extern struct UIItem diaPopsNetConfig[];
+extern struct UIItem diaPopsOverwrite[];
 extern struct UIItem diaMmceCommConfig[];
 extern struct UIItem diaMmcePathConfig[];
 extern struct UIItem diaSecurityConfig[];

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -273,8 +273,9 @@ enum UI_ITEMS {
     SECURITY_PARENTAL_BUTTON,
     ADV_PREFIX_BUTTON,
     ADV_STORAGE_BUTTON,
-    TOOLS_NET_UPDATE_BUTTON,
-    TOOLS_NBD_BUTTON,
+    CFG_HDDOPLPART,
+    GENERAL_GSM_DEFAULTS_BUTTON,
+    LAUNCH_GSM_DEFAULTS_BUTTON,
 
 #ifdef PADEMU
     PADEMU_GLOBAL_BUTTON,
@@ -375,6 +376,5 @@ extern struct UIItem diaSecurityConfig[];
 extern struct UIItem diaAdvancedConfig[];
 extern struct UIItem diaPathPrefixConfig[];
 extern struct UIItem diaStorageConfig[];
-extern struct UIItem diaToolsConfig[];
 
 #endif

--- a/include/ethsupport.h
+++ b/include/ethsupport.h
@@ -27,5 +27,6 @@ item_list_t *ethGetObject(int initOnly);
 // Resolve a stored ETH ISO favourite against the ISO backing view even while the live ETH page
 // is showing VCDs. Read-only; never changes the visible ETH list or L3 view.
 int ethResolveIsoFavourite(int id, const char *name, int *outId);
+const char *ethGetSMBPrefix(void);
 
 #endif

--- a/include/ethsupport.h
+++ b/include/ethsupport.h
@@ -19,7 +19,11 @@ void ethInit(item_list_t *itemList); // Full initialization (Start ETH + SMB and
 void ethDeinitModules(void);         // Module-only deinitialization, without the GUI's knowledge (for specific reasons, otherwise unused).
 int ethLoadInitModules(void);        // Initializes Ethernet and applies configuration.
 int ethGetModulesLoaded(void);       // 1 if the SMB NIC stack is loaded (UDPBD must not load on top).
-void ethDisplayErrorStatus(void);    // Displays the current error status (if any). GUI must be already initialized.
+// True only after OPENSHARE succeeded and the active smb0: prefix is usable. This is deliberately
+// stronger than "Network Protocol == SMB": callers must not turn a read-only import into a long
+// connection attempt or consume stale saved values.
+int ethIsSMBShareConnected(void);
+void ethDisplayErrorStatus(void); // Displays the current error status (if any). GUI must be already initialized.
 int ethGetNetConfig(u8 *ip_address, u8 *netmask, u8 *gateway);
 int ethApplyConfig(void);
 int ethGetDHCPStatus(void);

--- a/include/gui.h
+++ b/include/gui.h
@@ -142,7 +142,6 @@ int guiShowMmceConfig(void);
 void guiShowMmceCommConfig(void);
 void guiShowMmcePathConfig(void);
 void guiShowStorageConfig(void);
-void guiShowToolsConfig(void);
 void guiShowArtworkConfig(void);
 void guiShowCoverflowConfig(void);
 void guiShowColorsConfig(void);

--- a/include/guigame.h
+++ b/include/guigame.h
@@ -19,7 +19,9 @@ char *gameConfigSource(void);
 int guiGameVmcNameHandler(char *text, int maxLen);
 void guiGameShowVMCMenu(int id, item_list_t *support);
 void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configSet);
-void guiGameShowGSConfig(int forceGlobal);
+// Returns the child dialog result so Settings peer pages can preserve their shared Save Changes
+// contract after editing the global defaults.
+int guiGameShowGSConfig(int forceGlobal);
 void guiGameShowCheatConfig(void);
 
 #ifdef PADEMU

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -110,6 +110,20 @@ static inline int hddLoadModulesReady(void)
     return r == HDD_LOADMODULES_STATUS_NOERROR || r == HDD_LOADMODULES_STATUS_ALREADYLOADED;
 }
 void hddLoadSupportModules(void);
+
+// Normal APA data-home choices surfaced by Settings -> Game Sources. POPS loose files remain
+// separately owned by __common/POPS; this selector only controls OPL's regular data home.
+enum {
+    HDD_OPL_HOME_COMMON = 0,
+    HDD_OPL_HOME_PLUS = 1,
+};
+int hddGetOplHomeSelection(void);
+int hddOplHomeIsLegacy(void);
+int hddStageOplHomeSelection(int selection);
+int hddCommitOplHomeSelection(void);
+void hddDiscardOplHomeSelection(void);
+int hddOplHomeSelectionPending(void);
+
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
 int hddIsPresent();
 

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -98,6 +98,9 @@ void hddVcdInvalidateCache(void);
 void hddInit(item_list_t *itemList);
 item_list_t *hddGetObject(int initOnly);
 int hddLoadModules(void);
+// Non-acquiring residency check for short-lived probes. Unlike hddLoadModulesReady(), this does
+// not increment the HDD module-use count.
+int hddModulesAreLoaded(void);
 
 // Load (or confirm) the ATA stack and report residency, evaluating hddLoadModules EXACTLY ONCE.
 // A function, not a macro taking the call as its argument: the earlier HDD_LOADMODULES_OK(

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -123,6 +123,11 @@ enum {
 int hddGetOplHomeSelection(void);
 int hddOplHomeIsLegacy(void);
 int hddStageOplHomeSelection(int selection);
+// A successfully saved selector applies on the next boot, while pfs0: intentionally remains on
+// the current live data home. These helpers expose that next-home write target through pfs1:.
+int hddOplHomeSelectionNeedsTargetSave(void);
+int hddMountSelectedOplHome(char *prefix, int prefixLen);
+void hddUnmountSelectedOplHome(void);
 int hddCommitOplHomeSelection(void);
 void hddDiscardOplHomeSelection(void);
 int hddOplHomeSelectionPending(void);

--- a/include/menusys.h
+++ b/include/menusys.h
@@ -107,6 +107,9 @@ int menuHasRegisteredItems(void);
 void menuReinitMainMenu(void);
 void menuInitGameMenu(void);
 void menuInitAppMenu(void);
+// Reuses the lightweight item-operation menu, but exposes Rename only. VCD/POPSTARTER entries
+// must never enter the PS2 per-game configuration menu.
+void menuInitVcdMenu(void);
 
 void menuAppendItem(menu_item_t *item);
 

--- a/include/opl.h
+++ b/include/opl.h
@@ -79,6 +79,9 @@ void setErrorMessagePathCode(int strId, const char *path, int error);
 int loadConfig(int types);
 int saveConfig(int types, int showUI);
 void applyConfig(int themeID, int langID, int skipDeviceRefresh);
+// True only while init() is rendering the initial boot splash. GUI code uses this to keep the
+// normal deferred-operation spinner out of the startup presentation without changing runtime UI.
+int oplIsBootInProgress(void);
 void menuDeferredUpdate(void *data);
 void moduleUpdateMenu(int mode, int themeChanged, int langChanged);
 void handleLwnbdSrv();
@@ -175,7 +178,7 @@ enum { POPS_DEV_DEFAULT = 0, // cwd (gBootDir) /POPS/, then the VCD's own device
        POPS_DEV_MX4SIO,      // BDM "mx4sio"/sdc -> the mounted massN:
        POPS_DEV_MMCE,        // mmce0: / mmce1: (checklist item 1)
        POPS_DEV_EXFAT_HDD,   // BDM "ata" internal exFAT HDD -> the mounted massN:
-       POPS_DEV_APA_HDD,     // APA HDD: the mounted OPL data partition (pfs0:)
+       POPS_DEV_APA_HDD,     // APA HDD: canonical hdd0:__common/POPS via the native HDD VCD resolver
        POPS_DEV_CUSTOM,      // free-text gPopstarterPath
        POPS_DEV_GAME };      // the VCD's OWN device ONLY; appended last to keep saved ints stable
 extern int gPopstarterDevice;

--- a/include/opl.h
+++ b/include/opl.h
@@ -76,6 +76,9 @@ config_set_t *oplGetLegacyAppsInfo(char *name);
 void setErrorMessage(int strId);
 void setErrorMessageWithCode(int strId, int error);
 void setErrorMessagePathCode(int strId, const char *path, int error);
+// Drop a queued error only when it is the exact condition that subsequently recovered. This avoids
+// hiding an unrelated notification merely because a later storage probe happened to succeed.
+void clearErrorMessageIf(int strId);
 int loadConfig(int types);
 int saveConfig(int types, int showUI);
 void applyConfig(int themeID, int langID, int skipDeviceRefresh);
@@ -334,6 +337,9 @@ extern base_game_info_t *gAutoLaunchBDMGame;
 extern bdm_device_data_t *gAutoLaunchDeviceData;
 extern char *gHDDPrefix;
 extern char gOPLPart[128];
+
+// Conventional built-in-theme BGM location. This is a single resolved path, not a search.
+int oplGetDefaultThemeBgmPath(char *path, int pathSize);
 
 void initSupport(item_list_t *itemList, int mode, int force_reinit);
 

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -209,6 +209,28 @@ int vcdPopsNetChanged(const vcd_popsnet_t *orig, const vcd_popsnet_t *cur);
 // the file must exist either way. Returns 0, or the first vcdSafeWriteFile error (-2/-3).
 int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int writeIp);
 
+// ---- POPStarter SMB auto-provisioning for mc0:/POPSTARTER/ (RiptOPL launch helper) ----
+// Ensures the two required network files for SMB VCD launches exist on mc0:/POPSTARTER/.
+// Presence wins: an existing file is never parsed or overwritten.
+// Only missing files are generated, using current RiptOPL network/SMB globals when derivable.
+// DHCP / missing static PS2 triple -> NEED_STATIC (no bogus file). SMB share/IP validation -> INVALID.
+// Destination is fixed to mc0:/POPSTARTER/ (no mc1 fallback) - POPSTARTER module provisioning
+// (vcdInstallPopstarterMc) stays dual-slot.
+typedef enum {
+    VCD_POPSNET_READY = 0,       // both DAT files exist, or were successfully created
+    VCD_POPSNET_NEED_STATIC = 1, // missing file requires static PS2 IP / mask / gateway or resolved SMB IP
+    VCD_POPSNET_IO_ERROR = 2,    // MC full (-2) or IO error (-3) - partial removed
+    VCD_POPSNET_INVALID = 3,     // SMB share/IP etc invalid and not derivable
+    VCD_POPSNET_SMB_MISSING = 4  // required SMB IRX modules not present on MC
+} vcd_popsnet_ensure_t;
+
+vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void);
+
+// Shared SMB POPSTARTER preparation for both ETH VCD and APPS SB.*.ELF launches.
+// Installs missing MC support from smbPrefix (ethPrefix), verifies SMB modules,
+// and ensures mc0:/POPSTARTER/*.DAT. Returns VCD_POPSNET_READY on success.
+vcd_popsnet_ensure_t vcdPreparePopstarterSmbLaunch(const char *smbPrefix);
+
 // Render the RetroGEM Game ID optical barcode immediately prior to a POPStarter VCD launch.
 void vcdPrepareRetroGemBarcode(const char *vcdPath);
 

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -169,9 +169,10 @@ int vcdSmbModulesPresent(void);
 // ---- POPStarter network files (IPCONFIG.DAT / SMBCONFIG.DAT) --------------------------------
 // POPSLoader-parity flow: READ existing values when available, otherwise stay blank until the
 // user explicitly enters or imports values. Absence means "unknown/unconfigured", never "use
-// OPL defaults". Locations: mc0:/POPSTARTER -> mc1:/POPSTARTER, in that precedence order --
-// POPSTARTER reads its network files from the memory card ONLY (OPL's own settings live in the
-// boot dir/cwd, but that is OUR convention, not POPSTARTER's).
+// OPL defaults". The resolver evaluates mc0:/POPSTARTER and mc1:/POPSTARTER as complete homes:
+// a valid complete home wins (mc0 then mc1), then an existing partial or invalid home (so it can
+// be repaired rather than shadowed), then an available card for first setup. Callers keep the
+// selected home for validation, generation and launch preparation.
 //
 // Formats (POPStarter):
 //   IPCONFIG.DAT: one line "<PS2 IP> <NETMASK> <GATEWAY>"; a BLANK file = DHCP. The file should
@@ -183,6 +184,9 @@ typedef struct
     int smbExists; // SMBCONFIG.DAT was found (smbDir names where)
     int ipExists;  // IPCONFIG.DAT was found (ipDir names where)
     int ipDhcp;    // 1 = DHCP (file blank or absent); 0 = static triple below is valid
+    int smbInvalid;
+    int ipInvalid;
+    int homeAvailable;
     int ps2Ip[4];
     int ps2Mask[4];
     int ps2Gw[4];
@@ -193,29 +197,33 @@ typedef struct
     char smbPass[32];
     char smbDir[96];    // dir SMBCONFIG.DAT was read from ("" when absent)
     char ipDir[96];     // dir IPCONFIG.DAT was read from ("" when absent)
-    char createDir[96]; // where files that don't exist yet get created ("" = nowhere available)
+    char createDir[96]; // selected home where files that do not exist yet get created
+    char home[96];      // resolved POPSTARTER home used by this configuration
 } vcd_popsnet_t;
 
 // Scan the candidate dirs and fill *out. Absence of both files is DATA (all fields blank, the
-// exists-flags 0, ipDhcp 1), not an error. Returns 0, or -3 on a genuine mid-read IO error.
+// exists-flags 0, ipDhcp 1), not an error. Invalid file contents set ipInvalid/smbInvalid and
+// remain user-editable. Returns 0, or -3 on a genuine mid-read IO error.
 int vcdReadPopstarterNet(vcd_popsnet_t *out);
 
 // Change detection vs the read-time snapshot, for the save matrix: bit 0 = SMB fields differ,
 // bit 1 = IP fields differ. Compares semantic content only (never the dirs/exists flags).
 int vcdPopsNetChanged(const vcd_popsnet_t *orig, const vcd_popsnet_t *cur);
 
-// Write SMBCONFIG.DAT (writeSmb) and/or IPCONFIG.DAT (writeIp). Each file goes to its origin dir
-// when it existed, else to createDir (mkdir best-effort). A DHCP ipconfig is written BLANK --
-// the file must exist either way. Returns 0, or the first vcdSafeWriteFile error (-2/-3).
+// Validate values before a Settings-editor replacement. DHCP is a valid IPCONFIG.DAT value; a
+// non-DHCP write requires a complete static triple and SMB requires a usable numeric host/share.
+int vcdPopsNetValuesValid(const vcd_popsnet_t *cfg, int validateSmb, int validateIp);
+
+// Write SMBCONFIG.DAT (writeSmb) and/or IPCONFIG.DAT (writeIp) at the resolved home. A DHCP
+// ipconfig is written BLANK -- the file must exist either way. Returns 0, -2/-3 for card/IO
+// failure, or -4 when the requested values are invalid.
 int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int writeIp);
 
-// ---- POPStarter SMB auto-provisioning for mc0:/POPSTARTER/ (RiptOPL launch helper) ----
-// Ensures the two required network files for SMB VCD launches exist on mc0:/POPSTARTER/.
-// Presence wins: an existing file is never parsed or overwritten.
-// Only missing files are generated, using current RiptOPL network/SMB globals when derivable.
-// DHCP / missing static PS2 triple -> NEED_STATIC (no bogus file). SMB share/IP validation -> INVALID.
-// Destination is fixed to mc0:/POPSTARTER/ (no mc1 fallback) - POPSTARTER module provisioning
-// (vcdInstallPopstarterMc) stays dual-slot.
+// ---- POPStarter SMB auto-provisioning (RiptOPL launch helper) ----
+// Ensures the two required network files for SMB VCD launches exist at the validated resolved
+// POPSTARTER home. Existing valid files are preserved; only a missing peer is generated from the
+// current RiptOPL network/SMB globals when derivable. DHCP / missing static PS2 triple ->
+// NEED_STATIC (no bogus file). Malformed/unusable existing files -> INVALID.
 typedef enum {
     VCD_POPSNET_READY = 0,       // both DAT files exist, or were successfully created
     VCD_POPSNET_NEED_STATIC = 1, // missing file requires static PS2 IP / mask / gateway or resolved SMB IP
@@ -224,11 +232,9 @@ typedef enum {
     VCD_POPSNET_SMB_MISSING = 4  // required SMB IRX modules not present on MC
 } vcd_popsnet_ensure_t;
 
-vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void);
-
 // Shared SMB POPSTARTER preparation for both ETH VCD and APPS SB.*.ELF launches.
-// Installs missing MC support from smbPrefix (ethPrefix), verifies SMB modules,
-// and ensures mc0:/POPSTARTER/*.DAT. Returns VCD_POPSNET_READY on success.
+// Resolves one MC home, installs missing MC support there from smbPrefix (ethPrefix), verifies
+// the SMB modules there, and ensures its *.DAT files. Returns VCD_POPSNET_READY on success.
 vcd_popsnet_ensure_t vcdPreparePopstarterSmbLaunch(const char *smbPrefix);
 
 // Render the RetroGEM Game ID optical barcode immediately prior to a POPStarter VCD launch.

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -96,12 +96,22 @@ const char *vcdDisplayName(int mode, const char *text);
 void vcdToggleView(int mode);
 // Returns 1 exactly once after a toggle (and clears the flag) -- call from the support's NeedsUpdate.
 int vcdConsumeDirty(int mode);
+// Mark one VCD-capable mode dirty after its VCD storage changes. Runtime callers still enqueue that
+// support's normal deferred update; this only makes the existing NeedsUpdate path rescan it.
+void vcdMarkDirty(int mode);
 // Mark all VCD-capable modes dirty (one rescan each) -- used when the global default-view setting changes.
 void vcdMarkAllDirty(void);
 
 // Fill a base_game_info_t list (memalign'd like sbReadList; frees *outGames first) from
 // <devPrefix>POPS/*.VCD. Returns the count. name/startup = VCD basename without the extension.
 int vcdFillGameList(const char *devPrefix, base_game_info_t **outGames);
+// Rename one VCD in a device's POPS/ directory. The old entry is matched with the exact filename
+// spelling returned by the scan, so case-sensitive PFS/SMB filesystems retain their extension case.
+// Returns 0 on success; no list ownership is changed here.
+int vcdRenameFile(const char *devPrefix, const char *oldName, const char *newName);
+// As vcdRenameFile, but `dirPath` is already the directory containing the VCD (APA/PFS pooled
+// partitions use their mounted root, rather than a POPS/ child).
+int vcdRenameFileInDir(const char *dirPath, const char *oldName, const char *newName);
 // #118: 1 if a .VCD filename is disc 2+ of a multi-disc PS1 set ("(Disc N)"/"(CD N)"/"(Disk N)", N>=2,
 // case-insensitive). Callers hide it from the device lists when gVcdFirstDiscOnly is on.
 int vcdIsHiddenDisc(const char *name);

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -216,6 +216,17 @@ typedef struct
 // remain user-editable. Returns 0, or -3 on a genuine mid-read IO error.
 int vcdReadPopstarterNet(vcd_popsnet_t *out);
 
+typedef enum {
+    VCD_POPSNET_SMB_IMPORT_OK = 0,
+    VCD_POPSNET_SMB_IMPORT_NOT_CONNECTED = 1,
+    VCD_POPSNET_SMB_IMPORT_NOT_FOUND = 2,
+} vcd_popsnet_smb_import_t;
+
+// Read (never write) POPS/IPCONFIG.DAT and POPS/SMBCONFIG.DAT from the active mounted SMB share.
+// This does not connect SMB or use OPL's own saved network fields. Both files must pass the same
+// strict parser/validation as local POPSTARTER configuration before values are returned.
+vcd_popsnet_smb_import_t vcdReadPopstarterNetFromSmb(vcd_popsnet_t *out);
+
 // Change detection vs the read-time snapshot, for the save matrix: bit 0 = SMB fields differ,
 // bit 1 = IP fields differ. Compares semantic content only (never the dirs/exists flags).
 int vcdPopsNetChanged(const vcd_popsnet_t *orig, const vcd_popsnet_t *cur);

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -551,7 +551,7 @@ gui_strings:
 - label: CFM_VMODE_CHG
   string: Confirm video mode change?
 - label: CACHE_HDD_GAME_LIST
-  string: Cache Game List (HDD)
+  string: Cache Game List (HDD APA)
 - label: ENABLE_NOTIFICATIONS
   string: Notifications
 - label: CFG_NOTIFICATION
@@ -769,7 +769,7 @@ gui_strings:
 - label: GAME_SOURCES
   string: Game Sources
 - label: HINT_BDMA_APPLY
-  string: 'On: auto-equip the launched VCD''s matching exFAT driver to the memory card before boot (recommended). Off: manage it yourself with the BDMA Source/Mode pickers below.'
+  string: 'On: before a VCD launch, prepare the needed POPSTARTER BDMA memory-card environment when possible. POPSTARTER still launches if preparation fails. Off: manage the card drivers with the Source/Mode pickers below.'
 - label: HINT_BDMA_MODE
   string: exFAT block-device driver POPSTARTER loads. Changing it copies the modules to the card; FAT32 = none (built-in driver).
 - label: HINT_BDMA_SOURCE
@@ -805,7 +805,7 @@ gui_strings:
 - label: HINT_POPSTARTER_RETROGEM_GAMEID
   string: Render optical barcode for Pixel FX / RetroGEM / PS2Digital on PS1 VCD launch
 - label: HINT_POPS_IMPORT
-  string: Copy OPL's own Network Settings values (above) into these POPStarter fields. Nothing is written until you confirm with OK.
+  string: Read POPSTARTER IPCONFIG.DAT and SMBCONFIG.DAT from the connected SMB share's POPS directory. Nothing is written until you confirm with OK.
 - label: HINT_POPS_PORT
   string: SMB port on the server -- 445 is the default. Leave at 0 (or 445) for a normal share; use 139 for older SMB1 servers.
 - label: HINT_RUMBLE
@@ -901,7 +901,7 @@ gui_strings:
 - label: GAMEID_MODE_OFF
   string: 'Off'
 - label: POPS_IMPORT
-  string: Import POPSLoader Settings
+  string: Import from SMB POPS Directory
 - label: POPS_NONE_DETECTED
   string: No existing POPStarter SMB configuration was detected. Enter the correct network settings before creating one.
 - label: POPS_SMB_SECTION
@@ -1132,3 +1132,7 @@ gui_strings:
   string: Continue Editing
 - label: CONFIGURE
   string: Configure
+- label: HDD_UNAVAILABLE_ERROR
+  string: '%d: HardDisk Drive unavailable.'
+- label: HDD_PFS_UNAVAILABLE_ERROR
+  string: '%d: HardDisk Drive PFS support unavailable.'

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1036,6 +1036,16 @@ gui_strings:
   string: Loaded from %s
 - label: POPSTARTER_NET_ERR
   string: Couldn't write POPSTARTER network config to the memory card.
+- label: POPSTARTER_SMB_NEEDS_STATIC
+  string: POPSTARTER SMB requires a static network configuration. Configure POPSTARTER Network Settings first.
+- label: POPS_OVERWRITE_TITLE
+  string: Replace POPSTARTER Config?
+- label: POPS_OVERWRITE_MSG
+  string: POPSTARTER network configuration already exists. Replace it with these settings?
+- label: POPS_KEEP_EXISTING
+  string: Keep Existing
+- label: POPS_REPLACE
+  string: Replace
 - label: NEUTRINO_SETTING_NA
   string: This setting is not used with the Neutrino core.
 - label: DISABLE_ALL

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1150,5 +1150,7 @@ gui_strings:
   string: Restart RiptOPL to apply the selected OPL partition.
 - label: HDD_OPL_PARTITION_CHECKING
   string: Checking HDD OPL partition...
+- label: HDD_OPL_PARTITION_BUSY
+  string: HDD is busy. Try again once loading finishes.
 - label: GENERAL_SYSTEM
   string: General & System

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1136,3 +1136,19 @@ gui_strings:
   string: '%d: HardDisk Drive unavailable.'
 - label: HDD_PFS_UNAVAILABLE_ERROR
   string: '%d: HardDisk Drive PFS support unavailable.'
+- label: POPS_LOADING_SETTINGS
+  string: Loading POPSTARTER settings...
+- label: POPS_SMB_NOT_CONNECTED
+  string: SMB is not connected.
+- label: POPS_SMB_SETTINGS_NOT_FOUND
+  string: No POPSTARTER settings found in SMB POPS directory.
+- label: HDD_OPL_PLUS_NOT_FOUND
+  string: +OPL partition not found.
+- label: HDD_OPL_PARTITION_NOT_FOUND
+  string: HDD (APA) OPL partition not found.
+- label: HDD_OPL_PARTITION_RESTART
+  string: Restart or remount HDD to use the selected OPL partition.
+- label: HDD_OPL_PARTITION_CHECKING
+  string: Checking HDD OPL partition...
+- label: GENERAL_SYSTEM
+  string: General & System

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1144,10 +1144,10 @@ gui_strings:
   string: No POPSTARTER settings found in SMB POPS directory.
 - label: HDD_OPL_PLUS_NOT_FOUND
   string: +OPL partition not found.
-- label: HDD_OPL_PARTITION_NOT_FOUND
-  string: HDD (APA) OPL partition not found.
+- label: HDD_OPL_COMMON_NOT_FOUND
+  string: __common partition not found.
 - label: HDD_OPL_PARTITION_RESTART
-  string: Restart or remount HDD to use the selected OPL partition.
+  string: Restart RiptOPL to apply the selected OPL partition.
 - label: HDD_OPL_PARTITION_CHECKING
   string: Checking HDD OPL partition...
 - label: GENERAL_SYSTEM

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1036,6 +1036,8 @@ gui_strings:
   string: Loaded from %s
 - label: POPSTARTER_NET_ERR
   string: Couldn't write POPSTARTER network config to the memory card.
+- label: POPSTARTER_NET_INVALID
+  string: POPSTARTER network configuration is invalid. Correct it in POPSTARTER Network Settings.
 - label: POPSTARTER_SMB_NEEDS_STATIC
   string: POPSTARTER SMB requires a static network configuration. Configure POPSTARTER Network Settings first.
 - label: POPS_OVERWRITE_TITLE

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -9,6 +9,7 @@
 
 #include "include/bdmsupport.h"
 #include "include/ethsupport.h"
+#include "include/vcdsupport.h"
 #include "include/hddsupport.h"
 #include "include/texcache.h"
 #include "include/textures.h"
@@ -99,6 +100,29 @@ static char *appGetBoot(char *device, int max, char *path)
     }
 
     return appGetELFName(path);
+}
+
+// POPSTARTER SMB selector detection for APPS: APPS -> SB.<game>.ELF
+// Uses VCD_PREFIX_SMB and existing basename helper. Returns 1 if the
+// resolved APP startup basename matches SB.*.ELF (case-insensitive).
+static int appIsPopstarterSmb(const char *startup)
+{
+    const char *base;
+    if (startup == NULL || startup[0] == '\0')
+        return 0;
+    base = appGetELFName((char *)startup);
+    if (base == NULL || base[0] == '\0')
+        return 0;
+    if (strncasecmp(base, VCD_PREFIX_SMB, strlen(VCD_PREFIX_SMB)) != 0)
+        return 0;
+    size_t len = strlen(base);
+    size_t pre = strlen(VCD_PREFIX_SMB);
+    if (len <= pre + 4)
+        return 0;
+    const char *dot = strrchr(base, '.');
+    if (dot == NULL || strcasecmp(dot, ".ELF") != 0)
+        return 0;
+    return 1;
 }
 
 static unsigned int appHashStartup(const char *value)
@@ -758,6 +782,25 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
 
         if (mode == HDD_MODE)
             snprintf(partition, sizeof(partition), "%s:", gOPLPart);
+
+        // POPSTARTER SMB via APPS: APPS -> SB.<game>.ELF
+        // Run the same SMB environment preparation as ETH VCD.
+        // Uses shared helper vcdPreparePopstarterSmbLaunch(ethPrefix).
+        if (appIsPopstarterSmb(filename)) {
+            vcd_popsnet_ensure_t ens = vcdPreparePopstarterSmbLaunch(ethGetSMBPrefix());
+            if (ens == VCD_POPSNET_SMB_MISSING) {
+                guiMsgBox(_l(_STR_POPSTARTER_SMB_MISSING), 0, NULL);
+                return;
+            }
+            if (ens == VCD_POPSNET_NEED_STATIC) {
+                guiMsgBox(_l(_STR_POPSTARTER_SMB_NEEDS_STATIC), 0, NULL);
+                return;
+            }
+            if (ens == VCD_POPSNET_IO_ERROR || ens == VCD_POPSNET_INVALID) {
+                guiMsgBox(_l(_STR_POPSTARTER_NET_ERR), 0, NULL);
+                return;
+            }
+        }
 
         if (configGetStr(configSet, CONFIG_ITEM_ALTSTARTUP, &argv1) != 0) {
             // Copy before deinit(): argv1 points into the config heap which

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -103,15 +103,31 @@ static char *appGetBoot(char *device, int max, char *path)
 }
 
 // POPSTARTER SMB selector detection for APPS: APPS -> SB.<game>.ELF
-// Uses VCD_PREFIX_SMB and existing basename helper. Returns 1 if the
-// resolved APP startup basename matches SB.*.ELF (case-insensitive).
+// Uses VCD_PREFIX_SMB. Handles '/', '\\' and ':' separators locally so
+// smb0:\POPS\SB.Game.ELF is recognized without changing the generic
+// appGetELFName() semantics for other callers.
 static int appIsPopstarterSmb(const char *startup)
 {
     const char *base;
+    const char *p1;
+    const char *p2;
+    const char *p3;
+    const char *last;
+
     if (startup == NULL || startup[0] == '\0')
         return 0;
-    base = appGetELFName((char *)startup);
-    if (base == NULL || base[0] == '\0')
+
+    p1 = strrchr(startup, '/');
+    p2 = strrchr(startup, '\\');
+    p3 = strrchr(startup, ':');
+    last = p1;
+    if (p2 != NULL && (last == NULL || p2 > last))
+        last = p2;
+    if (p3 != NULL && (last == NULL || p3 > last))
+        last = p3;
+    base = (last != NULL) ? last + 1 : startup;
+
+    if (base[0] == '\0')
         return 0;
     if (strncasecmp(base, VCD_PREFIX_SMB, strlen(VCD_PREFIX_SMB)) != 0)
         return 0;

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -799,10 +799,10 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
         if (mode == HDD_MODE)
             snprintf(partition, sizeof(partition), "%s:", gOPLPart);
 
-        // POPSTARTER SMB via APPS: APPS -> SB.<game>.ELF
-        // Run the same SMB environment preparation as ETH VCD.
+        // POPSTARTER SMB via APPS: only an ETH/SMB SB.<game>.ELF receives the same preparation
+        // as an ETH VCD. A local SB.* tool is an ordinary app, never an SMB launch by filename alone.
         // Uses shared helper vcdPreparePopstarterSmbLaunch(ethPrefix).
-        if (appIsPopstarterSmb(filename)) {
+        if (mode == ETH_MODE && appIsPopstarterSmb(filename)) {
             vcd_popsnet_ensure_t ens = vcdPreparePopstarterSmbLaunch(ethGetSMBPrefix());
             if (ens == VCD_POPSNET_SMB_MISSING) {
                 guiMsgBox(_l(_STR_POPSTARTER_SMB_MISSING), 0, NULL);
@@ -812,8 +812,12 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
                 guiMsgBox(_l(_STR_POPSTARTER_SMB_NEEDS_STATIC), 0, NULL);
                 return;
             }
-            if (ens == VCD_POPSNET_IO_ERROR || ens == VCD_POPSNET_INVALID) {
+            if (ens == VCD_POPSNET_IO_ERROR) {
                 guiMsgBox(_l(_STR_POPSTARTER_NET_ERR), 0, NULL);
+                return;
+            }
+            if (ens == VCD_POPSNET_INVALID) {
+                guiMsgBox(_l(_STR_POPSTARTER_NET_INVALID), 0, NULL);
                 return;
             }
         }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -2169,6 +2169,109 @@ static void bdmRewriteBootDir(char *bootDir, int bootDirSize, int slot, const ch
     snprintf(bootDir, bootDirSize, "%s", resolved);
 }
 
+// Read identity from ONE literal massN: slot. The driver name is the authoritative classification;
+// USBMASS_IOCTL_GET_DEVICE_NUMBER is still requested for diagnostics, but some usable devices do not
+// implement it, so its failure must not discard a valid driver name.
+static int bdmReadLiteralMassIdentity(int slot, int *outType)
+{
+    char path[16], driver[32];
+    int deviceIndex = -1;
+
+    snprintf(path, sizeof(path), "mass%d:/", slot);
+    bdmReadDeviceIdentity(path, driver, sizeof(driver), &deviceIndex);
+    if (driver[0] == '\0')
+        return 0;
+
+    *outType = bdmDetermineDeviceType(driver);
+    LOG("BOOT literal mass%d: driver %s device %d\n", slot, driver, deviceIndex);
+    return 1;
+}
+
+// Resolve an explicit massN: boot identity without treating it as an invitation to search every
+// mounted BDM device. The launcher has already named the filesystem slot; after IOP reset the only
+// work required is to let a possible transport register THAT slot, then query its own driver/device
+// ioctls. A cold untyped slot needs bounded transport bring-up, but every Dopen/ioctl below remains
+// massN: itself. Bare mass: and typed launch aliases retain the legacy broader resolver below.
+static int bdmResolveLiteralMassSlot(int slot, int *ioBdmType,
+                                     u32 initialBudgetMs, u32 ataInitialBudgetMs,
+                                     u32 mx4sioExtraBudgetMs, u32 expensiveExtraBudgetMs)
+{
+    int knownType = *ioBdmType;
+    int detectedType;
+
+    if (bdmReadLiteralMassIdentity(slot, &detectedType)) {
+        *ioBdmType = detectedType;
+        return detectedType == BDM_TYPE_UDPBD ? -1 : 1;
+    }
+
+    // A UDPBD identity cannot be mounted until its network configuration has been read. Do not
+    // make that bootstrap cycle worse by loading unrelated local transports or scanning other slots.
+    if (knownType == BDM_TYPE_UDPBD)
+        return -1;
+
+    bdmLoadModules();
+
+    // A save-time retry may already know the exact backing family. Load only that family and wait
+    // only for the literal slot; an identity change never redirects settings to another massN:.
+    if (knownType != BDM_TYPE_UNKNOWN) {
+        u32 budgetMs = knownType == BDM_TYPE_ATA ? ataInitialBudgetMs : initialBudgetMs;
+        u64 start;
+
+        WaitSema(bdmLoadModuleLock);
+        bdmEnsureTransportLoaded(knownType);
+        SignalSema(bdmLoadModuleLock);
+
+        start = GetTimerSystemTime();
+        for (;;) {
+            if (bdmReadLiteralMassIdentity(slot, &detectedType)) {
+                *ioBdmType = detectedType;
+                return detectedType == BDM_TYPE_UDPBD ? -1 : 1;
+            }
+            if ((GetTimerSystemTime() - start) / (kBUSCLK / 1000) > budgetMs)
+                break;
+            DelayThread(100 * 1000);
+        }
+
+        *ioBdmType = knownType;
+        return -1;
+    }
+
+    // With an untyped massN: token, try the possible local transports in increasing cost. The
+    // final iLink/ATA tier shares a budget because both can be cold, but no tier ever probes a
+    // different mass slot to infer where the launcher came from.
+    for (int tier = 0; tier < 3; tier++) {
+        u32 budgetMs;
+        u64 start;
+
+        WaitSema(bdmLoadModuleLock);
+        if (tier == 0) {
+            bdmEnsureTransportLoaded(BDM_TYPE_USB);
+            budgetMs = initialBudgetMs;
+        } else if (tier == 1) {
+            bdmEnsureTransportLoaded(BDM_TYPE_SDC);
+            budgetMs = mx4sioExtraBudgetMs;
+        } else {
+            bdmEnsureTransportLoaded(BDM_TYPE_ILINK);
+            bdmEnsureTransportLoaded(BDM_TYPE_ATA);
+            budgetMs = expensiveExtraBudgetMs;
+        }
+        SignalSema(bdmLoadModuleLock);
+
+        start = GetTimerSystemTime();
+        for (;;) {
+            if (bdmReadLiteralMassIdentity(slot, &detectedType)) {
+                *ioBdmType = detectedType;
+                return detectedType == BDM_TYPE_UDPBD ? -1 : 1;
+            }
+            if ((GetTimerSystemTime() - start) / (kBUSCLK / 1000) > budgetMs)
+                break;
+            DelayThread(100 * 1000);
+        }
+    }
+
+    return -1;
+}
+
 // Resolve a boot directory that names a BDM device into that device's mounted massN: filesystem root,
 // force-loading whatever driver stack the boot device needs FIRST. Called from the deferred config
 // load -- after ioInit()/bdmInitSemaphore(), before the first configReadMulti() -- because at boot time
@@ -2177,11 +2280,13 @@ static void bdmRewriteBootDir(char *bootDir, int bootDirSize, int slot, const ch
 // families are handled:
 //   - launch-binding identities (usb0:/ilink0:/sd0:/mx4sio0:/sdc0:/ata0:) -- device names with no
 //     filesystem OPL reads; remapped to the SAME device's massN: mount.
-//   - massN:/mass: -- the right namespace, but the launcher's slot numbering need not match OPL's (and
-//     the device isn't mounted yet); verified/renumbered by probing for the booted ELF itself.
+//   - massN: -- an explicit filesystem slot. It is identified through THAT slot's driver/device ioctls
+//     after the required transport registers it; it is never renumbered by probing other devices.
+//   - mass: -- a legacy unspecified filesystem token, which has no literal slot and retains the
+//     broader boot-ELF proof below.
 // elfName (argv[0]'s basename; may be empty for a getcwd()-derived boot dir) anchors the verification:
-// the slot that actually holds <tail>/<elfName> IS the boot device, immune to slot renumbering. The
-// gEnable* config flags are deliberately ignored when loading transports -- the config is precisely
+// typed launch aliases and bare mass: are resolved to the slot that actually holds <tail>/<elfName>.
+// The gEnable* config flags are deliberately ignored when loading transports -- the config is precisely
 // what cannot be read yet (the exFAT-HDD chicken-and-egg: mounting it needs gEnableBdmHDD, which lives
 // in the unreadable config); the caller reconciles the flags after the config loads.
 // *ioBdmType is in/out: pass the boot device's BDM_TYPE_* when already known (the save-path re-resolve)
@@ -2189,8 +2294,10 @@ static void bdmRewriteBootDir(char *bootDir, int bootDirSize, int slot, const ch
 // holds the resolved device's type.
 // Returns 1 with bootDir rewritten in place on success; 0 when bootDir is not a BDM path (left
 // untouched -- mc/mmce/host/pfs/hdd/... prefixes are not ours); -1 when the boot device never mounted
-// within the budget (bootDir left untouched -- the caller drops it so legacy discovery re-arms).
-int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType)
+// within the budget (bootDir left untouched so its caller can keep the explicit identity and use defaults).
+static int bdmResolveBootDirWithBudget(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType,
+                                       u32 initialBudgetMs, u32 ataInitialBudgetMs,
+                                       u32 mx4sioExtraBudgetMs, u32 expensiveExtraBudgetMs)
 {
     char stem[16];
     int unit;
@@ -2221,27 +2328,31 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
     // which passes the already-classified type back in.
     //
     // The consequence is deliberate and not fixable here: a UDPBD/UDPFS-BD boot arriving as
-    // "massN:/OPL" is byte-identical to a USB one, its only evidence being the "udp" driver token,
-    // which needs the udpbd stack, which needs the static IP out of the config being sought. It
-    // therefore falls through to the ordinary massN: scan and simply never mounts. Adding a UDPBD rung
-    // to the escalation ladder would slow EVERY untyped massN: boot -- i.e. every ordinary USB boot --
-    // to buy that one case nothing, since the IP is still unknown.
+    // "massN:/OPL" is byte-identical to a USB one until the "udp" driver has registered, and that
+    // transport needs the static IP out of the config being sought. The literal-slot resolver therefore
+    // tries only local transports and fails closed rather than adding a network rung to every boot.
     if (filterType == BDM_TYPE_UDPBD) {
         *ioBdmType = filterType; // keep the classification so a later save retry stays pinned to it
         return -1;               // network block device: no local mount to resolve at config-load time
     }
 
+    // A numeric massN: names one filesystem slot. Do not use the boot ELF as a reason to scan
+    // MAX_BDM_DEVICES and potentially select a different device that happens to contain it.
+    if (isMass && unit >= 0)
+        return bdmResolveLiteralMassSlot(unit, ioBdmType, initialBudgetMs, ataInitialBudgetMs,
+                                         mx4sioExtraBudgetMs, expensiveExtraBudgetMs);
+
     const char *tail = strchr(bootDir, ':') + 1; // "" | "/APPS" | "APPS" (bdmParseBootStem proved the ':')
-    // The boot token's unit digit doubles as the scan-order hint for BOTH families: mass1: names the
-    // slot outright, and a typed usb1:/ata1: unit usually tracks same-type enumeration order too.
+    // A typed launch alias's unit digit is a scan-order hint. Bare mass: has no literal slot, so its
+    // legacy boot-ELF proof begins at mass0: and may inspect the remaining slots.
     int literalSlot = (unit >= 0 && unit < MAX_BDM_DEVICES) ? unit : 0;
     int haveElf = (elfName != NULL && elfName[0] != '\0');
 
     // Bring-up: the BDM core (bdm.irx + bdmfs_fatfs + hotplug events; idempotent -- every bdmInit calls
-    // it too) plus the transport(s) the boot prefix implies. An untyped massN: names the shared BDM
-    // filesystem, not a transport, so start with the cheap common ones (USB, MX4SIO) and only escalate
-    // to iLink + the ATA stack (iLinkman is known to break PCSX2, where a virtual-USB mass: boot is
-    // possible; ATA means dev9 power + drive spin-up) if nothing turns up holding the boot folder.
+    // it too) plus the transport(s) the boot prefix implies. Only a legacy bare mass: has no transport
+    // or literal slot, so start with the cheap common ones (USB, MX4SIO) and only escalate to iLink +
+    // the ATA stack (iLinkman is known to break PCSX2, where a virtual-USB mass: boot is possible; ATA
+    // means dev9 power + drive spin-up) if nothing turns up holding the boot folder.
     bdmLoadModules();
     WaitSema(bdmLoadModuleLock);
     if (filterType != BDM_TYPE_UNKNOWN) {
@@ -2252,8 +2363,8 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
         // mx4sio_bd is an SD-card driver on SIO2 -- THE PAD'S OWN BUS -- and once loaded it is
         // resident for the session: mx4sioModLoaded latches and no unload path exists. Turning
         // MX4SIO Off in settings afterwards cannot undo it, and this resolver ignores that flag by
-        // design. So every untyped massN: boot -- which is every ordinary USB boot -- has been
-        // running with an SD driver resident on the pad's bus.
+        // design. The literal massN: resolver above delays it until its second bounded tier; this
+        // remaining broad path is only for an old bare mass: token.
         //
         // rebuild-66 never reaches this resolver at all (its setDefaults clears gBootDir before
         // configInit), and uOPL has no resolver and loads MX4SIO only when the user enables it.
@@ -2265,12 +2376,13 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
     }
     SignalSema(bdmLoadModuleLock);
 
-    u32 budgetMs = (filterType == BDM_TYPE_ATA) ? 10000 : 3000; // ATA = dev9 power-up + platter spin-up
-    // Escalation tier for an untyped massN: search: 0 = only USB is up, 1 = MX4SIO added, 2 = iLink +
-    // ATA added, i.e. everything. A TYPED search starts past the end -- its one transport was loaded up
+    u32 budgetMs = (filterType == BDM_TYPE_ATA) ? ataInitialBudgetMs : initialBudgetMs;
+    // Escalation tier for a bare mass: search: 0 = only USB is up, 1 = MX4SIO added, 2 = iLink + ATA
+    // added, i.e. everything. A TYPED search starts past the end -- its one transport was loaded up
     // front and no other family can satisfy it -- which keeps its timeout path exactly as it was.
-    // Worst case for an untyped search is now 3000 + 3000 + 8000 = 14 s, inside the 30 s
-    // OPL_DEFERRED_IO_TIMEOUT_MS that bounds a post-boot reload (the boot call is not deferred at all).
+    // The full resolver receives 3000 + 3000 + 8000 = 14 s for explicit/save-time recovery. The
+    // bootstrap wrapper below uses a shorter bounded ladder: a missing first-run config must reach
+    // defaults promptly instead of spending that full recovery budget before the boot splash moves.
     int escalationTier = (filterType != BDM_TYPE_UNKNOWN) ? 2 : 0;
     // u64: GetTimerSystemTime() passes 2^32 bus ticks ~29 s after boot; a u32 start would make every
     // POST-BOOT resolve (the _saveConfig hotplug retry, a settings reload) compute a bogus huge elapsed
@@ -2337,7 +2449,7 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
                 WaitSema(bdmLoadModuleLock);
                 bdmEnsureTransportLoaded(BDM_TYPE_SDC);
                 SignalSema(bdmLoadModuleLock);
-                budgetMs += 3000;
+                budgetMs += mx4sioExtraBudgetMs;
                 continue;
             }
             if (escalationTier == 1) {
@@ -2349,7 +2461,7 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
                 bdmEnsureTransportLoaded(BDM_TYPE_ILINK);
                 bdmEnsureTransportLoaded(BDM_TYPE_ATA);
                 SignalSema(bdmLoadModuleLock);
-                budgetMs += 8000;
+                budgetMs += expensiveExtraBudgetMs;
                 continue;
             }
             // The weak fallback is now consumed LAST, after every transport has had its chance --
@@ -2373,6 +2485,22 @@ int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *
         }
         DelayThread(100 * 1000);
     }
+}
+
+int bdmResolveBootDir(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType)
+{
+    // Full-budget resolver for explicit Custom Settings Path and save-time hotplug recovery.
+    return bdmResolveBootDirWithBudget(bootDir, bootDirSize, elfName, ioBdmType,
+                                       3000, 10000, 3000, 8000);
+}
+
+int bdmResolveBootDirBootstrap(char *bootDir, int bootDirSize, const char *elfName, int *ioBdmType)
+{
+    // Bootstrap is allowed to defer a cold/ambiguous device to the first explicit save retry, but
+    // it must not make defaults wait for every BDM transport. ATA retains a little extra spin-up
+    // room; an untyped massN: ladder is at most 1500 + 1500 + 3500 ms, plus its one ATA settle.
+    return bdmResolveBootDirWithBudget(bootDir, bootDirSize, elfName, ioBdmType,
+                                       1500, 5000, 1500, 3500);
 }
 
 static int bdmDeviceIsATA(int deviceId)

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -894,8 +894,17 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (vcdListViewActive(itemList))
-        return; // #120: no rename in VCD view
+    if (vcdListViewActive(itemList)) {
+        base_game_info_t *game = bdmActiveGame(itemList, id);
+        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
+
+        if (game == &bdmEmptyGame)
+            return; // stale id in the toggle window
+        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
+        if (vcdRenameFile(vcdPrefix, game->name, newName) == 0)
+            pDeviceData->ForceRefresh = 1; // the queued menu update re-scans POPS/
+        return;
+    }
     if (bdmActiveGame(itemList, id) == &bdmEmptyGame)
         return;                                   // stale id in the toggle window (see bdmDeleteGame) -> avoid sbRename OOB
     sbSetBrowseSub(folderGetSub(itemList->mode)); // rename inside the current subfolder, not the root

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -518,7 +518,10 @@ static void bdmLoadBlockDeviceModules(void)
     }
 }
 
-void bdmLoadModules(void)
+// Bring up only the common BDM infrastructure. Literal massN: boot resolution uses this path so an
+// explicit filesystem slot never incidentally queues every transport enabled by the last settings
+// load; it determines its backing driver from that slot's own devctl/ioctl identity instead.
+static void bdmLoadCoreModules(void)
 {
     LOG("BDMSUPPORT LoadModules\n");
 
@@ -530,14 +533,19 @@ void bdmLoadModules(void)
     LOG("[BDMFS_FATFS]:\n");
     sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
 
-    // Load Optional Block Device drivers
-    ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
-
     LOG("[BDMEVENT]:\n");
     sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
     SifAddCmdHandler(0, &bdmEventHandler, NULL);
 
     LOG("BDMSUPPORT Modules loaded\n");
+}
+
+void bdmLoadModules(void)
+{
+    bdmLoadCoreModules();
+
+    // Normal enumeration retains the established asynchronous optional-transport load.
+    ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
 }
 
 static void bdmInit(item_list_t *itemList)
@@ -2209,7 +2217,7 @@ static int bdmResolveLiteralMassSlot(int slot, int *ioBdmType,
     if (knownType == BDM_TYPE_UDPBD)
         return -1;
 
-    bdmLoadModules();
+    bdmLoadCoreModules();
 
     // A save-time retry may already know the exact backing family. Load only that family and wait
     // only for the literal slot; an identity change never redirects settings to another massN:.

--- a/src/dia.c
+++ b/src/dia.c
@@ -812,9 +812,9 @@ void diaRenderUI(struct UIItem *ui, short inMenu, struct UIItem *cur, int haveFo
 
     int uiY = gTheme->usedHeight - 32;
     if (settingsContext) {
-        int uiHints[3] = {_STR_SELECT, _STR_BACK, _STR_SETTINGS};
-        int uiIcons[3] = {CROSS_ICON, CIRCLE_ICON, TRIANGLE_ICON};
-        int uiX = guiAlignSubMenuHints(3, uiHints, uiIcons, gTheme->fonts[0], 12, 2);
+        int uiHints[2] = {_STR_SELECT, _STR_BACK};
+        int uiIcons[2] = {CROSS_ICON, CIRCLE_ICON};
+        int uiX = guiAlignSubMenuHints(2, uiHints, uiIcons, gTheme->fonts[0], 12, 2);
 
         if (settingsShell) {
             // Use the same controller button textures as the rest of OPL. Do not introduce a
@@ -836,9 +836,7 @@ void diaRenderUI(struct UIItem *ui, short inMenu, struct UIItem *cur, int haveFo
         }
         uiX = guiDrawIconAndText(uiIcons[0], uiHints[0], gTheme->fonts[0], uiX, uiY, gTheme->textColor);
         uiX += 12;
-        uiX = guiDrawIconAndText(uiIcons[1], uiHints[1], gTheme->fonts[0], uiX, uiY, gTheme->textColor);
-        uiX += 12;
-        guiDrawIconAndText(uiIcons[2], uiHints[2], gTheme->fonts[0], uiX, uiY, gTheme->textColor);
+        guiDrawIconAndText(uiIcons[1], uiHints[1], gTheme->fonts[0], uiX, uiY, gTheme->textColor);
     } else {
         int uiHints[2] = {_STR_SELECT, _STR_BACK};
         int uiIcons[2] = {CIRCLE_ICON, CROSS_ICON};
@@ -1173,12 +1171,6 @@ int diaExecuteDialog(struct UIItem *ui, int uiId, short inMenu, int (*updater)(i
             // every peer screen retains the same focus, scrolling and modal-editor behavior as
             // existing dialogs. Ordinary dialogs never see these results unless their caller opts
             // into handling them.
-            if (settingsShell && getKeyOn(KEY_TRIANGLE)) {
-                diaRestoreScrollSpeed();
-                sfxPlay(SFX_CURSOR);
-                return DIA_RESULT_INDEX;
-            }
-
             if (settingsShell && getKeyOn(KEY_L1)) {
                 diaRestoreScrollSpeed();
                 sfxPlay(SFX_CURSOR);

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -393,7 +393,9 @@ struct UIItem diaVcdConfig[] = {
     {UI_SPACER},
     {UI_BUTTON, VCD_BDMA_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
-    {UI_BUTTON, VCD_LIST_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_GAME_LIST_SETTINGS}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_GAME_LIST_SETTINGS}}},
+    {UI_SPACER},
+    {UI_BUTTON, VCD_LIST_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_POPSTARTER_NETWORK_SETTINGS}}},
     {UI_SPACER},
@@ -598,12 +600,22 @@ struct UIItem diaMmcePathConfig[] = {
     // end of dialog
     {UI_TERMINATOR}};
 
-// Interface page (settings-layout restructure, was Display Settings): theme/language/list behavior.
-// Artwork, Coverflow and Colors are chained sub-dialogs; the video/offset/overscan/GameID-barcode
-// rows moved to the Display page (diaDisplayConfig). Ids unchanged.
+// Interface page (settings-layout restructure, was Display Settings): high-level view/video choice,
+// then theme/language/list behavior. Artwork, Coverflow and Colors are chained sub-dialogs; the
+// remaining geometry/GameID-barcode rows live in diaDisplayConfig. Ids unchanged.
 struct UIItem diaUIConfig[] = {
     {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_INTERFACE_SETTINGS}}},
     {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Default game view", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, UICFG_GAMEVIEW, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VMODE}}},
+    {UI_SPACER},
+    {UI_ENUM, UICFG_VMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_THEME}}},
     {UI_SPACER},
@@ -613,11 +625,6 @@ struct UIItem diaUIConfig[] = {
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_LANGUAGE}}},
     {UI_SPACER},
     {UI_ENUM, UICFG_LANG, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Default game view", -1}}},
-    {UI_SPACER},
-    {UI_ENUM, UICFG_GAMEVIEW, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_AUTOSORT}}},
@@ -732,8 +739,9 @@ struct UIItem diaColorsConfig[] = {
     // end of dialog
     {UI_TERMINATOR}};
 
-// Display page (settings-layout restructure): video mode / geometry / GameID barcode. Rows moved
-// out of diaUIConfig.
+// Display section of the composed Interface page: video mode / geometry / GameID barcode. The
+// Settings-shell composition omits this Video Mode copy because it supplies the same control at
+// the top of diaUIConfig; the standalone Display editor retains its complete legacy dialog.
 struct UIItem diaDisplayConfig[] = {
     {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_DISPLAY_SETTINGS}}},
     {UI_SPLITTER},

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -14,13 +14,6 @@ struct UIItem diaNetConfig[] = {
     {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MENU_NETWORK}}},
     {UI_SPLITTER},
 
-    // This button opens the same IPCONFIG.DAT/SMBCONFIG.DAT owner used by the POPSTARTER peer
-    // page; no POPSTARTER state is duplicated here.
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_POPSTARTER_NETWORK_SETTINGS}}},
-    {UI_SPACER},
-    {UI_BUTTON, NETCFG_POPSTARTER_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
-    {UI_BREAK},
-
     // Unified network rows (moved from diaDeviceConfig): Protocol (SMB/UDPFS/UDPBD) and Access
     // (Files/IMG) qualify the Game Sources "Network Start Mode" row. netConfigUpdater greys Access
     // for SMB and locks it to IMG for UDPBD (same rules guiDeviceUpdater used to apply).
@@ -143,6 +136,13 @@ struct UIItem diaNetConfig[] = {
     {UI_LABEL, NETCFG_LBL_SHARE_PASSWORD, 1, 1, -1, -40, 0, {.label = {NULL, _STR_PASSWORD}}},
     {UI_SPACER},
     {UI_PASSWORD, NETCFG_SHARE_PASSWORD, 1, 1, _STR_HINT_GUEST, 0, 0, {.stringvalue = {"", "", NULL}}},
+    {UI_BREAK},
+
+    // POPSTARTER owns its own IPCONFIG.DAT / SMBCONFIG.DAT editor. Keep its entry beside the
+    // SMB server data it relates to, without duplicating any of that state in this page.
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_POPSTARTER_NETWORK_SETTINGS}}},
+    {UI_SPACER},
+    {UI_BUTTON, NETCFG_POPSTARTER_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
 
     // buttons
@@ -268,6 +268,11 @@ struct UIItem diaConfig[] = {
     {UI_BOOL, CFG_FOLDERNAV, 1, 1, _STR_HINT_FOLDER_NAV, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_LANGUAGE}}},
+    {UI_SPACER},
+    {UI_ENUM, UICFG_LANG, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_EXITTO}}},
     {UI_SPACER},
     {UI_STRING, CFG_EXITTO, 1, 1, _STR_HINT_EXITPATH, 0, 0, {.stringvalue = {"", "", NULL}}},
@@ -276,6 +281,11 @@ struct UIItem diaConfig[] = {
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_CUSTOM_SETTINGS_PATH}}},
     {UI_SPACER},
     {UI_STRING, CFG_CUSTOMCFGPATH, 1, 1, _STR_HINT_CUSTOM_SETTINGS_PATH, 0, 0, {.stringvalue = {"", "", NULL}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_GSM_DEFAULTS}}},
+    {UI_SPACER},
+    {UI_BUTTON, GENERAL_GSM_DEFAULTS_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
 
     // buttons
@@ -297,64 +307,66 @@ struct UIItem diaDeviceConfig[] = {
     {UI_ENUM, CFG_DEFDEVICE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMMODE}}},
-    {UI_SPACER},
-    {UI_ENUM, CFG_BDMMODE, 1, 1, _STR_HINT_BDM_START, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {"  BDM Devices", -1}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"    USB", -1}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_ENABLEUSB, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"    iLink", -1}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_ENABLEILK, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"    MX4SIO", -1}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_ENABLEMX4SIO, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"    Internal HDD", -1}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_ENABLEBDMHDD, 1, 1, _STR_HDD_HINT, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HDDMODE}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD (APA) Start Mode", -1}}},
     {UI_SPACER},
     {UI_ENUM, CFG_HDDMODE, 1, 1, _STR_HDD_HINT, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    // Network Start Mode (Off/Manual/Auto) gates whether/when the stack loads; Protocol, Access and
-    // SMB Version live on the Network page now.
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_NET_PROTOCOL}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD (APA) OPL Partition", -1}}},
     {UI_SPACER},
-    {UI_ENUM, CFG_NETSTART, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_ENUM, CFG_HDDOPLPART, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_APPMODE}}},
-    {UI_SPACER},
-    {UI_ENUM, CFG_APPMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_FAVMODE}}},
-    {UI_SPACER},
-    {UI_ENUM, CFG_FAVMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_MMCEMODE}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"MMCE Start Mode", -1}}},
     {UI_SPACER},
     {UI_ENUM, CFG_MMCEMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"  MMCE Settings", -1}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"MMCE Settings", -1}}},
     {UI_SPACER},
     {UI_BUTTON, MMCE_SETTINGS_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"BDM Devices Start Mode", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_BDMMODE, 1, 1, _STR_HINT_BDM_START, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Internal HDD (exFAT)", -1}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_ENABLEBDMHDD, 1, 1, _STR_HDD_HINT, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"USB", -1}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_ENABLEUSB, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"MX4SIO", -1}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_ENABLEMX4SIO, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"iLink", -1}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_ENABLEILK, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    // Network Start Mode (Off/Manual/Auto) gates whether/when the stack loads; Protocol, Access and
+    // SMB Version live on the Network page now.
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Network Connectivity", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_NETSTART, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Applications Page Start Mode", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_APPMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Favorites Page Start Mode", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_FAVMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
     // buttons
@@ -393,7 +405,7 @@ struct UIItem diaVcdConfig[] = {
     {UI_SPACER},
     {UI_BUTTON, VCD_BDMA_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_GAME_LIST_SETTINGS}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"VCD Games List Settings", -1}}},
     {UI_SPACER},
     {UI_BUTTON, VCD_LIST_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
@@ -412,7 +424,7 @@ struct UIItem diaVcdConfig[] = {
 struct UIItem diaBdmaConfig[] = {
     // A label keeps the section visible when this block is composed into POPSTARTER. The
     // standalone legacy editor still has a readable title without making BDMA a peer page.
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_BDMA_SETTINGS}}},
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_BDMA_SETTINGS}}},
     {UI_SPLITTER},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDMA_APPLY}}},
@@ -448,7 +460,7 @@ struct UIItem diaBdmaConfig[] = {
 
 // POPStarter -> Game List Settings (VCD list display options). Rows moved out of diaVcdConfig.
 struct UIItem diaVcdListConfig[] = {
-    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_GAME_LIST_SETTINGS}}},
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {"VCD Games List Settings", -1}}},
     {UI_SPLITTER},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_VCD_HIDE_GAMEID}}},
@@ -560,7 +572,7 @@ struct UIItem diaMmceConfig[] = {
 struct UIItem diaMmceCommConfig[] = {
     // A label keeps this section visible when composed into MMCE Settings. The standalone legacy
     // editor remains readable without a separate peer-page title.
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_COMM_SETTINGS}}},
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_COMM_SETTINGS}}},
     {UI_SPLITTER},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_MMCE_WAIT_CYCLES}}},
@@ -585,7 +597,7 @@ struct UIItem diaMmceCommConfig[] = {
 struct UIItem diaMmcePathConfig[] = {
     // A label keeps this section visible when composed into MMCE Settings. The standalone legacy
     // editor remains readable without a separate peer-page title.
-    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_PATH_SETTINGS}}},
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_PATH_SETTINGS}}},
     {UI_SPLITTER},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_MMCE_PREFIX}}},
@@ -607,7 +619,7 @@ struct UIItem diaUIConfig[] = {
     {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_INTERFACE_SETTINGS}}},
     {UI_SPLITTER},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Default game view", -1}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"ISO/VCD Games Lists", -1}}},
     {UI_SPACER},
     {UI_ENUM, UICFG_GAMEVIEW, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
@@ -622,9 +634,32 @@ struct UIItem diaUIConfig[] = {
     {UI_ENUM, UICFG_THEME, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
+    // Theme-specific presentation controls stay together.
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_COVERFLOW_SETTINGS}}},
+    {UI_SPACER},
+    {UI_BUTTON, UICFG_COVERFLOW_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ARTWORK_SETTINGS}}},
+    {UI_SPACER},
+    {UI_BUTTON, UICFG_ARTWORK_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_COLORS_SETTINGS}}},
+    {UI_SPACER},
+    {UI_BUTTON, UICFG_COLORS_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
+    {UI_BREAK},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"VCD Games List Settings", -1}}},
+    {UI_SPACER},
+    {UI_BUTTON, UICFG_GAME_LIST_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
+    {UI_BREAK},
+
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_LANGUAGE}}},
     {UI_SPACER},
     {UI_ENUM, UICFG_LANG, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_NOTIFICATIONS}}},
+    {UI_SPACER},
+    {UI_BOOL, UICFG_NOTIFICATIONS, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_AUTOSORT}}},
@@ -635,29 +670,6 @@ struct UIItem diaUIConfig[] = {
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_AUTOREFRESH}}},
     {UI_SPACER},
     {UI_BOOL, UICFG_AUTOREFRESH, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_NOTIFICATIONS}}},
-    {UI_SPACER},
-    {UI_BOOL, UICFG_NOTIFICATIONS, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    // sub-pages
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ARTWORK_SETTINGS}}},
-    {UI_SPACER},
-    {UI_BUTTON, UICFG_ARTWORK_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
-    {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_COVERFLOW_SETTINGS}}},
-    {UI_SPACER},
-    {UI_BUTTON, UICFG_COVERFLOW_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
-    {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_COLORS_SETTINGS}}},
-    {UI_SPACER},
-    {UI_BUTTON, UICFG_COLORS_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
-    {UI_BREAK},
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_GAME_LIST_SETTINGS}}},
-    {UI_SPACER},
-    {UI_BUTTON, UICFG_GAME_LIST_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
 
     // buttons
@@ -816,6 +828,11 @@ struct UIItem diaLaunchConfig[] = {
     {UI_BUTTON, LAUNCH_OSD_DEFAULTS_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
 
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_GSM_DEFAULTS}}},
+    {UI_SPACER},
+    {UI_BUTTON, LAUNCH_GSM_DEFAULTS_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_MODIFY}}},
+    {UI_BREAK},
+
     // buttons
     {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
     {UI_BREAK},
@@ -845,7 +862,7 @@ struct UIItem diaNeutrinoDefaults[] = {
     {UI_ENUM, CFG_NEUTRINO_GSMCOMP, 1, 1, _STR_HINT_NEUTRINO_GSM_COMP, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ADVANCED_ARGUMENTS}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Neutrino Advanced Arguments", -1}}},
     {UI_SPACER},
     {UI_BUTTON, CFG_NEUTRINO_ARGS, 1, 1, _STR_HINT_NEUTRINO_ARGS, 0, 0, {.label = {NULL, _STR_MODIFY}}},
     {UI_BREAK},
@@ -867,6 +884,8 @@ struct UIItem diaSecurityConfig[] = {
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_WRITE}}},
     {UI_SPACER},
     {UI_BOOL, CFG_ENWRITEOP, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
     {UI_BREAK},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_PARENLOCK_PASSWORD}}},
@@ -892,6 +911,8 @@ struct UIItem diaAdvancedConfig[] = {
     {UI_BOOL, CFG_DEBUG, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
+    {UI_BREAK},
+
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"BDM Prefix Path", -1}}},
     {UI_SPACER},
     {UI_STRING, CFG_BDMPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
@@ -906,7 +927,9 @@ struct UIItem diaAdvancedConfig[] = {
     {UI_INT, CFG_HDDSPINDOWN, 1, 1, _STR_HINT_SPINDOWN, 0, 0, {.intvalue = {20, 20, 0, 20}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Cache Game List (HDD)", -1}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_CACHE_HDD_GAME_LIST}}},
     {UI_SPACER},
     {UI_BOOL, CFG_HDDGAMELISTCACHE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
@@ -992,22 +1015,6 @@ struct UIItem diaStorageConfig[] = {
     // end of dialog
     {UI_TERMINATOR}};
 
-// Tools page (settings-layout restructure): actions that used to be top-level menu entries.
-struct UIItem diaToolsConfig[] = {
-    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_TOOLS}}},
-    {UI_SPLITTER},
-
-    {UI_BUTTON, TOOLS_NET_UPDATE_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_NET_UPDATE}}},
-    {UI_BREAK},
-    {UI_BUTTON, TOOLS_NBD_BUTTON, 1, 1, -1, 0, 0, {.label = {NULL, _STR_STARTNBD}}},
-    {UI_BREAK},
-
-    // buttons
-    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
-    {UI_BREAK},
-
-    // end of dialog
-    {UI_TERMINATOR}};
 
 // Per-Game Modes Menu (row order per the settings-layout restructure tree: Loader Core, DMA,
 // Game ID, Alternate Startup, Modes 1-7, then the Neutrino overrides)

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -494,7 +494,7 @@ struct UIItem diaVcdUsbMode[] = {
     {UI_TERMINATOR}};
 
 // POPSTARTER overwrite confirmation: shown when POPSTARTER Network Settings would
-// overwrite existing mc0:/POPSTARTER/*.DAT files. Keep = preserve existing files
+// overwrite existing resolved mc0:/ or mc1:/POPSTARTER/*.DAT files. Keep = preserve existing files
 // (no write, return to editor); Replace = overwrite with current dialog values;
 // Cancel/Back = abort the save and return to the editor. Uses existing dialog
 // conventions - two explicit buttons plus the standard Back/Cancel.

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -493,6 +493,27 @@ struct UIItem diaVcdUsbMode[] = {
     // end of dialog
     {UI_TERMINATOR}};
 
+// POPSTARTER overwrite confirmation: shown when POPSTARTER Network Settings would
+// overwrite existing mc0:/POPSTARTER/*.DAT files. Keep = preserve existing files
+// (no write, return to editor); Replace = overwrite with current dialog values;
+// Cancel/Back = abort the save and return to the editor. Uses existing dialog
+// conventions - two explicit buttons plus the standard Back/Cancel.
+struct UIItem diaPopsOverwrite[] = {
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_POPS_OVERWRITE_TITLE}}},
+    {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_POPS_OVERWRITE_MSG}}},
+    {UI_BREAK},
+    {UI_BREAK},
+
+    {UI_BUTTON, POPS_OVERWRITE_KEEP, 1, 1, -1, 0, 0, {.label = {NULL, _STR_POPS_KEEP_EXISTING}}},
+    {UI_BREAK},
+    {UI_BUTTON, POPS_OVERWRITE_REPLACE, 1, 1, -1, 0, 0, {.label = {NULL, _STR_POPS_REPLACE}}},
+    {UI_BREAK},
+
+    // end of dialog
+    {UI_TERMINATOR}};
+
 // MMCE page (settings-layout restructure, was MMCE Settings): SD2PSX / MemCard PRO2 tuning.
 // Communication tuning and the path prefix are composed inline from diaMmceCommConfig /
 // diaMmcePathConfig; CFG ids unchanged.

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -778,9 +778,20 @@ static void ethLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
     // and utility IRX even when the required network stack was already complete. SMB keeps its hard
     // gate: all four network modules must exist after this best-effort install.
     (void)vcdInstallPopstarterMc(ethPrefix);
-    if (!vcdSmbModulesPresent()) {
-        guiMsgBox(_l(_STR_POPSTARTER_SMB_MISSING), 0, NULL);
-        return;
+    {
+        vcd_popsnet_ensure_t ens = vcdPreparePopstarterSmbLaunch(ethPrefix);
+        if (ens == VCD_POPSNET_SMB_MISSING) {
+            guiMsgBox(_l(_STR_POPSTARTER_SMB_MISSING), 0, NULL);
+            return;
+        }
+        if (ens == VCD_POPSNET_NEED_STATIC) {
+            guiMsgBox(_l(_STR_POPSTARTER_SMB_NEEDS_STATIC), 0, NULL);
+            return;
+        }
+        if (ens == VCD_POPSNET_IO_ERROR || ens == VCD_POPSNET_INVALID) {
+            guiMsgBox(_l(_STR_POPSTARTER_NET_ERR), 0, NULL);
+            return;
+        }
     }
     vcdBuildSelector(ethPrefix, VCD_PREFIX_SMB, vcdName, vcdSelector, sizeof(vcdSelector));
     size_t prefixLen = strlen(ethPrefix);
@@ -1054,6 +1065,11 @@ static int ethCheckVMC(item_list_t *itemList, char *name, int createSize)
 }
 
 static char *ethGetPrefix(item_list_t *itemList)
+{
+    return ethPrefix;
+}
+
+const char *ethGetSMBPrefix(void)
 {
     return ethPrefix;
 }

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -774,10 +774,6 @@ static void ethLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
         return;
     }
-    // Fill every missing external from this share's direct POPS/ folder, including optional icons
-    // and utility IRX even when the required network stack was already complete. SMB keeps its hard
-    // gate: all four network modules must exist after this best-effort install.
-    (void)vcdInstallPopstarterMc(ethPrefix);
     {
         vcd_popsnet_ensure_t ens = vcdPreparePopstarterSmbLaunch(ethPrefix);
         if (ens == VCD_POPSNET_SMB_MISSING) {

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -756,6 +756,17 @@ static void ethDeleteGame(item_list_t *itemList, int id)
 
 static void ethRenameGame(item_list_t *itemList, int id, char *newName)
 {
+    if (vcdListViewActive(itemList)) {
+        base_game_info_t *game = ethGameForView(itemList, id);
+
+        if (game != NULL && vcdRenameFile(ethPrefix, game->name, newName) == 0) {
+            ethInvalidateFavIsoBacking();
+            // ETH otherwise treats its VCD list as toggle-only; consume this on the already queued
+            // deferred update so the renamed POPS/ directory is scanned again.
+            vcdMarkDirty(itemList->mode);
+        }
+        return;
+    }
     ethInvalidateFavIsoBacking();
     sbRename(&ethGames, ethPrefix, "\\", ethGameCount, id, newName);
     ethULSizePrev = -2;

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -298,6 +298,11 @@ int ethGetModulesLoaded(void)
     return ethModulesLoaded;
 }
 
+int ethIsSMBShareConnected(void)
+{
+    return ethModulesLoaded && gNetworkStartup == 0 && ethPrefix[0] != '\0';
+}
+
 static int ethLoadModules(void)
 {
     LOG("ETHSUPPORT LoadModules\n");

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -784,8 +784,12 @@ static void ethLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
             guiMsgBox(_l(_STR_POPSTARTER_SMB_NEEDS_STATIC), 0, NULL);
             return;
         }
-        if (ens == VCD_POPSNET_IO_ERROR || ens == VCD_POPSNET_INVALID) {
+        if (ens == VCD_POPSNET_IO_ERROR) {
             guiMsgBox(_l(_STR_POPSTARTER_NET_ERR), 0, NULL);
+            return;
+        }
+        if (ens == VCD_POPSNET_INVALID) {
+            guiMsgBox(_l(_STR_POPSTARTER_NET_INVALID), 0, NULL);
             return;
         }
     }

--- a/src/gui.c
+++ b/src/gui.c
@@ -80,9 +80,10 @@ static int guiSettingsPromptSave(void);
 static void guiSettingsBeginDialog(struct UIItem *ui);
 static void guiSettingsEndDialog(void);
 static struct UIItem *guiSettingsCompose(const struct UIItem *const *parts, int partCount,
-                                         const int *skipIDs, int skipCount, int suppressSecondaryHeaders);
+                                         const int *skipIDs, int skipCount, int skipPart,
+                                         int suppressSecondaryHeaders);
 static struct UIItem *guiSettingsComposeInto(struct UIItem *dialog, const struct UIItem *const *parts,
-                                             int partCount, const int *skipIDs, int skipCount,
+                                             int partCount, const int *skipIDs, int skipCount, int skipPart,
                                              int suppressSecondaryHeaders);
 
 // Notification popup: START tick + how long to hold, NOT an absolute deadline. clock() is a
@@ -791,7 +792,7 @@ int guiShowMmceConfig(void)
     // diaSetEnum stores the array pointer rather than copying it. Keep the MMCE options alive for
     // the lifetime of the dedicated child dialog, including any parent re-entry after Circle.
     deviceSlots[2] = _l(_STR_AUTO);
-    ui = guiSettingsComposeInto(guiMmceSettingsDialog, parts, 3, skipIDs, 2, 1);
+    ui = guiSettingsComposeInto(guiMmceSettingsDialog, parts, 3, skipIDs, 2, -1, 1);
 
     if (ui == NULL)
         return -1;
@@ -917,10 +918,17 @@ void guiShowUIConfig(void)
     const char **themeNamesSnap = NULL;
     const char **langNamesSnap = NULL;
 
-    int previousTheme;
+    int previousTheme, previousVMode;
+    const char *vmodeNames[] = {_l(_STR_AUTO), "PAL 640x512i @50Hz 24bit", "NTSC 640x448i @60Hz 24bit",
+                                "EDTV 640x448p @60Hz 24bit", "EDTV 640x512p @50Hz 24bit", "VGA 640x480p @60Hz 24bit",
+                                "PAL 704x576i @50Hz 24bit (HIRES)", "NTSC 704x480i @60Hz 24bit (HIRES)",
+                                "EDTV 704x480p @60Hz 24bit (HIRES)", "EDTV 704x576p @50Hz 24bit (HIRES)",
+                                "HDTV 1280x720p @60Hz 16bit (HIRES)", "HDTV 1920x1080i @60Hz 16bit (HIRES)",
+                                "PAL 640x256p @50Hz 24bit", "NTSC 640x224p @60Hz 24bit", NULL};
 
 reshow_ui:
     previousTheme = thmGetGuiValue();
+    previousVMode = gVMode;
     // Snapshot the theme/language name lists into dialog-owned copies: diaSetEnum stores raw
     // pointers, and BOTH the outer arrays (thmRebuildGuiNames/lngRebuildLangNames free+realloc)
     // AND the theme name strings (thmReinit frees them on device removal) are rebuilt on the IO
@@ -945,6 +953,8 @@ reshow_ui:
     const char *gameViewNames[] = {"Both", "ISO", "VCD", NULL};
     diaSetEnum(diaUIConfig, UICFG_GAMEVIEW, gameViewNames);
     diaSetInt(diaUIConfig, UICFG_GAMEVIEW, gDefaultGameView);
+    diaSetEnum(diaUIConfig, UICFG_VMODE, vmodeNames);
+    diaSetInt(diaUIConfig, UICFG_VMODE, gVMode);
 
     int ret = diaExecuteDialog(diaUIConfig, -1, 1, NULL);
 
@@ -986,6 +996,7 @@ reshow_ui:
         if (gameViewChanged) {
             vcdMarkAllDirty(); // rebuild every VCD-capable page so the new default view takes effect
         }
+        diaGetInt(diaUIConfig, UICFG_VMODE, &gVMode);
 
         if (previousTheme != themeID && isBgmPlaying())
             bgmStop();
@@ -1002,6 +1013,11 @@ reshow_ui:
 
         if (gEnableBGM && !isBgmPlaying())
             bgmStart();
+
+        if (previousVMode != gVMode && guiConfirmVideoMode() == 0) {
+            gVMode = previousVMode;
+            applyConfig(-1, -1, 1);
+        }
     }
 
     guiFreeNameList(themeNamesSnap);
@@ -1443,6 +1459,11 @@ void guiShowVcdListConfig(void)
     int rebuildVcdLists = 0;
     int ret = diaExecuteDialog(diaVcdListConfig, -1, 1, NULL);
     if (ret) {
+        // This editor is reachable from both Settings parents. Its values still belong to the
+        // existing globals/config set, but an OK inside the shell must participate in the shell's
+        // shared Save Changes prompt regardless of which parent opened it.
+        if (guiSettingsShellActive)
+            guiSettingsSavePending = 1;
         {
             // #195: hide-gameid is NO LONGER purely cosmetic -- it is now a SORT KEY. The menu sort
             // (submenuSort) orders by the DISPLAYED title, i.e. past the hidden prefix, so a change must
@@ -2327,14 +2348,15 @@ static int guiSettingsSkipID(int id, const int *skipIDs, int skipCount)
 }
 
 static struct UIItem *guiSettingsCompose(const struct UIItem *const *parts, int partCount,
-                                         const int *skipIDs, int skipCount, int suppressSecondaryHeaders)
+                                         const int *skipIDs, int skipCount, int skipPart,
+                                         int suppressSecondaryHeaders)
 {
-    return guiSettingsComposeInto(guiSettingsDialog, parts, partCount, skipIDs, skipCount,
+    return guiSettingsComposeInto(guiSettingsDialog, parts, partCount, skipIDs, skipCount, skipPart,
                                   suppressSecondaryHeaders);
 }
 
 static struct UIItem *guiSettingsComposeInto(struct UIItem *dialog, const struct UIItem *const *parts,
-                                             int partCount, const int *skipIDs, int skipCount,
+                                             int partCount, const int *skipIDs, int skipCount, int skipPart,
                                              int suppressSecondaryHeaders)
 {
     int part, i, skipTrailingBreak, skipSecondarySplitter;
@@ -2359,17 +2381,18 @@ static struct UIItem *guiSettingsComposeInto(struct UIItem *dialog, const struct
                 if (item->type == UI_BREAK)
                     continue;
             }
-            if (guiSettingsSkipID(item->id, skipIDs, skipCount)) {
-                // Some legacy rows are represented as LABEL + SPACER + BUTTON. When the action
+            if ((skipPart < 0 || part == skipPart) && guiSettingsSkipID(item->id, skipIDs, skipCount)) {
+                // Some legacy rows are represented as LABEL + SPACER + CONTROL. When the control
                 // is omitted from a composed peer page, remove that now-orphaned label as well;
                 // otherwise the page shows an empty heading before the replacement inline block.
-                if (item->type == UI_BUTTON && count >= 2 && dialog[count - 1].type == UI_SPACER &&
+                if (item->type != UI_LABEL && item->type != UI_SPACER && count >= 2 &&
+                    dialog[count - 1].type == UI_SPACER &&
                     dialog[count - 2].type == UI_LABEL)
                     count -= 2;
-                // A skipped sub-page button owns the following break in the source dialog. Once
-                // the button is omitted from a composite page, that break would become an empty
+                // A skipped control owns the following break in the source dialog. Once it is
+                // omitted from a composite page, that break would become an empty
                 // row with no visual or navigation purpose.
-                if (item->type == UI_BUTTON)
+                if (item->type != UI_LABEL && item->type != UI_SPACER)
                     skipTrailingBreak = 1;
                 continue;
             }
@@ -2467,7 +2490,7 @@ static int guiSettingsGeneralUpdater(int modified)
 static int guiSettingsShowGeneral(void)
 {
     const struct UIItem *parts[] = {diaConfig, diaSecurityConfig, diaAdvancedConfig};
-    struct UIItem *ui = guiSettingsCompose(parts, 3, NULL, 0, 1);
+    struct UIItem *ui = guiSettingsCompose(parts, 3, NULL, 0, -1, 1);
     int result;
 
     if (ui == NULL)
@@ -2516,7 +2539,7 @@ static int guiSettingsShowSources(void)
     const struct UIItem *parts[] = {diaDeviceConfig};
     const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), _l(_STR_FAV), NULL};
     const char *deviceModes[] = {_l(_STR_OFF), _l(_STR_MANUAL), _l(_STR_AUTO), NULL};
-    struct UIItem *ui = guiSettingsCompose(parts, 1, NULL, 0, 0);
+    struct UIItem *ui = guiSettingsCompose(parts, 1, NULL, 0, -1, 0);
     int deviceModeIndex;
     int result;
 
@@ -2638,6 +2661,7 @@ static int guiSettingsDisplayUpdater(int modified)
 static int guiSettingsShowInterface(void)
 {
     const struct UIItem *parts[] = {diaUIConfig, diaDisplayConfig};
+    const int skipIDs[] = {UICFG_VMODE};
     const char *gameViewNames[] = {"Both", "ISO", "VCD", NULL};
     const char *vmodeNames[] = {_l(_STR_AUTO), "PAL 640x512i @50Hz 24bit", "NTSC 640x448i @60Hz 24bit",
                                 "EDTV 640x448p @60Hz 24bit", "EDTV 640x512p @50Hz 24bit", "VGA 640x480p @60Hz 24bit",
@@ -2645,7 +2669,9 @@ static int guiSettingsShowInterface(void)
                                 "EDTV 704x480p @60Hz 24bit (HIRES)", "EDTV 704x576p @50Hz 24bit (HIRES)",
                                 "HDTV 1280x720p @60Hz 16bit (HIRES)", "HDTV 1920x1080i @60Hz 16bit (HIRES)",
                                 "PAL 640x256p @50Hz 24bit", "NTSC 640x224p @60Hz 24bit", NULL};
-    struct UIItem *ui = guiSettingsCompose(parts, 2, NULL, 0, 1);
+    // Video Mode stays in diaDisplayConfig for the legacy standalone Display editor, but the
+    // composed Interface page supplies its one copy at the top of diaUIConfig.
+    struct UIItem *ui = guiSettingsCompose(parts, 2, skipIDs, 1, 1, 1);
     const char **themeNamesSnap = NULL;
     const char **langNamesSnap = NULL;
     int themeID, langID, previousTheme, previousVMode, result;
@@ -2777,7 +2803,7 @@ static int guiSettingsShowLaunch(void)
     const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", _l(_STR_GAMES_DEVICE), NULL};
     static const char *neutrinoVideoDefStrs[] = {"Off", "240p", "480p", "1080i x1", "1080i x2", "1080i x3", NULL};
     static const char *neutrinoGsmCompDefStrs[] = {"Off", "Type 1 (GSM/OPL)", "Type 2", "Type 3", NULL};
-    struct UIItem *ui = guiSettingsCompose(parts, 2, skipIDs, 1, 1);
+    struct UIItem *ui = guiSettingsCompose(parts, 2, skipIDs, 1, -1, 1);
     int result;
 
     if (ui == NULL)
@@ -2830,10 +2856,10 @@ static int guiSettingsPopstarterUpdater(int modified)
 
 static int guiSettingsShowPopstarter(void)
 {
-    const struct UIItem *parts[] = {diaVcdConfig, diaBdmaConfig, diaVcdListConfig};
-    const int skipIDs[] = {VCD_BDMA_BUTTON, VCD_LIST_BUTTON};
+    const struct UIItem *parts[] = {diaVcdConfig, diaBdmaConfig};
+    const int skipIDs[] = {VCD_BDMA_BUTTON};
     const char *popsDevStrs[] = {_l(_STR_DEFAULT), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", "Custom", _l(_STR_GAMES_DEVICE), NULL};
-    struct UIItem *ui = guiSettingsCompose(parts, 3, skipIDs, 2, 1);
+    struct UIItem *ui = guiSettingsCompose(parts, 2, skipIDs, 1, -1, 1);
     int result;
 
     if (ui == NULL)
@@ -2846,9 +2872,6 @@ static int guiSettingsShowPopstarter(void)
     diaSetInt(ui, CFG_POPSTARTER_RETROGEM_GAMEID, gPopstarterRetroGemGameID);
     diaSetVisible(ui, CFG_LBL_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
     diaSetVisible(ui, CFG_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
-    diaSetInt(ui, CFG_VCD_HIDE_GAMEID, gVcdHideGameId);
-    diaSetInt(ui, CFG_VCD_FIRST_DISC_ONLY, gVcdFirstDiscOnly);
-    diaSetInt(ui, CFG_VCD_SHOW_PP_POPS, gVcdShowPpPops);
     guiSetBdmaSettings(ui);
     guiSettingsBeginDialog(ui);
 
@@ -2858,12 +2881,14 @@ reshow_popstarter:
         guiShowPopsNetConfig();
         goto reshow_popstarter;
     }
+    if (result == VCD_LIST_BUTTON) {
+        // Reuse the exact same static editor as Interface. It owns the VCD-list globals and
+        // returns to the caller, so Circle naturally resumes the parent that launched it.
+        guiShowVcdListConfig();
+        goto reshow_popstarter;
+    }
 
     if (result != UIID_BTN_CANCEL && result != -1) {
-        int rebuildVcdLists = 0;
-        int previousHideGameId = gVcdHideGameId;
-        int previousFirstDiscOnly = gVcdFirstDiscOnly;
-        int previousShowPpPops = gVcdShowPpPops;
         char tmpPop[sizeof(gPopstarterPath)];
 
         diaGetInt(ui, CFG_POPSTARTER_DEVICE, &gPopstarterDevice);
@@ -2871,29 +2896,9 @@ reshow_popstarter:
         diaGetString(ui, CFG_POPSTARTER_PATH, tmpPop, sizeof(tmpPop));
         if (strncmp(tmpPop, gPopstarterPath, 31) != 0)
             snprintf(gPopstarterPath, sizeof(gPopstarterPath), "%s", tmpPop);
-        diaGetInt(ui, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId);
-        diaGetInt(ui, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
-        diaGetInt(ui, CFG_VCD_SHOW_PP_POPS, &gVcdShowPpPops);
         guiSaveBdmaSettings(ui);
-
-        if (gVcdHideGameId != previousHideGameId) {
-            vcdMarkAllDirty();
-            rebuildVcdLists = 1;
-        }
-        if (gVcdFirstDiscOnly != previousFirstDiscOnly) {
-            vcdMarkAllDirty();
-            hddVcdInvalidateCache();
-            rebuildVcdLists = 1;
-        }
-        if (gVcdShowPpPops != previousShowPpPops) {
-            vcdMarkAllDirty();
-            hddVcdInvalidateCache();
-            rebuildVcdLists = 1;
-        }
         applyConfig(-1, -1, 0);
         menuReinitMainMenu();
-        if (rebuildVcdLists)
-            oplQueueVcdDeviceUpdates();
     }
 
     guiSettingsEndDialog();
@@ -2902,8 +2907,8 @@ reshow_popstarter:
 }
 
 enum gui_settings_page {
-    SETTINGS_GENERAL = 0,
-    SETTINGS_SOURCES,
+    SETTINGS_SOURCES = 0,
+    SETTINGS_GENERAL,
     SETTINGS_NETWORK,
     SETTINGS_INTERFACE,
     SETTINGS_LAUNCH,
@@ -2982,8 +2987,8 @@ static void guiDrawSettingsIndexHints(void)
 static int guiSettingsShowIndex(int *page)
 {
     const char *labels[SETTINGS_PAGE_COUNT + 1] = {
-        "General & System",
         _l(_STR_GAME_SOURCES),
+        "General & System",
         _l(_STR_MENU_NETWORK),
         _l(_STR_INTERFACE_SETTINGS),
         _l(_STR_GAME_LAUNCHING),
@@ -2997,8 +3002,8 @@ static int guiSettingsShowIndex(int *page)
     int spacing = 25;
     int y;
 
-    if (selected < SETTINGS_GENERAL || selected >= SETTINGS_PAGE_COUNT)
-        selected = SETTINGS_GENERAL;
+    if (selected < SETTINGS_SOURCES || selected >= SETTINGS_PAGE_COUNT)
+        selected = SETTINGS_SOURCES;
 
     // This is intentionally rendered with the same geometry and highlight treatment as the main
     // menu. The Index is the Settings hub, not another dialog with a focus box around each row.
@@ -3057,7 +3062,7 @@ static int guiSettingsShowIndex(int *page)
 
 void guiShowSettings(void)
 {
-    int page = SETTINGS_GENERAL;
+    int page = SETTINGS_SOURCES;
     int result;
 
     guiSettingsShellActive = 1;
@@ -3687,7 +3692,7 @@ static void guiDrawOverlays()
             busyAlpha += 0x02;
     }
 
-    if (busyAlpha > 0x00)
+    if (!oplIsBootInProgress() && busyAlpha > 0x00)
         guiDrawBusy(busyAlpha);
 
 #ifdef __DEBUG

--- a/src/gui.c
+++ b/src/gui.c
@@ -776,7 +776,7 @@ reshow_device:
             if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
                 diaSetInt(diaDeviceConfig, CFG_HDDOPLPART, guiDeviceOplHomeInitial);
                 guiDeviceOplHomeTouched = 0;
-                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_PARTITION_NOT_FOUND),
+                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND),
                           0, NULL);
                 goto reshow_device;
             }
@@ -2796,7 +2796,7 @@ reshow_sources:
             (guiSourcesOplHomeLegacy && guiSourcesOplHomeTouched)) {
             if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
                 diaSetInt(ui, CFG_HDDOPLPART, guiSourcesOplHomeInitial);
-                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_PARTITION_NOT_FOUND),
+                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND),
                           0, NULL);
                 goto reshow_sources;
             }

--- a/src/gui.c
+++ b/src/gui.c
@@ -1624,6 +1624,26 @@ void guiShowPopsNetConfig(void)
             if (!popsCur.ipDhcp && !popsIpComplete)
                 popsCur.ipDhcp = 1;
         }
+        // Overwrite guard: existing mc0:/POPSTARTER/*.DAT files are user-owned.
+        // Normal SMB VCD launch never overwrites (vcdEnsurePopstarterSmbConfigMc0
+        // presence wins), but an explicit Settings save must ask before replacing.
+        // Keep = preserve existing files (only create missing ones), Replace =
+        // overwrite with current dialog values, Cancel/Back = abort the save.
+        if ((writeSmb && popsOriginal.smbExists) || (writeIp && popsOriginal.ipExists)) {
+            int ov = diaExecuteDialog(diaPopsOverwrite, -1, 1, NULL);
+            if (ov == POPS_OVERWRITE_KEEP) {
+                if (popsOriginal.smbExists)
+                    writeSmb = 0;
+                if (popsOriginal.ipExists)
+                    writeIp = 0;
+            } else if (ov == POPS_OVERWRITE_REPLACE) {
+                // proceed to write as calculated
+            } else {
+                // Cancel / Back -> abort save entirely
+                writeSmb = 0;
+                writeIp = 0;
+            }
+        }
         if ((writeSmb || writeIp) && vcdWritePopstarterNetFiles(&popsCur, writeSmb, writeIp) != 0)
             guiMsgBox(_l(_STR_POPSTARTER_NET_ERR), 0, NULL);
     }

--- a/src/gui.c
+++ b/src/gui.c
@@ -1520,11 +1520,15 @@ static int guiPopsNetUpdater(int modified)
 void guiShowPopsNetConfig(void)
 {
     size_t i;
-    const char *ipAddrConfModes[] = {_l(_STR_IP_ADDRESS_TYPE_STATIC), _l(_STR_IP_ADDRESS_TYPE_DHCP), NULL};
     // POPStarter read-time snapshot for the change-detection save matrix, + static storage for the
     // "Loaded from %s" notice (diaSetLabel stores a RAW POINTER -- it must outlive the dialog).
     static vcd_popsnet_t popsOriginal;
     static char popsNotice[128];
+    static const char *ipAddrConfModes[3];
+
+    ipAddrConfModes[0] = _l(_STR_IP_ADDRESS_TYPE_STATIC);
+    ipAddrConfModes[1] = _l(_STR_IP_ADDRESS_TYPE_DHCP);
+    ipAddrConfModes[2] = NULL;
     diaSetEnum(diaPopsNetConfig, NETCFG_POPS_IPTYPE, ipAddrConfModes); // same Static/DHCP index convention
 
     vcdReadPopstarterNet(&popsOriginal);
@@ -1544,17 +1548,18 @@ void guiShowPopsNetConfig(void)
     diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, popsOriginal.smbUser);
     diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, popsOriginal.smbPass);
 
-    if (popsOriginal.smbExists || popsOriginal.ipExists) {
+    if (popsOriginal.smbInvalid || popsOriginal.ipInvalid) {
+        diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, _l(_STR_POPSTARTER_NET_INVALID));
+    } else if (popsOriginal.smbExists || popsOriginal.ipExists) {
         snprintf(popsNotice, sizeof(popsNotice), _l(_STR_POPS_LOADED_FROM),
-                 popsOriginal.smbExists ? popsOriginal.smbDir : popsOriginal.ipDir);
+                 popsOriginal.home);
         diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, popsNotice);
     } else {
         diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, _l(_STR_POPS_NONE_DETECTED));
     }
 
-    int result;
-    do {
-        result = diaExecuteDialog(diaPopsNetConfig, -1, 1, &guiPopsNetUpdater);
+    for (;;) {
+        int result = diaExecuteDialog(diaPopsNetConfig, -1, 1, &guiPopsNetUpdater);
         if (result == NETCFG_POPS_IMPORT) {
             // IMPORT: the ONE sanctioned path that copies OPL's saved Network Settings into the
             // POPStarter fields. Pressing the button exits the dialog with its id; the dialog
@@ -1586,16 +1591,16 @@ void guiShowPopsNetConfig(void)
             diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, s);
             snprintf(s, sizeof(s), "%s", gPCPassword);
             diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, s);
+            continue;
         }
-    } while (result == NETCFG_POPS_IMPORT);
 
-    if (result) {
+        if (result != UIID_BTN_OK)
+            return;
+
         // POPStarter save matrix (POPSLoader parity): compare the dialog's POPStarter fields against
-        // the read-time snapshot and write ONLY what actually changed -- and only when the file
-        // already exists (overwrite at its origin dir) or the user supplied complete values (create
-        // at createDir). Blank/incomplete fields with no existing file create NOTHING: absence must
-        // never turn into a fabricated configuration.
-        vcd_popsnet_t popsCur = popsOriginal; // carries the origin dirs + exists flags over
+        // the read-time snapshot and write ONLY actual changes. The resolved home from the snapshot
+        // remains attached to popsCur, so a valid MC1 setup never causes a new MC0 shadow file.
+        vcd_popsnet_t popsCur = popsOriginal;
         diaGetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, &popsCur.ipDhcp);
         for (i = 0; i < 4; ++i) {
             diaGetInt(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, &popsCur.ps2Ip[i]);
@@ -1609,43 +1614,43 @@ void guiShowPopsNetConfig(void)
         diaGetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, popsCur.smbPass, sizeof(popsCur.smbPass));
 
         int popsMask = vcdPopsNetChanged(&popsOriginal, &popsCur);
-        int popsSmbComplete = popsCur.smbShare[0] != '\0' &&
-                              (popsCur.smbIp[0] | popsCur.smbIp[1] | popsCur.smbIp[2] | popsCur.smbIp[3]) != 0;
-        int popsIpComplete = (popsCur.ps2Ip[0] | popsCur.ps2Ip[1] | popsCur.ps2Ip[2] | popsCur.ps2Ip[3]) != 0 &&
-                             (popsCur.ps2Mask[0] | popsCur.ps2Mask[1] | popsCur.ps2Mask[2] | popsCur.ps2Mask[3]) != 0 &&
-                             (popsCur.ps2Gw[0] | popsCur.ps2Gw[1] | popsCur.ps2Gw[2] | popsCur.ps2Gw[3]) != 0;
+        int popsSmbComplete = vcdPopsNetValuesValid(&popsCur, 1, 0);
+        int popsIpComplete = !popsCur.ipDhcp && vcdPopsNetValuesValid(&popsCur, 0, 1);
         int writeSmb = (popsMask & 1) && (popsOriginal.smbExists || popsSmbComplete);
-        int writeIp = (popsMask & 2) && (popsOriginal.ipExists || popsCur.ipDhcp || popsIpComplete);
-        // Creating a fresh SMBCONFIG.DAT with no IPCONFIG.DAT anywhere: create the pair -- POPStarter
-        // expects IPCONFIG.DAT to exist even when blank (DHCP). An incomplete static entry becomes a
-        // BLANK file (never garbage); the user can complete it later and it will overwrite.
+        // A malformed IPCONFIG.DAT initially displays as DHCP because no static triple can be
+        // trusted. Treat an OK as an explicit repair candidate too, so Replace can rewrite it as
+        // the valid blank-DHCP file instead of forcing the user through an unrelated static edit.
+        int writeIp = ((popsMask & 2) || popsOriginal.ipInvalid) &&
+                      (popsOriginal.ipExists || popsCur.ipDhcp || popsIpComplete);
+
+        // Creating a fresh SMBCONFIG.DAT also creates IPCONFIG.DAT. DHCP deliberately serializes
+        // as a blank file; an incomplete static entry is never serialized as malformed text.
         if (writeSmb && !popsOriginal.smbExists && !popsOriginal.ipExists) {
             writeIp = 1;
             if (!popsCur.ipDhcp && !popsIpComplete)
                 popsCur.ipDhcp = 1;
         }
-        // Overwrite guard: existing mc0:/POPSTARTER/*.DAT files are user-owned.
-        // Normal SMB VCD launch never overwrites (vcdEnsurePopstarterSmbConfigMc0
-        // presence wins), but an explicit Settings save must ask before replacing.
-        // Keep = preserve existing files (only create missing ones), Replace =
-        // overwrite with current dialog values, Cancel/Back = abort the save.
+
+        if (!writeSmb && !writeIp)
+            return;
+        if (!vcdPopsNetValuesValid(&popsCur, writeSmb, writeIp)) {
+            guiMsgBox(_l(_STR_POPSTARTER_NET_INVALID), 0, NULL);
+            continue;
+        }
+
+        // Existing files are user-owned. Keep and Cancel deliberately re-open the SAME editor:
+        // diaPopsNetConfig retains its typed fields, while popsOriginal remains the read snapshot.
         if ((writeSmb && popsOriginal.smbExists) || (writeIp && popsOriginal.ipExists)) {
             int ov = diaExecuteDialog(diaPopsOverwrite, -1, 1, NULL);
-            if (ov == POPS_OVERWRITE_KEEP) {
-                if (popsOriginal.smbExists)
-                    writeSmb = 0;
-                if (popsOriginal.ipExists)
-                    writeIp = 0;
-            } else if (ov == POPS_OVERWRITE_REPLACE) {
-                // proceed to write as calculated
-            } else {
-                // Cancel / Back -> abort save entirely
-                writeSmb = 0;
-                writeIp = 0;
-            }
+            if (ov != POPS_OVERWRITE_REPLACE)
+                continue;
         }
-        if ((writeSmb || writeIp) && vcdWritePopstarterNetFiles(&popsCur, writeSmb, writeIp) != 0)
+
+        if (vcdWritePopstarterNetFiles(&popsCur, writeSmb, writeIp) != 0) {
             guiMsgBox(_l(_STR_POPSTARTER_NET_ERR), 0, NULL);
+            continue;
+        }
+        return;
     }
 }
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -119,6 +119,19 @@ static int guiSettingsStageOplHome(int selection);
 static const char **guiCopyNameList(const char **src);
 static void guiFreeNameList(const char **list);
 
+enum {
+    GUI_OPL_HOME_STAGE_NOT_FOUND = 0,
+    GUI_OPL_HOME_STAGE_OK = 1,
+    GUI_OPL_HOME_STAGE_UNAVAILABLE = -1,
+};
+
+static const char *guiOplHomeStageError(int selection, int result)
+{
+    if (result == GUI_OPL_HOME_STAGE_UNAVAILABLE)
+        return _l(_STR_HDD_OPL_PARTITION_BUSY);
+    return selection == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND);
+}
+
 #ifdef __DEBUG
 
 // debug version displays an FPS meter
@@ -769,15 +782,16 @@ reshow_device:
     if (ret) {
         int netProtocolWas = gNetworkProtocol;
         int hddOplHomeChoice;
+        int hddOplHomeStageResult;
 
         diaGetInt(diaDeviceConfig, CFG_HDDOPLPART, &hddOplHomeChoice);
         if (hddOplHomeChoice != guiDeviceOplHomeInitial ||
             (guiDeviceOplHomeLegacy && guiDeviceOplHomeTouched)) {
-            if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
+            hddOplHomeStageResult = guiSettingsStageOplHome(hddOplHomeChoice);
+            if (hddOplHomeStageResult != GUI_OPL_HOME_STAGE_OK) {
                 diaSetInt(diaDeviceConfig, CFG_HDDOPLPART, guiDeviceOplHomeInitial);
                 guiDeviceOplHomeTouched = 0;
-                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND),
-                          0, NULL);
+                guiMsgBox(guiOplHomeStageError(hddOplHomeChoice, hddOplHomeStageResult), 0, NULL);
                 goto reshow_device;
             }
             guiMsgBox(_l(_STR_HDD_OPL_PARTITION_RESTART), 0, NULL);
@@ -2711,7 +2725,7 @@ static int guiSettingsStageOplHome(int selection)
     // Do not overwrite the static request payload after a timed-out worker. The I/O queue is
     // single-threaded, so another request cannot begin until that worker actually returns.
     if (guiSourcesOplHomeStageInFlight)
-        return 0;
+        return GUI_OPL_HOME_STAGE_UNAVAILABLE;
 
     guiSourcesOplHomeStageChoice = selection;
     guiSourcesOplHomeStageResult = 0;
@@ -2725,7 +2739,7 @@ static int guiSettingsStageOplHome(int selection)
         // a later Save Settings persist a choice the user did not get to confirm.
         guiSourcesOplHomeStageAbandoned = 1;
         hddDiscardOplHomeSelection();
-        return 0;
+        return GUI_OPL_HOME_STAGE_UNAVAILABLE;
     }
     return guiSourcesOplHomeStageResult;
 }
@@ -2790,14 +2804,16 @@ reshow_sources:
     if (result != UIID_BTN_CANCEL && result != -1) {
         int netProtocolWas = gNetworkProtocol;
         int hddOplHomeChoice;
+        int hddOplHomeStageResult;
 
         diaGetInt(ui, CFG_HDDOPLPART, &hddOplHomeChoice);
         if (hddOplHomeChoice != guiSourcesOplHomeInitial ||
             (guiSourcesOplHomeLegacy && guiSourcesOplHomeTouched)) {
-            if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
+            hddOplHomeStageResult = guiSettingsStageOplHome(hddOplHomeChoice);
+            if (hddOplHomeStageResult != GUI_OPL_HOME_STAGE_OK) {
                 diaSetInt(ui, CFG_HDDOPLPART, guiSourcesOplHomeInitial);
-                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND),
-                          0, NULL);
+                guiSourcesOplHomeTouched = 0;
+                guiMsgBox(guiOplHomeStageError(hddOplHomeChoice, hddOplHomeStageResult), 0, NULL);
                 goto reshow_sources;
             }
             guiMsgBox(_l(_STR_HDD_OPL_PARTITION_RESTART), 0, NULL);

--- a/src/gui.c
+++ b/src/gui.c
@@ -24,6 +24,7 @@
 #include "include/udpfssupport.h" // udpfsGetModulesLoaded() -- network-protocol restart-notice check
 #include "include/artindex.h"
 #include "include/bdmsupport.h" // bdmIsUDPBDLoaded() + bdmForceDeviceRefresh()
+#include "include/hddsupport.h" // staged normal APA OPL-home selector
 #include "include/vcdsupport.h" // POPStarter pages: BDMA equip, list options, POPS net config
 #include "include/compatupd.h"
 #include "include/pggsm.h"
@@ -113,6 +114,10 @@ static const char *volatile gBootStickyLabel = NULL;
 
 // forward decl.
 static void guiShow();
+static void guiDrawOverlays(void);
+static int guiSettingsStageOplHome(int selection);
+static const char **guiCopyNameList(const char **src);
+static void guiFreeNameList(const char **list);
 
 #ifdef __DEBUG
 
@@ -605,11 +610,14 @@ int guiIoModeToDeviceType(int ioMode)
     return 0;
 }
 
-// Settings page (settings-layout restructure): the slim "Settings" category -- remember/auto-start
-// last played and Exit To. Everything else moved to the Game Sources, Display, Game Launching,
-// Security, Controller, Audio, Advanced and Tools pages.
+// Legacy standalone General editor. The Settings peer shell is the normal route, but this stays
+// functional for callers outside it and shares the same Language/GSM backends.
 void guiShowConfig()
 {
+    const char **langNamesSnap = NULL;
+    int langID;
+    int ret;
+
     // Exit To auto-resolves a built-in default when blank, so show a dim "Default" placeholder
     // rather than "<not set>" -- the empty value (and thus the fallback) is kept.
     diaSetShowDefaultWhenEmpty(diaConfig, CFG_EXITTO, 1);
@@ -625,8 +633,20 @@ void guiShowConfig()
     diaSetVisible(diaConfig, CFG_AUTOSTARTLAST, gRememberLastPlayed);
     diaSetVisible(diaConfig, CFG_LBL_AUTOSTARTLAST, gRememberLastPlayed);
 
-    int ret = diaExecuteDialog(diaConfig, -1, 1, &guiUpdater);
+    guiLock();
+    langNamesSnap = guiCopyNameList((const char **)lngGetGuiList());
+    guiUnlock();
+    diaSetEnum(diaConfig, UICFG_LANG, langNamesSnap != NULL ? langNamesSnap : (const char **)lngGetGuiList());
+    diaSetInt(diaConfig, UICFG_LANG, lngGetGuiValue());
+
+reshow_config:
+    ret = diaExecuteDialog(diaConfig, -1, 1, &guiUpdater);
+    if (ret == GENERAL_GSM_DEFAULTS_BUTTON) {
+        guiGameShowGSConfig(1);
+        goto reshow_config;
+    }
     if (ret) {
+        diaGetInt(diaConfig, UICFG_LANG, &langID);
         diaGetString(diaConfig, CFG_EXITTO, gExitPath, sizeof(gExitPath));
         diaGetString(diaConfig, CFG_CUSTOMCFGPATH, gCustomSettingsPath, sizeof(gCustomSettingsPath));
         diaGetInt(diaConfig, CFG_LASTPLAYED, &gRememberLastPlayed);
@@ -635,9 +655,11 @@ void guiShowConfig()
 
         DisableCron = 1; // Disable Auto Start Last Played counter (we don't want to call it right after enable it on GUI)
 
-        applyConfig(-1, -1, 0);
+        applyConfig(-1, langID, 0);
         menuReinitMainMenu();
     }
+
+    guiFreeNameList(langNamesSnap);
 }
 
 // Game Sources page: device start modes, the default device, and the block-device enables
@@ -673,10 +695,30 @@ int guiNetProtocolNeedsRestart(void)
     return gNetworkProtocol != resident;
 }
 
+// guiShowDeviceConfig is retained for the legacy entry point outside the Settings peer shell.
+// Keep its APA selector semantics identical to the shell: merely opening/saving another field
+// must not normalize a legacy custom hdd_partition, while an explicit selector interaction may.
+static int guiDeviceOplHomeInitial;
+static int guiDeviceOplHomeLegacy;
+static int guiDeviceOplHomeTouched;
+
+static int guiDeviceConfigUpdater(int modified)
+{
+    int selection;
+
+    if (modified) {
+        diaGetInt(diaDeviceConfig, CFG_HDDOPLPART, &selection);
+        if (selection != guiDeviceOplHomeInitial)
+            guiDeviceOplHomeTouched = 1;
+    }
+    return 0;
+}
+
 void guiShowDeviceConfig(void)
 {
     const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), _l(_STR_FAV), NULL};
     const char *deviceModes[] = {_l(_STR_OFF), _l(_STR_MANUAL), _l(_STR_AUTO), NULL};
+    static const char *hddOplHomes[] = {"__common/OPL/", "+OPL/", NULL};
 
     // Devices & modes
     diaSetEnum(diaDeviceConfig, CFG_DEFDEVICE, deviceNames);
@@ -711,15 +753,36 @@ void guiShowDeviceConfig(void)
     diaSetInt(diaDeviceConfig, CFG_MMCEMODE, gMMCEStartMode);
     diaSetEnabled(diaDeviceConfig, CFG_MMCEMODE, 1);
 
+    guiDeviceOplHomeInitial = hddGetOplHomeSelection();
+    guiDeviceOplHomeLegacy = hddOplHomeIsLegacy();
+    guiDeviceOplHomeTouched = 0;
+    diaSetEnum(diaDeviceConfig, CFG_HDDOPLPART, hddOplHomes);
+    diaSetInt(diaDeviceConfig, CFG_HDDOPLPART, guiDeviceOplHomeInitial);
+
     int ret;
 reshow_device:
-    ret = diaExecuteDialog(diaDeviceConfig, -1, 1, NULL);
+    ret = diaExecuteDialog(diaDeviceConfig, -1, 1, &guiDeviceConfigUpdater);
     if (ret == MMCE_SETTINGS_BUTTON) {
         guiShowMmceConfig();
         goto reshow_device;
     }
     if (ret) {
         int netProtocolWas = gNetworkProtocol;
+        int hddOplHomeChoice;
+
+        diaGetInt(diaDeviceConfig, CFG_HDDOPLPART, &hddOplHomeChoice);
+        if (hddOplHomeChoice != guiDeviceOplHomeInitial ||
+            (guiDeviceOplHomeLegacy && guiDeviceOplHomeTouched)) {
+            if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
+                diaSetInt(diaDeviceConfig, CFG_HDDOPLPART, guiDeviceOplHomeInitial);
+                guiDeviceOplHomeTouched = 0;
+                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? "+OPL partition not found." : "HDD (APA) OPL partition not found.",
+                          0, NULL);
+                goto reshow_device;
+            }
+            guiMsgBox("Restart or remount HDD to use the selected OPL partition.", 0, NULL);
+        }
+
         diaGetInt(diaDeviceConfig, CFG_DEFDEVICE, &deviceModeIndex);
         gDefaultDevice = guiDeviceTypeToIoMode(deviceModeIndex);
         diaGetInt(diaDeviceConfig, CFG_BDMMODE, &gBDMStartMode);
@@ -1515,6 +1578,113 @@ void guiShowVcdListConfig(void)
     }
 }
 
+// POPSTARTER's local memory-card resolver evaluates both mc0 and mc1, including directory/file
+// RPCs. On a slow or absent card that work can take seconds. Keep it on the I/O worker and pump a
+// real runtime frame here; guiHandleDeferedIO is intentionally not used because its text screen
+// does not poll input or animate the Settings plasma.
+#define POPSNET_READ_TIMEOUT_MS  15000
+#define GUI_POPSNET_READ_ABORTED (-100)
+enum gui_popsnet_read_source {
+    GUI_POPSNET_READ_LOCAL = 0,
+    GUI_POPSNET_READ_SMB,
+};
+static int guiPopsNetReadPending;
+static int guiPopsNetReadInFlight;
+static int guiPopsNetReadAbandoned;
+static int guiPopsNetReadSource;
+static int guiPopsNetReadResult;
+static vcd_popsnet_t guiPopsNetReadData;
+
+static void guiPopsNetReadWorker(void)
+{
+    vcd_popsnet_t data;
+    int result;
+
+    if (guiPopsNetReadSource == GUI_POPSNET_READ_LOCAL)
+        result = vcdReadPopstarterNet(&data);
+    else
+        result = vcdReadPopstarterNetFromSmb(&data);
+
+    if (!guiPopsNetReadAbandoned) {
+        guiPopsNetReadData = data;
+        guiPopsNetReadResult = result;
+    }
+    guiPopsNetReadInFlight = 0;
+    guiPopsNetReadPending = 0;
+}
+
+static int guiReadPopsNet(int source, vcd_popsnet_t *out)
+{
+    clock_t startTick;
+    clock_t timeoutTicks = (clock_t)POPSNET_READ_TIMEOUT_MS * (CLOCKS_PER_SEC / 1000);
+
+    if (guiPopsNetReadInFlight) {
+        // A cancelled request still owns the static payload until its I/O RPC returns. Reopening the
+        // same editor may resume its wait, but a second source may not overwrite that payload.
+        if (guiPopsNetReadSource != source)
+            return GUI_POPSNET_READ_ABORTED;
+        guiPopsNetReadAbandoned = 0;
+    } else {
+        memset(&guiPopsNetReadData, 0, sizeof(guiPopsNetReadData));
+        guiPopsNetReadSource = source;
+        guiPopsNetReadResult = GUI_POPSNET_READ_ABORTED;
+        guiPopsNetReadAbandoned = 0;
+        guiPopsNetReadPending = 1;
+        guiPopsNetReadInFlight = 1;
+        if (ioPutRequest(IO_CUSTOM_SIMPLEACTION, &guiPopsNetReadWorker) != IO_OK) {
+            guiPopsNetReadInFlight = 0;
+            guiPopsNetReadPending = 0;
+            return GUI_POPSNET_READ_ABORTED;
+        }
+    }
+
+    startTick = clock();
+    while (guiPopsNetReadInFlight) {
+        guiStartFrame();
+        if (guiDrawBGSettings() == 0)
+            guiDrawBGPlasma();
+        rmDrawRect(0, 0, screenWidth, screenHeight, gColDarker);
+        fntRenderString(gTheme->fonts[0], screenWidth >> 1, gTheme->usedHeight >> 1,
+                        ALIGN_CENTER, 0, 0, "Loading POPSTARTER settings...", gTheme->textColor);
+        guiDrawOverlays();
+        guiEndFrame();
+
+        readPads();
+        if (getKeyOn(KEY_CIRCLE)) {
+            guiPopsNetReadAbandoned = 1;
+            return GUI_POPSNET_READ_ABORTED;
+        }
+        if ((clock() - startTick) >= timeoutTicks) {
+            guiPopsNetReadAbandoned = 1;
+            return GUI_POPSNET_READ_ABORTED;
+        }
+    }
+
+    if (out != NULL)
+        *out = guiPopsNetReadData;
+    return guiPopsNetReadResult;
+}
+
+static void guiSetPopsNetDialogFields(const vcd_popsnet_t *cfg)
+{
+    size_t i;
+
+    diaSetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, cfg->ipDhcp);
+    for (i = 0; i < 4; ++i) {
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, cfg->ps2Ip[i]);
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, cfg->ps2Mask[i]);
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, cfg->ps2Gw[i]);
+        diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_IP_0 + i, cfg->smbIp[i]);
+        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, !cfg->ipDhcp);
+        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, !cfg->ipDhcp);
+        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, !cfg->ipDhcp);
+    }
+    diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_PORT, cfg->smbPort);
+    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_SHARE, cfg->smbShare);
+    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, cfg->smbUser);
+    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, cfg->smbPass);
+}
+
 // POPStarter -> Network Settings live-updater: DHCP = no static IP/mask/gateway triple.
 static int guiPopsNetUpdater(int modified)
 {
@@ -1532,17 +1702,12 @@ static int guiPopsNetUpdater(int modified)
     return 0;
 }
 
-// POPStarter -> Network Settings (VCD over SMB). Shows POPSTARTER's OWN IPCONFIG.DAT /
-// SMBCONFIG.DAT contents. Absent files leave the fields blank with the notice visible -- absence
-// means unknown/unconfigured, NEVER "use OPL's values". Only an explicit edit or the Import button
-// fills them, and only an actual change vs the read-time snapshot is written back on OK (the save
-// matrix below). Moved out of guiShowNetConfig by the settings-layout restructure; the Import
-// source is now the SAVED OPL network globals (the OPL fields no longer share this dialog).
+// POPStarter -> Network Settings (VCD over SMB). The local memory-card snapshot remains the sole
+// write owner. The explicit import path only copies valid POPS/*.DAT values into the editor, so the
+// normal change-detection/Replace flow still decides whether anything is committed to an MC.
 void guiShowPopsNetConfig(void)
 {
     size_t i;
-    // POPStarter read-time snapshot for the change-detection save matrix, + static storage for the
-    // "Loaded from %s" notice (diaSetLabel stores a RAW POINTER -- it must outlive the dialog).
     static vcd_popsnet_t popsOriginal;
     static char popsNotice[128];
     static const char *ipAddrConfModes[3];
@@ -1550,30 +1715,16 @@ void guiShowPopsNetConfig(void)
     ipAddrConfModes[0] = _l(_STR_IP_ADDRESS_TYPE_STATIC);
     ipAddrConfModes[1] = _l(_STR_IP_ADDRESS_TYPE_DHCP);
     ipAddrConfModes[2] = NULL;
-    diaSetEnum(diaPopsNetConfig, NETCFG_POPS_IPTYPE, ipAddrConfModes); // same Static/DHCP index convention
+    diaSetEnum(diaPopsNetConfig, NETCFG_POPS_IPTYPE, ipAddrConfModes);
 
-    vcdReadPopstarterNet(&popsOriginal);
-    diaSetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, popsOriginal.ipDhcp);
-    for (i = 0; i < 4; ++i) {
-        diaSetInt(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, popsOriginal.ps2Ip[i]);
-        diaSetInt(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, popsOriginal.ps2Mask[i]);
-        diaSetInt(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, popsOriginal.ps2Gw[i]);
-        diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_IP_0 + i, popsOriginal.smbIp[i]);
-
-        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, !popsOriginal.ipDhcp);
-        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, !popsOriginal.ipDhcp);
-        diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, !popsOriginal.ipDhcp);
-    }
-    diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_PORT, popsOriginal.smbPort);
-    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_SHARE, popsOriginal.smbShare);
-    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, popsOriginal.smbUser);
-    diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, popsOriginal.smbPass);
+    if (guiReadPopsNet(GUI_POPSNET_READ_LOCAL, &popsOriginal) == GUI_POPSNET_READ_ABORTED)
+        return;
+    guiSetPopsNetDialogFields(&popsOriginal);
 
     if (popsOriginal.smbInvalid || popsOriginal.ipInvalid) {
         diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, _l(_STR_POPSTARTER_NET_INVALID));
     } else if (popsOriginal.smbExists || popsOriginal.ipExists) {
-        snprintf(popsNotice, sizeof(popsNotice), _l(_STR_POPS_LOADED_FROM),
-                 popsOriginal.home);
+        snprintf(popsNotice, sizeof(popsNotice), _l(_STR_POPS_LOADED_FROM), popsOriginal.home);
         diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, popsNotice);
     } else {
         diaSetLabel(diaPopsNetConfig, NETCFG_POPS_NOTICE, _l(_STR_POPS_NONE_DETECTED));
@@ -1582,36 +1733,27 @@ void guiShowPopsNetConfig(void)
     for (;;) {
         int result = diaExecuteDialog(diaPopsNetConfig, -1, 1, &guiPopsNetUpdater);
         if (result == NETCFG_POPS_IMPORT) {
-            // IMPORT: the ONE sanctioned path that copies OPL's saved Network Settings into the
-            // POPStarter fields. Pressing the button exits the dialog with its id; the dialog
-            // struct keeps every field's value across the re-execution, so nothing the user typed
-            // elsewhere is lost.
-            char s[32];
+            vcd_popsnet_t imported;
+            int importResult;
 
-            diaSetInt(diaPopsNetConfig, NETCFG_POPS_IPTYPE, ps2_ip_use_dhcp);
-            for (i = 0; i < 4; ++i) {
-                diaSetInt(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, ps2_ip[i]);
-                diaSetInt(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, ps2_netmask[i]);
-                diaSetInt(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, ps2_gateway[i]);
-
-                diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_IP_0 + i, !ps2_ip_use_dhcp);
-                diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_MASK_0 + i, !ps2_ip_use_dhcp);
-                diaSetEnabled(diaPopsNetConfig, NETCFG_POPS_GW_0 + i, !ps2_ip_use_dhcp);
+            // Do not start or reconnect SMB merely to import. Its mounted state, not the saved
+            // protocol picker, is the authority for whether these files are readable.
+            if (!ethIsSMBShareConnected()) {
+                guiMsgBox("SMB is not connected.", 0, NULL);
+                continue;
             }
-
-            // A NetBIOS share name can't be turned into an IP -- leave the POPStarter server IP
-            // untouched in that case instead of importing a wrong value.
-            if (!gPCShareAddressIsNetBIOS) {
-                for (i = 0; i < 4; ++i)
-                    diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_IP_0 + i, pc_ip[i]);
+            importResult = guiReadPopsNet(GUI_POPSNET_READ_SMB, &imported);
+            if (importResult == GUI_POPSNET_READ_ABORTED)
+                return;
+            if (importResult == VCD_POPSNET_SMB_IMPORT_NOT_CONNECTED) {
+                guiMsgBox("SMB is not connected.", 0, NULL);
+                continue;
             }
-            diaSetInt(diaPopsNetConfig, NETCFG_POPS_SMB_PORT, gPCPort);
-            snprintf(s, sizeof(s), "%s", gPCShareName);
-            diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_SHARE, s);
-            snprintf(s, sizeof(s), "%s", gPCUserName);
-            diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_USER, s);
-            snprintf(s, sizeof(s), "%s", gPCPassword);
-            diaSetString(diaPopsNetConfig, NETCFG_POPS_SMB_PASS, s);
+            if (importResult != VCD_POPSNET_SMB_IMPORT_OK) {
+                guiMsgBox("No POPSTARTER settings found in SMB POPS directory.", 0, NULL);
+                continue;
+            }
+            guiSetPopsNetDialogFields(&imported);
             continue;
         }
 
@@ -1638,14 +1780,9 @@ void guiShowPopsNetConfig(void)
         int popsSmbComplete = vcdPopsNetValuesValid(&popsCur, 1, 0);
         int popsIpComplete = !popsCur.ipDhcp && vcdPopsNetValuesValid(&popsCur, 0, 1);
         int writeSmb = (popsMask & 1) && (popsOriginal.smbExists || popsSmbComplete);
-        // A malformed IPCONFIG.DAT initially displays as DHCP because no static triple can be
-        // trusted. Treat an OK as an explicit repair candidate too, so Replace can rewrite it as
-        // the valid blank-DHCP file instead of forcing the user through an unrelated static edit.
         int writeIp = ((popsMask & 2) || popsOriginal.ipInvalid) &&
                       (popsOriginal.ipExists || popsCur.ipDhcp || popsIpComplete);
 
-        // Creating a fresh SMBCONFIG.DAT also creates IPCONFIG.DAT. DHCP deliberately serializes
-        // as a blank file; an incomplete static entry is never serialized as malformed text.
         if (writeSmb && !popsOriginal.smbExists && !popsOriginal.ipExists) {
             writeIp = 1;
             if (!popsCur.ipDhcp && !popsIpComplete)
@@ -1659,8 +1796,6 @@ void guiShowPopsNetConfig(void)
             continue;
         }
 
-        // Existing files are user-owned. Keep and Cancel deliberately re-open the SAME editor:
-        // diaPopsNetConfig retains its typed fields, while popsOriginal remains the read snapshot.
         if ((writeSmb && popsOriginal.smbExists) || (writeIp && popsOriginal.ipExists)) {
             int ov = diaExecuteDialog(diaPopsOverwrite, -1, 1, NULL);
             if (ov != POPS_OVERWRITE_REPLACE)
@@ -1958,21 +2093,6 @@ void guiShowStorageConfig(void)
         diaGetInt(diaStorageConfig, CFG_SMBCACHE, &smbCacheSize);
 
         applyConfig(-1, -1, 0);
-    }
-}
-
-void guiShowToolsConfig(void)
-{
-    int ret;
-reshow_tools:
-    ret = diaExecuteDialog(diaToolsConfig, -1, 1, NULL);
-    if (ret == TOOLS_NET_UPDATE_BUTTON) {
-        guiShowNetCompatUpdate();
-        goto reshow_tools;
-    }
-    if (ret == TOOLS_NBD_BUTTON) {
-        handleLwnbdSrv();
-        goto reshow_tools;
     }
 }
 
@@ -2491,10 +2611,21 @@ static int guiSettingsShowGeneral(void)
 {
     const struct UIItem *parts[] = {diaConfig, diaSecurityConfig, diaAdvancedConfig};
     struct UIItem *ui = guiSettingsCompose(parts, 3, NULL, 0, -1, 1);
+    const char **langNamesSnap = NULL;
+    int langID;
     int result;
 
     if (ui == NULL)
         return 0;
+
+    // The General language row is intentionally the same enum/value as Interface, not a second
+    // setting. Snapshot ownership matches Interface so deferred language discovery cannot free a
+    // list while this dialog renders it.
+    guiLock();
+    langNamesSnap = guiCopyNameList((const char **)lngGetGuiList());
+    guiUnlock();
+    diaSetEnum(ui, UICFG_LANG, langNamesSnap != NULL ? langNamesSnap : (const char **)lngGetGuiList());
+    diaSetInt(ui, UICFG_LANG, lngGetGuiValue());
 
     diaSetShowDefaultWhenEmpty(ui, CFG_EXITTO, 1);
     diaSetString(ui, CFG_EXITTO, gExitPath);
@@ -2511,9 +2642,16 @@ static int guiSettingsShowGeneral(void)
     guiSetAdvancedSettings(ui);
     guiSettingsBeginDialog(ui);
 
+reshow_general:
     result = diaExecuteDialog(ui, -1, 1, &guiSettingsGeneralUpdater);
+    if (result == GENERAL_GSM_DEFAULTS_BUTTON) {
+        if (guiGameShowGSConfig(1))
+            guiSettingsSavePending = 1;
+        goto reshow_general;
+    }
 
     if (result != UIID_BTN_CANCEL && result != -1) {
+        diaGetInt(ui, UICFG_LANG, &langID);
         diaGetString(ui, CFG_EXITTO, gExitPath, sizeof(gExitPath));
         diaGetString(ui, CFG_CUSTOMCFGPATH, gCustomSettingsPath, sizeof(gCustomSettingsPath));
         diaGetInt(ui, CFG_LASTPLAYED, &gRememberLastPlayed);
@@ -2525,13 +2663,71 @@ static int guiSettingsShowGeneral(void)
         guiSaveAdvancedSettings(ui);
 
         DisableCron = 1;
-        applyConfig(-1, -1, 0);
+        applyConfig(-1, langID, 0);
         menuReinitMainMenu();
     }
 
+    guiFreeNameList(langNamesSnap);
     guiSettingsEndDialog();
     guiSettingsActiveDialog = NULL;
     return guiSettingsPageResult(result);
+}
+
+static int guiSourcesOplHomeInitial;
+static int guiSourcesOplHomeLegacy;
+static int guiSourcesOplHomeTouched;
+static int guiSourcesOplHomeStagePending;
+static int guiSourcesOplHomeStageResult;
+static int guiSourcesOplHomeStageChoice;
+static int guiSourcesOplHomeStageInFlight;
+static int guiSourcesOplHomeStageAbandoned;
+
+static int guiSettingsSourcesUpdater(int modified)
+{
+    int selection;
+
+    if (modified) {
+        diaGetInt(guiSettingsActiveDialog, CFG_HDDOPLPART, &selection);
+        if (selection != guiSourcesOplHomeInitial)
+            guiSourcesOplHomeTouched = 1;
+    }
+    return 0;
+}
+
+static void guiSettingsStageOplHomeWorker(void)
+{
+    int result = hddStageOplHomeSelection(guiSourcesOplHomeStageChoice);
+
+    if (guiSourcesOplHomeStageAbandoned)
+        hddDiscardOplHomeSelection();
+    else
+        guiSourcesOplHomeStageResult = result;
+    guiSourcesOplHomeStageInFlight = 0;
+    guiSourcesOplHomeStagePending = 0;
+}
+
+static int guiSettingsStageOplHome(int selection)
+{
+    // Do not overwrite the static request payload after a timed-out worker. The I/O queue is
+    // single-threaded, so another request cannot begin until that worker actually returns.
+    if (guiSourcesOplHomeStageInFlight)
+        return 0;
+
+    guiSourcesOplHomeStageChoice = selection;
+    guiSourcesOplHomeStageResult = 0;
+    guiSourcesOplHomeStagePending = 1;
+    guiSourcesOplHomeStageInFlight = 1;
+    guiSourcesOplHomeStageAbandoned = 0;
+    guiHandleDeferedIO(&guiSourcesOplHomeStagePending, "Checking HDD OPL partition...",
+                       IO_CUSTOM_SIMPLEACTION, &guiSettingsStageOplHomeWorker, 15000);
+    if (gLastDeferredTimedOut) {
+        // The late worker only ever changes our staged selector; never let an abandoned wait make
+        // a later Save Settings persist a choice the user did not get to confirm.
+        guiSourcesOplHomeStageAbandoned = 1;
+        hddDiscardOplHomeSelection();
+        return 0;
+    }
+    return guiSourcesOplHomeStageResult;
 }
 
 static int guiSettingsShowSources(void)
@@ -2539,6 +2735,7 @@ static int guiSettingsShowSources(void)
     const struct UIItem *parts[] = {diaDeviceConfig};
     const char *deviceNames[] = {_l(_STR_BDM_GAMES), _l(_STR_NET_GAMES), _l(_STR_HDD_GAMES), _l(_STR_APPS), _l(_STR_MMCE), _l(_STR_FAV), NULL};
     const char *deviceModes[] = {_l(_STR_OFF), _l(_STR_MANUAL), _l(_STR_AUTO), NULL};
+    static const char *hddOplHomes[] = {"__common/OPL/", "+OPL/", NULL};
     struct UIItem *ui = guiSettingsCompose(parts, 1, NULL, 0, -1, 0);
     int deviceModeIndex;
     int result;
@@ -2568,10 +2765,15 @@ static int guiSettingsShowSources(void)
     diaSetEnum(ui, CFG_MMCEMODE, deviceModes);
     diaSetInt(ui, CFG_MMCEMODE, gMMCEStartMode);
     diaSetEnabled(ui, CFG_MMCEMODE, 1);
+    guiSourcesOplHomeInitial = hddGetOplHomeSelection();
+    guiSourcesOplHomeLegacy = hddOplHomeIsLegacy();
+    guiSourcesOplHomeTouched = 0;
+    diaSetEnum(ui, CFG_HDDOPLPART, hddOplHomes);
+    diaSetInt(ui, CFG_HDDOPLPART, guiSourcesOplHomeInitial);
     guiSettingsBeginDialog(ui);
 
 reshow_sources:
-    result = diaExecuteDialog(ui, -1, 1, NULL);
+    result = diaExecuteDialog(ui, -1, 1, &guiSettingsSourcesUpdater);
     if (result == MMCE_SETTINGS_BUTTON) {
         // MMCE uses a separate composition buffer. Confirming the child editor finishes the
         // Settings page and returns to the hub; Circle resumes Game Sources as the parent page.
@@ -2587,6 +2789,19 @@ reshow_sources:
 
     if (result != UIID_BTN_CANCEL && result != -1) {
         int netProtocolWas = gNetworkProtocol;
+        int hddOplHomeChoice;
+
+        diaGetInt(ui, CFG_HDDOPLPART, &hddOplHomeChoice);
+        if (hddOplHomeChoice != guiSourcesOplHomeInitial ||
+            (guiSourcesOplHomeLegacy && guiSourcesOplHomeTouched)) {
+            if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
+                diaSetInt(ui, CFG_HDDOPLPART, guiSourcesOplHomeInitial);
+                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? "+OPL partition not found." : "HDD (APA) OPL partition not found.",
+                          0, NULL);
+                goto reshow_sources;
+            }
+            guiMsgBox("Restart or remount HDD to use the selected OPL partition.", 0, NULL);
+        }
 
         diaGetInt(ui, CFG_DEFDEVICE, &deviceModeIndex);
         gDefaultDevice = guiDeviceTypeToIoMode(deviceModeIndex);
@@ -2731,7 +2946,8 @@ reshow_interface:
         goto reshow_interface;
     }
     if (result == DISPLAY_GSM_DEFAULTS_BUTTON) {
-        guiGameShowGSConfig(1);
+        if (guiGameShowGSConfig(1))
+            guiSettingsSavePending = 1;
         goto reshow_interface;
     }
 
@@ -2825,6 +3041,11 @@ reshow_launch:
     result = diaExecuteDialog(ui, -1, 1, &guiSettingsLaunchUpdater);
     if (result == LAUNCH_OSD_DEFAULTS_BUTTON) {
         guiGameShowOSDLanguageConfig(1);
+        goto reshow_launch;
+    }
+    if (result == LAUNCH_GSM_DEFAULTS_BUTTON) {
+        if (guiGameShowGSConfig(1))
+            guiSettingsSavePending = 1;
         goto reshow_launch;
     }
     if (result == CFG_NEUTRINO_ARGS) {
@@ -3053,6 +3274,7 @@ static int guiSettingsShowIndex(int *page)
                     return 0;
                 }
             } else if (promptResult == SETTINGS_PROMPT_EXIT) {
+                hddDiscardOplHomeSelection();
                 guiSettingsSavePending = 0;
                 return 0;
             }
@@ -3068,6 +3290,7 @@ void guiShowSettings(void)
     guiSettingsShellActive = 1;
     guiSettingsSavePending = 0;
     if (!guiSettingsShowIndex(&page)) {
+        hddDiscardOplHomeSelection();
         guiSettingsShellActive = 0;
         guiSettingsSavePending = 0;
         return;
@@ -3101,6 +3324,7 @@ void guiShowSettings(void)
                 result = guiShowAudioConfig();
                 break;
             default:
+                hddDiscardOplHomeSelection();
                 guiSettingsShellActive = 0;
                 guiSettingsSavePending = 0;
                 return;
@@ -3108,6 +3332,7 @@ void guiShowSettings(void)
 
         if (result == DIA_RESULT_INDEX) {
             if (!guiSettingsShowIndex(&page)) {
+                hddDiscardOplHomeSelection();
                 guiSettingsShellActive = 0;
                 guiSettingsSavePending = 0;
                 return;
@@ -3117,6 +3342,7 @@ void guiShowSettings(void)
         } else if (result == DIA_RESULT_PREV) {
             page = (page + SETTINGS_PAGE_COUNT - 1) % SETTINGS_PAGE_COUNT;
         } else {
+            hddDiscardOplHomeSelection();
             guiSettingsShellActive = 0;
             guiSettingsSavePending = 0;
             return;
@@ -3675,7 +3901,8 @@ void guiDrawSubMenuHints(void)
     guiDrawIconAndText(gSelectButton == KEY_CIRCLE ? subMenuIcons[1] : subMenuIcons[0], subMenuHints[1], gTheme->fonts[0], x, y, gTheme->textColor);
 }
 
-static int endIntro = 0; // Break intro loop and start 'Last Played Auto Start' countdown
+static int endIntro = 0;           // Break intro loop and start 'Last Played Auto Start' countdown
+static int gIntroSplashActive = 0; // The intro is a splash, never a generic I/O-spinner screen.
 static void guiDrawOverlays()
 {
     // are there any pending operations?
@@ -3692,7 +3919,7 @@ static void guiDrawOverlays()
             busyAlpha += 0x02;
     }
 
-    if (!oplIsBootInProgress() && busyAlpha > 0x00)
+    if (!oplIsBootInProgress() && !gIntroSplashActive && busyAlpha > 0x00)
         guiDrawBusy(busyAlpha);
 
 #ifdef __DEBUG
@@ -3904,6 +4131,9 @@ void guiIntroLoop(void)
     clock_t tFadeDelay = 0;
     int tFadeArmed = 0;
 
+    // oplIsBootInProgress() can become false while background startup work is still queued. That
+    // is correct for runtime overlays, but the animated greeting owns the entire intro lifecycle.
+    gIntroSplashActive = 1;
     while (!endIntro) {
         guiStartFrame();
 
@@ -3947,6 +4177,7 @@ void guiIntroLoop(void)
         if (!screenHandlerTarget && screenHandler)
             screenHandler->handleInput();
     }
+    gIntroSplashActive = 0;
 }
 
 void guiMainLoop(void)

--- a/src/gui.c
+++ b/src/gui.c
@@ -776,11 +776,11 @@ reshow_device:
             if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
                 diaSetInt(diaDeviceConfig, CFG_HDDOPLPART, guiDeviceOplHomeInitial);
                 guiDeviceOplHomeTouched = 0;
-                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? "+OPL partition not found." : "HDD (APA) OPL partition not found.",
+                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_PARTITION_NOT_FOUND),
                           0, NULL);
                 goto reshow_device;
             }
-            guiMsgBox("Restart or remount HDD to use the selected OPL partition.", 0, NULL);
+            guiMsgBox(_l(_STR_HDD_OPL_PARTITION_RESTART), 0, NULL);
         }
 
         diaGetInt(diaDeviceConfig, CFG_DEFDEVICE, &deviceModeIndex);
@@ -1645,7 +1645,7 @@ static int guiReadPopsNet(int source, vcd_popsnet_t *out)
             guiDrawBGPlasma();
         rmDrawRect(0, 0, screenWidth, screenHeight, gColDarker);
         fntRenderString(gTheme->fonts[0], screenWidth >> 1, gTheme->usedHeight >> 1,
-                        ALIGN_CENTER, 0, 0, "Loading POPSTARTER settings...", gTheme->textColor);
+                        ALIGN_CENTER, 0, 0, _l(_STR_POPS_LOADING_SETTINGS), gTheme->textColor);
         guiDrawOverlays();
         guiEndFrame();
 
@@ -1739,18 +1739,18 @@ void guiShowPopsNetConfig(void)
             // Do not start or reconnect SMB merely to import. Its mounted state, not the saved
             // protocol picker, is the authority for whether these files are readable.
             if (!ethIsSMBShareConnected()) {
-                guiMsgBox("SMB is not connected.", 0, NULL);
+                guiMsgBox(_l(_STR_POPS_SMB_NOT_CONNECTED), 0, NULL);
                 continue;
             }
             importResult = guiReadPopsNet(GUI_POPSNET_READ_SMB, &imported);
             if (importResult == GUI_POPSNET_READ_ABORTED)
                 return;
             if (importResult == VCD_POPSNET_SMB_IMPORT_NOT_CONNECTED) {
-                guiMsgBox("SMB is not connected.", 0, NULL);
+                guiMsgBox(_l(_STR_POPS_SMB_NOT_CONNECTED), 0, NULL);
                 continue;
             }
             if (importResult != VCD_POPSNET_SMB_IMPORT_OK) {
-                guiMsgBox("No POPSTARTER settings found in SMB POPS directory.", 0, NULL);
+                guiMsgBox(_l(_STR_POPS_SMB_SETTINGS_NOT_FOUND), 0, NULL);
                 continue;
             }
             guiSetPopsNetDialogFields(&imported);
@@ -2718,7 +2718,7 @@ static int guiSettingsStageOplHome(int selection)
     guiSourcesOplHomeStagePending = 1;
     guiSourcesOplHomeStageInFlight = 1;
     guiSourcesOplHomeStageAbandoned = 0;
-    guiHandleDeferedIO(&guiSourcesOplHomeStagePending, "Checking HDD OPL partition...",
+    guiHandleDeferedIO(&guiSourcesOplHomeStagePending, _l(_STR_HDD_OPL_PARTITION_CHECKING),
                        IO_CUSTOM_SIMPLEACTION, &guiSettingsStageOplHomeWorker, 15000);
     if (gLastDeferredTimedOut) {
         // The late worker only ever changes our staged selector; never let an abandoned wait make
@@ -2796,11 +2796,11 @@ reshow_sources:
             (guiSourcesOplHomeLegacy && guiSourcesOplHomeTouched)) {
             if (!guiSettingsStageOplHome(hddOplHomeChoice)) {
                 diaSetInt(ui, CFG_HDDOPLPART, guiSourcesOplHomeInitial);
-                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? "+OPL partition not found." : "HDD (APA) OPL partition not found.",
+                guiMsgBox(hddOplHomeChoice == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_PARTITION_NOT_FOUND),
                           0, NULL);
                 goto reshow_sources;
             }
-            guiMsgBox("Restart or remount HDD to use the selected OPL partition.", 0, NULL);
+            guiMsgBox(_l(_STR_HDD_OPL_PARTITION_RESTART), 0, NULL);
         }
 
         diaGetInt(ui, CFG_DEFDEVICE, &deviceModeIndex);
@@ -3209,7 +3209,7 @@ static int guiSettingsShowIndex(int *page)
 {
     const char *labels[SETTINGS_PAGE_COUNT + 1] = {
         _l(_STR_GAME_SOURCES),
-        "General & System",
+        _l(_STR_GENERAL_SYSTEM),
         _l(_STR_MENU_NETWORK),
         _l(_STR_INTERFACE_SETTINGS),
         _l(_STR_GAME_LAUNCHING),

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -413,7 +413,7 @@ static int guiGameGSMUpdater(int modified)
 // forceGlobal: shown from Settings -> Display Settings as the GLOBAL defaults page instead of from a
 // game's settings. Same dialog, source row pinned to Global, values read from and written back to
 // the global config set -- that block is what every game inherits when it has no GSM keys of its own.
-void guiGameShowGSConfig(int forceGlobal)
+int guiGameShowGSConfig(int forceGlobal)
 {
     // configure the enumerations
     // Third source: per-KEY inheritance. Only offered here (the GSM page); the cheats/VMC/etc
@@ -493,6 +493,8 @@ void guiGameShowGSConfig(int forceGlobal)
             guiGameSaveGSMGlobalConfig(configGetByType(CONFIG_GAME));
         forceGlobalGSM = 0;
     }
+
+    return ret;
 }
 
 // CHEATS

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -43,6 +43,9 @@ static unsigned char hddSupportErrToasted = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
+// After the selector is committed, retain its next-boot value for later saves in this process.
+// The live pfs0: data home remains unchanged until the requested restart.
+static int hddOplHomeCommitted = -1;
 // +OPL can be the existing automatic home only when __common was unavailable during discovery.
 // Keep that distinct from an explicit conf_hdd.cfg redirect, which may fall back to __common.
 static unsigned char hddOplHomeAutoPlus = 0;
@@ -143,18 +146,32 @@ static int hddCheckHDProKit(void)
     return ret;
 }
 
-static void hddCheckOPLFolder(const char *mountPoint)
+static int hddCheckOPLFolder(const char *mountPoint)
 {
     DIR *dir;
     char path[32];
+    int n;
 
-    sprintf(path, "%sOPL", mountPoint);
+    n = snprintf(path, sizeof(path), "%sOPL", mountPoint);
+    if (n < 0 || n >= (int)sizeof(path))
+        return 0;
 
     dir = opendir(path);
-    if (dir == NULL)
-        mkdir(path, 0777);
-    else
+    if (dir != NULL) {
         closedir(dir);
+        return 1;
+    }
+
+    if (mkdir(path, 0777) == 0)
+        return 1;
+
+    // A competing normal-folder creation can win the race. Treat that existing folder as success,
+    // but never report a usable common-home target when the directory still cannot be opened.
+    dir = opendir(path);
+    if (dir == NULL)
+        return 0;
+    closedir(dir);
+    return 1;
 }
 
 static int hddPartitionMountable(const char *partition)
@@ -568,7 +585,7 @@ void hddLoadSupportModules(void)
     hddSupportErrToasted = 0;
     hddClearRecoveredErrors();
     if (!strcmp(gOPLPart, "hdd0:__common")) {
-        hddCheckOPLFolder(hddPrefix);
+        (void)hddCheckOPLFolder(hddPrefix);
         gHDDPrefix = "pfs0:OPL/";
     } else {
         gHDDPrefix = "pfs0:";
@@ -984,11 +1001,15 @@ int hddGetOplHomeSelection(void)
 {
     if (hddOplHomePending >= 0)
         return hddOplHomePending;
+    if (hddOplHomeCommitted >= 0)
+        return hddOplHomeCommitted;
     return strcmp(gOPLPart, "hdd0:+OPL") == 0 ? HDD_OPL_HOME_PLUS : HDD_OPL_HOME_COMMON;
 }
 
 int hddOplHomeIsLegacy(void)
 {
+    if (hddOplHomePending >= 0 || hddOplHomeCommitted >= 0)
+        return 0;
     return gOPLPart[0] != '\0' && strcmp(gOPLPart, "hdd0:__common") != 0 &&
            strcmp(gOPLPart, "hdd0:+OPL") != 0;
 }
@@ -1027,6 +1048,63 @@ int hddStageOplHomeSelection(int selection)
     return 1;
 }
 
+int hddOplHomeSelectionNeedsTargetSave(void)
+{
+    int selection = hddGetOplHomeSelection();
+
+    if (hddOplHomePending < 0 && hddOplHomeCommitted < 0)
+        return 0;
+
+    return selection == HDD_OPL_HOME_PLUS ? strcmp(gOPLPart, "hdd0:+OPL") != 0 : strcmp(gOPLPart, "hdd0:__common") != 0;
+}
+
+int hddMountSelectedOplHome(char *prefix, int prefixLen)
+{
+    const char *partition;
+    const char *selectedPrefix;
+    int selection;
+    int n;
+
+    if (prefix == NULL || prefixLen <= 0)
+        return 0;
+    prefix[0] = '\0';
+
+    selection = hddGetOplHomeSelection();
+    if (hddOplHomePending < 0 && hddOplHomeCommitted < 0)
+        return 0;
+    if (!hddModulesAreLoaded() || !hddLoadCoreSupportModules())
+        return 0;
+
+    partition = selection == HDD_OPL_HOME_PLUS ? "hdd0:+OPL" : "hdd0:__common";
+    fileXioUmount("pfs1:");
+    if (fileXioMount("pfs1:", partition, FIO_MT_RDWR) < 0)
+        return 0;
+
+    if (selection == HDD_OPL_HOME_COMMON) {
+        if (!hddCheckOPLFolder("pfs1:")) {
+            fileXioUmount("pfs1:");
+            return 0;
+        }
+        selectedPrefix = "pfs1:OPL/";
+    } else {
+        selectedPrefix = "pfs1:";
+    }
+
+    n = snprintf(prefix, prefixLen, "%s", selectedPrefix);
+    if (n < 0 || n >= prefixLen) {
+        fileXioUmount("pfs1:");
+        prefix[0] = '\0';
+        return 0;
+    }
+
+    return 1;
+}
+
+void hddUnmountSelectedOplHome(void)
+{
+    fileXioUmount("pfs1:");
+}
+
 int hddCommitOplHomeSelection(void)
 {
     config_set_t *config = NULL;
@@ -1047,6 +1125,7 @@ int hddCommitOplHomeSelection(void)
         return 0;
     if (hddOplHomePending == HDD_OPL_HOME_PLUS && hddOplHomeAutoPlus &&
         !strcmp(gOPLPart, "hdd0:+OPL") && gHDDPrefix != NULL) {
+        hddOplHomeCommitted = hddOplHomePending;
         hddOplHomePending = -1;
         return 1;
     }
@@ -1086,8 +1165,10 @@ int hddCommitOplHomeSelection(void)
     }
 
     fileXioUmount("pfs1:");
-    if (result)
+    if (result) {
+        hddOplHomeCommitted = hddOplHomePending;
         hddOplHomePending = -1;
+    }
     return result;
 }
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -40,6 +40,19 @@ static unsigned char hddSupportModulesLoaded = 0;
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
+// A Settings selection is deliberately staged until Save Settings. It never changes the active
+// pfs0: mount: a live OPL data home can have artwork/config readers using it.
+static int hddOplHomePending = -1;
+
+static void hddClearRecoveredErrors(void)
+{
+    // Do not blank an unrelated queued notification. These are the only messages emitted by this
+    // support path, and each call is made only after the underlying APA/PFS check succeeded.
+    clearErrorMessageIf(_STR_HDD_NOT_CONNECTED_ERROR);
+    clearErrorMessageIf(_STR_HDD_NOT_FORMATTED_ERROR);
+    clearErrorMessageIf(_STR_HDD_UNAVAILABLE_ERROR);
+    clearErrorMessageIf(_STR_HDD_PFS_UNAVAILABLE_ERROR);
+}
 
 static char *hddPrefix = "pfs0:";
 static hdl_games_list_t hddGames;
@@ -370,7 +383,10 @@ int hddDetectNonSonyFileSystem()
     return result;
 }
 
-void hddLoadSupportModules(void)
+// Bring up only the APA/PFS support needed for a read-only pfs1: probe. This intentionally does
+// not discover, mount, or create the persistent pfs0: OPL data home: Settings uses it to validate
+// an already-existing selector target without changing the live data-home state.
+static int hddLoadCoreSupportModules(void)
 {
     static char hddarg[] = "-o"
                            "\0"
@@ -414,9 +430,12 @@ void hddLoadSupportModules(void)
             setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_NOT_DETECTED);
             hddSupportErrToasted = 1;
         } else if (nonSony > 0) {
-            hddSupportErrToasted = 0; // probe SUCCEEDED (genuine MBR/GPT) -- a future failure is new news
+            // A recognized MBR/GPT/exFAT disk is normal BDM territory, not an APA formatting
+            // failure. It also proves a prior transient APA probe error is stale.
+            hddSupportErrToasted = 0;
+            hddClearRecoveredErrors();
         }
-        return;
+        return 0;
     }
 
     if (!hddSupportModulesLoaded) {
@@ -428,34 +447,65 @@ void hddLoadSupportModules(void)
                 setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_MODULE_HDD_FAILURE);
                 hddSupportErrToasted = 1;
             }
-            return;
+            return 0;
         }
 
-        // Check if a HDD unit is connected.
-        if (hddCheck() < 0) {
+        // hddCheck distinguishes a connected formatted APA disk (0), a genuinely unformatted one
+        // (1), an unusable drive (2), and no usable drive (<0). Only status 1 earns the specific
+        // "not formatted" wording; a PFS module/load or selected-data-home problem is not proof of
+        // that condition.
+        ret = hddCheck();
+        if (ret < 0) {
             LOG("HDD: No HardDisk Drive detected.\n");
             if (!hddSupportErrToasted) {
                 setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_NOT_DETECTED);
                 hddSupportErrToasted = 1;
             }
-            return;
+            return 0;
+        }
+        if (ret == 1) {
+            LOG("HDD: APA status reports an unformatted drive.\n");
+            if (!hddSupportErrToasted) {
+                setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
+                hddSupportErrToasted = 1;
+            }
+            return 0;
+        }
+        if (ret == 2) {
+            LOG("HDD: APA status reports an unavailable drive.\n");
+            if (!hddSupportErrToasted) {
+                setErrorMessageWithCode(_STR_HDD_UNAVAILABLE_ERROR, ERROR_HDD_NOT_DETECTED);
+                hddSupportErrToasted = 1;
+            }
+            return 0;
         }
 
         LOG("[PS2FS]:\n");
         ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
-            LOG("HDD: HardDisk Drive not formatted (PFS).\n");
+            LOG("HDD: PFS support module failed to load.\n");
             if (!hddSupportErrToasted) {
-                setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
+                setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
                 hddSupportErrToasted = 1;
             }
-            return;
+            return 0;
         }
 
         hddSupportModulesLoaded = 1;
         hddSupportErrToasted = 0;
+        hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
     }
+
+    return 1;
+}
+
+void hddLoadSupportModules(void)
+{
+    int ret;
+
+    if (!hddLoadCoreSupportModules())
+        return;
 
     // The modules and the persistent pfs0: data mount have separate lifetimes. If an
     // existing partition was temporarily unavailable, keep the modules loaded and retry
@@ -467,10 +517,10 @@ void hddLoadSupportModules(void)
         hddFindOPLPartition();
 
     if (gOPLPart[0] == '\0') {
-        if (!hddSupportErrToasted) {
-            setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
-            hddSupportErrToasted = 1;
-        }
+        // HDL/VCD enumeration can still work without a persistent OPL data home. A missing or
+        // stale redirect is not evidence that the APA disk is unformatted, so retry discovery
+        // later without poisoning the user with a false formatting warning.
+        hddSupportErrToasted = 0;
         return;
     }
 
@@ -492,14 +542,12 @@ void hddLoadSupportModules(void)
         // Force the next call to rediscover. This does not unload/reload the APA/PFS modules.
         gOPLPart[0] = '\0';
         gHDDPrefix = NULL;
-        if (!hddSupportErrToasted) {
-            setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
-            hddSupportErrToasted = 1;
-        }
+        hddSupportErrToasted = 0;
         return;
     }
 
     hddSupportErrToasted = 0;
+    hddClearRecoveredErrors();
     if (!strcmp(gOPLPart, "hdd0:__common")) {
         hddCheckOPLFolder(hddPrefix);
         gHDDPrefix = "pfs0:OPL/";
@@ -896,6 +944,115 @@ static void hddDeleteGame(item_list_t *itemList, int id)
         return; // stale id in the VCD->ISO toggle window -> don't delete a wrong/OOB HDL partition
     hddDeleteHDLGame(game);
     hddForceUpdate = 1;
+}
+
+// Settings probes use pfs1:, never pfs0:. The latter is the persistent OPL data-home mount and
+// remounting it under live readers is both unsafe and unnecessary just to prove an APA partition
+// already exists.
+static int hddPartitionMountableAt(const char *mountPoint, const char *partition, int flags)
+{
+    int ret;
+
+    fileXioUmount(mountPoint);
+    ret = fileXioMount(mountPoint, partition, flags);
+    if (ret == 0)
+        fileXioUmount(mountPoint);
+
+    return ret == 0;
+}
+
+int hddGetOplHomeSelection(void)
+{
+    if (hddOplHomePending >= 0)
+        return hddOplHomePending;
+    return strcmp(gOPLPart, "hdd0:+OPL") == 0 ? HDD_OPL_HOME_PLUS : HDD_OPL_HOME_COMMON;
+}
+
+int hddOplHomeIsLegacy(void)
+{
+    return gOPLPart[0] != '\0' && strcmp(gOPLPart, "hdd0:__common") != 0 &&
+           strcmp(gOPLPart, "hdd0:+OPL") != 0;
+}
+
+int hddOplHomeSelectionPending(void)
+{
+    return hddOplHomePending >= 0;
+}
+
+void hddDiscardOplHomeSelection(void)
+{
+    hddOplHomePending = -1;
+}
+
+int hddStageOplHomeSelection(int selection)
+{
+    const char *partition;
+
+    if (selection != HDD_OPL_HOME_COMMON && selection != HDD_OPL_HOME_PLUS)
+        return 0;
+
+    // Bring up only the APA/PFS drivers. Do not call hddLoadSupportModules here: its normal data
+    // home recovery may mount pfs0: and create OPL folders, neither of which belongs to a source
+    // selector proof.
+    if (!hddLoadModulesReady())
+        return 0;
+    if (!hddLoadCoreSupportModules())
+        return 0;
+
+    partition = selection == HDD_OPL_HOME_PLUS ? "hdd0:+OPL" : "hdd0:__common";
+    if (!hddPartitionMountableAt("pfs1:", partition, FIO_MT_RDONLY))
+        return 0;
+
+    hddOplHomePending = selection;
+    return 1;
+}
+
+int hddCommitOplHomeSelection(void)
+{
+    config_set_t *config;
+    const char *path = "pfs1:OPL/conf_hdd.cfg";
+    int fd;
+    int exists;
+    int result = 0;
+
+    if (hddOplHomePending < 0)
+        return 1;
+
+    // Re-prove the common owner at commit time. No raw APA operation, partition creation, or pfs0:
+    // remount is involved; this is only a bounded pfs1: read/write mount of an existing partition.
+    if (!hddLoadModulesReady())
+        return 0;
+    if (!hddLoadCoreSupportModules() || !hddPartitionMountableAt("pfs1:", "hdd0:__common", FIO_MT_RDWR))
+        return 0;
+
+    if (fileXioMount("pfs1:", "hdd0:__common", FIO_MT_RDWR) < 0)
+        return 0;
+
+    fd = open(path, O_RDONLY);
+    exists = fd >= 0;
+    if (fd >= 0)
+        close(fd);
+
+    config = configAlloc(0, NULL, (char *)path);
+    if (config != NULL) {
+        // A present-but-unreadable file is user data, not an invitation to replace it with a new
+        // selector. A missing file is the normal common-home default and can be born only for an
+        // explicit +OPL choice.
+        if (!exists || configRead(config)) {
+            if (hddOplHomePending == HDD_OPL_HOME_PLUS)
+                configSetStr(config, "hdd_partition", "+OPL");
+            else
+                configRemoveKey(config, "hdd_partition");
+
+            result = configWrite(config) > 0;
+        }
+        configFree(config);
+    }
+
+    fileXioUmount("pfs1:");
+    if (result)
+        hddOplHomePending = -1;
+    return result;
 }
 
 // A PP.<DISC-ID>.POPS.<title> VCD is the APA/PFS partition itself, not a loose .VCD file. Preserve

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -898,10 +898,75 @@ static void hddDeleteGame(item_list_t *itemList, int id)
     hddForceUpdate = 1;
 }
 
+// A PP.<DISC-ID>.POPS.<title> VCD is the APA/PFS partition itself, not a loose .VCD file. Preserve
+// the strict POPSTARTER prefix and replace only its title component; the next VCD scan then resolves
+// the new literal partition label for the handoff selector.
+static int hddRenamePopsPartition(const char *part, const char *newName)
+{
+    char oldPath[APA_IDMAX + 6];
+    char newPart[APA_IDMAX + 1];
+    char newPath[APA_IDMAX + 6];
+    int titleOfs;
+    int n;
+
+    if (part == NULL || newName == NULL || newName[0] == '\0' || strpbrk(newName, ":/\\") != NULL)
+        return -1;
+    titleOfs = vcdPopsPartitionTitleOffset(part);
+    if (titleOfs <= 0)
+        return -1;
+
+    n = snprintf(newPart, sizeof(newPart), "%.*s%s", titleOfs, part, newName);
+    if (n < 0 || n > APA_IDMAX)
+        return -1; // an APA label cannot grow past its on-disk field
+    snprintf(oldPath, sizeof(oldPath), "hdd0:%s", part);
+    snprintf(newPath, sizeof(newPath), "hdd0:%s", newPart);
+    return fileXioRename(oldPath, newPath);
+}
+
+static void hddRenameVcd(int id, const char *newName)
+{
+    char oldName[VCD_NAME_MAX];
+    char part[APA_IDMAX + 1];
+    int renamed = 0;
+
+    // The list builder owns pfs1: and the backing arrays on the IO worker. Block it before copying
+    // the selected storage identity and before temporarily mounting a pooled POPS partition RW.
+    ioBlockOps(1);
+    if (hddVcdGames != NULL && hddVcdParts != NULL && id >= 0 && id < hddVcdGameCount) {
+        snprintf(oldName, sizeof(oldName), "%s", hddVcdGames[id].name);
+        snprintf(part, sizeof(part), "%s", hddVcdParts[id]);
+
+        if (vcdPopsPartitionTitleOffset(part) > 0) {
+            // One-game PP.* POPS installs boot from their partition label, so a file rename would
+            // change nothing. Rename the APA record while retaining its required prefix instead.
+            renamed = (hddRenamePopsPartition(part, newName) == 0);
+        } else {
+            char mountSrc[APA_IDMAX + 6];
+
+            snprintf(mountSrc, sizeof(mountSrc), "hdd0:%s", part);
+            fileXioUmount("pfs1:");
+            if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDWR) == 0) {
+                renamed = (vcdRenameFileInDir("pfs1:/", oldName, newName) == 0);
+                fileXioUmount("pfs1:");
+            }
+        }
+    }
+    ioBlockOps(0);
+
+    if (renamed) {
+        // vcdRenameFileInDir already clears this for a loose file; doing it again keeps the
+        // partition-label path identical and is harmless.
+        vcdInvalidateGameIds();
+        hddVcdInvalidateCache();
+    }
+}
+
 static void hddRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (vcdListViewActive(itemList))
-        return; // a VCD is not an HDL partition -- no rename in VCD view
+    if (vcdListViewActive(itemList)) {
+        hddRenameVcd(id, newName);
+        return;
+    }
     hdl_game_info_t *game = hddActiveHdl(id);
     if (game == &hddEmptyHdl)
         return; // stale id in the VCD->ISO toggle window -> don't rename a wrong/OOB HDL partition

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -306,6 +306,11 @@ int hddLoadModules(void)
     return retStatus;
 }
 
+int hddModulesAreLoaded(void)
+{
+    return hddModulesLoaded != 0;
+}
+
 // Validate an APA header sector without ps2hdd: the "APA" magic plus the header checksum
 // (sum of the 127 little-endian words after the checksum word itself, per ps2sdk apaCheckSum).
 static int hddApaHeaderValid(const u8 *pSectorData)
@@ -991,10 +996,11 @@ int hddStageOplHomeSelection(int selection)
     if (selection != HDD_OPL_HOME_COMMON && selection != HDD_OPL_HOME_PLUS)
         return 0;
 
-    // Bring up only the APA/PFS drivers. Do not call hddLoadSupportModules here: its normal data
-    // home recovery may mount pfs0: and create OPL folders, neither of which belongs to a source
-    // selector proof.
-    if (!hddLoadModulesReady())
+    // Use only the already-resident ATA stack. The selector is a short-lived proof, not an owner
+    // of a module reference; hddLoadModulesReady() would retain one on every stage/save cycle.
+    // Do not call hddLoadSupportModules here: its normal data-home recovery may mount pfs0: and
+    // create OPL folders, neither of which belongs to a source selector proof.
+    if (!hddModulesAreLoaded())
         return 0;
     if (!hddLoadCoreSupportModules())
         return 0;
@@ -1009,7 +1015,7 @@ int hddStageOplHomeSelection(int selection)
 
 int hddCommitOplHomeSelection(void)
 {
-    config_set_t *config;
+    config_set_t *config = NULL;
     const char *path = "pfs1:OPL/conf_hdd.cfg";
     int fd;
     int exists;
@@ -1020,7 +1026,7 @@ int hddCommitOplHomeSelection(void)
 
     // Re-prove the common owner at commit time. No raw APA operation, partition creation, or pfs0:
     // remount is involved; this is only a bounded pfs1: read/write mount of an existing partition.
-    if (!hddLoadModulesReady())
+    if (!hddModulesAreLoaded())
         return 0;
     if (!hddLoadCoreSupportModules() || !hddPartitionMountableAt("pfs1:", "hdd0:__common", FIO_MT_RDWR))
         return 0;
@@ -1033,7 +1039,12 @@ int hddCommitOplHomeSelection(void)
     if (fd >= 0)
         close(fd);
 
-    config = configAlloc(0, NULL, (char *)path);
+    // A missing selector already means __common/OPL/. Keep that default fileless; only an
+    // explicit +OPL selection needs to materialize conf_hdd.cfg.
+    if (!exists && hddOplHomePending == HDD_OPL_HOME_COMMON)
+        result = 1;
+    else
+        config = configAlloc(0, NULL, (char *)path);
     if (config != NULL) {
         // A present-but-unreadable file is user data, not an invitation to replace it with a new
         // selector. A missing file is the normal common-home default and can be born only for an
@@ -1199,8 +1210,11 @@ static void hddDoLaunchVcd(item_list_t *itemList, const char *name, const char *
     // reported success. Note cacheAbortMmce* only covers SIO2 requests, so the second call (which
     // covers ALL of them) is the one that matters here and its result is the one worth honouring.
     cacheAbortMmceImageLoadsTimed(HDD_ART_QUIESCE_MS);
-    if (!cacheCancelPendingImageLoadsTimed(HDD_ART_QUIESCE_MS))
-        LOG("HDD VCD: art did not quiesce before the pfs0: remount\n");
+    if (!cacheCancelPendingImageLoadsTimed(HDD_ART_QUIESCE_MS)) {
+        LOG("HDD VCD: art did not quiesce; refusing the pfs0: remount\n");
+        guiMsgBox(_l(_STR_PLEASE_WAIT), 0, NULL);
+        return;
+    }
     ioBlockOps(1);
     if (!hddResolveHddPopstarter(vcdElf, sizeof(vcdElf))) {
         ioBlockOps(0); // resolver already restored pfs0: to the OPL data partition on failure

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -43,6 +43,9 @@ static unsigned char hddSupportErrToasted = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
+// +OPL can be the existing automatic home only when __common was unavailable during discovery.
+// Keep that distinct from an explicit conf_hdd.cfg redirect, which may fall back to __common.
+static unsigned char hddOplHomeAutoPlus = 0;
 
 static void hddClearRecoveredErrors(void)
 {
@@ -176,9 +179,10 @@ static void hddFindOPLPartition(void)
     char candidate[sizeof(gOPLPart)];
     const char *label;
 
-    // __common/OPL/conf_hdd.cfg is the one authoritative APA data-home selector. Honour it
-    // only when it names an existing mountable hdd0 PFS partition; discovery never manufactures
-    // a partition, resizes one, or writes raw hdd0: metadata.
+    // When __common is usable, its OPL/conf_hdd.cfg is the authoritative APA data-home selector.
+    // If __common itself is unavailable, an existing mountable +OPL is the legacy automatic home.
+    // Discovery never manufactures a partition, resizes one, or writes raw hdd0: metadata.
+    hddOplHomeAutoPlus = 0;
     fileXioUmount(hddPrefix);
     if (fileXioMount(hddPrefix, "hdd0:__common", FIO_MT_RDONLY) == 0) {
         config = configAlloc(0, NULL, "pfs0:OPL/conf_hdd.cfg");
@@ -215,13 +219,21 @@ static void hddFindOPLPartition(void)
             }
             LOG("HDD: configured data partition %s is unavailable; ignoring it\n", name);
         }
-    }
 
-    // A missing, stale, or invalid redirect falls back only to __common/OPL. The presence of
-    // +OPL alone is intentionally not an ownership decision.
-    if (hddPartitionMountable("hdd0:__common")) {
+        // The successful __common mount above is already the proof required for the default.
+        // Do not remount it merely to rediscover the same topology.
         snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:__common");
         LOG("HDD: no usable configured data partition; using canonical __common/OPL/ fallback\n");
+        return;
+    }
+
+    // Official OPL's existing +OPL layout remains valid when a drive has no usable __common.
+    // It is an automatic effective choice, not a request to create conf_hdd.cfg or a new APA
+    // partition. +OPL owns its PFS root directly, so the mounted data prefix is pfs0:.
+    if (hddPartitionMountable("hdd0:+OPL")) {
+        snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:+OPL");
+        hddOplHomeAutoPlus = 1;
+        LOG("HDD: __common unavailable; using existing +OPL data-home fallback\n");
         return;
     }
 
@@ -533,8 +545,10 @@ void hddLoadSupportModules(void)
     ret = fileXioMount(hddPrefix, gOPLPart, FIO_MT_RDWR);
 
     // A configured data partition may disappear or cease to mount. Never respond by
-    // creating/reformatting APA metadata. Fall back to the existing __common partition only.
-    if (ret < 0 && strcmp(gOPLPart, "hdd0:__common") != 0) {
+    // creating/reformatting APA metadata. An automatic +OPL home was chosen because __common
+    // was unavailable, so fail closed rather than probing it again. An explicit redirect keeps
+    // the established existing-__common fallback.
+    if (ret < 0 && strcmp(gOPLPart, "hdd0:__common") != 0 && !hddOplHomeAutoPlus) {
         LOG("HDD: could not mount %s (%d); trying existing __common/OPL/ fallback\n", gOPLPart, ret);
         fileXioUmount(hddPrefix);
         ret = fileXioMount(hddPrefix, "hdd0:__common", FIO_MT_RDWR);
@@ -1024,11 +1038,22 @@ int hddCommitOplHomeSelection(void)
     if (hddOplHomePending < 0)
         return 1;
 
-    // Re-prove the common owner at commit time. No raw APA operation, partition creation, or pfs0:
-    // remount is involved; this is only a bounded pfs1: read/write mount of an existing partition.
+    // An automatic +OPL home has no __common control file. The active pfs0: mount proves the
+    // staged effective choice, so commit it as a fileless no-op without probing or writing
+    // __common. This preserves the no-__common topology across ordinary Settings saves.
     if (!hddModulesAreLoaded())
         return 0;
-    if (!hddLoadCoreSupportModules() || !hddPartitionMountableAt("pfs1:", "hdd0:__common", FIO_MT_RDWR))
+    if (!hddLoadCoreSupportModules())
+        return 0;
+    if (hddOplHomePending == HDD_OPL_HOME_PLUS && hddOplHomeAutoPlus &&
+        !strcmp(gOPLPart, "hdd0:+OPL") && gHDDPrefix != NULL) {
+        hddOplHomePending = -1;
+        return 1;
+    }
+
+    // Re-prove the common owner at commit time. No raw APA operation, partition creation, or pfs0:
+    // remount is involved; this is only a bounded pfs1: read/write mount of an existing partition.
+    if (!hddPartitionMountableAt("pfs1:", "hdd0:__common", FIO_MT_RDWR))
         return 0;
 
     if (fileXioMount("pfs1:", "hdd0:__common", FIO_MT_RDWR) < 0)

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -83,9 +83,9 @@ static void hddInitModules(void)
     snprintf(path, sizeof(path), "%sLNG", gHDDPrefix);
     lngAddLanguages(path, "/", hddGameList.mode);
 
-    // Create normal OPL folders only INSIDE the selected mounted PFS data home. For +OPL this
-    // is pfs0:; for the safe __common fallback it is pfs0:OPL/. Never spray OPL folders into
-    // the root of __common and never create an APA partition to obtain a home.
+    // Create normal OPL folders only inside the selected mounted PFS data home. A configured
+    // existing APA partition owns its root; the canonical __common fallback owns __common/OPL/.
+    // Never create an APA partition to obtain a home.
     sbCreateFolders(gHDDPrefix, 0);
 }
 
@@ -161,11 +161,13 @@ static void hddFindOPLPartition(void)
     config_set_t *config;
     char name[64] = {0};
     char candidate[sizeof(gOPLPart)];
+    const char *label;
 
-    // First honour an existing __common/OPL/conf_hdd.cfg, but only when the named
-    // partition already exists and mounts as PFS. Discovery must never manufacture it.
+    // __common/OPL/conf_hdd.cfg is the one authoritative APA data-home selector. Honour it
+    // only when it names an existing mountable hdd0 PFS partition; discovery never manufactures
+    // a partition, resizes one, or writes raw hdd0: metadata.
     fileXioUmount(hddPrefix);
-    if (fileXioMount(hddPrefix, "hdd0:__common", FIO_MT_RDWR) == 0) {
+    if (fileXioMount(hddPrefix, "hdd0:__common", FIO_MT_RDONLY) == 0) {
         config = configAlloc(0, NULL, "pfs0:OPL/conf_hdd.cfg");
         if (config != NULL) {
             if (configRead(config))
@@ -175,14 +177,23 @@ static void hddFindOPLPartition(void)
         fileXioUmount(hddPrefix);
 
         if (name[0] != '\0') {
-            // conf_hdd.cfg historically stores a bare APA ID (for example +OPL).
-            // Accept hdd0:<id> too, but never redirect data ownership to hdd1 here.
+            // The historical value is a bare APA ID (for example +OPL). Accept an hdd0:
+            // spelling too, but never silently redirect this drive's owner to hdd1.
             if (!strncmp(name, "hdd0:", 5))
-                snprintf(candidate, sizeof(candidate), "%s", name);
+                label = name + 5;
             else if (!strncmp(name, "hdd", 3))
+                label = NULL;
+            else
+                label = name;
+
+            // conf_hdd.cfg names one APA partition label, not a raw hdd device or a PFS path.
+            // Reject delimiters and an empty/oversized label before passing anything to the mount
+            // RPC, so an invalid redirect can only select the documented __common fallback.
+            if (label == NULL || label[0] == '\0' || strlen(label) > APA_IDMAX ||
+                strpbrk(label, ":/\\") != NULL)
                 candidate[0] = '\0';
             else
-                snprintf(candidate, sizeof(candidate), "hdd0:%s", name);
+                snprintf(candidate, sizeof(candidate), "hdd0:%s", label);
 
             if (candidate[0] != '\0' && hddPartitionMountable(candidate)) {
                 snprintf(gOPLPart, sizeof(gOPLPart), "%s", candidate);
@@ -193,11 +204,8 @@ static void hddFindOPLPartition(void)
         }
     }
 
-    // No usable configured target: __common/OPL is the canonical safe HDD home.
-    // Do NOT opportunistically select +OPL merely because it exists. A +OPL (or any other
-    // partition) is used only when __common/OPL/conf_hdd.cfg explicitly points to it.
-    // This keeps ownership deterministic and guarantees that discovery never needs to
-    // manufacture an APA partition just to obtain a writable config/data home.
+    // A missing, stale, or invalid redirect falls back only to __common/OPL. The presence of
+    // +OPL alone is intentionally not an ownership decision.
     if (hddPartitionMountable("hdd0:__common")) {
         snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:__common");
         LOG("HDD: no usable configured data partition; using canonical __common/OPL/ fallback\n");
@@ -492,7 +500,7 @@ void hddLoadSupportModules(void)
     }
 
     hddSupportErrToasted = 0;
-    if (gOPLPart[5] != '+') {
+    if (!strcmp(gOPLPart, "hdd0:__common")) {
         hddCheckOPLFolder(hddPrefix);
         gHDDPrefix = "pfs0:OPL/";
     } else {
@@ -912,27 +920,23 @@ static int hddFindVcdByName(const char *vcdName)
     return -1;
 }
 
-// Resolve POPSTARTER.ELF for an HDD VCD launch: search hdd0:__common then hdd0:+OPL, each at its ROOT
-// /POPS/ (NOT the OPL/POPS/ data subfolder). On success returns 1 with elfOut = "pfs0:/POPS/POPSTARTER.ELF"
+// Resolve POPSTARTER.ELF for an HDD VCD launch from hdd0:__common/POPS/ only. APA VCD data can live
+// in its normal __.POPS / PP.* partitions and OPL data can be redirected elsewhere, but loose
+// POPS/POPSTARTER support payloads are always owned by __common. On success returns 1 with
+// elfOut = "pfs0:/POPS/POPSTARTER.ELF"
 // and LEAVES pfs0: mounted on that partition so the caller can load the ELF from it; on failure returns 0
 // with pfs0: restored to the OPL data partition. The CALLER must quiesce the art + IO workers first --
 // this remounts the single pfs0: slot, and umounting it under a live cover read is the HDD-freeze hazard.
 static int hddResolveHddPopstarter(char *elfOut, int elfLen)
 {
-    static const char *cands[2] = {"hdd0:__common", "hdd0:+OPL"};
-
-    for (int i = 0; i < 2; i++) {
-        fileXioUmount(hddPrefix);
-        if (fileXioMount(hddPrefix, cands[i], FIO_MT_RDONLY) < 0)
-            continue; // partition absent / unmountable -> try the next
-        // The APA contract is hdd0:__common/POPS/ (with +OPL retained as the existing fallback).
-        // Install directly from whichever candidate is mounted before checking its POPSTARTER.ELF.
+    fileXioUmount(hddPrefix);
+    if (fileXioMount(hddPrefix, "hdd0:__common", FIO_MT_RDONLY) == 0) {
         (void)vcdInstallPopstarterMc("pfs0:/");
         int fd = open("pfs0:/POPS/POPSTARTER.ELF", O_RDONLY);
         if (fd >= 0) {
             close(fd);
             snprintf(elfOut, elfLen, "pfs0:/POPS/POPSTARTER.ELF");
-            return 1; // keep pfs0: on this partition for the ELF load
+            return 1; // keep pfs0: on __common for the ELF load
         }
     }
 

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -607,6 +607,18 @@ void menuInitAppMenu(void)
     appMenuCurrent = appMenu;
 }
 
+void menuInitVcdMenu(void)
+{
+    if (appMenu)
+        submenuDestroy(&appMenu);
+
+    // VCDs launch through POPSTARTER, not OPL's PS2 loader/core. Keep their Triangle menu on this
+    // item-operation path so merely opening it cannot create or read a per-game CFG.
+    submenuAppendItem(&appMenu, -1, NULL, 0, _STR_RENAME);
+
+    appMenuCurrent = appMenu;
+}
+
 // -------------------------------------------------------------------------------------------
 // ---------------------------------------- Menu manipulation --------------------------------
 // -------------------------------------------------------------------------------------------

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -28,7 +28,8 @@
 
 enum MENU_IDs {
     MENU_SETTINGS = 0,
-    MENU_TOOLS,
+    MENU_NETWORK_UPDATE,
+    MENU_NBD,
     MENU_ABOUT,
     MENU_SAVE_CHANGES,
     MENU_EXIT,
@@ -556,7 +557,8 @@ static void menuInitMainMenu(void)
     // initialize the menu
     submenuAppendItem(&mainMenu, -1, NULL, MENU_LAUNCH_PS2_DISC, _STR_LAUNCH_PS2_DISC);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_SETTINGS, _STR_SETTINGS);
-    submenuAppendItem(&mainMenu, -1, NULL, MENU_TOOLS, _STR_TOOLS);
+    submenuAppendItem(&mainMenu, -1, NULL, MENU_NETWORK_UPDATE, _STR_NET_UPDATE);
+    submenuAppendItem(&mainMenu, -1, NULL, MENU_NBD, _STR_STARTNBD);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_ABOUT, _STR_ABOUT);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_EXIT, _STR_EXIT);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_POWER_OFF, _STR_POWEROFF);
@@ -1316,9 +1318,12 @@ void menuHandleInputMenu()
         } else if (id == MENU_SETTINGS) {
             if (menuCheckParentalLock() == 0)
                 guiShowSettings();
-        } else if (id == MENU_TOOLS) {
+        } else if (id == MENU_NETWORK_UPDATE) {
             if (menuCheckParentalLock() == 0)
-                guiShowToolsConfig();
+                guiShowNetCompatUpdate();
+        } else if (id == MENU_NBD) {
+            if (menuCheckParentalLock() == 0)
+                handleLwnbdSrv();
         } else if (id == MENU_ABOUT) {
             guiShowAbout();
         } else if (id == MENU_SAVE_CHANGES) {

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -682,8 +682,21 @@ static void mmceDeleteGame(item_list_t *itemList, int id)
 
 static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (vcdViewActive(itemList->mode))
-        return; // #120: no rename in VCD view
+    if (vcdViewActive(itemList->mode)) {
+        base_game_info_t *game = mmceActiveGame(itemList, id);
+
+        if (game == &mmceEmptyGame)
+            return; // stale id in the VCD->ISO toggle window
+        if (vcdRenameFile(mmcePrefix, game->name, newName) == 0) {
+            // MMCE normally latches a successful VCD scan under NOUPDATE. Re-arm its normal scan
+            // path so the deferred menu update publishes the new filename immediately.
+            mmceVcdScanned = 0;
+            mmceVcdScanFailed = 0;
+            mmceVcdScanRetries = 0;
+            mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
+        }
+        return;
+    }
     if (mmceActiveGame(itemList, id) == &mmceEmptyGame)
         return;                                   // stale id in the VCD->ISO toggle window (see mmceDeleteGame) -> avoid sbRename OOB
     sbSetBrowseSub(folderGetSub(itemList->mode)); // rename inside the current subfolder, not the root

--- a/src/opl.c
+++ b/src/opl.c
@@ -1808,9 +1808,11 @@ static int prepareCustomSettingsPath(char *path, int pathLen)
 // Last-resort READ-ONLY discovery for a missing/stale config.path. This exists to recover the
 // chicken-and-egg custom-settings value from an already-existing config; it never creates a config,
 // never changes APA metadata, and never makes an arbitrary discovered device the permanent save home.
-// A known local boot self-migrates the loaded in-memory sets back to its normal boot home; if the
-// recovered config contains Custom Settings Path, _saveConfig will honor it and regenerate config.path
-// on the user's next explicit Save Changes.
+// A known non-MC local boot self-migrates the loaded in-memory sets back to its normal boot home. A
+// concrete MC boot preserves the same-card directory it recovered, so its first save cannot relocate
+// an already-working MC1 configuration to the card root or the other slot. If the recovered config
+// contains Custom Settings Path, _saveConfig will honor it and regenerate config.path on the user's
+// next explicit Save Changes.
 static int tryReadRecoveryConfigHome(int types, const char *home)
 {
     DIR *dir = opendir(home);
@@ -1826,10 +1828,19 @@ static int tryReadRecoveryConfigHome(int types, const char *home)
     return value;
 }
 
+static int sameConcreteMcSlot(const char *first, const char *second)
+{
+    return first != NULL && second != NULL &&
+           !strncmp(first, "mc", 2) && !strncmp(second, "mc", 2) &&
+           (first[2] == '0' || first[2] == '1') && first[3] == ':' &&
+           first[2] == second[2] && second[3] == ':';
+}
+
 static void restoreRecoverySaveHome(const char *recoveredHome)
 {
-    // Recovery is discovery only and never writes by itself. Known local boots return to their
-    // real boot home; a bare launch has no independent owner, so the existing config home that was
+    // Recovery is discovery only and never writes by itself. Known local boots normally return to
+    // their real boot home, but a concrete MC boot keeps the same-card directory that supplied it.
+    // A bare launch has no independent owner, so the existing config home that was
     // actually recovered becomes the next explicit-save home. A deferred network boot cannot save
     // back to its unreadable share during bootstrap, so select a concrete reachable MC home when possible.
     if (gBootHomeDeferred) {
@@ -1858,6 +1869,12 @@ static void restoreRecoverySaveHome(const char *recoveredHome)
             configSetMove((char *)mcHome);
         else
             configSetMove(NULL); // no concrete MC is reachable: keep the normal fail-visible wildcard home
+    } else if (sameConcreteMcSlot(gBootDir, recoveredHome)) {
+        // A concrete MC boot that recovered its existing settings from the same card keeps that
+        // exact directory as its save owner. In particular, a launcher that supplies only "mc1:"
+        // as the boot CWD must not move a successfully read mc1:/OPL configuration to the card
+        // root (or to mc0 when both cards are inserted).
+        configSetMove((char *)recoveredHome);
     } else if (gBootDir[0] != '\0') {
         configSetMove(gBootDir);
     } else {
@@ -2049,7 +2066,13 @@ static int tryAlternateDevice(int types)
             // already serving this config -- sysCheckMC() gated the whole branch.
             if (gBootHomeDeferred)
                 homeLeftOnCard = 1;
-            else
+            else if (sameConcreteMcSlot(gBootDir, concreteMcHome)) {
+                configSetMove(concreteMcHome); // MC legacy config remains at the exact discovered home
+                // configSetMove already made the exact MC1/MC0 home the notification/save owner.
+                // Do not overwrite that with a compact/root boot CWD below: failure reporting must
+                // name the same directory that configWriteMulti will actually use.
+                homeLeftOnCard = 1;
+            } else
                 configSetMove(gBootDir); // home (and notifications) back on the boot dir: saves self-migrate
 
             if (value & CONFIG_OPL)
@@ -4362,6 +4385,23 @@ static void autoLaunchBDMGame(char *argv[])
 }
 
 // --------------------- Main --------------------
+// Memory-card roots require an explicit slash for file creation (mc1:/FILE, not mc1:FILE).
+// Some launchers provide an equivalent compact path such as mc1:APPS/OPL.ELF or leave getcwd()
+// at mc1:. Normalize the generic device representation once, without any launcher-specific branch.
+static void normalizeMcBootDir(void)
+{
+    if (strncmp(gBootDir, "mc", 2) || (gBootDir[2] != '0' && gBootDir[2] != '1') ||
+        gBootDir[3] != ':' || gBootDir[4] == '/')
+        return;
+
+    size_t len = strlen(gBootDir);
+    if (len + 1 >= sizeof(gBootDir))
+        return;
+
+    memmove(&gBootDir[5], &gBootDir[4], len - 3);
+    gBootDir[4] = '/';
+}
+
 static void setBootDir(const char *bootPath)
 {
     gBootDir[0] = '\0';
@@ -4426,6 +4466,7 @@ int main(int argc, char *argv[])
             snprintf(gBootDir, sizeof(gBootDir), "%s", cwd);
         }
     }
+    normalizeMcBootDir();
 
     if (argc >= 5) {
         /* argv[0] boot path

--- a/src/opl.c
+++ b/src/opl.c
@@ -133,6 +133,7 @@ static clock_t lastBgRescan[MODE_COUNT];
 static unsigned int lastSeenBdmGeneration;
 
 static char errorMessage[256];
+static int errorMessageStringId = -1;
 
 static opl_io_module_t list_support[MODE_COUNT];
 
@@ -1284,6 +1285,7 @@ static void clearErrorMessage(void)
 {
     // reset the original frame hook
     frameCounter = 0;
+    errorMessageStringId = -1;
     guiSetFrameHook(&menuUpdateHook);
 }
 
@@ -1296,19 +1298,28 @@ static void errorMessageHook()
 void setErrorMessageWithCode(int strId, int error)
 {
     snprintf(errorMessage, sizeof(errorMessage), _l(strId), error);
+    errorMessageStringId = strId;
     guiSetFrameHook(&errorMessageHook);
 }
 
 void setErrorMessage(int strId)
 {
     snprintf(errorMessage, sizeof(errorMessage), _l(strId));
+    errorMessageStringId = strId;
     guiSetFrameHook(&errorMessageHook);
 }
 
 void setErrorMessagePathCode(int strId, const char *path, int error)
 {
     snprintf(errorMessage, sizeof(errorMessage), _l(strId), path ? path : "", error);
+    errorMessageStringId = strId;
     guiSetFrameHook(&errorMessageHook);
+}
+
+void clearErrorMessageIf(int strId)
+{
+    if (errorMessageStringId == strId)
+        clearErrorMessage();
 }
 
 // ----------------------------------------------------------
@@ -1456,6 +1467,45 @@ static int gBootDirBdmType = BDM_TYPE_UNKNOWN;
 // registering and therefore has no driver classification yet. This keeps a missing first-run file
 // on that explicit slot from triggering the legacy all-device recovery scan.
 static int gBootHomeBdm = 0;
+
+// The built-in themes have no theme directory. Their conventional BGM belongs to the normal OPL
+// data home, never POPS: `pfs0:OPL/THM/bgm.ogg` for __common/OPL and `pfs0:THM/bgm.ogg` for +OPL.
+// Every non-APA home is the exact RiptOPL working directory resolved at boot. Do not turn this into
+// a directory scan: a missing file is simply silence.
+int oplGetDefaultThemeBgmPath(char *path, int pathSize)
+{
+    int length;
+
+    if (path == NULL || pathSize <= 1)
+        return 0;
+
+    path[0] = '\0';
+    if (gBootHomeApa) {
+        if (gHDDPrefix == NULL || gHDDPrefix[0] == '\0')
+            return 0;
+
+        length = snprintf(path, pathSize, "%sTHM/bgm.ogg", gHDDPrefix);
+    } else {
+        size_t baseLength;
+
+        if (gBootDir[0] == '\0')
+            return 0;
+
+        baseLength = strlen(gBootDir);
+        if (gBootDir[baseLength - 1] == ':' || gBootDir[baseLength - 1] == '/' ||
+            gBootDir[baseLength - 1] == '\\')
+            length = snprintf(path, pathSize, "%sbgm.ogg", gBootDir);
+        else
+            length = snprintf(path, pathSize, "%s/bgm.ogg", gBootDir);
+    }
+
+    if (length < 0 || length >= pathSize) {
+        path[0] = '\0';
+        return 0;
+    }
+
+    return 1;
+}
 
 // When this function is called, the current device for loading/saving config is the memory card.
 // "Custom Settings Path" bootstrap.
@@ -2910,6 +2960,17 @@ static void _saveConfig()
     char temp[256];
     char customSettingsTarget[sizeof(gCustomSettingsPath)] = {0};
     int customSettingsExplicit = 0;
+
+    // The APA OPL-home picker is deliberately a separate, explicitly staged policy file under
+    // __common/OPL. Commit it only as part of the ordinary Save Settings operation; opening or
+    // saving an unrelated page cannot rewrite an existing legacy hdd_partition redirect.
+    if ((lscstatus & CONFIG_OPL) && hddOplHomeSelectionPending() && !hddCommitOplHomeSelection()) {
+        snprintf(gLastSaveTarget, sizeof(gLastSaveTarget), "%s", "hdd0:__common/OPL/conf_hdd.cfg");
+        gLastSaveErrno = EIO;
+        lscret = 0;
+        lscstatus = 0;
+        return;
+    }
 
     if (lscstatus & CONFIG_OPL) {
         config_set_t *configOPL = configGetByType(CONFIG_OPL);

--- a/src/opl.c
+++ b/src/opl.c
@@ -557,6 +557,17 @@ static void itemExecTriangle(struct menu_item *curMenu)
     item_list_t *support = curMenu->userdata;
 
     if (support) {
+        // A VCD is a POPSTARTER title, not a PS2-loader title. Route before the generic per-game
+        // settings branch: that branch loads/creates CFG state and exposes controls that can never
+        // affect a POPSTARTER handoff. vcdListViewActive also covers a forced-VCD Favourites proxy.
+        if (vcdListViewActive(support)) {
+            if (menuCheckParentalLock() == 0) {
+                menuInitVcdMenu();
+                guiSwitchScreen(GUI_SCREEN_APP_MENU);
+            }
+            return;
+        }
+
         unsigned char flags = (support->mode == FAV_MODE) ? favGetFlags(support) : support->flags;
 
         if (!(flags & MODE_FLAG_NO_COMPAT)) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -1893,8 +1893,8 @@ static int isApaSettingsPath(const char *path)
 
 // Resolve the normal safe HDD settings home after an explicit HDD path cannot be used.
 // hddLoadSupportModules owns the policy: read the existing __common/OPL/conf_hdd.cfg redirect
-// first, otherwise use __common/OPL/. It never creates or formats an APA partition. This helper
-// only accepts the resulting mounted PFS namespace.
+// first, otherwise use __common/OPL/, or an existing +OPL when __common is unavailable. It never
+// creates or formats an APA partition. This helper only accepts the resulting mounted PFS namespace.
 static int prepareHddSettingsFallback(char *path, int pathLen)
 {
     DIR *dir;
@@ -3011,9 +3011,9 @@ static void _saveConfig()
     char customSettingsTarget[sizeof(gCustomSettingsPath)] = {0};
     int customSettingsExplicit = 0;
 
-    // The APA OPL-home picker is deliberately a separate, explicitly staged policy file under
-    // __common/OPL. Commit it only as part of the ordinary Save Settings operation; opening or
-    // saving an unrelated page cannot rewrite an existing legacy hdd_partition redirect.
+    // The APA OPL-home picker is deliberately a separate, explicitly staged policy file when
+    // __common owns the selector. Commit it only as part of the ordinary Save Settings operation;
+    // an automatic existing +OPL home remains fileless and unrelated pages cannot rewrite a redirect.
     if ((lscstatus & CONFIG_OPL) && hddOplHomeSelectionPending() && !hddCommitOplHomeSelection()) {
         snprintf(gLastSaveTarget, sizeof(gLastSaveTarget), "%s", "hdd0:__common/OPL/conf_hdd.cfg");
         gLastSaveErrno = EIO;

--- a/src/opl.c
+++ b/src/opl.c
@@ -1379,6 +1379,7 @@ void clearErrorMessageIf(int strId)
 static int lscstatus = CONFIG_ALL;
 static int lscret = 0;
 static char gLastSaveTarget[sizeof(gCustomSettingsPath)];
+static int gLastSaveWasStagedOplHome = 0;
 static int gHddSettingsFallbackNotice = 0;
 static int gBootHddCommonFallback = 0;
 
@@ -3005,22 +3006,103 @@ static int configWriteChecked(int types)
     return result;
 }
 
+static const char *configFileName(const config_set_t *config)
+{
+    const char *name;
+
+    if (config == NULL || config->filename == NULL)
+        return NULL;
+
+    name = strrchr(config->filename, '/');
+    if (name != NULL)
+        return name + 1;
+    name = strrchr(config->filename, ':');
+    return name != NULL ? name + 1 : config->filename;
+}
+
+// The source picker does not remount live pfs0:. When the next boot's APA home differs from
+// the live one, persist each changed global set through pfs1: first, then let the selector commit.
+// This keeps a failed settings write from stranding the next boot on a home that never received it.
+static int saveSelectedHddOplHome(int types)
+{
+    char prefix[64];
+    char path[256];
+    int selection = hddGetOplHomeSelection();
+    int result = 1;
+
+    snprintf(gLastSaveTarget, sizeof(gLastSaveTarget), "%s",
+             selection == HDD_OPL_HOME_PLUS ? "hdd0:+OPL" : "hdd0:__common/OPL");
+    if (!hddMountSelectedOplHome(prefix, sizeof(prefix))) {
+        gLastSaveErrno = EIO;
+        return 0;
+    }
+
+    for (int bit = 1; bit < (1 << CONFIG_INDEX_COUNT); bit <<= 1) {
+        config_set_t *source;
+        config_set_t *target;
+        const char *name;
+        int n;
+
+        if (!(types & bit))
+            continue;
+
+        source = configGetByType(bit);
+        // configWrite() only materializes a set that actually changed. Preserve that normal
+        // contract so a selector-only save neither creates optional empty files nor overwrites an
+        // existing target-side config that the user did not edit this session.
+        if (source == NULL || !source->modified)
+            continue;
+
+        name = configFileName(source);
+        n = name == NULL ? -1 : snprintf(path, sizeof(path), "%s%s", prefix, name);
+        if (n < 0 || n >= (int)sizeof(path)) {
+            gLastSaveErrno = EIO;
+            result = 0;
+            break;
+        }
+
+        // Keep the live sets pointing at their pfs0: home. The target is an isolated copy that
+        // carries the live format and values, so pfs1: can be unmounted before selector commit.
+        target = configAlloc(source->type, NULL, path);
+        if (target == NULL) {
+            gLastSaveErrno = EIO;
+            result = 0;
+            break;
+        }
+        target->format = source->format;
+        configMerge(target, source);
+        target->modified = 1;
+
+        if (!configWrite(target) || target->modified) {
+            if (gLastSaveErrno == 0)
+                gLastSaveErrno = EIO;
+            result = 0;
+            configFree(target);
+            break;
+        }
+        configFree(target);
+        source->modified = 0;
+    }
+
+    hddUnmountSelectedOplHome();
+    return result;
+}
+
+static int commitSelectedHddOplHome(void)
+{
+    if (hddCommitOplHomeSelection())
+        return 1;
+
+    snprintf(gLastSaveTarget, sizeof(gLastSaveTarget), "%s", "hdd0:__common/OPL/conf_hdd.cfg");
+    gLastSaveErrno = EIO;
+    return 0;
+}
+
 static void _saveConfig()
 {
     char temp[256];
     char customSettingsTarget[sizeof(gCustomSettingsPath)] = {0};
     int customSettingsExplicit = 0;
-
-    // The APA OPL-home picker is deliberately a separate, explicitly staged policy file when
-    // __common owns the selector. Commit it only as part of the ordinary Save Settings operation;
-    // an automatic existing +OPL home remains fileless and unrelated pages cannot rewrite a redirect.
-    if ((lscstatus & CONFIG_OPL) && hddOplHomeSelectionPending() && !hddCommitOplHomeSelection()) {
-        snprintf(gLastSaveTarget, sizeof(gLastSaveTarget), "%s", "hdd0:__common/OPL/conf_hdd.cfg");
-        gLastSaveErrno = EIO;
-        lscret = 0;
-        lscstatus = 0;
-        return;
-    }
 
     if (lscstatus & CONFIG_OPL) {
         config_set_t *configOPL = configGetByType(CONFIG_OPL);
@@ -3144,6 +3226,22 @@ static void _saveConfig()
         configSetStr(configNet, CONFIG_NET_SMB_PASSW, gPCPassword);
     }
 
+    // A current APA session keeps pfs0: mounted on its original data home until restart. When the
+    // selected next-boot home differs, write only the changed sets through pfs1: and commit the
+    // selector only after that write succeeds. The normal automatic +OPL case still uses pfs0:.
+    if (gBootHomeApa && gCustomSettingsPath[0] == '\0' && hddOplHomeSelectionNeedsTargetSave()) {
+        if (!saveSelectedHddOplHome(lscstatus) ||
+            (hddOplHomeSelectionPending() && !commitSelectedHddOplHome())) {
+            lscret = 0;
+            lscstatus = 0;
+            return;
+        }
+        gLastSaveWasStagedOplHome = 1;
+        lscret = 1;
+        lscstatus = 0;
+        return;
+    }
+
     // APA launch identity is raw partition space, never a writable config filesystem. Even when
     // discovery loaded defaults or recovered settings elsewhere, an ordinary APA save without an
     // explicit Custom Settings Path must resolve the existing-PFS ownership chain NOW. This keeps
@@ -3242,6 +3340,8 @@ static void _saveConfig()
             gLastSaveErrno = EIO;
             lscret = 0;
         }
+        if (lscret > 0 && hddOplHomeSelectionPending() && !commitSelectedHddOplHome())
+            lscret = 0;
         lscstatus = 0;
         return;
     }
@@ -3275,6 +3375,8 @@ static void _saveConfig()
         if (lscret > 0)
             writeConfigPathRedirect(configGetDir());
     }
+    if (lscret > 0 && hddOplHomeSelectionPending() && !commitSelectedHddOplHome())
+        lscret = 0;
     lscstatus = 0;
 }
 
@@ -3383,6 +3485,7 @@ int saveConfig(int types, int showUI)
     // usually the 0 that produced the nonsensical "(error 0)".
     gLastSaveErrno = 0;
     gLastSaveTarget[0] = '\0';
+    gLastSaveWasStagedOplHome = 0;
     gHddSettingsFallbackNotice = 0;
 
     guiHandleDeferedIO(&lscstatus, _l(_STR_SAVING_SETTINGS), IO_CUSTOM_SIMPLEACTION, &_saveConfig, OPL_DEFERRED_IO_TIMEOUT_MS);
@@ -3390,19 +3493,20 @@ int saveConfig(int types, int showUI)
     if (showUI) {
         if (lscret) {
             char *path = configGetDir();
-            const char *displayHome = path;
-            int savedOnHddHome = path != NULL && !strncmp(path, "pfs", 3) && gOPLPart[0] != '\0';
+            const char *displayHome = gLastSaveWasStagedOplHome ? gLastSaveTarget : path;
+            int savedOnHddHome = gLastSaveWasStagedOplHome ||
+                                 (path != NULL && !strncmp(path, "pfs", 3) && gOPLPart[0] != '\0');
 
             // pfs0: is only the transient mount name. For every successful HDD save, show the
             // physical APA/PFS owner the user can actually find in a partition browser.
-            if (savedOnHddHome) {
+            if (savedOnHddHome && !gLastSaveWasStagedOplHome) {
                 if (!strcmp(gOPLPart, "hdd0:__common"))
                     displayHome = "hdd0:__common/OPL";
                 else
                     displayHome = gOPLPart;
             }
 
-            if (gHddSettingsFallbackNotice || (gBootHddCommonFallback && savedOnHddHome))
+            if (gHddSettingsFallbackNotice || (!gLastSaveWasStagedOplHome && gBootHddCommonFallback && savedOnHddHome))
                 snprintf(notification, sizeof(notification), _l(_STR_SETTINGS_HDD_FALLBACK), displayHome);
             else
                 snprintf(notification, sizeof(notification), _l(_STR_SETTINGS_SAVED), displayHome);

--- a/src/opl.c
+++ b/src/opl.c
@@ -1295,23 +1295,73 @@ static void errorMessageHook()
     clearErrorMessage();
 }
 
+// Language strings can choose the order of the supported substitutions, but are never handed to
+// printf directly. Unknown conversion sequences remain literal text instead of consuming an
+// argument that this caller did not provide.
+static void formatErrorMessage(const char *format, const char *path, int error, int allowPath, int allowError)
+{
+    char errorText[16];
+    size_t used = 0;
+
+    if (format == NULL) {
+        errorMessage[0] = '\0';
+        return;
+    }
+
+    snprintf(errorText, sizeof(errorText), "%d", error);
+    while (*format != '\0' && used < sizeof(errorMessage) - 1) {
+        const char *replacement = NULL;
+
+        if (*format != '%') {
+            errorMessage[used++] = *format++;
+            continue;
+        }
+
+        format++;
+        if (*format == '\0') {
+            errorMessage[used++] = '%';
+            break;
+        }
+        if (*format == '%') {
+            errorMessage[used++] = *format++;
+            continue;
+        }
+        if (*format == 's' && allowPath)
+            replacement = path ? path : "";
+        else if ((*format == 'd' || *format == 'i') && allowError)
+            replacement = errorText;
+
+        if (replacement != NULL) {
+            format++;
+            while (*replacement != '\0' && used < sizeof(errorMessage) - 1)
+                errorMessage[used++] = *replacement++;
+        } else {
+            errorMessage[used++] = '%';
+            if (used < sizeof(errorMessage) - 1)
+                errorMessage[used++] = *format;
+            format++;
+        }
+    }
+    errorMessage[used] = '\0';
+}
+
 void setErrorMessageWithCode(int strId, int error)
 {
-    snprintf(errorMessage, sizeof(errorMessage), _l(strId), error);
+    formatErrorMessage(_l(strId), NULL, error, 0, 1);
     errorMessageStringId = strId;
     guiSetFrameHook(&errorMessageHook);
 }
 
 void setErrorMessage(int strId)
 {
-    snprintf(errorMessage, sizeof(errorMessage), _l(strId));
+    formatErrorMessage(_l(strId), NULL, 0, 0, 0);
     errorMessageStringId = strId;
     guiSetFrameHook(&errorMessageHook);
 }
 
 void setErrorMessagePathCode(int strId, const char *path, int error)
 {
-    snprintf(errorMessage, sizeof(errorMessage), _l(strId), path ? path : "", error);
+    formatErrorMessage(_l(strId), path, error, 1, 1);
     errorMessageStringId = strId;
     guiSetFrameHook(&errorMessageHook);
 }

--- a/src/opl.c
+++ b/src/opl.c
@@ -705,6 +705,11 @@ void initSupport(item_list_t *itemList, int mode, int force_reinit)
 // (which runs on the IO thread with the menu showing; an ungated redraw would flash the boot logo).
 static int gBootInProgress = 0;
 
+int oplIsBootInProgress(void)
+{
+    return gBootInProgress;
+}
+
 static void initAllSupport(int force_reinit)
 {
     guiSetBootStatus(_l(_STR_BOOT_SCANNING_BDM));
@@ -1427,6 +1432,20 @@ static int gBootHomeDeferred = 0;
 // itself was launched from, and by discovery to prohibit an unrelated MC write fallback.
 static int gBootHomeApa = 0;
 
+// Basename of the ELF OPL was booted as (argv[0]); pairs with gBootDir. The BDM resolver uses it
+// to verify typed launch aliases and a legacy bare mass: token. An explicit massN: is already a
+// concrete slot and is identified from that slot's own ioctls instead. Empty when argv[0] had no
+// filename part or the boot dir came from getcwd().
+static char gBootElfName[64];
+// BDM_TYPE_* of the resolved boot device, BDM_TYPE_UNKNOWN for an unclassified boot. The save-path
+// retry pins a later re-resolve to this type; config recovery also uses it to keep a known BDM boot
+// from probing unrelated storage classes.
+static int gBootDirBdmType = BDM_TYPE_UNKNOWN;
+// True for a typed BDM boot or a concrete massN: token, even when the latter has not finished
+// registering and therefore has no driver classification yet. This keeps a missing first-run file
+// on that explicit slot from triggering the legacy all-device recovery scan.
+static int gBootHomeBdm = 0;
+
 // When this function is called, the current device for loading/saving config is the memory card.
 // "Custom Settings Path" bootstrap.
 //
@@ -1652,7 +1671,10 @@ static int prepareCustomApaSettingsPath(char *path, int pathLen)
 
     const char *activeLabel = strchr(gOPLPart, ':');
     activeLabel = activeLabel ? activeLabel + 1 : gOPLPart;
-    int commonStyleHome = (activeLabel[0] != '+');
+    // Only the canonical __common fallback maps the OPL data home below a physical OPL/
+    // subdirectory. Every valid conf_hdd.cfg-selected partition, including a non-+ label,
+    // owns its PFS root directly.
+    int commonStyleHome = !strcmp(gOPLPart, "hdd0:__common");
 
     if (isPfsAlias) {
         // Compatibility spellings seen on hardware include pfs0:, pfs:/__common/OPL and
@@ -1759,9 +1781,9 @@ static int isApaSettingsPath(const char *path)
 }
 
 // Resolve the normal safe HDD settings home after an explicit HDD path cannot be used.
-// hddLoadSupportModules owns the policy: honour an existing conf_hdd.cfg target first;
-// otherwise mount the guaranteed __common partition and use __common/OPL/. It never creates
-// or formats an APA partition. This helper only accepts the resulting mounted PFS namespace.
+// hddLoadSupportModules owns the policy: read the existing __common/OPL/conf_hdd.cfg redirect
+// first, otherwise use __common/OPL/. It never creates or formats an APA partition. This helper
+// only accepts the resulting mounted PFS namespace.
 static int prepareHddSettingsFallback(char *path, int pathLen)
 {
     DIR *dir;
@@ -1834,6 +1856,83 @@ static int sameConcreteMcSlot(const char *first, const char *second)
            !strncmp(first, "mc", 2) && !strncmp(second, "mc", 2) &&
            (first[2] == '0' || first[2] == '1') && first[3] == ':' &&
            first[2] == second[2] && second[3] == ':';
+}
+
+static void restoreRecoverySaveHome(const char *recoveredHome);
+
+static int bootHomeIsConcreteMc(void)
+{
+    return !strncmp(gBootDir, "mc", 2) &&
+           (gBootDir[2] == '0' || gBootDir[2] == '1') && gBootDir[3] == ':';
+}
+
+static int bootHomeIsKnownMmce(void)
+{
+    return !strncmp(gBootDir, "mmce", 4) &&
+           (gBootDir[4] == '0' || gBootDir[4] == '1') && gBootDir[5] == ':';
+}
+
+static int bootPathIsConcreteMass(const char *path)
+{
+    const char *p;
+
+    if (path == NULL || strncmp(path, "mass", 4) != 0)
+        return 0;
+    p = path + 4;
+    if (*p < '0' || *p > '9')
+        return 0;
+    while (*p >= '0' && *p <= '9')
+        p++;
+    return *p == ':';
+}
+
+static int bootHomeIsKnownBdm(void)
+{
+    // A resolved BDM driver or a literal massN: token is a concrete local owner. The latter can
+    // remain unclassified while its transport starts, but must not be turned into a broad search.
+    return !gBootHomeDeferred && gBootHomeBdm;
+}
+
+// A known local boot gets at most its own conventional legacy locations. The normal CWD was read
+// before this function, so these probes are migration reads only: <device>:/OPL then the device
+// root. They cannot wake USB/ATA/MMCE/other MC slots or turn an absent first-run config into a
+// whole-machine discovery pass.
+static int tryKnownBootConfigRecovery(int types)
+{
+    const char *colon = strchr(gBootDir, ':');
+    char root[16];
+    char home[32];
+    int value;
+    int n;
+
+    if (colon == NULL)
+        return 0;
+
+    n = (int)(colon - gBootDir) + 1;
+    if (n <= 0 || n >= (int)sizeof(root))
+        return 0;
+    memcpy(root, gBootDir, n);
+    root[n] = '\0';
+
+    snprintf(home, sizeof(home), "%s/OPL", root);
+    value = tryReadRecoveryConfigHome(types, home);
+    if (value & CONFIG_OPL) {
+        restoreRecoverySaveHome(home);
+        return value;
+    }
+
+    snprintf(home, sizeof(home), "%s/", root);
+    value = tryReadRecoveryConfigHome(types, home);
+    if (value & CONFIG_OPL) {
+        restoreRecoverySaveHome(home);
+        return value;
+    }
+
+    // Failed recovery probes re-home every config set. Restore the known source before returning
+    // defaults so the first explicit save stays on that same device.
+    configEnd();
+    configInit(gBootDir);
+    return 0;
 }
 
 static void restoreRecoverySaveHome(const char *recoveredHome)
@@ -1999,10 +2098,10 @@ static int tryAlternateDevice(int types)
     }
 
     // APA/PFS boot identity is authoritative. After an explicit redirect misses, ONLY the
-    // existing HDD ownership chain is eligible: conf_hdd.cfg's existing target, otherwise
-    // __common/OPL. Never import an unrelated MC/USB master config into an FHDB/APA session; that
-    // can resurrect stale Custom Settings Path state and makes the next save destination depend on
-    // whichever removable device happened to be inserted.
+    // deterministic existing-PFS ownership chain is eligible: __common/OPL/conf_hdd.cfg's valid
+    // existing target, otherwise __common/OPL. Never import an unrelated MC/USB master config into
+    // an FHDB/APA session; that can resurrect stale Custom Settings Path state and makes the next
+    // save destination depend on whichever removable device happened to be inserted.
     if (gBootHomeApa) {
         value = checkLoadConfigHDD(types);
         if (value & CONFIG_OPL)
@@ -2018,7 +2117,22 @@ static int tryAlternateDevice(int types)
         return 0;
     }
 
-    // Non-APA missing/stale redirect recovery retains the existing read-only MC/USB behavior.
+    // A missing file on a known local boot is an ordinary first-run state, not a signal to scan all
+    // supported storage. Limit migration reads to the boot device's own conventional legacy homes:
+    // same MC slot, the resolved BDM device, or the corresponding MMCE card. This is deliberately
+    // before the broad legacy hunt below, whose USB module wait and MMCE probing are unacceptable
+    // on a known device that simply has no config yet.
+    if (bootHomeIsConcreteMc() || bootHomeIsKnownBdm() || bootHomeIsKnownMmce()) {
+        value = tryKnownBootConfigRecovery(types);
+        if (value & CONFIG_OPL)
+            return value;
+
+        showCfgPopup = 0;
+        return 0;
+    }
+
+    // Bare, deferred-network, and otherwise unclassified boots retain the bounded read-only
+    // recovery chain. These have no verified local settings owner to prefer.
     value = tryMissingConfigPathRecovery(types);
     if (value & CONFIG_OPL)
         return value;
@@ -2148,19 +2262,13 @@ static void configReadNeutrinoGlobals(config_set_t *configOPL)
     }
 }
 
-// Basename of the ELF OPL was booted as (argv[0]); pairs with gBootDir. resolveBootDirToMass uses
-// it to verify WHICH mounted massN: slot is the boot device (launcher slot numbering need not
-// match OPL's). Empty when the boot dir came from getcwd() or argv[0] had no filename part.
-static char gBootElfName[64];
-// BDM_TYPE_* of the resolved boot device, BDM_TYPE_UNKNOWN for non-BDM boots. Set by
-// resolveBootDirToMass(); consumed by the _saveConfig re-resolve retry.
-static int gBootDirBdmType = BDM_TYPE_UNKNOWN;
-
-
 static void resolveBootDirToMass(void)
 {
     gBootHomeApa = 0;
     gBootHddCommonFallback = 0;
+    gBootHomeBdm = 0;
+    gBootDirBdmType = BDM_TYPE_UNKNOWN;
+    gBootHomeDeferred = 0;
     if (gBootDir[0] == '\0')
         return;
 
@@ -2288,8 +2396,8 @@ static void resolveBootDirToMass(void)
 
     char before[sizeof(gBootDir)];
     snprintf(before, sizeof(before), "%s", gBootDir);
-    gBootDirBdmType = BDM_TYPE_UNKNOWN; // classify fresh from the prefix
-    int ret = bdmResolveBootDir(gBootDir, sizeof(gBootDir), gBootElfName, &gBootDirBdmType);
+    int ret = bdmResolveBootDirBootstrap(gBootDir, sizeof(gBootDir), gBootElfName, &gBootDirBdmType);
+    gBootHomeBdm = ret != 0 && (gBootDirBdmType != BDM_TYPE_UNKNOWN || bootPathIsConcreteMass(before));
     if (ret < 0) {
         // The boot device's BDM stack did not mount within the resolve budget. It served this ELF, so it
         // IS present -- do NOT blank gBootDir and re-home the config to a plain mc here (the old
@@ -2301,7 +2409,7 @@ static void resolveBootDirToMass(void)
         // defaults if the stack is still coming up, and a save targets the boot device -- failing visibly
         // if it is genuinely gone -- never a plain mc. bdmResolveBootDir leaves gBootDir UNCHANGED on a
         // failed resolve (it only rewrites on success), so the identity here is intact.
-        LOG("BOOT boot device %s not mounted after resolve -> keep as config home (mc untouched)\n", before);
+        LOG("BOOT boot device %s not mounted during bounded bootstrap resolve -> keep as config home (mc untouched)\n", before);
         return;
     }
     if (ret > 0 && strcmp(before, gBootDir) != 0) {
@@ -3016,18 +3124,18 @@ static void _saveConfig()
         return;
     }
 
-    // Boot-device save retry: BDM slot numbering can change between the boot-time resolve and this
-    // save (a hotplug add/remove renumbers massN:). Re-resolve against the SAME boot device once --
-    // pinned to its known BDM type -- and retry. Never a different device: if the boot device is
-    // truly gone the save fails visibly. (This is gBootDirBdmType's second consumer, the one the
-    // comment in bdmsupport.c has been promising.)
-    if (lscret <= 0 && gBootDir[0] != '\0' && gBootDirBdmType != BDM_TYPE_UNKNOWN) {
+    // Boot-device save retry: ask the same concrete BDM identity to register once more, then retry
+    // the write. A literal massN: remains that exact slot and is never replaced by another device;
+    // a typed launch alias may still rewrite to its verified mount. If the boot device is gone the
+    // save fails visibly instead of scattering settings elsewhere.
+    if (lscret <= 0 && gBootDir[0] != '\0' && gBootHomeBdm) {
         char before[sizeof(gBootDir)];
         snprintf(before, sizeof(before), "%s", gBootDir);
-        if (bdmResolveBootDir(gBootDir, sizeof(gBootDir), gBootElfName, &gBootDirBdmType) > 0 &&
-            strcmp(before, gBootDir) != 0) {
-            LOG("BOOT re-resolved boot dir for save: %s -> %s\n", before, gBootDir);
-            configSetMove(gBootDir); // keep the pending values; re-point the files to the new slot
+        if (bdmResolveBootDir(gBootDir, sizeof(gBootDir), gBootElfName, &gBootDirBdmType) > 0) {
+            if (strcmp(before, gBootDir) != 0) {
+                LOG("BOOT re-resolved boot dir for save: %s -> %s\n", before, gBootDir);
+                configSetMove(gBootDir); // keep the pending values; re-point the files to the verified mount
+            }
             lscret = configWriteChecked(lscstatus);
         }
     }
@@ -4210,6 +4318,7 @@ void miniDeinit(config_set_t *configSet)
 static void autoLaunchHDDGame(char *argv[])
 {
     char path[256];
+    char launchPart[sizeof(gOPLPart)];
     config_set_t *configSet;
 
     miniInit(HDD_MODE);
@@ -4226,7 +4335,12 @@ static void autoLaunchHDDGame(char *argv[])
     // varargs list. Same below for argv[2] in the BDM twin.
     snprintf(gAutoLaunchGame->startup, sizeof(gAutoLaunchGame->startup), "%s", argv[1]);
     gAutoLaunchGame->start_sector = strtoul(argv[2], NULL, 0);
-    snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:%s", argv[3]);
+    snprintf(launchPart, sizeof(launchPart), "hdd0:%s", argv[3]);
+    // argv[3] is a compatibility hint from the launching OPL instance. Re-read the authoritative
+    // __common/OPL/conf_hdd.cfg policy in miniInit() rather than letting a stale launcher hint
+    // overwrite the mounted data home used for CFG/VMC sidecars in this process.
+    if (gOPLPart[0] != '\0' && strcmp(gOPLPart, launchPart) != 0)
+        LOG("HDD mini launch: ignoring stale partition hint %s; policy selected %s\n", launchPart, gOPLPart);
 
     if (gHDDPrefix != NULL && gHDDPrefix[0] != '\0') {
         snprintf(path, sizeof(path), "%sCFG/%s.cfg", gHDDPrefix, gAutoLaunchGame->startup);
@@ -4472,7 +4586,7 @@ int main(int argc, char *argv[])
         /* argv[0] boot path
            argv[1] game->startup
            argv[2] str to u32 game->start_sector
-           argv[3] opl partition read from hdd0:__common/OPL/conf_hdd.cfg
+           argv[3] legacy OPL data-partition hint (revalidated from hdd0:__common/OPL/conf_hdd.cfg)
            argv[4] "mini" */
         if (!strcmp(argv[4], "mini"))
             autoLaunchHDDGame(argv);

--- a/src/sound.c
+++ b/src/sound.c
@@ -508,6 +508,26 @@ static void bgmIoThread(void *arg)
     SignalSema(outSema);
 }
 
+static int bgmTryLoadPath(const char *bgmPath, const char *source)
+{
+    FILE *bgmFile = fopen(bgmPath, "rb");
+
+    if (bgmFile == NULL) {
+        LOG("BGM: %s BGM not found: %s\n", source, bgmPath);
+        return 0;
+    }
+
+    if (ov_open_callbacks(bgmFile, vorbisFile, NULL, 0, OV_CALLBACKS_DEFAULT) == 0) {
+        LOG("BGM: Loaded %s BGM %s\n", source, bgmPath);
+        return 1;
+    }
+
+    LOG("BGM: %s BGM is not a valid Ogg bitstream: %s\n", source, bgmPath);
+    fclose(bgmFile);
+    memset(vorbisFile, 0, sizeof(OggVorbis_File));
+    return 0;
+}
+
 static int bgmLoad(void)
 {
     char bgmPath[256];
@@ -521,45 +541,26 @@ static int bgmLoad(void)
 
     themeID = thmGetGuiValue();
     char *thmPath = thmGetFilePath(themeID);
-    if (thmPath != NULL) { // NULL for <OPL> + the built-in <Coverflow> -> no theme BGM folder
+    if (thmPath != NULL) { // NULL for <OPL> + the built-in <Coverflow>
         snprintf(bgmPath, sizeof(bgmPath), "%ssound/bgm.ogg", thmPath);
-        FILE *bgmFile = fopen(bgmPath, "rb");
-        if (bgmFile != NULL) {
-            if (ov_open_callbacks(bgmFile, vorbisFile, NULL, 0, OV_CALLBACKS_DEFAULT) == 0) {
-                LOG("BGM: Loaded theme BGM %s\n", bgmPath);
-                return 0;
-            }
-
-            LOG("BGM: Theme BGM is not a valid Ogg bitstream: %s\n", bgmPath);
-            fclose(bgmFile);
-            memset(vorbisFile, 0, sizeof(OggVorbis_File));
-        } else {
-            LOG("BGM: Theme BGM not found: %s\n", bgmPath);
-        }
+        if (bgmTryLoadPath(bgmPath, "theme"))
+            return 0;
     }
 
     if (gDefaultBGMPath[0] != '\0') {
-        FILE *bgmFile;
-
         snprintf(bgmPath, sizeof(bgmPath), "%s", gDefaultBGMPath);
-        bgmFile = fopen(bgmPath, "rb");
-        if (bgmFile != NULL) {
-            if (ov_open_callbacks(bgmFile, vorbisFile, NULL, 0, OV_CALLBACKS_DEFAULT) == 0) {
-                LOG("BGM: Loaded configured BGM %s\n", bgmPath);
-                return 0;
-            }
-
-            LOG("BGM: Configured BGM is not a valid Ogg bitstream: %s\n", bgmPath);
-            fclose(bgmFile);
-            memset(vorbisFile, 0, sizeof(OggVorbis_File));
-        } else {
-            LOG("BGM: Configured BGM not found: %s\n", bgmPath);
-        }
+        if (bgmTryLoadPath(bgmPath, "configured"))
+            return 0;
     }
 
-    // No embedded fallback BGM (removed to save ~324 KB); BGM plays only when a
-    // theme provides sound/bgm.ogg or a BGM path is configured.
-    LOG("BGM: No theme or configured BGM available.\n");
+    // Disk themes keep their existing sound/bgm.ogg -> configured-file priority. Only the two
+    // built-in themes fall back to this one conventional data-home file after the configured path.
+    if (thmPath == NULL && oplGetDefaultThemeBgmPath(bgmPath, sizeof(bgmPath))) {
+        if (bgmTryLoadPath(bgmPath, "built-in theme"))
+            return 0;
+    }
+
+    LOG("BGM: No usable theme, configured, or built-in BGM available.\n");
     free(vorbisFile);
     vorbisFile = NULL;
 

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -17,11 +17,13 @@
 
 extern void *_gp;
 
-// Tagged, not anonymous, because the record now carries its OWN queue link: art no longer rides an
+// Tagged, not anonymous, because the record now carries its OWN queue links: art no longer rides an
 // ioman request node, it rides this one.
 typedef struct load_image_request
 {
-    struct load_image_request *next; // art FIFO link, owned by whoever owns the request
+    struct load_image_request *next;
+    struct load_image_request *prev; // art FIFO links, owned by whoever owns the request
+    unsigned int queueEpoch;         // FIFO generation while queued; cleared when the worker owns it
     image_cache_t *cache;
     cache_entry_t *entry;
     item_list_t *list;
@@ -89,6 +91,10 @@ static volatile int gArtNavActive = 0;
 static load_image_request_t *gArtReqList = NULL;
 static load_image_request_t *gArtReqEnd = NULL;
 static load_image_request_t *volatile gArtCurrentReq = NULL;
+// artDetachAll() swaps the queue in O(1), then frees its old nodes with interrupts enabled. A
+// request can therefore retain old next/prev links briefly after the swap; generation membership
+// makes a later promotion reject that detached chain without turning the splice back into O(n).
+static unsigned int gArtQueueEpoch = 1;
 
 static void cacheWakeArtWorker(void);
 
@@ -395,9 +401,10 @@ static void cacheWakeArtWorker(void)
 
 static void artPush(load_image_request_t *req)
 {
-    req->next = NULL;
-
     DIntr();
+    req->next = NULL;
+    req->prev = gArtReqEnd;
+    req->queueEpoch = gArtQueueEpoch;
     if (gArtReqEnd)
         gArtReqEnd->next = req;
     else
@@ -410,10 +417,14 @@ static void artPush(load_image_request_t *req)
 static void artPushFront(load_image_request_t *req)
 {
     DIntr();
+    req->prev = NULL;
     req->next = gArtReqList;
-    gArtReqList = req;
-    if (!gArtReqEnd)
+    req->queueEpoch = gArtQueueEpoch;
+    if (gArtReqList)
+        gArtReqList->prev = req;
+    else
         gArtReqEnd = req;
+    gArtReqList = req;
     gArtQueuedCount++;
     EIntr();
 }
@@ -424,22 +435,25 @@ static void artPromote(load_image_request_t *req)
         return;
 
     DIntr();
-    // Guard against promoting a request the worker is ALREADY executing, or one that is already at the head.
-    // Checked inside the DIntr bracket to prevent a race with artPop().
-    if (gArtCurrentReq != req && gArtReqList != NULL && gArtReqList != req) {
-        load_image_request_t *prev = gArtReqList;
-        while (prev->next != NULL && prev->next != req) {
-            prev = prev->next;
-        }
+    // The selected cover can be a warmed neighbour buried in a deep queue. This used to scan the
+    // singly-linked FIFO under DIntr(), making one selection's priority handoff O(queue depth) and
+    // extending the interrupts-off window as browsing filled cache slots. The intrusive back link
+    // keeps this splice O(1); no allocation, free, or device work occurs in the bracket.
+    // Guard against promoting the request the worker is already executing, or one already at head.
+    if (gArtCurrentReq != req && req->queueEpoch == gArtQueueEpoch && req->prev != NULL) {
+        load_image_request_t *prev = req->prev;
+        load_image_request_t *next = req->next;
 
-        if (prev->next == req) {
-            prev->next = req->next;
-            if (gArtReqEnd == req)
-                gArtReqEnd = prev;
+        prev->next = next;
+        if (next)
+            next->prev = prev;
+        else
+            gArtReqEnd = prev;
 
-            req->next = gArtReqList;
-            gArtReqList = req;
-        }
+        req->prev = NULL;
+        req->next = gArtReqList;
+        gArtReqList->prev = req;
+        gArtReqList = req;
     }
     EIntr();
 }
@@ -472,9 +486,13 @@ static load_image_request_t *artPop(void)
         }
 
         gArtReqList = req->next;
-        if (!gArtReqList)
+        if (gArtReqList)
+            gArtReqList->prev = NULL;
+        else
             gArtReqEnd = NULL;
         req->next = NULL;
+        req->prev = NULL;
+        req->queueEpoch = 0;
 
         if (gArtQueuedCount > 0)
             gArtQueuedCount--;
@@ -501,6 +519,8 @@ static load_image_request_t *artDetachAll(void)
     gArtReqList = NULL;
     gArtReqEnd = NULL;
     gArtQueuedCount = 0;
+    if (++gArtQueueEpoch == 0)
+        gArtQueueEpoch = 1;
     EIntr();
 
     return list;
@@ -974,6 +994,8 @@ void cacheInit()
     gArtReqList = NULL;
     gArtReqEnd = NULL;
     gArtCurrentReq = NULL;
+    if (++gArtQueueEpoch == 0)
+        gArtQueueEpoch = 1;
     gArtQueuedCount = 0;
     gArtActiveCount = 0;
     gArtNavActive = 0;
@@ -1396,6 +1418,8 @@ GSTEXTURE *cacheGetTextureEx(image_cache_t *cache, item_list_t *list, int *cache
         req->focusEpoch = gArtFocusEpoch; // selected-game neighborhood this speculative read serves
         req->abortRequested = 0;
         req->next = NULL;
+        req->prev = NULL;
+        req->queueEpoch = 0;
         req->sio2 = (unsigned char)isSio2; // resolved above, on the GUI thread
 
         cacheClearItem(oldestEntry, 1);

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -1718,15 +1718,13 @@ static const char *vcdPopstarterMcFile[9] = {
     "smbman.irx", "ps2ip.irx", "ps2smap.irx", "ps2dev9.irx", "SMSUTILS.irx", "poweroff.irx", "del.icn", "list.icn", "icon.sys"};
 static const char *vcdSmbModule[4] = {"smbman.irx", "ps2ip.irx", "ps2smap.irx", "ps2dev9.irx"};
 
-int vcdInstallPopstarterMc(const char *devPrefix)
+static int vcdInstallPopstarterMcAt(const char *devPrefix, const char *mcDir)
 {
-    char mcDir[64], src[320], dst[96];
+    char src[320], dst[96];
     int firstError = 0;
 
-    if (devPrefix == NULL || devPrefix[0] == '\0')
+    if (devPrefix == NULL || devPrefix[0] == '\0' || mcDir == NULL || mcDir[0] == '\0')
         return -1;
-    if (!vcdResolvePopstarterMc(mcDir, sizeof(mcDir)))
-        return -3;
 
     for (unsigned int i = 0; i < sizeof(vcdPopstarterMcFile) / sizeof(vcdPopstarterMcFile[0]); i++) {
         snprintf(dst, sizeof(dst), "%s/%s", mcDir, vcdPopstarterMcFile[i]);
@@ -1755,22 +1753,35 @@ int vcdInstallPopstarterMc(const char *devPrefix)
     return firstError;
 }
 
+int vcdInstallPopstarterMc(const char *devPrefix)
+{
+    char mcDir[64];
+
+    if (!vcdResolvePopstarterMc(mcDir, sizeof(mcDir)))
+        return -3;
+    return vcdInstallPopstarterMcAt(devPrefix, mcDir);
+}
+
+static int vcdSmbModulesPresentAt(const char *mcDir)
+{
+    for (int i = 0; i < 4; i++) {
+        char path[96];
+        int fd;
+
+        snprintf(path, sizeof(path), "%s/%s", mcDir, vcdSmbModule[i]);
+        fd = open(path, O_RDONLY);
+        if (fd < 0)
+            return 0;
+        close(fd);
+    }
+    return 1;
+}
+
 int vcdSmbModulesPresent(void)
 {
     static const char *cards[2] = {"mc0:/POPSTARTER", "mc1:/POPSTARTER"};
     for (int c = 0; c < 2; c++) {
-        int all = 1;
-        for (int i = 0; i < 4; i++) {
-            char path[96];
-            snprintf(path, sizeof(path), "%s/%s", cards[c], vcdSmbModule[i]);
-            int fd = open(path, O_RDONLY);
-            if (fd < 0) {
-                all = 0;
-                break;
-            }
-            close(fd);
-        }
-        if (all)
+        if (vcdSmbModulesPresentAt(cards[c]))
             return 1; // this card has the complete SMB stack
     }
     return 0;
@@ -1779,10 +1790,10 @@ int vcdSmbModulesPresent(void)
 // ---- POPStarter network files (IPCONFIG.DAT / SMBCONFIG.DAT) --------------------------------
 // POPSLoader-parity flow (see include/vcdsupport.h for the formats). The central rule: read
 // existing values when available, otherwise stay blank -- absence of POPStarter's files means
-// "unknown/unconfigured", NEVER "use OPL's defaults". Candidate dirs, in POPStarter's
-// precedence order: mc0:/POPSTARTER -> mc1:/POPSTARTER. That's it -- POPSTARTER reads its
-// network files from the memory card ONLY (OPL's own settings live in the boot dir/cwd, but
-// that is OUR convention, not POPSTARTER's). Nothing here touches VCD files.
+// "unknown/unconfigured", NEVER "use OPL's defaults". Each candidate is evaluated as one complete
+// home: a usable pair wins before an arbitrary writable card, with MC0 only breaking a true tie.
+// POPSTARTER reads its network files from the memory card ONLY (OPL's own settings live in the
+// boot dir/cwd, but that is OUR convention, not POPSTARTER's). Nothing here touches VCD files.
 static int vcdPopstarterNetDirs(char dirs[][96], int maxDirs)
 {
     int n = 0;
@@ -1795,22 +1806,25 @@ static int vcdPopstarterNetDirs(char dirs[][96], int maxDirs)
 }
 
 // Read a small text config file fully. Returns the length (>= 0), -1 when absent, -2 on a real
-// IO error. Absence is data (unknown/unconfigured), not a failure.
+// IO error, or -3 when too large to be a usable POPStarter config. Absence is data
+// (unknown/unconfigured), not a failure.
 static int vcdReadNetFile(const char *path, char *buf, int bufSize)
 {
     int fd = open(path, O_RDONLY);
     if (fd < 0)
-        return -1;
+        return errno == ENOENT ? -1 : -2;
     int size = lseek(fd, 0, SEEK_END);
     if (size < 0 || lseek(fd, 0, SEEK_SET) < 0) {
         close(fd);
         return -2;
     }
-    if (size >= bufSize)
-        size = bufSize - 1; // a bigger file is garbage/truncated, but never smashes the buffer
+    if (size >= bufSize) {
+        close(fd);
+        return -3; // never silently parse a truncated configuration
+    }
     int rd = read(fd, buf, size);
     close(fd);
-    if (rd < 0)
+    if (rd != size)
         return -2;
     buf[rd] = '\0';
     return rd;
@@ -1824,8 +1838,8 @@ static int vcdQuadOk(const int q[4])
     return 1;
 }
 
-// Parse "<IP> <NETMASK> <GATEWAY>". Returns 1 when a full valid triple was read; 0 means the
-// file is blank/garbage -- the caller treats that as DHCP and shows NO invented values.
+// Parse "<IP> <NETMASK> <GATEWAY>". Returns 1 when a full valid triple was read. The caller
+// separately recognizes blank as DHCP; nonblank parse failure is invalid, never silently DHCP.
 static int vcdParseIpConfig(const char *buf, vcd_popsnet_t *out)
 {
     int n = sscanf(buf, "%d.%d.%d.%d %d.%d.%d.%d %d.%d.%d.%d",
@@ -1895,57 +1909,189 @@ static void vcdParseSmbConfig(const char *buf, vcd_popsnet_t *out)
         snprintf(out->smbPass, sizeof(out->smbPass), "%s", lines[2]);
 }
 
+static int vcdNetTextBlank(const char *text)
+{
+    while (*text != '\0') {
+        if (*text != ' ' && *text != '\t' && *text != '\r' && *text != '\n')
+            return 0;
+        text++;
+    }
+    return 1;
+}
+
+static int vcdStaticIpUsable(const vcd_popsnet_t *cfg)
+{
+    return vcdQuadOk(cfg->ps2Ip) && vcdQuadOk(cfg->ps2Mask) && vcdQuadOk(cfg->ps2Gw) &&
+           (cfg->ps2Ip[0] | cfg->ps2Ip[1] | cfg->ps2Ip[2] | cfg->ps2Ip[3]) != 0 &&
+           (cfg->ps2Mask[0] | cfg->ps2Mask[1] | cfg->ps2Mask[2] | cfg->ps2Mask[3]) != 0 &&
+           (cfg->ps2Gw[0] | cfg->ps2Gw[1] | cfg->ps2Gw[2] | cfg->ps2Gw[3]) != 0;
+}
+
+static int vcdSmbConfigUsable(const vcd_popsnet_t *cfg)
+{
+    return cfg->smbShare[0] != '\0' && vcdQuadOk(cfg->smbIp) &&
+           (cfg->smbIp[0] | cfg->smbIp[1] | cfg->smbIp[2] | cfg->smbIp[3]) != 0 &&
+           cfg->smbPort >= 0 && cfg->smbPort <= 65535;
+}
+
+enum vcd_popsnet_file_state {
+    VCD_POPSNET_FILE_MISSING = 0,
+    VCD_POPSNET_FILE_DHCP,
+    VCD_POPSNET_FILE_STATIC,
+    VCD_POPSNET_FILE_VALID,
+    VCD_POPSNET_FILE_INVALID,
+    VCD_POPSNET_FILE_IO
+};
+
+typedef struct
+{
+    int rootPresent;
+    int dirPresent;
+    int ipState;
+    int smbState;
+    vcd_popsnet_t cfg;
+} vcd_popsnet_home_t;
+
+static void vcdInspectPopstarterNetHome(const char *dir, vcd_popsnet_home_t *home)
+{
+    char root[8];
+    char path[128];
+    char buf[256];
+    DIR *d;
+    int rd;
+
+    memset(home, 0, sizeof(*home));
+    home->cfg.ipDhcp = 1;
+    snprintf(home->cfg.home, sizeof(home->cfg.home), "%s", dir);
+    snprintf(home->cfg.createDir, sizeof(home->cfg.createDir), "%s", dir);
+    snprintf(root, sizeof(root), "mc%c:/", dir[2]);
+
+    d = opendir(root);
+    if (d == NULL) {
+        if (errno != ENOENT && errno != ENXIO) {
+            home->ipState = VCD_POPSNET_FILE_IO;
+            home->smbState = VCD_POPSNET_FILE_IO;
+        }
+        return; // an absent card is not an IO error for the other slot
+    }
+    closedir(d);
+    home->rootPresent = 1;
+    home->cfg.homeAvailable = 1;
+
+    d = opendir(dir);
+    if (d == NULL) {
+        if (errno != ENOENT) {
+            home->ipState = VCD_POPSNET_FILE_IO;
+            home->smbState = VCD_POPSNET_FILE_IO;
+        }
+        return;
+    }
+    closedir(d);
+    home->dirPresent = 1;
+
+    snprintf(path, sizeof(path), "%s/IPCONFIG.DAT", dir);
+    rd = vcdReadNetFile(path, buf, sizeof(buf));
+    if (rd == -2)
+        home->ipState = VCD_POPSNET_FILE_IO;
+    else if (rd == -3) {
+        home->ipState = VCD_POPSNET_FILE_INVALID;
+        home->cfg.ipExists = 1;
+        home->cfg.ipInvalid = 1;
+        snprintf(home->cfg.ipDir, sizeof(home->cfg.ipDir), "%s", dir);
+    } else if (rd >= 0) {
+        home->cfg.ipExists = 1;
+        snprintf(home->cfg.ipDir, sizeof(home->cfg.ipDir), "%s", dir);
+        if (vcdNetTextBlank(buf)) {
+            home->ipState = VCD_POPSNET_FILE_DHCP;
+        } else if (vcdParseIpConfig(buf, &home->cfg)) {
+            home->cfg.ipDhcp = 0;
+            home->ipState = VCD_POPSNET_FILE_STATIC;
+        } else {
+            home->ipState = VCD_POPSNET_FILE_INVALID;
+            home->cfg.ipInvalid = 1;
+        }
+    }
+
+    snprintf(path, sizeof(path), "%s/SMBCONFIG.DAT", dir);
+    rd = vcdReadNetFile(path, buf, sizeof(buf));
+    if (rd == -2)
+        home->smbState = VCD_POPSNET_FILE_IO;
+    else if (rd == -3) {
+        home->smbState = VCD_POPSNET_FILE_INVALID;
+        home->cfg.smbExists = 1;
+        home->cfg.smbInvalid = 1;
+        snprintf(home->cfg.smbDir, sizeof(home->cfg.smbDir), "%s", dir);
+    } else if (rd >= 0) {
+        home->cfg.smbExists = 1;
+        snprintf(home->cfg.smbDir, sizeof(home->cfg.smbDir), "%s", dir);
+        vcdParseSmbConfig(buf, &home->cfg);
+        if (vcdSmbConfigUsable(&home->cfg))
+            home->smbState = VCD_POPSNET_FILE_VALID;
+        else {
+            home->smbState = VCD_POPSNET_FILE_INVALID;
+            home->cfg.smbInvalid = 1;
+        }
+    }
+}
+
+static int vcdPopstarterNetHomeScore(const vcd_popsnet_home_t *home)
+{
+    if (!home->rootPresent)
+        return 0;
+    if (home->ipState == VCD_POPSNET_FILE_STATIC && vcdStaticIpUsable(&home->cfg) &&
+        home->smbState == VCD_POPSNET_FILE_VALID)
+        return 5; // a complete usable setup always wins over an arbitrary writable card
+    if (!home->cfg.ipInvalid && !home->cfg.smbInvalid &&
+        (home->ipState == VCD_POPSNET_FILE_STATIC || home->ipState == VCD_POPSNET_FILE_DHCP ||
+         home->smbState == VCD_POPSNET_FILE_VALID))
+        return 4; // preserve an existing valid partial setup and generate only its missing peer
+    if (home->cfg.ipInvalid || home->cfg.smbInvalid)
+        return 3; // make the user repair bad data instead of silently shadowing it on the other card
+    if (home->dirPresent)
+        return 2; // existing POPSTARTER install, with no network configuration yet
+    return 1;     // first-time setup: this card root is available
+}
+
+static int vcdResolvePopstarterNetHome(vcd_popsnet_home_t *out)
+{
+    char dirs[2][96];
+    vcd_popsnet_home_t homes[2];
+    int count = vcdPopstarterNetDirs(dirs, 2);
+    int best = -1;
+    int bestScore = 0;
+
+    for (int i = 0; i < count; i++) {
+        int score;
+
+        vcdInspectPopstarterNetHome(dirs[i], &homes[i]);
+        score = vcdPopstarterNetHomeScore(&homes[i]);
+        if (score > bestScore) {
+            best = i;
+            bestScore = score;
+        }
+    }
+
+    if (best < 0)
+        return 0;
+    *out = homes[best];
+    return 1;
+}
+
 int vcdReadPopstarterNet(vcd_popsnet_t *out)
 {
+    vcd_popsnet_home_t home;
+
     if (out == NULL)
         return -3;
     memset(out, 0, sizeof(*out));
     out->ipDhcp = 1; // absent/blank IPCONFIG.DAT displays as DHCP, with no invented values
 
-    char dirs[2][96];
-    int ndirs = vcdPopstarterNetDirs(dirs, 2);
-    char buf[256];
+    if (!vcdResolvePopstarterNetHome(&home))
+        return 0; // no card at all: show the normal first-time blank editor state
 
-    for (int i = 0; i < ndirs && (!out->smbExists || !out->ipExists); i++) {
-        char path[128];
-        if (!out->smbExists) {
-            snprintf(path, sizeof(path), "%s/SMBCONFIG.DAT", dirs[i]);
-            int rd = vcdReadNetFile(path, buf, sizeof(buf));
-            if (rd == -2)
-                return -3;
-            if (rd >= 0) {
-                out->smbExists = 1;
-                snprintf(out->smbDir, sizeof(out->smbDir), "%s", dirs[i]);
-                vcdParseSmbConfig(buf, out);
-            }
-        }
-        if (!out->ipExists) {
-            snprintf(path, sizeof(path), "%s/IPCONFIG.DAT", dirs[i]);
-            int rd = vcdReadNetFile(path, buf, sizeof(buf));
-            if (rd == -2)
-                return -3;
-            if (rd >= 0) {
-                out->ipExists = 1;
-                snprintf(out->ipDir, sizeof(out->ipDir), "%s", dirs[i]);
-                if (vcdParseIpConfig(buf, out))
-                    out->ipDhcp = 0;
-            }
-        }
-    }
-
-    // Create-target for files that don't exist yet: the first candidate dir that EXISTS; else
-    // mc0:/POPSTARTER, created best-effort at write time. Empty when no card is present at all --
-    // creation then reports IO.
-    for (int i = 0; i < ndirs; i++) {
-        DIR *d = opendir(dirs[i]);
-        if (d != NULL) {
-            closedir(d);
-            snprintf(out->createDir, sizeof(out->createDir), "%s", dirs[i]);
-            break;
-        }
-    }
-    if (out->createDir[0] == '\0' && ndirs > 0)
-        snprintf(out->createDir, sizeof(out->createDir), "mc0:/POPSTARTER");
+    *out = home.cfg;
+    if (home.ipState == VCD_POPSNET_FILE_IO || home.smbState == VCD_POPSNET_FILE_IO)
+        return -3;
 
     return 0;
 }
@@ -1994,36 +2140,69 @@ static int vcdBuildSmbConfig(const vcd_popsnet_t *cfg, char *buf, int bufSize)
     return snprintf(buf, bufSize, "%s %s\n%s\n%s\n", host, cfg->smbShare, cfg->smbUser, cfg->smbPass);
 }
 
-int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int writeIp)
+static int vcdEnsurePopstarterNetDir(const char *dir)
+{
+    DIR *d;
+
+    if (dir == NULL || dir[0] == '\0')
+        return 0;
+    d = opendir(dir);
+    if (d != NULL) {
+        closedir(d);
+        return 1;
+    }
+    if (mkdir(dir, 0777) != 0 && errno != EEXIST)
+        return 0;
+    d = opendir(dir);
+    if (d == NULL)
+        return 0;
+    closedir(d);
+    return 1;
+}
+
+int vcdPopsNetValuesValid(const vcd_popsnet_t *cfg, int validateSmb, int validateIp)
 {
     if (cfg == NULL)
-        return -3;
+        return 0;
+    if (validateSmb && !vcdSmbConfigUsable(cfg))
+        return 0;
+    if (validateIp && !cfg->ipDhcp && !vcdStaticIpUsable(cfg))
+        return 0;
+    return 1;
+}
+
+int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int writeIp)
+{
     char buf[256];
+    char path[128];
+    const char *dir;
+    int rc;
+
+    if (cfg == NULL)
+        return -3;
+    if (!writeSmb && !writeIp)
+        return 0;
+    if (!vcdPopsNetValuesValid(cfg, writeSmb, writeIp))
+        return -4;
+
+    dir = cfg->home[0] != '\0' ? cfg->home : cfg->createDir;
+    if (dir[0] == '\0' || !vcdEnsurePopstarterNetDir(dir))
+        return -3;
 
     if (writeSmb) {
-        const char *dir = cfg->smbExists ? cfg->smbDir : cfg->createDir;
-        if (dir[0] == '\0')
-            return -3;
-        if (!cfg->smbExists)
-            mkdir(dir, 0777); // best-effort; exists already -> error, ignored
-        char path[128];
-        snprintf(path, sizeof(path), "%s/SMBCONFIG.DAT", dir);
         int len = vcdBuildSmbConfig(cfg, buf, sizeof(buf));
-        int rc = vcdSafeWriteFile(path, buf, len);
+
+        snprintf(path, sizeof(path), "%s/SMBCONFIG.DAT", dir);
+        rc = vcdSafeWriteFile(path, buf, len);
         if (rc != 0)
             return rc;
     }
 
     if (writeIp) {
-        const char *dir = cfg->ipExists ? cfg->ipDir : cfg->createDir;
-        if (dir[0] == '\0')
-            return -3;
-        if (!cfg->ipExists)
-            mkdir(dir, 0777);
-        char path[128];
-        snprintf(path, sizeof(path), "%s/IPCONFIG.DAT", dir);
         int len = vcdBuildIpConfig(cfg, buf, sizeof(buf));
-        int rc = vcdSafeWriteFile(path, buf, len);
+
+        snprintf(path, sizeof(path), "%s/IPCONFIG.DAT", dir);
+        rc = vcdSafeWriteFile(path, buf, len);
         if (rc != 0)
             return rc;
     }
@@ -2031,113 +2210,95 @@ int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int write
     return 0;
 }
 
-// ---- POPStarter SMB auto-provisioning for mc0:/POPSTARTER/ ------------------
-// Presence-wins helper for SMB VCD launches. See include/vcdsupport.h for contract.
-// Only missing files are generated; existing files are never parsed or touched.
-// Uses current RiptOPL globals (ps2_ip*, pc_ip, gPCShareName, etc.) when derivable.
-// Reuses vcdBuildIpConfig / vcdBuildSmbConfig / vcdSafeWriteFile so the DAT
-// byte-shape stays single-sourced.
-#define VCD_POPS_MC0_DIR       "mc0:/POPSTARTER"
-#define VCD_POPS_MC0_IPCONFIG  "mc0:/POPSTARTER/IPCONFIG.DAT"
-#define VCD_POPS_MC0_SMBCONFIG "mc0:/POPSTARTER/SMBCONFIG.DAT"
-
-static int vcdPopsMc0Exists(const char *path)
+static int vcdCanDeriveCurrentStatic(void)
 {
-    int fd = open(path, O_RDONLY);
-    if (fd >= 0) {
-        close(fd);
-        return 1;
-    }
-    if (errno == ENOENT)
+    vcd_popsnet_t cfg;
+
+    if (ps2_ip_use_dhcp)
         return 0;
-    return -1;
+    memset(&cfg, 0, sizeof(cfg));
+    memcpy(cfg.ps2Ip, ps2_ip, sizeof(cfg.ps2Ip));
+    memcpy(cfg.ps2Mask, ps2_netmask, sizeof(cfg.ps2Mask));
+    memcpy(cfg.ps2Gw, ps2_gateway, sizeof(cfg.ps2Gw));
+    return vcdStaticIpUsable(&cfg);
 }
 
-vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
+static int vcdCanDeriveCurrentSmb(void)
 {
-    int ipExists = vcdPopsMc0Exists(VCD_POPS_MC0_IPCONFIG);
-    int smbExists = vcdPopsMc0Exists(VCD_POPS_MC0_SMBCONFIG);
+    vcd_popsnet_t cfg;
 
-    if (ipExists < 0 || smbExists < 0)
+    if (strlen(gPCShareName) >= sizeof(cfg.smbShare) ||
+        strlen(gPCUserName) >= sizeof(cfg.smbUser) ||
+        strlen(gPCPassword) >= sizeof(cfg.smbPass))
+        return 0;
+    memset(&cfg, 0, sizeof(cfg));
+    memcpy(cfg.smbIp, pc_ip, sizeof(cfg.smbIp));
+    cfg.smbPort = gPCPort;
+    snprintf(cfg.smbShare, sizeof(cfg.smbShare), "%s", gPCShareName);
+    return vcdSmbConfigUsable(&cfg);
+}
+
+static vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfig(vcd_popsnet_t *cfg)
+{
+    char ipPath[128];
+    char smbPath[128];
+    char buf[256];
+    int needIp;
+    int needSmb;
+    int createdIp = 0;
+    int rc;
+
+    if (cfg == NULL || !cfg->homeAvailable || cfg->home[0] == '\0')
+        return VCD_POPSNET_IO_ERROR;
+    if (cfg->ipInvalid || cfg->smbInvalid)
+        return VCD_POPSNET_INVALID;
+
+    needIp = !cfg->ipExists;
+    needSmb = !cfg->smbExists;
+
+    // A blank IPCONFIG.DAT is a valid POPStarter DHCP file, but SMB launch needs a usable static
+    // PS2 address. Preserve it untouched and explain the requirement rather than rewriting it.
+    if (!needIp && (cfg->ipDhcp || !vcdStaticIpUsable(cfg)))
+        return VCD_POPSNET_NEED_STATIC;
+
+    if (needIp && !vcdCanDeriveCurrentStatic())
+        return VCD_POPSNET_NEED_STATIC;
+    if (needSmb && !vcdCanDeriveCurrentSmb()) {
+        if (gPCShareName[0] != '\0' &&
+            (pc_ip[0] | pc_ip[1] | pc_ip[2] | pc_ip[3]) == 0)
+            return VCD_POPSNET_NEED_STATIC; // unresolved hostname / NetBIOS host
+        return VCD_POPSNET_INVALID;
+    }
+
+    if (!needIp && !needSmb)
+        return VCD_POPSNET_READY;
+    if (!vcdEnsurePopstarterNetDir(cfg->home))
         return VCD_POPSNET_IO_ERROR;
 
-    if (ipExists && smbExists)
-        return VCD_POPSNET_READY;
-
-    int needIp = !ipExists;
-    int needSmb = !smbExists;
-
-    int canDeriveIp = 0;
-    int canDeriveSmb = 0;
+    snprintf(ipPath, sizeof(ipPath), "%s/IPCONFIG.DAT", cfg->home);
+    snprintf(smbPath, sizeof(smbPath), "%s/SMBCONFIG.DAT", cfg->home);
 
     if (needIp) {
-        if (!ps2_ip_use_dhcp &&
-            vcdQuadOk(ps2_ip) && vcdQuadOk(ps2_netmask) && vcdQuadOk(ps2_gateway) &&
-            (ps2_ip[0] | ps2_ip[1] | ps2_ip[2] | ps2_ip[3]) != 0 &&
-            (ps2_netmask[0] | ps2_netmask[1] | ps2_netmask[2] | ps2_netmask[3]) != 0 &&
-            (ps2_gateway[0] | ps2_gateway[1] | ps2_gateway[2] | ps2_gateway[3]) != 0) {
-            canDeriveIp = 1;
-        }
-        if (!canDeriveIp)
-            return VCD_POPSNET_NEED_STATIC;
-    }
-
-    if (needSmb) {
-        if (gPCShareName[0] != '\0' && vcdQuadOk(pc_ip) &&
-            (pc_ip[0] | pc_ip[1] | pc_ip[2] | pc_ip[3]) != 0 &&
-            strlen(gPCShareName) < sizeof(((vcd_popsnet_t *)0)->smbShare) &&
-            strlen(gPCUserName) < sizeof(((vcd_popsnet_t *)0)->smbUser) &&
-            strlen(gPCPassword) < sizeof(((vcd_popsnet_t *)0)->smbPass)) {
-            if (gPCPort >= 0 && gPCPort <= 65535)
-                canDeriveSmb = 1;
-        }
-        if (!canDeriveSmb) {
-            if (gPCShareName[0] != '\0' && (pc_ip[0] | pc_ip[1] | pc_ip[2] | pc_ip[3]) == 0)
-                return VCD_POPSNET_NEED_STATIC;
-            return VCD_POPSNET_INVALID;
-        }
-    }
-
-    if (needIp || needSmb) {
-        DIR *d = opendir(VCD_POPS_MC0_DIR);
-        if (d == NULL) {
-            mkdir(VCD_POPS_MC0_DIR, 0777);
-        } else {
-            closedir(d);
-        }
-    }
-
-    int createdIp = 0;
-
-    if (needIp) {
-        vcd_popsnet_t tmp;
-        memset(&tmp, 0, sizeof(tmp));
-        tmp.ipDhcp = 0;
-        memcpy(tmp.ps2Ip, ps2_ip, sizeof(tmp.ps2Ip));
-        memcpy(tmp.ps2Mask, ps2_netmask, sizeof(tmp.ps2Mask));
-        memcpy(tmp.ps2Gw, ps2_gateway, sizeof(tmp.ps2Gw));
-        char buf[256];
-        int len = vcdBuildIpConfig(&tmp, buf, sizeof(buf));
-        int rc = vcdSafeWriteFile(VCD_POPS_MC0_IPCONFIG, buf, len);
+        memcpy(cfg->ps2Ip, ps2_ip, sizeof(cfg->ps2Ip));
+        memcpy(cfg->ps2Mask, ps2_netmask, sizeof(cfg->ps2Mask));
+        memcpy(cfg->ps2Gw, ps2_gateway, sizeof(cfg->ps2Gw));
+        cfg->ipDhcp = 0;
+        rc = vcdSafeWriteFile(ipPath, buf, vcdBuildIpConfig(cfg, buf, sizeof(buf)));
         if (rc != 0)
             return VCD_POPSNET_IO_ERROR;
         createdIp = 1;
     }
 
     if (needSmb) {
-        vcd_popsnet_t tmp;
-        memset(&tmp, 0, sizeof(tmp));
-        memcpy(tmp.smbIp, pc_ip, sizeof(tmp.smbIp));
-        tmp.smbPort = gPCPort;
-        snprintf(tmp.smbShare, sizeof(tmp.smbShare), "%s", gPCShareName);
-        snprintf(tmp.smbUser, sizeof(tmp.smbUser), "%s", gPCUserName);
-        snprintf(tmp.smbPass, sizeof(tmp.smbPass), "%s", gPCPassword);
-        char buf[256];
-        int len = vcdBuildSmbConfig(&tmp, buf, sizeof(buf));
-        int rc = vcdSafeWriteFile(VCD_POPS_MC0_SMBCONFIG, buf, len);
+        memcpy(cfg->smbIp, pc_ip, sizeof(cfg->smbIp));
+        cfg->smbPort = gPCPort;
+        snprintf(cfg->smbShare, sizeof(cfg->smbShare), "%s", gPCShareName);
+        snprintf(cfg->smbUser, sizeof(cfg->smbUser), "%s", gPCUserName);
+        snprintf(cfg->smbPass, sizeof(cfg->smbPass), "%s", gPCPassword);
+        rc = vcdSafeWriteFile(smbPath, buf, vcdBuildSmbConfig(cfg, buf, sizeof(buf)));
         if (rc != 0) {
             if (createdIp)
-                unlink(VCD_POPS_MC0_IPCONFIG);
+                unlink(ipPath);
             return VCD_POPSNET_IO_ERROR;
         }
     }
@@ -2147,16 +2308,23 @@ vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
 
 vcd_popsnet_ensure_t vcdPreparePopstarterSmbLaunch(const char *smbPrefix)
 {
+    vcd_popsnet_t cfg;
     int installRes = 0;
-    if (smbPrefix != NULL && smbPrefix[0] != '\0') {
-        installRes = vcdInstallPopstarterMc(smbPrefix);
-    }
-    if (!vcdSmbModulesPresent()) {
+
+    if (vcdReadPopstarterNet(&cfg) != 0 || !cfg.homeAvailable || cfg.home[0] == '\0')
+        return VCD_POPSNET_IO_ERROR;
+    if (cfg.ipInvalid || cfg.smbInvalid)
+        return VCD_POPSNET_INVALID;
+    if (!vcdEnsurePopstarterNetDir(cfg.home))
+        return VCD_POPSNET_IO_ERROR;
+    if (smbPrefix != NULL && smbPrefix[0] != '\0')
+        installRes = vcdInstallPopstarterMcAt(smbPrefix, cfg.home);
+    if (!vcdSmbModulesPresentAt(cfg.home)) {
         if (installRes == -2 || installRes == -3)
             return VCD_POPSNET_IO_ERROR;
         return VCD_POPSNET_SMB_MISSING;
     }
-    return vcdEnsurePopstarterSmbConfigMc0();
+    return vcdEnsurePopstarterSmbConfig(&cfg);
 }
 
 void vcdPrepareRetroGemBarcode(const char *vcdPath)

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -678,6 +678,102 @@ static char vcdSep(const char *devPrefix)
     return (n > 0 && devPrefix[n - 1] == '\\') ? '\\' : '/';
 }
 
+// Choose the separator already used by a directory path. Unlike vcdSep(), this also handles an
+// SMB path whose final component is "POPS" rather than a trailing backslash.
+static char vcdDirSep(const char *dirPath)
+{
+    const char *slash = (dirPath != NULL) ? strrchr(dirPath, '/') : NULL;
+    const char *backslash = (dirPath != NULL) ? strrchr(dirPath, '\\') : NULL;
+
+    return (backslash != NULL && (slash == NULL || backslash > slash)) ? '\\' : '/';
+}
+
+static int vcdJoinDirFile(char *out, int outSize, const char *dirPath, const char *fileName)
+{
+    int n;
+    int dirLen;
+    char sep[2] = {0, 0};
+
+    if (out == NULL || outSize <= 0 || dirPath == NULL || fileName == NULL)
+        return -1;
+
+    dirLen = strlen(dirPath);
+    if (dirLen == 0)
+        return -1;
+    if (dirPath[dirLen - 1] != '/' && dirPath[dirLen - 1] != '\\')
+        sep[0] = vcdDirSep(dirPath);
+
+    n = snprintf(out, outSize, "%s%s%s", dirPath, sep, fileName);
+    return (n >= 0 && n < outSize) ? 0 : -1;
+}
+
+// Keep a VCD rename inside the POPSTARTER addressable name space. The scanner cannot represent a
+// longer basename and deliberately omits POPSTARTER itself, so accepting either here would make a
+// successful-looking rename vanish from the list or cease to launch.
+static int vcdValidRenameName(const char *name)
+{
+    size_t len;
+
+    if (name == NULL || name[0] == '\0' || strpbrk(name, ":/\\") != NULL)
+        return 0;
+    len = strlen(name);
+    return len <= ISO_GAME_NAME_MAX && strcasecmp(name, "POPSTARTER") != 0;
+}
+
+int vcdRenameFileInDir(const char *dirPath, const char *oldName, const char *newName)
+{
+    DIR *dir;
+    struct dirent *de;
+    char oldFile[VCD_NAME_MAX + 4];
+    char newFile[VCD_NAME_MAX + 4];
+    char oldPath[512];
+    char newPath[512];
+    size_t oldLen;
+
+    if (dirPath == NULL || oldName == NULL || !vcdValidRenameName(oldName) || !vcdValidRenameName(newName))
+        return -1;
+
+    oldLen = strlen(oldName);
+    dir = opendir(dirPath);
+    if (dir == NULL)
+        return -1;
+
+    oldFile[0] = '\0';
+    while ((de = readdir(dir)) != NULL) {
+        size_t len = strlen(de->d_name);
+        if (len == oldLen + 4 && !strncmp(de->d_name, oldName, oldLen) && !strcasecmp(de->d_name + oldLen, ".VCD")) {
+            snprintf(oldFile, sizeof(oldFile), "%s", de->d_name);
+            break;
+        }
+    }
+    closedir(dir);
+
+    if (oldFile[0] == '\0')
+        return -1;
+    if (snprintf(newFile, sizeof(newFile), "%s%s", newName, oldFile + oldLen) >= (int)sizeof(newFile))
+        return -1;
+    if (vcdJoinDirFile(oldPath, sizeof(oldPath), dirPath, oldFile) < 0 ||
+        vcdJoinDirFile(newPath, sizeof(newPath), dirPath, newFile) < 0)
+        return -1;
+
+    if (rename(oldPath, newPath) != 0) {
+        LOG("VCD rename failed: %s -> %s (%d)\n", oldPath, newPath, errno);
+        return -1;
+    }
+
+    vcdInvalidateGameIds();
+    return 0;
+}
+
+int vcdRenameFile(const char *devPrefix, const char *oldName, const char *newName)
+{
+    char dirPath[256];
+
+    if (devPrefix == NULL || snprintf(dirPath, sizeof(dirPath), "%s%s", devPrefix, POPS_FOLDER) >= (int)sizeof(dirPath))
+        return -1;
+    return vcdRenameFileInDir(dirPath, oldName, newName);
+}
+
 // VCD (PS1) cover FALLBACK. OPL's own art (<dev>ART/<name>_COV.png) is the PRIMARY -- each device's
 // getImage tries it first; this only runs on a genuine miss. It loads the POPSLoader-style cover named
 // exactly like the .VCD (suffixless "<name>.png"), sitting NEXT TO the game in the same POPS/ folder the
@@ -924,13 +1020,18 @@ int vcdConsumeDirty(int mode)
     return 1;
 }
 
+void vcdMarkDirty(int mode)
+{
+    if (mode >= 0 && mode < MODE_COUNT && vcdModeSupported(mode))
+        vcdDirty[mode] = 1;
+}
+
 // Mark every VCD-capable mode for one rescan -- call after the global default-view setting changes so
 // each device page rebuilds its list (ISO <-> VCD) on its next refresh.
 void vcdMarkAllDirty(void)
 {
     for (int m = 0; m < MODE_COUNT; m++)
-        if (vcdModeSupported(m))
-            vcdDirty[m] = 1;
+        vcdMarkDirty(m);
 }
 
 // #118: a multi-disc PS1 game is a set of separate .VCD files whose titles carry a disc token, e.g.

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -2031,6 +2031,120 @@ int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int write
     return 0;
 }
 
+// ---- POPStarter SMB auto-provisioning for mc0:/POPSTARTER/ ------------------
+// Presence-wins helper for SMB VCD launches. See include/vcdsupport.h for contract.
+// Only missing files are generated; existing files are never parsed or touched.
+// Uses current RiptOPL globals (ps2_ip*, pc_ip, gPCShareName, etc.) when derivable.
+// Reuses vcdBuildIpConfig / vcdBuildSmbConfig / vcdSafeWriteFile so the DAT
+// byte-shape stays single-sourced.
+#define VCD_POPS_MC0_DIR       "mc0:/POPSTARTER"
+#define VCD_POPS_MC0_IPCONFIG  "mc0:/POPSTARTER/IPCONFIG.DAT"
+#define VCD_POPS_MC0_SMBCONFIG "mc0:/POPSTARTER/SMBCONFIG.DAT"
+
+static int vcdPopsMc0Exists(const char *path)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd >= 0) {
+        close(fd);
+        return 1;
+    }
+    return 0;
+}
+
+vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
+{
+    int ipExists = vcdPopsMc0Exists(VCD_POPS_MC0_IPCONFIG);
+    int smbExists = vcdPopsMc0Exists(VCD_POPS_MC0_SMBCONFIG);
+
+    if (ipExists && smbExists)
+        return VCD_POPSNET_READY;
+
+    int needIp = !ipExists;
+    int needSmb = !smbExists;
+
+    int canDeriveIp = 0;
+    int canDeriveSmb = 0;
+
+    if (needIp) {
+        if (!ps2_ip_use_dhcp &&
+            vcdQuadOk(ps2_ip) && vcdQuadOk(ps2_netmask) && vcdQuadOk(ps2_gateway) &&
+            (ps2_ip[0] | ps2_ip[1] | ps2_ip[2] | ps2_ip[3]) != 0 &&
+            (ps2_netmask[0] | ps2_netmask[1] | ps2_netmask[2] | ps2_netmask[3]) != 0 &&
+            (ps2_gateway[0] | ps2_gateway[1] | ps2_gateway[2] | ps2_gateway[3]) != 0) {
+            canDeriveIp = 1;
+        }
+        if (!canDeriveIp)
+            return VCD_POPSNET_NEED_STATIC;
+    }
+
+    if (needSmb) {
+        if (gPCShareName[0] != '\0' && vcdQuadOk(pc_ip) &&
+            (pc_ip[0] | pc_ip[1] | pc_ip[2] | pc_ip[3]) != 0 &&
+            strlen(gPCShareName) < sizeof(((vcd_popsnet_t *)0)->smbShare) &&
+            strlen(gPCUserName) < sizeof(((vcd_popsnet_t *)0)->smbUser) &&
+            strlen(gPCPassword) < sizeof(((vcd_popsnet_t *)0)->smbPass)) {
+            if (gPCPort >= 0 && gPCPort <= 65535)
+                canDeriveSmb = 1;
+        }
+        if (!canDeriveSmb) {
+            if (gPCShareName[0] != '\0' && (pc_ip[0] | pc_ip[1] | pc_ip[2] | pc_ip[3]) == 0)
+                return VCD_POPSNET_NEED_STATIC;
+            return VCD_POPSNET_INVALID;
+        }
+    }
+
+    if (needIp || needSmb) {
+        DIR *d = opendir(VCD_POPS_MC0_DIR);
+        if (d == NULL) {
+            mkdir(VCD_POPS_MC0_DIR, 0777);
+        } else {
+            closedir(d);
+        }
+    }
+
+    if (needIp) {
+        vcd_popsnet_t tmp;
+        memset(&tmp, 0, sizeof(tmp));
+        tmp.ipDhcp = 0;
+        memcpy(tmp.ps2Ip, ps2_ip, sizeof(tmp.ps2Ip));
+        memcpy(tmp.ps2Mask, ps2_netmask, sizeof(tmp.ps2Mask));
+        memcpy(tmp.ps2Gw, ps2_gateway, sizeof(tmp.ps2Gw));
+        char buf[256];
+        int len = vcdBuildIpConfig(&tmp, buf, sizeof(buf));
+        int rc = vcdSafeWriteFile(VCD_POPS_MC0_IPCONFIG, buf, len);
+        if (rc != 0)
+            return VCD_POPSNET_IO_ERROR;
+    }
+
+    if (needSmb) {
+        vcd_popsnet_t tmp;
+        memset(&tmp, 0, sizeof(tmp));
+        memcpy(tmp.smbIp, pc_ip, sizeof(tmp.smbIp));
+        tmp.smbPort = gPCPort;
+        snprintf(tmp.smbShare, sizeof(tmp.smbShare), "%s", gPCShareName);
+        snprintf(tmp.smbUser, sizeof(tmp.smbUser), "%s", gPCUserName);
+        snprintf(tmp.smbPass, sizeof(tmp.smbPass), "%s", gPCPassword);
+        char buf[256];
+        int len = vcdBuildSmbConfig(&tmp, buf, sizeof(buf));
+        int rc = vcdSafeWriteFile(VCD_POPS_MC0_SMBCONFIG, buf, len);
+        if (rc != 0)
+            return VCD_POPSNET_IO_ERROR;
+    }
+
+    return VCD_POPSNET_READY;
+}
+
+vcd_popsnet_ensure_t vcdPreparePopstarterSmbLaunch(const char *smbPrefix)
+{
+    if (smbPrefix != NULL && smbPrefix[0] != '\0') {
+        (void)vcdInstallPopstarterMc(smbPrefix);
+    }
+    if (!vcdSmbModulesPresent()) {
+        return VCD_POPSNET_SMB_MISSING;
+    }
+    return vcdEnsurePopstarterSmbConfigMc0();
+}
+
 void vcdPrepareRetroGemBarcode(const char *vcdPath)
 {
     char gameID[RETROGEM_GAMEID_MAX];

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -2175,7 +2175,9 @@ int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int write
 {
     char buf[256];
     char path[128];
+    char smbPath[128];
     const char *dir;
+    int createdSmb = 0;
     int rc;
 
     if (cfg == NULL)
@@ -2192,10 +2194,11 @@ int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int write
     if (writeSmb) {
         int len = vcdBuildSmbConfig(cfg, buf, sizeof(buf));
 
-        snprintf(path, sizeof(path), "%s/SMBCONFIG.DAT", dir);
-        rc = vcdSafeWriteFile(path, buf, len);
+        snprintf(smbPath, sizeof(smbPath), "%s/SMBCONFIG.DAT", dir);
+        rc = vcdSafeWriteFile(smbPath, buf, len);
         if (rc != 0)
             return rc;
+        createdSmb = !cfg->smbExists;
     }
 
     if (writeIp) {
@@ -2203,8 +2206,13 @@ int vcdWritePopstarterNetFiles(const vcd_popsnet_t *cfg, int writeSmb, int write
 
         snprintf(path, sizeof(path), "%s/IPCONFIG.DAT", dir);
         rc = vcdSafeWriteFile(path, buf, len);
-        if (rc != 0)
+        if (rc != 0) {
+            // Pair creation must not leave a newly generated SMB configuration behind when its
+            // companion IPCONFIG.DAT cannot be committed. Existing SMB files are user-owned.
+            if (createdSmb)
+                unlink(smbPath);
             return rc;
+        }
     }
 
     return 0;

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -728,7 +728,8 @@ int vcdResolvePopstarter(const char *devPrefix, char *out, int outSize)
     // (mc/usb/mx4sio/mmce/exfat/apa) -> <root>:/POPS/POPSTARTER.ELF | Default -> the boot device (cwd)
     // then the VCD's own device. Each candidate is open()-probed; a miss falls through to the next tier.
     // NOTE: this serves the bdm/eth/mmce launch paths; the HDD VCD launch keeps its own freeze-guarded
-    // hddResolveHddPopstarter (the __common/+OPL pfs search), so HDD VCDs always load POPSTARTER off the HDD.
+    // hddResolveHddPopstarter (__common/POPS only), so HDD VCDs always load POPSTARTER from the
+    // canonical APA loose-file home rather than the selected OPL data partition.
 
     // GAME'S DEVICE: resolve ONLY on the VCD's own device (devPrefix); no boot-device (cwd) tier and
     // no Default fallthrough. A miss returns 0 so the launch path shows "Missing POPSTARTER.ELF"
@@ -782,7 +783,8 @@ int vcdResolvePopstarter(const char *devPrefix, char *out, int outSize)
                 // pfs0: BEFORE sysLaunchPopstarter re-opens the resolved ELF, so a pfs0: path that
                 // open()-probes fine HERE is dead by the time it is read (black screen into deinit'd
                 // OPL). HDD-page VCD launches keep APA POPSTARTER via their own freeze-guarded
-                // hddResolveHddPopstarter; for the rest, fall through to the Default tiers below.
+                // hddResolveHddPopstarter, which mounts hdd0:__common/POPS rather than the selected
+                // OPL data partition; for the rest, fall through to the Default tiers below.
                 LOG("VCD POPSTARTER Device 'HDD (APA)' is HDD-page-only; falling back to Default for this launch\n");
                 break;
             default:

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -21,6 +21,7 @@
 #include "include/system.h"      // POPS_FOLDER
 #include "include/ioman.h"       // LOG (BDMA equip probe trace)
 #include "include/bdmsupport.h"  // BDM_TYPE_* + bdmGetDeviceRootByType (BDMA source differentiation)
+#include "include/ethsupport.h"  // active mounted SMB prefix for manual POPS DAT import
 #include "include/mmcesupport.h" // mmceLoadModules (ensure mmceman for the MMCE BDMA source)
 #include "include/gui.h"         // guiWarning (passing toast on a failed launch-path BDMA equip)
 #include "include/texcache.h"    // cosmetic ID resolver yields while artwork is pending
@@ -2197,6 +2198,54 @@ int vcdReadPopstarterNet(vcd_popsnet_t *out)
         return -3;
 
     return 0;
+}
+
+vcd_popsnet_smb_import_t vcdReadPopstarterNetFromSmb(vcd_popsnet_t *out)
+{
+    char ipPath[128];
+    char smbPath[128];
+    char ipBuf[256];
+    char smbBuf[256];
+    const char *prefix;
+    int ipRead;
+    int smbRead;
+
+    if (out == NULL)
+        return VCD_POPSNET_SMB_IMPORT_NOT_CONNECTED;
+
+    memset(out, 0, sizeof(*out));
+    out->ipDhcp = 1;
+    if (!ethIsSMBShareConnected())
+        return VCD_POPSNET_SMB_IMPORT_NOT_CONNECTED;
+
+    prefix = ethGetSMBPrefix();
+    if (prefix == NULL || prefix[0] == '\0')
+        return VCD_POPSNET_SMB_IMPORT_NOT_CONNECTED;
+
+    // smbman/smb2man use the same backslash form as the active ETH/VCD paths. `prefix` already
+    // has one for a configured subfolder; at share root it is exactly `smb0:`.
+    snprintf(ipPath, sizeof(ipPath), "%sPOPS\\IPCONFIG.DAT", prefix);
+    snprintf(smbPath, sizeof(smbPath), "%sPOPS\\SMBCONFIG.DAT", prefix);
+    ipRead = vcdReadNetFile(ipPath, ipBuf, sizeof(ipBuf));
+    smbRead = vcdReadNetFile(smbPath, smbBuf, sizeof(smbBuf));
+    if (ipRead < 0 || smbRead < 0)
+        return VCD_POPSNET_SMB_IMPORT_NOT_FOUND;
+
+    out->ipExists = 1;
+    out->smbExists = 1;
+    snprintf(out->ipDir, sizeof(out->ipDir), "%sPOPS", prefix);
+    snprintf(out->smbDir, sizeof(out->smbDir), "%sPOPS", prefix);
+    if (!vcdNetTextBlank(ipBuf)) {
+        if (!vcdParseIpConfig(ipBuf, out) || !vcdStaticIpUsable(out))
+            return VCD_POPSNET_SMB_IMPORT_NOT_FOUND;
+        out->ipDhcp = 0;
+    }
+
+    vcdParseSmbConfig(smbBuf, out);
+    if (!vcdSmbConfigUsable(out))
+        return VCD_POPSNET_SMB_IMPORT_NOT_FOUND;
+
+    return VCD_POPSNET_SMB_IMPORT_OK;
 }
 
 int vcdPopsNetChanged(const vcd_popsnet_t *orig, const vcd_popsnet_t *cur)

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -2048,13 +2048,18 @@ static int vcdPopsMc0Exists(const char *path)
         close(fd);
         return 1;
     }
-    return 0;
+    if (errno == ENOENT)
+        return 0;
+    return -1;
 }
 
 vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
 {
     int ipExists = vcdPopsMc0Exists(VCD_POPS_MC0_IPCONFIG);
     int smbExists = vcdPopsMc0Exists(VCD_POPS_MC0_SMBCONFIG);
+
+    if (ipExists < 0 || smbExists < 0)
+        return VCD_POPSNET_IO_ERROR;
 
     if (ipExists && smbExists)
         return VCD_POPSNET_READY;
@@ -2102,6 +2107,8 @@ vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
         }
     }
 
+    int createdIp = 0;
+
     if (needIp) {
         vcd_popsnet_t tmp;
         memset(&tmp, 0, sizeof(tmp));
@@ -2114,6 +2121,7 @@ vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
         int rc = vcdSafeWriteFile(VCD_POPS_MC0_IPCONFIG, buf, len);
         if (rc != 0)
             return VCD_POPSNET_IO_ERROR;
+        createdIp = 1;
     }
 
     if (needSmb) {
@@ -2127,8 +2135,11 @@ vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
         char buf[256];
         int len = vcdBuildSmbConfig(&tmp, buf, sizeof(buf));
         int rc = vcdSafeWriteFile(VCD_POPS_MC0_SMBCONFIG, buf, len);
-        if (rc != 0)
+        if (rc != 0) {
+            if (createdIp)
+                unlink(VCD_POPS_MC0_IPCONFIG);
             return VCD_POPSNET_IO_ERROR;
+        }
     }
 
     return VCD_POPSNET_READY;
@@ -2136,10 +2147,13 @@ vcd_popsnet_ensure_t vcdEnsurePopstarterSmbConfigMc0(void)
 
 vcd_popsnet_ensure_t vcdPreparePopstarterSmbLaunch(const char *smbPrefix)
 {
+    int installRes = 0;
     if (smbPrefix != NULL && smbPrefix[0] != '\0') {
-        (void)vcdInstallPopstarterMc(smbPrefix);
+        installRes = vcdInstallPopstarterMc(smbPrefix);
     }
     if (!vcdSmbModulesPresent()) {
+        if (installRes == -2 || installRes == -3)
+            return VCD_POPSNET_IO_ERROR;
         return VCD_POPSNET_SMB_MISSING;
     }
     return vcdEnsurePopstarterSmbConfigMc0();


### PR DESCRIPTION
## Hardware Pass #2 — Settings UX, APA Selection, POPSTARTER Network, BGM, Boot/HDD Fixes

Continues the existing PR behavior from `504fd0f6`; the current APA topology and save-transaction correction is at [`a295d8b9`](https://github.com/NathanNeurotic/Open-PS2-Loader/commit/a295d8b9ae2e3603f4f7b7b9df92497c8efe4150) on the current `rebuild/main` base [`69b287ab`](https://github.com/NathanNeurotic/Open-PS2-Loader/commit/69b287ab5160cf00cbb33bb1762586a35e0af4fd).

### Main menu and Sources

- Removed the otherwise-empty Tools page. **Network Update** and **Start NBD Server** are direct Main Menu actions with the same handlers and parental-lock gate.
- Sources now reads, in order: Default Device; **HDD (APA) Start Mode**; **HDD (APA) OPL Partition**; MMCE Start Mode; MMCE Settings; **BDM Devices Start Mode**; **Internal HDD (exFAT)**; USB; MX4SIO; iLink; **Network Connectivity**; **Applications Page Start Mode**; **Favorites Page Start Mode**.
- MMCE is positioned between APA and BDM/exFAT controls; its composed editor no longer repeats Communication Settings / Path Settings headers.

### APA OPL data-home selector

- The new selector exposes only `__common/OPL/` and `+OPL/`.
- It validates an already-existing target with a temporary `pfs1:` mount, stages the choice until **Save Settings**, and tells the user to restart RiptOPL before the active data home changes.
- With a mountable `__common`, an explicit `+OPL` choice writes `hdd_partition=+OPL` to `__common/OPL/conf_hdd.cfg`; the common choice removes that key. A legacy custom redirect is untouched by merely visiting or saving unrelated Sources settings.
- If `__common` is absent or unmountable but an existing `+OPL` mounts, `+OPL` is the automatic effective home: `gOPLPart = hdd0:+OPL`, `gHDDPrefix = pfs0:`, no selector file is read or written, and normal config, ART, THM, LNG, cache, and BGM use its PFS root.
- The selector never creates, formats, resizes, or writes raw APA metadata, and never remounts live `pfs0:`. Loose POPS files remain owned by `__common/POPS/`.

### Settings UI

- General & System adds the requested three visual breaks, a second shared Language entry, and shared GSM Defaults access.
- Interface now starts **ISO/VCD Games Lists**, Video Mode, Theme, Coverflow Settings, Artwork Settings, and Color Palettes; it keeps shared Language, puts Notifications above Sort Games Alphabetically, and calls the shared editor **VCD Games List Settings**.
- Game Launching has shared GSM Defaults and **Neutrino Advanced Arguments**.
- POPSTARTER removes the inline BDMA heading/splitter, retains all BDMA rows, uses the corrected best-effort BDMA hint, and calls the shared VCD list editor **VCD Games List Settings**.
- Settings peer pages no longer advertise or handle Triangle → Settings Index; L1/R1 and Circle hierarchy remain unchanged.

### POPSTARTER network

- The roughly 10-second entry stall came from synchronous `vcdReadPopstarterNet()` work before the editor existed: MC0/MC1 home resolution plus directory/DAT RPC probes ran on the GUI thread.
- That read now runs on the existing I/O queue with an animated Settings frame, live input, Circle abort, and a 15-second bounded wait. The normal runtime overlay can render here; initial-startup spinner suppression is unaffected.
- **Import from SMB POPS Directory** reads the active mounted share’s `POPS/IPCONFIG.DAT` and `POPS/SMBCONFIG.DAT` through the existing strict parser. It neither reconnects SMB nor writes memory-card files until normal editor confirmation. Disconnected SMB and missing/malformed remote files leave editor values intact with a direct message.
- Automatic SMB VCD / `SB.*.ELF` preparation remains separate and unchanged.

### Default-theme BGM

- Disk themes retain their existing `sound/bgm.ogg` then configured-path behavior.
- Built-in themes use: explicit Default Theme Music path → automatic conventional `bgm.ogg` → silence.
- The automatic path is exactly the boot CWD on non-APA devices; on APA it is `pfs0:OPL/THM/bgm.ogg` for `__common/OPL` or `pfs0:THM/bgm.ogg` for `+OPL`. There is no device scan and a missing file is normal.

### Startup and HDD reporting

- The prior spinner gate watched only `gBootInProgress`, which could clear while the intro splash still owned the screen. The generic busy spinner is now suppressed for the entire intro-splash lifecycle and remains available for runtime I/O.
- The false HDD-not-formatted report came from treating unresolved/mount-failed OPL data-home discovery and PFS-load failure as formatting evidence. Only `hddCheck() == 1` now emits that wording. unavailable/PFS conditions receive distinct messages; successful retry and recognized BDM-style disk probes clear only the matching stale HDD notification.

### Post-publish reviewer cleanup

- Existing `+OPL` now remains a valid automatic APA data home when `__common` is absent or unmountable; the fallback neither creates a partition nor probes/re-writes `__common` after `+OPL` is established.
- APA selector stage/commit checks now use the already-resident ATA stack, so repeated Sources → stage → save → reopen flows do not retain extra HDD/DEV9 module references.
- A missing `__common/OPL/conf_hdd.cfg` plus the default Common choice is a successful no-op; only an explicit `+OPL` selection creates the selector file. Existing selector files still remove `hdd_partition` when returning to Common.
- An HDD VCD launch now stops before any `pfs0:` unmount/remount if artwork cannot quiesce within its bounded timeout.
- The new UI text is localized and the language tables were regenerated. Error-message rendering preserves supported `%s`/`%d` substitutions without treating arbitrary localized text as a printf format.
- The Makefile BGM comment now documents the distinct non-APA boot/CWD and APA `<gHDDPrefix>THM/bgm.ogg` fallbacks.

### Latest APA selector transaction (`a295d8b9`)

- When a user stages a different APA OPL home, changed configuration sets are written through a temporary `pfs1:` target mount before the selector file is committed. The live `pfs0:` mount remains untouched; a failed target write leaves the selector pending rather than pointing next boot at an unwritten home.
- After a successful selector save, later saves before restart use that selected target home as well. The automatic no-`__common` existing-`+OPL` fallback remains fileless and retains its established live data home.
- Sources now restores both the displayed selector and its staged-change marker after a failed stage. It also distinguishes a genuinely missing partition from a busy/deferred-I/O condition.

### Validation

- `git diff --check` passed for `a295d8b9`.
- Project-pinned clang-format 12 equivalent passed for every changed C/H file.
- Language tables were regenerated normally.
- Focused PS2DEV EE compilation passed for `gui`, `guigame`, `hddsupport`, `vcdsupport`, `ethsupport`, `opl`, `sound`, `dialogs`, `dia`, and `menusys`.
- Fresh current-head CI passed: [format check #2467](https://github.com/NathanNeurotic/Open-PS2-Loader/actions/runs/32754194215) and [four-flavour build #572](https://github.com/NathanNeurotic/Open-PS2-Loader/actions/runs/32754194208).
- Fresh test artifacts for `a295d8b9`: [PS2DEVPINNED](https://github.com/NathanNeurotic/Open-PS2-Loader/actions/runs/32754194208/artifacts/9530235109), [PS2DEVROLLING](https://github.com/NathanNeurotic/Open-PS2-Loader/actions/runs/32754194208/artifacts/9530229712), [OFFICIALPINNED](https://github.com/NathanNeurotic/Open-PS2-Loader/actions/runs/32754194208/artifacts/9530227930), and [OFFICIALROLLING](https://github.com/NathanNeurotic/Open-PS2-Loader/actions/runs/32754194208/artifacts/9530237785).
- CodeRabbit incremental re-review was requested after CI, but CodeRabbit reported its review rate limit; no review thread has been manually resolved or altered.

### Console validation still required

- Main Menu direct Network Update / Start NBD Server and parental-lock behavior.
- Sources order/labels; MMCE layout; shared Language/GSM/VCD-list editors and peer navigation.
- APA common / configured +OPL / no-`__common` existing-`+OPL` / neither-home cases, including cold-boot timing, fileless automatic `+OPL`, and unchanged `__common/POPS` ownership.
- POPSTARTER local-editor responsiveness, disconnected/valid/malformed SMB import controls.
- BGM precedence on non-APA, APA common, APA +OPL, and a disk theme.
- Intro splash has no generic pink spinner while runtime operations still do.
- APA + BDM/exFAT startup has no stale HDD-format notification; a real unformatted APA disk still reports a real failure.
- Existing VCD Rename-only routing and POPSTARTER-only launches across supported device views.

No merge has been performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved POPSTARTER network configuration, including SMB import, validation, overwrite choices, and clearer error handling.
  - Added HDD APA OPL partition selection with staged, save-time changes.
  - Added VCD-specific menus and rename support across supported storage devices.
  - Added video-mode editing, language settings, GSM defaults, and improved settings navigation.
  - Added automatic SMB preparation when launching supported network applications.
- **Bug Fixes**
  - Improved boot recovery, fallback behavior, configuration persistence, background-music loading, and artwork reliability.
  - Corrected POPSTARTER home resolution and HDD availability reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->