### PR TITLE
fix(elfldr): restore keep-IOP Neutrino handoff

### DIFF
--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -129,26 +129,25 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
 {
     elf_header_t eh;
     elf_pheader_t ph;
-    int fd, i, loaded = 0;
+    int fd = -1, i, loaded = 0;
 
     if (fileXioInit() < 0)
         return -1;
+
     fd = fileXioOpen(path, FIO_O_RDONLY);
     if (fd < 0)
-        return -1;
+        goto fail;
 
     // phentsize must match our struct or the per-header stride below reads garbage.
     if (readAll(fd, &eh, sizeof(eh)) != 0 || _lw((u32)&eh.ident) != ELF_MAGIC || eh.phnum == 0 ||
         eh.phentsize != sizeof(elf_pheader_t)) {
-        fileXioClose(fd);
-        return -1;
+        goto fail;
     }
 
     for (i = 0; i < eh.phnum; i++) {
         if (fileXioLseek(fd, eh.phoff + i * sizeof(elf_pheader_t), SEEK_SET) < 0 ||
             readAll(fd, &ph, sizeof(ph)) != 0) {
-            fileXioClose(fd);
-            return -1;
+            goto fail;
         }
         if (ph.type != ELF_PT_LOAD || ph.memsz == 0)
             continue;
@@ -158,13 +157,11 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         // FIRST so the subtraction in the last clause cannot underflow.
         if (ph.filesz > ph.memsz || (u32)ph.vaddr < 0x100000 ||
             ph.memsz > (u32)GetMemorySize() || (u32)ph.vaddr > (u32)GetMemorySize() - ph.memsz) {
-            fileXioClose(fd);
-            return -1;
+            goto fail;
         }
         if (ph.filesz > 0) {
             if (fileXioLseek(fd, ph.offset, SEEK_SET) < 0 || readAll(fd, ph.vaddr, ph.filesz) != 0) {
-                fileXioClose(fd);
-                return -1;
+                goto fail;
             }
         }
         if (ph.memsz > ph.filesz)
@@ -172,11 +169,19 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         loaded++;
     }
     fileXioClose(fd);
+    fd = -1;
 
     if (!loaded)
-        return -1;
+        goto fail;
+
     *entry = eh.entry;
     return 0;
+
+fail:
+    if (fd >= 0)
+        fileXioClose(fd);
+    fileXioExit();
+    return -1;
 }
 
 // argv[0] = path of the ELF to LOAD; argv[1..] = the target's FULL argv, forwarded verbatim

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -12,7 +12,8 @@
 # the target ELF through the STILL-LIVE IOP -- OPL's drivers and mounts stay
 # up -- and jumps into it. The target (Neutrino/POPSTARTER) reads its
 # config/modules and the game through those mounts, then performs its own
-# IOP reset.
+# IOP reset. On a SUCCESSFUL handoff we must NOT exit SIF RPC or fileXio;
+# doing so would tear down the environment the target needs before its reset.
 #
 # The target is read via SifLoadElf (rom0:LOADFILE) FIRST, with fileXio
 # (iomanX) as the rescue path. Both are needed:
@@ -120,6 +121,10 @@ static int readAll(int fd, void *buf, int size)
 // into user memory (>= 0x100000, already wiped) well above this loader's bram home, so reading
 // straight to each vaddr is safe. Returns 0 and sets *entry on success. gp stays 0 at ExecPS2:
 // standard PS2 crt0s load $gp themselves (POPSLoader's embedded loader ships the same way).
+//
+// INVARIANT: on SUCCESS we intentionally leave fileXio/RPC bound. The target (Neutrino/POPSTARTER)
+// inherits OPL's live IOP, mounts, and RPC environment and performs its own reset when ready.
+// Only the failure paths may tear down the local client, because there is no target handoff.
 static int loadElfViaFileXio(const char *path, u32 *entry)
 {
     elf_header_t eh;
@@ -129,16 +134,13 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
     if (fileXioInit() < 0)
         return -1;
     fd = fileXioOpen(path, FIO_O_RDONLY);
-    if (fd < 0) {
-        fileXioExit();
+    if (fd < 0)
         return -1;
-    }
 
     // phentsize must match our struct or the per-header stride below reads garbage.
     if (readAll(fd, &eh, sizeof(eh)) != 0 || _lw((u32)&eh.ident) != ELF_MAGIC || eh.phnum == 0 ||
         eh.phentsize != sizeof(elf_pheader_t)) {
         fileXioClose(fd);
-        fileXioExit();
         return -1;
     }
 
@@ -146,7 +148,6 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         if (fileXioLseek(fd, eh.phoff + i * sizeof(elf_pheader_t), SEEK_SET) < 0 ||
             readAll(fd, &ph, sizeof(ph)) != 0) {
             fileXioClose(fd);
-            fileXioExit();
             return -1;
         }
         if (ph.type != ELF_PT_LOAD || ph.memsz == 0)
@@ -158,13 +159,11 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         if (ph.filesz > ph.memsz || (u32)ph.vaddr < 0x100000 ||
             ph.memsz > (u32)GetMemorySize() || (u32)ph.vaddr > (u32)GetMemorySize() - ph.memsz) {
             fileXioClose(fd);
-            fileXioExit();
             return -1;
         }
         if (ph.filesz > 0) {
             if (fileXioLseek(fd, ph.offset, SEEK_SET) < 0 || readAll(fd, ph.vaddr, ph.filesz) != 0) {
                 fileXioClose(fd);
-                fileXioExit();
                 return -1;
             }
         }
@@ -173,7 +172,6 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         loaded++;
     }
     fileXioClose(fd);
-    fileXioExit();
 
     if (!loaded)
         return -1;
@@ -208,7 +206,8 @@ int main(int argc, char *argv[])
     ret = SifLoadElf(argv[0], &elfdata);
     SifLoadFileExit();
     if (ret == 0 && elfdata.epc != 0) {
-        SifExitRpc();
+        // SUCCESSFUL handoff: keep SIF RPC alive so Neutrino/POPSTARTER can use OPL's live IOP,
+        // mounts, and config/modules before performing their own IOP reset.
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, &argv[1]);
@@ -216,7 +215,7 @@ int main(int argc, char *argv[])
 
     // Rescue: fileXio (iomanX) for the devices LOADFILE cannot see (mmceN:, pfs, ...).
     if (loadElfViaFileXio(argv[0], &entry) == 0) {
-        SifExitRpc();
+        // SUCCESSFUL handoff: keep SIF RPC alive (see comment above).
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)entry, NULL, argc - 1, &argv[1]);

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -245,6 +245,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     int EnablePS2Logo = 0;
     int result;
     char filename[32], partname[256];
+    char udpfsStartup[GAME_STARTUP_MAX + 1];
     base_game_info_t *game = &udpfsGames[id];
 
     // Folder browsing: a folder row is never launched (the dispatch descends first); guard defensively
@@ -344,11 +345,16 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     if (sysNeutrinoPreflight("udpfs", neutrinoPath) < 0)
         return;
     int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+
+    // game->startup lives inside udpfsGames, which itemCleanUp frees below. Copy it before the teardown
+    // so sysLaunchNeutrino reads valid stack memory instead of freed heap (UAF).
+    snprintf(udpfsStartup, sizeof(udpfsStartup), "%s", game->startup);
+
     deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees udpfsGames/game
 
-    // Hand off to Neutrino with the udpfs driver token. `partname` (the filesystem game path) + the token
-    // survive the deinit above; `game` does not and is not used past this point.
-    sysLaunchNeutrino("udpfs", partname, game->startup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: udpfs is fileid, no fs layer */, &neutrinoVmc);
+    // Hand off to Neutrino with the udpfs driver token. `partname` and `udpfsStartup` (the filesystem
+    // game path + startup) survive the deinit above; `game` does not and is not used past this point.
+    sysLaunchNeutrino("udpfs", partname, udpfsStartup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: udpfs is fileid, no fs layer */, &neutrinoVmc);
 }
 
 static config_set_t *udpfsGetConfig(item_list_t *itemList, int id)


### PR DESCRIPTION
## Summary

Restores the historically working keep-IOP handoff semantics for Neutrino/POPSTARTER launches.

## Problem

Commit 53a86a2b added `SifExitRpc()` and `fileXioExit()` cleanup on the **successful** handoff paths in `elfldr/loader.c`. This tears down the live SIF RPC / fileXio environment that Neutrino needs **before** it performs its own IOP reset. Neutrino uses the inherited environment to process `-cwd`, `chdir()`, probe `config/system.toml`, and load config/modules/driver files.

## Changes

### `elfldr/loader.c`
- Removed `SifExitRpc()` before successful `ExecPS2()` on both the primary `SifLoadElf` path and the fileXio rescue path.
- Removed `fileXioExit()` from the successful rescue-load path.
- Added explicit comments documenting the invariant: on successful handoff we intentionally inherit OPL's live IOP, mounts, and RPC environment; the target owns the eventual reset.

### `src/udpfssupport.c`
- Fixed an independent use-after-free: `udpfsLaunchGame` was passing `game->startup` to `sysLaunchNeutrino` after `deinitEx` had freed `udpfsGames`.
- Now copies `game->startup` into stack storage (`udpfsStartup`) before teardown, matching the pattern already used by BDM/HDD/MMCE Neutrino paths.

## Not changed

- `udpfsbd` backend name and `bsd-udpfsbd.toml` are preserved as RiptOPL's intentional Neutrino extension.
- No switch to NHDDL-style `-qb` quickboot.
- No changes to deinitEx, device mappings, VMC behavior, or `-cwd` budgeting.
- PR #533 (APA artwork/vibration) is untouched.

## Validation

- [x] `git diff --check` clean
- [x] `clang-format` applied to touched files
- [ ] Local PS2DEV build (toolchain not available in this environment)
- [ ] CI format check
- [ ] CI all four flavour builds
- [ ] Hardware test: USB, APA/HDL, MMCE, MX4SIO, iLink, ATA/exFAT, UDPBD, UDPFS, UDPFSBD

Do not merge until CI and hardware validation are complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved game launching by preserving the required runtime environment for launched titles.
  - Fixed UDP file-system launches that could access released game data during startup.
  - Improved recovery handling when launching games through file-based rescue paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->