### PR TITLE
fix(hdd): keep APA art on the selected OPL home

### DIFF
--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -166,6 +166,11 @@ typedef struct _item_list_t
     /// source without mutating the real source page's independent view. Appended last so all legacy
     /// positional item_list_t initializers default safely to native behavior.
     unsigned char viewOverride;
+
+    /// Resolve this item's ART/art.tar to one exact path. Return >0 after writing that path, 0 to
+    /// retain the generic archive lookup, or <0 to skip archive probing entirely. APA uses this to
+    /// keep artwork on its already-selected PFS data home.
+    int (*itemGetArtArchivePath)(item_list_t *itemList, const char *value, char *path, int pathSize);
 } item_list_t;
 
 #define ITEM_VIEW_NATIVE    0

--- a/include/pad.h
+++ b/include/pad.h
@@ -50,14 +50,20 @@ void padRestoreSettings(int *buffer);
  * that is still held when the destination appears. */
 void padFreezeEdgeBaseline(int freeze);
 
-/** Starts a menu rumble pulse on every connected pad that has actuators.
- * @param durationMs pulse length in ms (clamped internally)
- * @param large large-engine strength 0..255; the small engine runs for the whole pulse */
-void padRumble(int durationMs, int large);
+/** Enables menu rumble after startup. Before this, the intro loop can emit SFX_CURSOR without
+ * polling pads, so actuator commands must stay disabled. */
+void padRumbleActivate(void);
 
-/** Stops any rumble pulse in flight. Call before blocking the GUI thread -- the decay only runs
- * from readPads(), so a pulse started just before a blocking read would outlast it. */
+/** Navigation thump and decision bump. Both no-op when controller vibration is disabled. */
+void padRumbleTap(void);
+void padRumbleTapList(void);
+void padRumbleBump(void);
+
+/** Plays out a short in-flight decision bump, then stops it before blocking the GUI thread. */
 void padRumbleFlush(void);
+
+/** Stops all pad actuators immediately before polling or pad ownership stops. */
+void padRumbleStopAll(void);
 
 /** Debug HUD: longest run of polls where the pad could not be READ (freepad not ready -> SIO2 or
  * IOP-side), and longest run of polls that read fine but carried no buttons (fresh, empty sample ->

--- a/include/tar.h
+++ b/include/tar.h
@@ -66,6 +66,9 @@ typedef enum {
     TAR_KIND_ART = 0,
     TAR_KIND_CFG = 1,
     TAR_KIND_CHT = 2,
+    // APA artwork has one selected PFS data home per session. Keep its index independent from the
+    // generic all-device ART archive so it can never select another source's archive.
+    TAR_KIND_HDD_ART = 3,
     TAR_KIND_MAX
 } TarKind;
 
@@ -75,6 +78,9 @@ int tarClose(TarKind kind);
 
 TarEntryBase *tarFind(TarKind kind, const char *filename);
 TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix);
+// Exact-path lookup: never scans the generic device list. Reuses the selected path's index for the
+// session and reads members back from that same path.
+TarEntryBase *tarFindPrefixFromPath(TarKind kind, const char *path, const char *prefix);
 void *tarGet(TarKind kind, const char *filename);
 u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize);
 

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -907,6 +907,23 @@ static int appGetImage(item_list_t *itemList, char *folder, int isRelative, char
     return oplGetAppImageByMode(app->artMode, folder, isRelative, value, suffix, resultTex, psm);
 }
 
+// Apps proxy artwork to their recorded source mode. Preserve a selected APA source's one-home
+// rule for packed art too; an unavailable HDD source must not fall back to the generic tar sweep.
+static int appGetArtArchivePath(item_list_t *itemList, const char *value, char *path, int pathSize)
+{
+    app_info_t *app = appLookupByStartup(value);
+
+    if (app == NULL || app->artMode < 0 || app->artMode >= MODE_COUNT)
+        return 0;
+
+    opl_io_module_t *module = oplGetModule(app->artMode);
+    item_list_t *source = module != NULL ? module->support : NULL;
+    if (source != NULL && source->itemGetArtArchivePath != NULL)
+        return source->itemGetArtArchivePath(source, value, path, pathSize);
+
+    return app->artMode == HDD_MODE ? -1 : 0;
+}
+
 static int appGetTextId(item_list_t *itemList)
 {
     return _STR_APPS;
@@ -948,4 +965,4 @@ static void appShutdown(item_list_t *itemList)
 static item_list_t appItemList = {
     APP_MODE, -1, 0, MODE_FLAG_NO_COMPAT | MODE_FLAG_NO_UPDATE, MENU_MIN_INACTIVE_FRAMES, APP_MODE_UPDATE_DELAY, NULL, NULL, &appGetTextId, NULL, &appInit, &appNeedsUpdate, &appUpdateItemList,
     &appGetItemCount, NULL, &appGetItemName, &appGetItemNameLength, &appGetItemStartup, &appDeleteItem, &appRenameItem, &appLaunchItem,
-    &appGetConfig, &appGetImage, &appCleanUp, &appShutdown, NULL, &appGetIconId};
+    &appGetConfig, &appGetImage, &appCleanUp, &appShutdown, NULL, &appGetIconId, NULL, ITEM_VIEW_NATIVE, &appGetArtArchivePath};

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -754,6 +754,42 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
     return -1;
 }
 
+// Keep a favourite's archive lookup with its owning source. In particular, an HDD favourite must
+// use the selected APA PFS home rather than the generic multi-device ART archive search.
+static int favGetArtArchivePath(item_list_t *itemList, const char *value, char *path, int pathSize)
+{
+    if (favArray == NULL || value == NULL)
+        return 0;
+
+    for (int i = 0; i < favCount; i++) {
+        item_list_t ownerView;
+        item_list_t *o = favOwnerView(i, &ownerView);
+        if (o == NULL)
+            continue;
+
+        if (favArray[i].isVcd) {
+            if (strcmp(favArray[i].text, value) != 0) {
+                char fallbackKey[VCD_ID_MAX];
+                if (!vcdExtractGameId(favArray[i].text, fallbackKey, sizeof(fallbackKey)) ||
+                    strcmp(fallbackKey, value) != 0)
+                    continue;
+            }
+        } else {
+            if (o->itemGetStartup == NULL || !favOwnerHasId(o, favArray[i].id))
+                continue;
+            char *startup = o->itemGetStartup(o, favArray[i].id);
+            if (startup == NULL || strcmp(startup, value) != 0)
+                continue;
+        }
+
+        return o->itemGetArtArchivePath != NULL ?
+                   o->itemGetArtArchivePath(o, value, path, pathSize) :
+                   0;
+    }
+
+    return 0;
+}
+
 // Resolve an art-cache `value` (a source item's startup, or a VCD favourite's .VCD name /
 // strict PS1 id) to the favourite's SOURCE device mode, using the same matching favGetImage
 // uses to route the actual read. Lets texcache apply MMCE idle deferral, abort,
@@ -975,4 +1011,4 @@ item_list_t *favGetObject(int initOnly)
 static item_list_t favItemList = {
     FAV_MODE, -1, 0, 0, MENU_MIN_INACTIVE_FRAMES, FAV_MODE_UPDATE_DELAY, NULL, NULL, &favGetTextId, NULL, &favInit, &favNeedsUpdate, &favUpdateItemList,
     &favGetItemCount, NULL, &favGetItemName, &favGetItemNameLength, &favGetItemStartup, &favDeleteItem, &favRenameItem, &favLaunchItem,
-    &favGetConfig, &favGetImage, &favCleanUp, &favShutdown, &favCheckVMC, &favGetIconId};
+    &favGetConfig, &favGetImage, &favCleanUp, &favShutdown, &favCheckVMC, &favGetIconId, NULL, ITEM_VIEW_NATIVE, &favGetArtArchivePath};

--- a/src/gui.c
+++ b/src/gui.c
@@ -2144,8 +2144,10 @@ void guiShowArtworkConfig(void)
             // does nothing".
             int previousArtTar = gEnableArtTar;
             diaGetInt(diaArtworkConfig, UICFG_ENABLE_ART_TAR, &gEnableArtTar);
-            if (gEnableArtTar != previousArtTar)
+            if (gEnableArtTar != previousArtTar) {
                 tarInvalidate(TAR_KIND_ART);
+                tarInvalidate(TAR_KIND_HDD_ART);
+            }
         }
         int artDelayIdx = 0;
         diaGetInt(diaArtworkConfig, UICFG_ART_DELAY, &artDelayIdx);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -35,6 +35,11 @@ static unsigned char hddForceUpdate = 0;
 static unsigned char hddHDProKitDetected = 0;
 static unsigned char hddModulesLoadCount = 0;
 static unsigned char hddModulesLoaded = 0;
+// Residency is published before the one-second ATA settle so list retry can observe it, but PFS
+// must not start until the settle has completed. With every source on Auto another boot task can
+// otherwise see the resident latch mid-delay, start PS2FS too early, and leave a false code-222
+// notification behind even though the next retry mounts APA normally.
+static unsigned char hddModulesSettled = 0;
 static unsigned char hddSupportModulesLoaded = 0;
 // One toast per failure streak: hddUpdateGameList now RETRIES the support-module load every refresh
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
@@ -273,6 +278,7 @@ int hddLoadModules(void)
         // Increment the load count as soon as possible to prevent thread scheduling from allowing another thread to
         // call into here and try to double load modules.
         hddModulesLoadCount = 1;
+        hddModulesSettled = 0;
 
         // DEV9 must be loaded, as HDD.IRX depends on it. Even if not required by the I/F (i.e. HDPro)
         sysInitDev9();
@@ -314,6 +320,7 @@ int hddLoadModules(void)
             // arm did not, and rebuild-153's device-refresh bump made the retry more frequent.
             sysShutdownDev9();
             hddModulesLoadCount = 0;
+            hddModulesSettled = 0;
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;
             hddModulesLoaded = 1;
@@ -324,6 +331,7 @@ int hddLoadModules(void)
             // ATA_DEVCTL_READ_PARTITION_SECTOR probe / ps2hdd init can otherwise race a drive that is
             // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
             DelayThread(1000 * 1000);
+            hddModulesSettled = 1;
         }
     } else {
         hddModulesLoadCount++;
@@ -537,6 +545,12 @@ static int hddLoadCoreSupportModules(void)
 void hddLoadSupportModules(void)
 {
     int ret;
+
+    // Do not turn a concurrent Auto boot caller's mid-settle observation into a real PFS probe.
+    // The loader that owns the settle resumes into this function after the delay; if it is a
+    // BDM-only caller, the normal HDD list retry makes the first support attempt after it instead.
+    if (!hddModulesSettled)
+        return;
 
     if (!hddLoadCoreSupportModules())
         return;
@@ -1847,6 +1861,7 @@ static void hddShutdown(item_list_t *itemList)
             // DEV9 will remain active if ETH is in use, so put the HDD in IDLE state.
             // The HDD should still enter standby state after 21 minutes & 15 seconds, as per the ATAD defaults.
             hddSetIdleImmediate();
+            hddModulesSettled = 0;
         }
 
         // Only shut down dev9 from here, if it was initialized from here before -- and only on a
@@ -1977,7 +1992,23 @@ static char *hddGetPrefix(item_list_t *itemList)
     return gHDDPrefix;
 }
 
+// The persistent PFS mount is the session's sole APA data home. Keep packed artwork on that same
+// root: __common maps to pfs0:OPL/ART/art.tar, while +OPL maps to pfs0:ART/art.tar.
+static int hddGetArtArchivePath(item_list_t *itemList, const char *value, char *path, int pathSize)
+{
+    int len;
+
+    (void)itemList;
+    (void)value;
+
+    if (gHDDPrefix == NULL)
+        return -1;
+
+    len = snprintf(path, pathSize, "%sART/art.tar", gHDDPrefix);
+    return (len > 0 && len < pathSize) ? 1 : -1;
+}
+
 static item_list_t hddGameList = {
     HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, NULL, NULL, &hddGetTextId, &hddGetPrefix, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
     &hddGetGameCount, &hddGetGame, &hddGetGameName, &hddGetGameNameLength, &hddGetGameStartup, &hddDeleteGame, &hddRenameGame,
-    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId, &hddLaunchVcd};
+    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId, &hddLaunchVcd, ITEM_VIEW_NATIVE, &hddGetArtArchivePath};

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -45,6 +45,11 @@ static unsigned char hddSupportModulesLoaded = 0;
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
+// Auto startup enqueues hddInitModules before the initial HDD list refresh. A PS2FS load can still
+// transiently fail on that first post-settle attempt while the other Auto transports are coming up,
+// then succeed on the queued refresh. Keep that first failure pending so code 222 describes an
+// actually unavailable PFS stack, not a condition that already recovered before the menu is usable.
+static unsigned char hddPfsLoadRetryPending = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -526,14 +531,16 @@ static int hddLoadCoreSupportModules(void)
         ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: PFS support module failed to load.\n");
-            if (!hddSupportErrToasted) {
+            if (hddPfsLoadRetryPending && !hddSupportErrToasted) {
                 setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
                 hddSupportErrToasted = 1;
             }
+            hddPfsLoadRetryPending = 1;
             return 0;
         }
 
         hddSupportModulesLoaded = 1;
+        hddPfsLoadRetryPending = 0;
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
@@ -1838,6 +1845,8 @@ static int hddCheckVMC(item_list_t *itemList, char *name, int createSize)
 static void hddShutdown(item_list_t *itemList)
 {
     LOG("HDDSUPPORT Shutdown\n");
+
+    hddPfsLoadRetryPending = 0;
 
     if (hddGameList.enabled) {
         hddFreeHDLGamelist(&hddGames);

--- a/src/opl.c
+++ b/src/opl.c
@@ -3396,6 +3396,7 @@ void applyConfig(int themeID, int langID, int skipDeviceRefresh)
     // so returning to List Mode does not re-probe USB 1.1 storage.
     if (skipDeviceRefresh == 0) {
         tarInvalidate(TAR_KIND_ART);
+        tarInvalidate(TAR_KIND_HDD_ART);
         cacheInvalidateFailMemo();
         artIndexInvalidate(); // a full settings apply is the user's own "I changed something, look again"
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -4051,6 +4051,10 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
 
+    // Stop before the I/O drain and before PADEMU is reset below. Port closure alone leaves a
+    // latched motor running through a slow launch or exit.
+    padRumbleStopAll();
+
     // Give up on the covers still QUEUED before draining. The drain waits on the ioman LIST, and the
     // worker keeps servicing it regardless of isIOBlocked, so without this the handoff pays for every
     // queued cover to be read off the game device first -- for a menu guiEnd() is about to destroy.
@@ -4108,6 +4112,9 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 void deinit(int exception, int modeSelected)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
+
+    // See deinitEx(): pulse shutdown must precede any blocking drain or PADEMU reset.
+    padRumbleStopAll();
 
     // Give up on the covers still QUEUED before draining. The drain waits on the ioman LIST, and the
     // worker keeps servicing it regardless of isIOBlocked, so without this the handoff pays for every
@@ -4845,6 +4852,11 @@ int main(int argc, char *argv[])
     // and it must not gate a boot that otherwise works fine.
     if (strchr(configGetDir(), '?') != NULL)
         guiWarning(_l(_STR_SETTINGS_NO_HOME), 6);
+
+    // guiIntroLoop handles input against a frozen pad snapshot. Do not send actuator RPCs until
+    // guiMainLoop is about to resume normal polling, otherwise a held boot button can race IOP loads.
+    padRumbleActivate();
+    padRumbleBump();
 
     guiMainLoop();
 

--- a/src/pad.c
+++ b/src/pad.c
@@ -497,8 +497,21 @@ pulse is timed against raw cpu_ticks() deltas so it remains correct across the 3
 // then killed rumble silently for the whole session.
 static void padRumbleRealign(struct pad_data_t *pad)
 {
-    if (pad->actAligned || pad->actuators == 0)
+    if (!rumbleLive || pad->actAligned)
         return;
+
+    // initializePad() deliberately clears this on every attempt: retaining a count across an
+    // unplug could drive a replacement digital pad. A bounded startup attempt can also return
+    // before padInfoAct() while the controller is already usable. Rumble is live only after boot,
+    // and padInfoAct() is an EE-local query, so recover the current controller's actuator count at
+    // the first real menu pulse instead of permanently sending through freepad's 0xff alignment.
+    if (pad->actuators == 0) {
+        pad->actuators = padInfoAct(pad->port, pad->slot, -1, 0);
+        if (pad->actuators <= 0) {
+            pad->actuators = 0;
+            return;
+        }
+    }
 
     pad->actAlign[0] = 0; // small engine -> byte 0 of padSetActDirect
     pad->actAlign[1] = 1; // big engine   -> byte 1

--- a/src/pad.c
+++ b/src/pad.c
@@ -93,6 +93,26 @@ static u32 oldpaddata;
 static int delaycnt[16];
 static int paddelay[16];
 
+// Menu rumble is intentionally a short pulse, never sustained feedback. Navigation follows the
+// RETROLauncher timing model: a soft, long big-motor thump which gives the ERM time to spin up.
+#define RUMBLE_MAX_MS           500
+#define RUMBLE_TAP_MS           240
+#define RUMBLE_TAP_LEVEL        0x50
+#define RUMBLE_BUMP_MS          110
+#define RUMBLE_BUMP_LEVEL       0x60
+#define RUMBLE_REPEAT_WINDOW_MS 400
+#define RUMBLE_REPEAT_DUTY_PCT  45
+#define RUMBLE_REPEAT_FLOOR_MS  80
+
+static u32 rumbleStartTicks = 0;
+static u32 rumbleDurTicks = 0;
+static u32 rumbleLastTicks = 0;
+static int rumbleActive = 0;
+static int rumbleLarge = 0;
+static int rumbleSmall = 0;
+static int rumbleLive = 0;
+static int rumbleLastTicksValid = 0;
+
 // KEY_ to PAD_ conversion table
 static const int keyToPad[17] = {
     -1,
@@ -394,9 +414,14 @@ static int readPad(struct pad_data_t *pad, int *pollClean)
     }
 
 #ifdef PADEMU
+    // Unlike a native pad, a DS3/DS4/DS5 never passes through padSetActDirect(). Its motors are
+    // driven by this PADEMU path, so always sending zero here silently discards every menu pulse.
+    // Drive both motors together, matching the known-good RETROLauncher behavior.
+    u8 rumble = (gEnableRumble && rumbleActive) ? (u8)rumbleLarge : 0;
+
     if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING) {
         ret = ds34bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34bt_set_rumble(pad->port, 0, 0);
+        ds34bt_set_rumble(pad->port, rumble, rumble);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -405,7 +430,7 @@ static int readPad(struct pad_data_t *pad, int *pollClean)
 
     if (ds34usb_get_status(pad->port) & DS34USB_STATE_RUNNING) {
         ret = ds34usb_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34usb_set_rumble(pad->port, 0, 0);
+        ds34usb_set_rumble(pad->port, rumble, rumble);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -463,36 +488,9 @@ static int getKeyDelay(int id, int repeat)
 }
 
 /*--    Menu rumble    ------------------------------------------------------------------------------
-Opt-in (gEnableRumble). The pulse is timed against RAW cpu_ticks() elapsed since it started, and
-NOT against time_since_last below -- that value is the difference of two ALREADY divided cpu_ticks()
-readings, so it goes wild once every ~29.1 s when the 32-bit tick counter wraps. On a decrementing
-"milliseconds left" counter a single bad sample adds ~29 s to the pulse: a motor latched on. An
-elapsed comparison in raw ticks is correct across one wrap by ordinary unsigned arithmetic, and a
-pulse is capped below at a fraction of a second, so one wrap is the most that can occur inside it.
-This is why the feature needs none of the pad-clock rework it was originally blocked on.
+The native pad and PADEMU paths use distinct actuator APIs, but share the same pulse lifetime. The
+pulse is timed against raw cpu_ticks() deltas so it remains correct across the 32-bit tick wrap.
 ----------------------------------------------------------------------------------------------------*/
-static u32 rumbleStartTicks = 0;
-static u32 rumbleDurTicks = 0;
-static int rumbleActive = 0;
-static int rumbleLarge = 0;
-
-// Longest pulse we will ever hold a motor on for. Menu feedback, not a sustained buzz.
-#define RUMBLE_MAX_MS 500
-
-/* THE TWO THINGS THAT MAKE THIS SILENT ON REAL HARDWARE, both properties of freepad.irx -- which is
-   what we ship as padman (Makefile: asm/padman.c is built from $(PS2SDK)/iop/irx/freepad.irx):
-
-   1. freepad DROPS padSetActDirect unless its current task is TASK_UPDATE_PAD, and it still returns
-      1 when it does. Sending once per pulse means one unlucky frame eats the whole pulse. So the
-      command is RE-SENT every frame for the pulse's life. Do NOT "optimise" this back to send-once.
-
-   2. freepad fills its actuator alignment with 0xFF on padPortOpen, and padSetActAlign is the only
-      thing that overwrites it. padSetActDirect latches the bytes and returns 1 WITHOUT consulting
-      the alignment -- so if padSetActAlign never ran, every send reports success and drives actuator
-      index 0xFF, i.e. nothing at all. initializePad() has five bail-outs above padSetActAlign, so
-      this is reachable; padRumbleRealign() below retries it.
-
-   Neither shows up in a log or a return value. Both were found the expensive way. */
 
 // Alignment confirmed for this pad. Tracked so it can be RETRIED -- never used to veto a send: an
 // earlier fork revision gated sends on this and on a padInfoAct count, and any single init hiccup
@@ -520,7 +518,9 @@ static void padActSet(struct pad_data_t *pad, int small, int large)
 {
     char act[6];
 
-    if (pad->actuators == 0)
+    // A ready pad accepts the command; a digital-only controller ignores it. Do not let a transient
+    // padInfoAct failure permanently veto rumble for this session.
+    if (!isPadReadyState(pad->state))
         return;
 
     padRumbleRealign(pad);
@@ -533,38 +533,77 @@ static void padActSet(struct pad_data_t *pad, int small, int large)
     padSetActDirect(pad->port, pad->slot, act);
 }
 
-/** Stops any pulse in flight, on every pad.
- * The decay only runs from readPads(), so anything that can block the GUI thread for longer than a
- * pulse has to stop the motor on the way in or it buzzes for the whole operation.
- */
-void padRumbleFlush(void)
+static void padPademuSetRumble(struct pad_data_t *pad, int level)
+{
+#ifdef PADEMU
+    if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING)
+        ds34bt_set_rumble(pad->port, level, level);
+    if (ds34usb_get_status(pad->port) & DS34USB_STATE_RUNNING)
+        ds34usb_set_rumble(pad->port, level, level);
+#else
+    (void)pad;
+    (void)level;
+#endif
+}
+
+void padRumbleActivate(void)
+{
+    rumbleLive = 1;
+    rumbleLastTicksValid = 0;
+}
+
+/** Stops all actuators now. Closing pad ports does not clear a latched motor state. */
+void padRumbleStopAll(void)
 {
     int i;
-
-    if (!rumbleActive)
-        return;
 
     rumbleActive = 0;
     rumbleDurTicks = 0;
     rumbleLarge = 0;
-    // Sent twice: the IOP LATCHES the actuator state, so a dropped "off" leaves the motor spinning
-    // with nothing left to stop it. The "on" gets a re-send every frame; the "off" gets no frames.
-    for (i = 0; i < pad_count; ++i)
+    rumbleSmall = 0;
+
+    // Send native stops twice because freepad may drop an actuator command outside TASK_UPDATE_PAD.
+    // PADEMU uses its own command channel, so it needs an explicit stop as well once polling ends.
+    for (i = 0; i < pad_count; ++i) {
+        padPademuSetRumble(&pad_data[i], 0);
         padActSet(&pad_data[i], 0, 0);
+    }
     for (i = 0; i < pad_count; ++i)
         padActSet(&pad_data[i], 0, 0);
 }
 
-/** Starts a rumble pulse on every connected pad that has actuators.
- * @param durationMs pulse length, clamped to RUMBLE_MAX_MS
- * @param large      large (variable-speed) engine strength, 0..255; the small engine runs for the
- *                   whole pulse regardless, since it is the one that gives a crisp click
- */
-void padRumble(int durationMs, int large)
+/** Lets a decision bump complete before a caller starts work that will stop readPads(). */
+void padRumbleFlush(void)
+{
+    u32 elapsedTicks;
+    u32 remainingTicks;
+    int waitMs;
+
+    if (!rumbleActive)
+        return;
+
+    elapsedTicks = cpu_ticks() - rumbleStartTicks;
+    if (elapsedTicks < rumbleDurTicks) {
+        remainingTicks = rumbleDurTicks - elapsedTicks;
+        waitMs = (int)((remainingTicks + CLOCKS_PER_MILISEC - 1) / CLOCKS_PER_MILISEC);
+        if (waitMs > RUMBLE_BUMP_MS)
+            waitMs = RUMBLE_BUMP_MS;
+        if (waitMs > 0)
+            DelayThread(waitMs * 1000);
+    }
+
+    padRumbleStopAll();
+}
+
+static void padRumbleArm(int durationMs, int large, int small)
 {
     int i;
+    u32 nowTicks;
+    u32 intervalMs;
 
-    if (durationMs <= 0)
+    // guiIntroLoop can fire SFX_CURSOR against frozen pad data while the IOP is still loading modules.
+    // Keep every actuator RPC out of that window; main activates rumble just before guiMainLoop().
+    if (!rumbleLive || !gEnableRumble || durationMs <= 0)
         return;
     if (durationMs > RUMBLE_MAX_MS)
         durationMs = RUMBLE_MAX_MS;
@@ -573,13 +612,47 @@ void padRumble(int durationMs, int large)
     if (large > 255)
         large = 255;
 
-    rumbleStartTicks = cpu_ticks();
+    // RETROLauncher-style held navigation: first press gets the full thump, measured repeats ride
+    // at about 45 percent duty, and steps too fast for an ERM to spin up remain silent.
+    nowTicks = cpu_ticks();
+    intervalMs = rumbleLastTicksValid ? (nowTicks - rumbleLastTicks) / CLOCKS_PER_MILISEC : 0xffffffff;
+    rumbleLastTicks = nowTicks;
+    rumbleLastTicksValid = 1;
+    if (!small && intervalMs < RUMBLE_REPEAT_WINDOW_MS) {
+        int dutyMs = (int)(intervalMs * RUMBLE_REPEAT_DUTY_PCT / 100);
+        if (dutyMs < RUMBLE_REPEAT_FLOOR_MS)
+            return;
+        if (dutyMs < durationMs)
+            durationMs = dutyMs;
+    }
+
+    rumbleStartTicks = nowTicks;
     rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
     rumbleActive = 1;
     rumbleLarge = large;
+    rumbleSmall = small ? 1 : 0;
 
-    for (i = 0; i < pad_count; ++i)
-        padActSet(&pad_data[i], 1, large);
+    for (i = 0; i < pad_count; ++i) {
+        // Native pads are kicked immediately and re-sent from readPads(); PADEMU gets the same
+        // immediate command so a confirm followed by blocking work still reaches a DS3/DS4/DS5.
+        padActSet(&pad_data[i], rumbleSmall, rumbleLarge);
+        padPademuSetRumble(&pad_data[i], rumbleLarge);
+    }
+}
+
+void padRumbleTap(void)
+{
+    padRumbleArm(RUMBLE_TAP_MS, RUMBLE_TAP_LEVEL, 0);
+}
+
+void padRumbleTapList(void)
+{
+    padRumbleTap();
+}
+
+void padRumbleBump(void)
+{
+    padRumbleArm(RUMBLE_BUMP_MS, RUMBLE_BUMP_LEVEL, 1);
 }
 
 /* Screen-transition edge freeze. During the fade the main loop polls pads but dispatches no input,
@@ -665,15 +738,14 @@ int readPads()
         }
     }
 
-    // Rumble decay + re-send. Unsigned elapsed in RAW ticks -- see the note above padActSet().
-    // The re-send is not redundant: freepad drops padSetActDirect outside TASK_UPDATE_PAD and still
-    // reports success, so a pulse sent only once can be silently swallowed whole.
+    // Rumble decay + re-send. The native re-send is not redundant: freepad can drop a direct
+    // actuator command outside its update task, and PADEMU is kept in sync by readPad() above.
     if (rumbleActive) {
-        if ((u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
-            padRumbleFlush();
+        if (!gEnableRumble || (u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
+            padRumbleStopAll();
         } else {
             for (i = 0; i < pad_count; ++i)
-                padActSet(&pad_data[i], 1, rumbleLarge);
+                padActSet(&pad_data[i], rumbleSmall, rumbleLarge);
         }
     }
 
@@ -794,9 +866,9 @@ void unloadPads()
 {
     int i;
 
-    // Last chance to stop a motor. Closing the port does not clear the actuators, and OPL is on its
-    // way out here -- a pulse still in flight would keep buzzing into whatever we hand off to.
-    padRumbleFlush();
+    // Closing a port does not clear a latched motor. Do not wait here: the caller is dismantling the
+    // pad stack, so the immediate stop is the only safe behavior.
+    padRumbleStopAll();
 
     for (i = 0; i < pad_count; ++i)
         unloadPad(&pad_data[i]);

--- a/src/sound.c
+++ b/src/sound.c
@@ -283,38 +283,17 @@ void sfxGetDropDiag(unsigned int *staleDrops, unsigned int *fullDrops)
 
 static void sfxRumble(int id)
 {
-    if (!gEnableRumble)
-        return;
-
     switch (id) {
-        case SFX_CURSOR: {
-            // Cursor sounds are emitted for every navigation step, including held buttons. Keep the
-            // prompt responsive without turning a long scroll into a continuous motor buzz.
-            static u32 lastCursorRumbleTicks;
-            u32 now = cpu_ticks();
-            if (lastCursorRumbleTicks != 0 && (now - lastCursorRumbleTicks) / SFX_CLOCKS_PER_MS < 80)
-                return;
-            lastCursorRumbleTicks = now;
-            padRumble(35, 64);
+        case SFX_CURSOR:
+            padRumbleTap();
             break;
-        }
         case SFX_CONFIRM:
-            padRumble(120, 160);
-            break;
         case SFX_CANCEL:
-            padRumble(90, 96);
-            break;
         case SFX_MESSAGE:
-            padRumble(120, 160);
-            break;
         case SFX_TRANSITION:
-            padRumble(150, 200);
-            break;
         case SFX_BD_CONNECT:
-            padRumble(100, 128);
-            break;
         case SFX_BD_DISCONNECT:
-            padRumble(75, 96);
+            padRumbleBump();
             break;
         default:
             break;

--- a/src/tar.c
+++ b/src/tar.c
@@ -55,13 +55,18 @@ static const TarDevice gDevices[] = {
 static const TarKindInfo gTarInfo[TAR_KIND_MAX] = {
     {"ART/art.tar", "art_cache.bin", sizeof(TarEntryArt)},
     {"CFG/cfg.tar", "cfg_cache.bin", sizeof(TarEntryCfg)},
-    {"CHT/cht.tar", "cht_cache.bin", sizeof(TarEntryCht)}};
+    {"CHT/cht.tar", "cht_cache.bin", sizeof(TarEntryCht)},
+    {"ART/art.tar", "art_cache.bin", sizeof(TarEntryArt)}};
 
-static void *s_index[TAR_KIND_MAX] = {NULL, NULL, NULL};
-static u32 s_count[TAR_KIND_MAX] = {0, 0, 0};
-static u32 s_cap[TAR_KIND_MAX] = {0, 0, 0};
-static const TarDevice *s_dev[TAR_KIND_MAX] = {NULL, NULL, NULL};
-static int s_inactive[TAR_KIND_MAX] = {0, 0, 0};
+static void *s_index[TAR_KIND_MAX] = {0};
+static u32 s_count[TAR_KIND_MAX] = {0};
+static u32 s_cap[TAR_KIND_MAX] = {0};
+static const TarDevice *s_dev[TAR_KIND_MAX] = {0};
+static int s_inactive[TAR_KIND_MAX] = {0};
+// An exact archive path is intentionally separate from the device probe table. The HDD art path
+// is the PFS data home selected for this session, not an alternate source to discover.
+static char s_exactPath[TAR_KIND_MAX][256];
+static int s_hasExactPath[TAR_KIND_MAX] = {0};
 
 static const unsigned char s_zeroBlock[TAR_BLOCK_SIZE] __attribute__((aligned(64))) = {0};
 
@@ -91,6 +96,8 @@ static void tarCloseInternal(TarKind kind)
     s_count[kind] = 0;
     s_cap[kind] = 0;
     s_dev[kind] = NULL;
+    s_exactPath[kind][0] = '\0';
+    s_hasExactPath[kind] = 0;
 }
 
 static int buildTarPath(const TarDevice *dev, TarKind kind, char *out, int outSize)
@@ -378,16 +385,51 @@ fail:
     return -1;
 }
 
+static int tarLoadExactPath(TarKind kind, const char *path)
+{
+    int len;
+
+    if (path == NULL || path[0] == '\0')
+        return -1;
+
+    if (s_hasExactPath[kind] && strcmp(s_exactPath[kind], path) == 0)
+        return s_inactive[kind] ? -1 : 0;
+
+    tarCloseInternal(kind);
+    s_inactive[kind] = 0;
+
+    len = snprintf(s_exactPath[kind], sizeof(s_exactPath[kind]), "%s", path);
+    if (len <= 0 || len >= (int)sizeof(s_exactPath[kind])) {
+        s_exactPath[kind][0] = '\0';
+        return -1;
+    }
+    s_hasExactPath[kind] = 1;
+
+    if (tarParseFile(kind, s_exactPath[kind]) == 0)
+        return 0;
+
+    // A missing selected archive should cost one open, not one open per cover. Unlike the generic
+    // loader, this latch is scoped to the exact PFS home and therefore never falls through to a
+    // second APA partition or another device.
+    s_inactive[kind] = 1;
+    LOG("TAR no archive at selected path %s -- probing disabled for this path\n", s_exactPath[kind]);
+    return -1;
+}
+
 int tarLoadFile(TarKind kind, const char *path)
 {
-    s_dev[kind] = NULL;
-    return tarParseFile(kind, path);
+    return tarLoadExactPath(kind, path);
 }
 
 int tarLoadFromAnyDevice(TarKind kind)
 {
     if (s_inactive[kind])
         return -1;
+
+    // An exact-path caller owns this kind's archive location. Never replace it with the first
+    // archive found by the generic device scan.
+    if (s_hasExactPath[kind])
+        return 0;
 
     if (s_index[kind] && s_dev[kind]) {
         char tarPath[256];
@@ -449,9 +491,12 @@ TarEntryBase *tarFind(TarKind kind, const char *filename)
     if (s_inactive[kind])
         return NULL;
 
-    if (!s_index[kind] || s_count[kind] == 0)
+    if ((!s_index[kind] || s_count[kind] == 0) && !s_hasExactPath[kind])
         if (tarLoadFromAnyDevice(kind) < 0)
             return NULL;
+
+    if (!s_index[kind] || s_count[kind] == 0)
+        return NULL;
 
     const char *queryClean = filename;
     if (!strncasecmp(queryClean, "./", 2))
@@ -478,15 +523,8 @@ TarEntryBase *tarFind(TarKind kind, const char *filename)
     return NULL;
 }
 
-TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
+static TarEntryBase *tarFindPrefixLoaded(TarKind kind, const char *prefix)
 {
-    if (s_inactive[kind])
-        return NULL;
-
-    if (!s_index[kind] || s_count[kind] == 0)
-        if (tarLoadFromAnyDevice(kind) < 0)
-            return NULL;
-
     size_t prefixLen = strlen(prefix);
     u32 entrySize = gTarInfo[kind].entrySize;
     char *base = (char *)s_index[kind];
@@ -505,6 +543,29 @@ TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
     return NULL;
 }
 
+TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
+{
+    if (s_inactive[kind])
+        return NULL;
+
+    if ((!s_index[kind] || s_count[kind] == 0) && !s_hasExactPath[kind])
+        if (tarLoadFromAnyDevice(kind) < 0)
+            return NULL;
+
+    if (!s_index[kind] || s_count[kind] == 0)
+        return NULL;
+
+    return tarFindPrefixLoaded(kind, prefix);
+}
+
+TarEntryBase *tarFindPrefixFromPath(TarKind kind, const char *path, const char *prefix)
+{
+    if (tarLoadExactPath(kind, path) < 0 || !s_index[kind] || s_count[kind] == 0)
+        return NULL;
+
+    return tarFindPrefixLoaded(kind, prefix);
+}
+
 u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize)
 {
     if (s_inactive[kind])
@@ -514,8 +575,13 @@ u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize)
         return 0;
 
     char tarPath[256];
-    if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) < 0)
+    if (s_hasExactPath[kind]) {
+        int len = snprintf(tarPath, sizeof(tarPath), "%s", s_exactPath[kind]);
+        if (len < 0 || len >= (int)sizeof(tarPath))
+            return 0;
+    } else if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) < 0) {
         return 0;
+    }
 
     int fd = open(tarPath, O_RDONLY);
     if (fd < 0)
@@ -569,6 +635,9 @@ int tarEnsureLoaded(TarKind kind)
 {
     if (s_inactive[kind])
         return -1;
+
+    if (s_hasExactPath[kind])
+        return 0;
 
     if (!s_index[kind] || s_count[kind] == 0)
         return tarLoadFromAnyDevice(kind);

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -116,7 +116,7 @@ static void cacheWakeArtWorker(void);
 //       non-fatal (tarParseFile ignores the result) and happens only when the archive changes, but it
 //       is the thing to instrument first if a .tar-enabled build ever feels worse than a plain one.
 //   DEFAULT PATH: gEnableArtTar ships 0, so none of the above is reachable unless the user opts in.
-static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *texture)
+static int artTarLoadImage(TarKind kind, const char *archivePath, const char *value, const char *suffix, GSTEXTURE *texture)
 {
     char prefix[64];
     TarEntryBase *entry = NULL;
@@ -126,7 +126,7 @@ static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *tex
     if (snprintf(prefix, sizeof(prefix), "%s_%s.", value, suffix) >= (int)sizeof(prefix))
         return -1;
 
-    entry = tarFindPrefix(TAR_KIND_ART, prefix);
+    entry = archivePath != NULL ? tarFindPrefixFromPath(kind, archivePath, prefix) : tarFindPrefix(kind, prefix);
 
     if (entry == NULL) {
         LOG("ART TAR: '%s_%s' not in the archive index\n", value, suffix);
@@ -139,7 +139,7 @@ static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *tex
         return -1;
     }
 
-    if (tarRead(TAR_KIND_ART, entry, buffer, entry->rawSize) != entry->rawSize) {
+    if (tarRead(kind, entry, buffer, entry->rawSize) != entry->rawSize) {
         LOG("ART TAR: short read for '%s' (%u bytes expected)\n", prefix, entry->rawSize);
         free(buffer);
         return -1;
@@ -826,8 +826,21 @@ static void cacheLoadImage(load_image_request_t *req)
 
     texSetLoadAbortFlag(&req->abortRequested);
 
-    if (gEnableArtTar)
-        result = artTarLoadImage(req->value, req->cache->suffix, &staged);
+    if (gEnableArtTar) {
+        char archivePath[256];
+        int archivePathResult = 0;
+
+        // HDD artwork owns a single PFS data home for the session. Its callback supplies the exact
+        // ART/art.tar path, so this lookup cannot scan __common, +OPL, or another device. A negative
+        // result means that source has no mounted home and must not fall back to the generic probe.
+        if (req->cache->isPrefixRelative && handler->itemGetArtArchivePath != NULL)
+            archivePathResult = handler->itemGetArtArchivePath(handler, req->value, archivePath, sizeof(archivePath));
+
+        if (archivePathResult > 0)
+            result = artTarLoadImage(TAR_KIND_HDD_ART, archivePath, req->value, req->cache->suffix, &staged);
+        else if (archivePathResult == 0)
+            result = artTarLoadImage(TAR_KIND_ART, NULL, req->value, req->cache->suffix, &staged);
+    }
 
     // Fall through to the per-file lookup whenever the archive is off, absent, or lacks this key.
     if (result < 0)


### PR DESCRIPTION
## Summary
- Keep APA loose artwork and opt-in `ART/art.tar` on exactly the current session's mounted OPL data home.
  - `__common/OPL/` uses `pfs0:OPL/ART/`
  - `+OPL/` uses `pfs0:ART/`
- Give the exact HDD archive path an independent cache, so missing art never falls through to the other APA home or another device.
- Preserve the same rule for HDD-backed Favourites and Apps.
- Defer concurrent Auto-start PFS setup until the fresh ATA stack has completed its required settle delay, preventing the transient false code-222 PFS warning while preserving real post-settle failures.

## Validation
- `git diff --check`
- staged `clang-format --dry-run --Werror`
- clean PS2DEV `make LOCALVERSION=APA-HDD-AUDIT release` build in a read-only source container

Hardware validation is still required for the two APA homes and an all-Auto cold boot.

## Vibration follow-up
- Fix PADEMU menu rumble: DS3/DS4/DS5 motors now receive the active pulse instead of an unconditional zero on every poll.
- Use the RETROLauncher-style navigation pulse (240 ms at level 80, big motor) with bounded decision bumps and repeat duty control.
- Keep actuator commands out of the intro/IOP-loading phase and explicitly stop native and PADEMU motors before blocking teardown.

Hardware validation: native DualShock and PADEMU controller navigation, confirm/cancel, disable-vibration, launch, and exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artwork archives now load from the correct item-specific source, preventing unrelated artwork from being selected.
  * Added dedicated hard-drive artwork archive support and exact archive-path lookups.
  * Improved menu controller rumble with clearer tap and navigation feedback across supported controllers.

* **Bug Fixes**
  * Improved artwork cache invalidation when settings or device configurations change.
  * Prevented premature hard-drive checks during device initialization.
  * Preserved selected artwork locations when generic archive lookup is unavailable.
  * Ensured rumble stops during application launch, exit, and controller unloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->