### PR TITLE
fix: consolidate APA, vibration and Neutrino launch fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ PNG_ASSETS_DIR = gfx/
 MMCE_ASSETS_DIR = $(PS2SDK)/iop/irx
 
 MAPFILE = opl.map
+EE_LINKFILE := linkfile
 EE_LDFLAGS += -Wl,-Map,$(MAPFILE)
 
 EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lpoweroff -lfileXio -lpatches -lpng -lz -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv -lvorbisfile -lvorbis -logg -lpadx -lelf-loader-nocolour

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -129,26 +129,25 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
 {
     elf_header_t eh;
     elf_pheader_t ph;
-    int fd, i, loaded = 0;
+    int fd = -1, i, loaded = 0;
 
     if (fileXioInit() < 0)
         return -1;
+
     fd = fileXioOpen(path, FIO_O_RDONLY);
     if (fd < 0)
-        return -1;
+        goto fail;
 
     // phentsize must match our struct or the per-header stride below reads garbage.
     if (readAll(fd, &eh, sizeof(eh)) != 0 || _lw((u32)&eh.ident) != ELF_MAGIC || eh.phnum == 0 ||
         eh.phentsize != sizeof(elf_pheader_t)) {
-        fileXioClose(fd);
-        return -1;
+        goto fail;
     }
 
     for (i = 0; i < eh.phnum; i++) {
         if (fileXioLseek(fd, eh.phoff + i * sizeof(elf_pheader_t), SEEK_SET) < 0 ||
             readAll(fd, &ph, sizeof(ph)) != 0) {
-            fileXioClose(fd);
-            return -1;
+            goto fail;
         }
         if (ph.type != ELF_PT_LOAD || ph.memsz == 0)
             continue;
@@ -158,13 +157,11 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         // FIRST so the subtraction in the last clause cannot underflow.
         if (ph.filesz > ph.memsz || (u32)ph.vaddr < 0x100000 ||
             ph.memsz > (u32)GetMemorySize() || (u32)ph.vaddr > (u32)GetMemorySize() - ph.memsz) {
-            fileXioClose(fd);
-            return -1;
+            goto fail;
         }
         if (ph.filesz > 0) {
             if (fileXioLseek(fd, ph.offset, SEEK_SET) < 0 || readAll(fd, ph.vaddr, ph.filesz) != 0) {
-                fileXioClose(fd);
-                return -1;
+                goto fail;
             }
         }
         if (ph.memsz > ph.filesz)
@@ -172,11 +169,19 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         loaded++;
     }
     fileXioClose(fd);
+    fd = -1;
 
     if (!loaded)
-        return -1;
+        goto fail;
+
     *entry = eh.entry;
     return 0;
+
+fail:
+    if (fd >= 0)
+        fileXioClose(fd);
+    fileXioExit();
+    return -1;
 }
 
 // argv[0] = path of the ELF to LOAD; argv[1..] = the target's FULL argv, forwarded verbatim

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -12,7 +12,8 @@
 # the target ELF through the STILL-LIVE IOP -- OPL's drivers and mounts stay
 # up -- and jumps into it. The target (Neutrino/POPSTARTER) reads its
 # config/modules and the game through those mounts, then performs its own
-# IOP reset.
+# IOP reset. On a SUCCESSFUL handoff we must NOT exit SIF RPC or fileXio;
+# doing so would tear down the environment the target needs before its reset.
 #
 # The target is read via SifLoadElf (rom0:LOADFILE) FIRST, with fileXio
 # (iomanX) as the rescue path. Both are needed:
@@ -120,6 +121,10 @@ static int readAll(int fd, void *buf, int size)
 // into user memory (>= 0x100000, already wiped) well above this loader's bram home, so reading
 // straight to each vaddr is safe. Returns 0 and sets *entry on success. gp stays 0 at ExecPS2:
 // standard PS2 crt0s load $gp themselves (POPSLoader's embedded loader ships the same way).
+//
+// INVARIANT: on SUCCESS we intentionally leave fileXio/RPC bound. The target (Neutrino/POPSTARTER)
+// inherits OPL's live IOP, mounts, and RPC environment and performs its own reset when ready.
+// Only the failure paths may tear down the local client, because there is no target handoff.
 static int loadElfViaFileXio(const char *path, u32 *entry)
 {
     elf_header_t eh;
@@ -129,16 +134,13 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
     if (fileXioInit() < 0)
         return -1;
     fd = fileXioOpen(path, FIO_O_RDONLY);
-    if (fd < 0) {
-        fileXioExit();
+    if (fd < 0)
         return -1;
-    }
 
     // phentsize must match our struct or the per-header stride below reads garbage.
     if (readAll(fd, &eh, sizeof(eh)) != 0 || _lw((u32)&eh.ident) != ELF_MAGIC || eh.phnum == 0 ||
         eh.phentsize != sizeof(elf_pheader_t)) {
         fileXioClose(fd);
-        fileXioExit();
         return -1;
     }
 
@@ -146,7 +148,6 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         if (fileXioLseek(fd, eh.phoff + i * sizeof(elf_pheader_t), SEEK_SET) < 0 ||
             readAll(fd, &ph, sizeof(ph)) != 0) {
             fileXioClose(fd);
-            fileXioExit();
             return -1;
         }
         if (ph.type != ELF_PT_LOAD || ph.memsz == 0)
@@ -158,13 +159,11 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         if (ph.filesz > ph.memsz || (u32)ph.vaddr < 0x100000 ||
             ph.memsz > (u32)GetMemorySize() || (u32)ph.vaddr > (u32)GetMemorySize() - ph.memsz) {
             fileXioClose(fd);
-            fileXioExit();
             return -1;
         }
         if (ph.filesz > 0) {
             if (fileXioLseek(fd, ph.offset, SEEK_SET) < 0 || readAll(fd, ph.vaddr, ph.filesz) != 0) {
                 fileXioClose(fd);
-                fileXioExit();
                 return -1;
             }
         }
@@ -173,7 +172,6 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         loaded++;
     }
     fileXioClose(fd);
-    fileXioExit();
 
     if (!loaded)
         return -1;
@@ -208,7 +206,8 @@ int main(int argc, char *argv[])
     ret = SifLoadElf(argv[0], &elfdata);
     SifLoadFileExit();
     if (ret == 0 && elfdata.epc != 0) {
-        SifExitRpc();
+        // SUCCESSFUL handoff: keep SIF RPC alive so Neutrino/POPSTARTER can use OPL's live IOP,
+        // mounts, and config/modules before performing their own IOP reset.
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, &argv[1]);
@@ -216,7 +215,7 @@ int main(int argc, char *argv[])
 
     // Rescue: fileXio (iomanX) for the devices LOADFILE cannot see (mmceN:, pfs, ...).
     if (loadElfViaFileXio(argv[0], &entry) == 0) {
-        SifExitRpc();
+        // SUCCESSFUL handoff: keep SIF RPC alive (see comment above).
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)entry, NULL, argc - 1, &argv[1]);

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -66,6 +66,17 @@ typedef enum {
     HDD_LOADMODULES_STATUS_COUNT,
 } hdd_loadmodules_status;
 
+typedef enum {
+    HDD_PFS_UNKNOWN = 0,
+    HDD_PFS_SETTLING,
+    HDD_PFS_RECOVERING,
+    HDD_PFS_READY,
+    HDD_PFS_FAILED_FINAL,
+} hdd_pfs_state_t;
+
+hdd_pfs_state_t hddGetPfsState(void);
+void hddSetPfsFailedFinal(void);
+
 // See hddLoadModulesReady() below the prototypes -- the single evaluate-once way to ask "is the ATA
 // stack actually resident?". Callers used to test `hddLoadModules() >= 0`, which also accepted
 // BUSYLOADING(2) -- returned for the whole session after a FAILED first load consumed the one-shot

--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -166,6 +166,11 @@ typedef struct _item_list_t
     /// source without mutating the real source page's independent view. Appended last so all legacy
     /// positional item_list_t initializers default safely to native behavior.
     unsigned char viewOverride;
+
+    /// Resolve this item's ART/art.tar to one exact path. Return >0 after writing that path, 0 to
+    /// retain the generic archive lookup, or <0 to skip archive probing entirely. APA uses this to
+    /// keep artwork on its already-selected PFS data home.
+    int (*itemGetArtArchivePath)(item_list_t *itemList, const char *value, char *path, int pathSize);
 } item_list_t;
 
 #define ITEM_VIEW_NATIVE    0

--- a/include/pad.h
+++ b/include/pad.h
@@ -50,14 +50,20 @@ void padRestoreSettings(int *buffer);
  * that is still held when the destination appears. */
 void padFreezeEdgeBaseline(int freeze);
 
-/** Starts a menu rumble pulse on every connected pad that has actuators.
- * @param durationMs pulse length in ms (clamped internally)
- * @param large large-engine strength 0..255; the small engine runs for the whole pulse */
-void padRumble(int durationMs, int large);
+/** Enables menu rumble after startup. Before this, the intro loop can emit SFX_CURSOR without
+ * polling pads, so actuator commands must stay disabled. */
+void padRumbleActivate(void);
 
-/** Stops any rumble pulse in flight. Call before blocking the GUI thread -- the decay only runs
- * from readPads(), so a pulse started just before a blocking read would outlast it. */
+/** Navigation thump and decision bump. Both no-op when controller vibration is disabled. */
+void padRumbleTap(void);
+void padRumbleTapList(void);
+void padRumbleBump(void);
+
+/** Plays out a short in-flight decision bump, then stops it before blocking the GUI thread. */
 void padRumbleFlush(void);
+
+/** Stops all pad actuators immediately before polling or pad ownership stops. */
+void padRumbleStopAll(void);
 
 /** Debug HUD: longest run of polls where the pad could not be READ (freepad not ready -> SIO2 or
  * IOP-side), and longest run of polls that read fine but carried no buttons (fresh, empty sample ->

--- a/include/system.h
+++ b/include/system.h
@@ -34,6 +34,7 @@ typedef struct neutrino_vmc_args
 
 // neutrinoBsdfs: per-game -bsdfs override, 0=Auto (per-device default), 1=exfat, 2=hdl, 3=bd.
 void sysLaunchNeutrino(const char *driver, const char *path, const char *startup, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *extraArgs, int neutrinoVideo, int neutrinoGsmComp, int neutrinoBsdfs, const neutrino_vmc_args_t *vmcArgs);
+int sysLaunchNeutrinoDirect(const char *neutrinoPath, int argc, char *argv[]);
 
 // Pre-deinit launch pre-flight: validates the driver token while every mount is up and the GUI
 // can still toast. Call BEFORE deinit in every Neutrino leg. Returns 0 = proceed; <0 = abort

--- a/include/tar.h
+++ b/include/tar.h
@@ -66,6 +66,9 @@ typedef enum {
     TAR_KIND_ART = 0,
     TAR_KIND_CFG = 1,
     TAR_KIND_CHT = 2,
+    // APA artwork has one selected PFS data home per session. Keep its index independent from the
+    // generic all-device ART archive so it can never select another source's archive.
+    TAR_KIND_HDD_ART = 3,
     TAR_KIND_MAX
 } TarKind;
 
@@ -75,6 +78,9 @@ int tarClose(TarKind kind);
 
 TarEntryBase *tarFind(TarKind kind, const char *filename);
 TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix);
+// Exact-path lookup: never scans the generic device list. Reuses the selected path's index for the
+// session and reads members back from that same path.
+TarEntryBase *tarFindPrefixFromPath(TarKind kind, const char *path, const char *prefix);
 void *tarGet(TarKind kind, const char *filename);
 u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize);
 

--- a/linkfile
+++ b/linkfile
@@ -1,0 +1,127 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Linkfile script for ee-ld (OPL with protected BRAM direct launch region)
+*/
+
+ENTRY(__start);
+
+MEMORY {
+	bram	: ORIGIN = 0x000e0000, LENGTH = 0x20000 /* 0x000e0000 - 0x00100000: Protected kernel memory (128 KB) */
+	gram	: ORIGIN = 0x00100000, LENGTH = 31M     /* 0x00100000 - 0x02000000: User memory */
+}
+
+REGION_ALIAS("MAIN_REGION", gram);
+
+PHDRS {
+  text PT_LOAD;
+}
+
+SECTIONS {
+	.text : {
+		*(._launch_elf)
+		*libkernel.a:*(.text .text.*)
+	} >bram
+	.rodata : {
+		*libkernel.a:*(.rodata .rodata.*)
+	} >bram
+	.data : {
+		*libkernel.a:*(.data .data.*)
+		*(._launch_args)
+	} >bram
+
+	.text 0x00100000: {
+		_ftext = . ;
+		*(.text)
+		*(.text.*)
+		*(.gnu.linkonce.t*)
+		KEEP(*(.init))
+		KEEP(*(.fini))
+		QUAD(0)
+	} >MAIN_REGION :text
+
+	PROVIDE(_etext = .);
+	PROVIDE(etext = .);
+
+	/* Global/static constructors and deconstructors. */
+	.ctors ALIGN(16): {
+		KEEP(*crtbegin*.o(.ctors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
+		KEEP(*(SORT(.ctors.*)))
+		KEEP(*(.ctors))
+	} >MAIN_REGION
+	.dtors ALIGN(16): {
+		KEEP(*crtbegin*.o(.dtors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
+		KEEP(*(SORT(.dtors.*)))
+		KEEP(*(.dtors))
+	} >MAIN_REGION
+
+	.reginfo : { *(.reginfo) } >MAIN_REGION
+
+	.data ALIGN(128): {
+		_fdata = . ;
+		*(.data)
+		*(.data.*)
+		*(.gnu.linkonce.d*)
+		SORT(CONSTRUCTORS)
+	} >MAIN_REGION
+
+	/* Static data.  */
+	.rodata ALIGN(128): {
+		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
+	} >MAIN_REGION
+
+	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION
+	.gcc_except_table ALIGN(128): { *(.gcc_except_table) } >MAIN_REGION
+
+	_gp = ALIGN(128) + 0x7ff0;
+	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
+	.lit8 ALIGN(128): { *(.lit8) } >MAIN_REGION
+
+	.sdata ALIGN(128): {
+		*(.sdata)
+		*(.sdata.*)
+		*(.gnu.linkonce.s*)
+	} >MAIN_REGION
+
+	_edata = .;
+	PROVIDE(edata = .);
+
+	/* Uninitialized data.  */
+	.sbss ALIGN(128) : {
+		_fbss = . ;
+		*(.sbss)
+		*(.sbss.*)
+		*(.gnu.linkonce.sb*)
+		*(.scommon)
+	} >MAIN_REGION
+
+	.bss ALIGN(128) : {
+		*(.bss)
+		*(.bss.*)
+		*(.gnu.linkonce.b*)
+		*(COMMON)
+	} >MAIN_REGION
+	_end_bss = .;
+
+	_end = . ;
+	PROVIDE(end = .);
+
+	.spad 0x70000000: {
+		*(.spad)
+	} >MAIN_REGION
+
+	/* Symbols needed by crt0.s.  */
+	PROVIDE(_heap_size = -1);
+	PROVIDE(_stack = -1);
+	PROVIDE(_stack_size = 128 * 1024);
+}

--- a/linkfile
+++ b/linkfile
@@ -20,6 +20,7 @@ MEMORY {
 REGION_ALIAS("MAIN_REGION", gram);
 
 PHDRS {
+  bram PT_LOAD;
   text PT_LOAD;
 }
 
@@ -27,14 +28,14 @@ SECTIONS {
 	.text : {
 		*(._launch_elf)
 		*libkernel.a:*(.text .text.*)
-	} >bram
+	} >bram :bram
 	.rodata : {
 		*libkernel.a:*(.rodata .rodata.*)
-	} >bram
+	} >bram :bram
 	.data : {
 		*libkernel.a:*(.data .data.*)
 		*(._launch_args)
-	} >bram
+	} >bram :bram
 
 	.text 0x00100000: {
 		_ftext = . ;
@@ -55,15 +56,15 @@ SECTIONS {
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
 		KEEP(*(SORT(.ctors.*)))
 		KEEP(*(.ctors))
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 	.dtors ALIGN(16): {
 		KEEP(*crtbegin*.o(.dtors))
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
 		KEEP(*(SORT(.dtors.*)))
 		KEEP(*(.dtors))
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 
-	.reginfo : { *(.reginfo) } >MAIN_REGION
+	.reginfo : { *(.reginfo) } >MAIN_REGION :text
 
 	.data ALIGN(128): {
 		_fdata = . ;
@@ -71,27 +72,27 @@ SECTIONS {
 		*(.data.*)
 		*(.gnu.linkonce.d*)
 		SORT(CONSTRUCTORS)
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 
 	/* Static data.  */
 	.rodata ALIGN(128): {
 		*(.rodata)
 		*(.rodata.*)
 		*(.gnu.linkonce.r*)
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 
-	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION
-	.gcc_except_table ALIGN(128): { *(.gcc_except_table) } >MAIN_REGION
+	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION :text
+	.gcc_except_table ALIGN(128): { *(.gcc_except_table) } >MAIN_REGION :text
 
 	_gp = ALIGN(128) + 0x7ff0;
-	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
-	.lit8 ALIGN(128): { *(.lit8) } >MAIN_REGION
+	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION :text
+	.lit8 ALIGN(128): { *(.lit8) } >MAIN_REGION :text
 
 	.sdata ALIGN(128): {
 		*(.sdata)
 		*(.sdata.*)
 		*(.gnu.linkonce.s*)
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 
 	_edata = .;
 	PROVIDE(edata = .);
@@ -103,14 +104,14 @@ SECTIONS {
 		*(.sbss.*)
 		*(.gnu.linkonce.sb*)
 		*(.scommon)
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 
 	.bss ALIGN(128) : {
 		*(.bss)
 		*(.bss.*)
 		*(.gnu.linkonce.b*)
 		*(COMMON)
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 	_end_bss = .;
 
 	_end = . ;
@@ -118,7 +119,7 @@ SECTIONS {
 
 	.spad 0x70000000: {
 		*(.spad)
-	} >MAIN_REGION
+	} >MAIN_REGION :text
 
 	/* Symbols needed by crt0.s.  */
 	PROVIDE(_heap_size = -1);

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -907,6 +907,23 @@ static int appGetImage(item_list_t *itemList, char *folder, int isRelative, char
     return oplGetAppImageByMode(app->artMode, folder, isRelative, value, suffix, resultTex, psm);
 }
 
+// Apps proxy artwork to their recorded source mode. Preserve a selected APA source's one-home
+// rule for packed art too; an unavailable HDD source must not fall back to the generic tar sweep.
+static int appGetArtArchivePath(item_list_t *itemList, const char *value, char *path, int pathSize)
+{
+    app_info_t *app = appLookupByStartup(value);
+
+    if (app == NULL || app->artMode < 0 || app->artMode >= MODE_COUNT)
+        return 0;
+
+    opl_io_module_t *module = oplGetModule(app->artMode);
+    item_list_t *source = module != NULL ? module->support : NULL;
+    if (source != NULL && source->itemGetArtArchivePath != NULL)
+        return source->itemGetArtArchivePath(source, value, path, pathSize);
+
+    return app->artMode == HDD_MODE ? -1 : 0;
+}
+
 static int appGetTextId(item_list_t *itemList)
 {
     return _STR_APPS;
@@ -948,4 +965,4 @@ static void appShutdown(item_list_t *itemList)
 static item_list_t appItemList = {
     APP_MODE, -1, 0, MODE_FLAG_NO_COMPAT | MODE_FLAG_NO_UPDATE, MENU_MIN_INACTIVE_FRAMES, APP_MODE_UPDATE_DELAY, NULL, NULL, &appGetTextId, NULL, &appInit, &appNeedsUpdate, &appUpdateItemList,
     &appGetItemCount, NULL, &appGetItemName, &appGetItemNameLength, &appGetItemStartup, &appDeleteItem, &appRenameItem, &appLaunchItem,
-    &appGetConfig, &appGetImage, &appCleanUp, &appShutdown, NULL, &appGetIconId};
+    &appGetConfig, &appGetImage, &appCleanUp, &appShutdown, NULL, &appGetIconId, NULL, ITEM_VIEW_NATIVE, &appGetArtArchivePath};

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -369,8 +369,8 @@ int bdmModeIsSIO2(int mode)
 
 static int bdmShouldQueueModuleLoad(void)
 {
-    if (gEnableUSB && !iUSBModLoaded)
-        return 1;
+    // USB is loaded synchronously in bdmLoadCoreModules(); it never needs an
+    // optional-transport retry queue.
     if (gEnableILK && !iLinkModLoaded)
         return 1;
     if (gEnableMX4SIO && !mx4sioModLoaded)
@@ -394,14 +394,8 @@ static void bdmLoadBlockDeviceModules(void)
 
     // Snapshot, compared after the loads below. See the refresh at the end of this function for why
     // a transport enabled from Settings needed a "double tap" before its tab appeared.
-    int modsWere = iUSBModLoaded + iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
-
-    if (gEnableUSB && !iUSBModLoaded) {
-        // Load USB Block Device drivers -- the prime suspect for a real exFAT/USB boot wedge.
-        guiSetBootStatusSticky(_l(_STR_BOOT_LOADING_USB));
-        if (bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx) >= 0)
-            iUSBModLoaded = 1;
-    }
+    // USB is intentionally omitted: it is loaded synchronously in bdmLoadCoreModules().
+    int modsWere = iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
 
     if (gEnableILK && !iLinkModLoaded) {
         // Load iLink Block Device drivers
@@ -460,7 +454,8 @@ static void bdmLoadBlockDeviceModules(void)
             sysShutdownDev9();
     }
 
-    int modsNow = iUSBModLoaded + iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
+    // USB is loaded synchronously in bdmLoadCoreModules(); omit from late-load detection.
+    int modsNow = iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
 
     // BOOT PASS BUMPS NOTHING. On the first call every enabled transport loads for the first time, so
     // the comparison below is guaranteed true -- and bdmInitDevicesData is about to publish all of
@@ -518,9 +513,9 @@ static void bdmLoadBlockDeviceModules(void)
     }
 }
 
-// Bring up only the common BDM infrastructure. Literal massN: boot resolution uses this path so an
-// explicit filesystem slot never incidentally queues every transport enabled by the last settings
-// load; it determines its backing driver from that slot's own devctl/ioctl identity instead.
+// Bring up the common BDM infrastructure plus USBMASS_BD. USB is part of the base
+// BDM stack in upstream OPL and Grimdoomer; loading it here keeps it resident for
+// literal massN: boot resolution without queuing the optional-transport loader.
 static void bdmLoadCoreModules(void)
 {
     LOG("BDMSUPPORT LoadModules\n");
@@ -532,6 +527,17 @@ static void bdmLoadCoreModules(void)
     // Load FATFS (mass:) driver
     LOG("[BDMFS_FATFS]:\n");
     sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
+
+    // Load USBMASS_BD synchronously as part of the base BDM stack. USBD is already
+    // resident from sysReset() (src/system.c:287); upstream OPL and Grimdoomer load
+    // both here in bdmLoadModules(). Treating USBMASS_BD as an optional async
+    // transport created a boot race where a stick could fail to attach and then not
+    // be retried until another generation event.
+    if (!iUSBModLoaded) {
+        LOG("[USBMASS_BD]:\n");
+        if (sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL) >= 0)
+            iUSBModLoaded = 1;
+    }
 
     LOG("[BDMEVENT]:\n");
     sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
@@ -2009,8 +2015,8 @@ static int bdmEnsureTransportLoaded(int bdmType)
 {
     switch (bdmType) {
         case BDM_TYPE_USB:
-            if (!iUSBModLoaded && bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx) >= 0)
-                iUSBModLoaded = 1;
+            // USB is loaded synchronously in bdmLoadCoreModules(); this is now a
+            // simple loaded-state query.
             return iUSBModLoaded;
         case BDM_TYPE_SDC:
             if (!mx4sioModLoaded && bdmLoadOptionalModule("MX4SIO_BD", &mx4sio_bd_irx, size_mx4sio_bd_irx) >= 0)

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -259,6 +259,23 @@ static int bdmLoadOptionalModule(const char *name, void *module, int moduleSize)
     return result;
 }
 
+// Load USBMASS_BD and record success. Callers inside bdmLoadBlockDeviceModules()/bdmEnsureTransportLoaded()
+// already hold bdmLoadModuleLock; early init callers (bdmLoadCoreModules) are single-threaded.
+static int bdmLoadUsbMassBd(void)
+{
+    if (iUSBModLoaded)
+        return 1;
+
+    LOG("[USBMASS_BD]:\n");
+    if (sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL) >= 0) {
+        iUSBModLoaded = 1;
+        return 1;
+    }
+
+    LOG("USBMASS_BD failed to load\n");
+    return 0;
+}
+
 // Like bdmLoadOptionalModule, but passes IOP module args (arglen = byte length of the packed,
 // NUL-terminated args buffer). smap_udpbd requires an "ip=A.B.C.D" arg; the base loader passes none.
 static int bdmLoadOptionalModuleArgs(const char *name, void *module, int moduleSize, int arglen, char *args)
@@ -533,11 +550,7 @@ static void bdmLoadCoreModules(void)
     // both here in bdmLoadModules(). Treating USBMASS_BD as an optional async
     // transport created a boot race where a stick could fail to attach and then not
     // be retried until another generation event.
-    if (!iUSBModLoaded) {
-        LOG("[USBMASS_BD]:\n");
-        if (sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL) >= 0)
-            iUSBModLoaded = 1;
-    }
+    bdmLoadUsbMassBd();
 
     LOG("[BDMEVENT]:\n");
     sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
@@ -2015,9 +2028,9 @@ static int bdmEnsureTransportLoaded(int bdmType)
 {
     switch (bdmType) {
         case BDM_TYPE_USB:
-            // USB is loaded synchronously in bdmLoadCoreModules(); this is now a
-            // simple loaded-state query.
-            return iUSBModLoaded;
+            // USB is loaded synchronously in bdmLoadCoreModules(); this path also
+            // recovers from an initial load failure during normal discovery passes.
+            return bdmLoadUsbMassBd();
         case BDM_TYPE_SDC:
             if (!mx4sioModLoaded && bdmLoadOptionalModule("MX4SIO_BD", &mx4sio_bd_irx, size_mx4sio_bd_irx) >= 0)
                 mx4sioModLoaded = 1;

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -754,6 +754,42 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
     return -1;
 }
 
+// Keep a favourite's archive lookup with its owning source. In particular, an HDD favourite must
+// use the selected APA PFS home rather than the generic multi-device ART archive search.
+static int favGetArtArchivePath(item_list_t *itemList, const char *value, char *path, int pathSize)
+{
+    if (favArray == NULL || value == NULL)
+        return 0;
+
+    for (int i = 0; i < favCount; i++) {
+        item_list_t ownerView;
+        item_list_t *o = favOwnerView(i, &ownerView);
+        if (o == NULL)
+            continue;
+
+        if (favArray[i].isVcd) {
+            if (strcmp(favArray[i].text, value) != 0) {
+                char fallbackKey[VCD_ID_MAX];
+                if (!vcdExtractGameId(favArray[i].text, fallbackKey, sizeof(fallbackKey)) ||
+                    strcmp(fallbackKey, value) != 0)
+                    continue;
+            }
+        } else {
+            if (o->itemGetStartup == NULL || !favOwnerHasId(o, favArray[i].id))
+                continue;
+            char *startup = o->itemGetStartup(o, favArray[i].id);
+            if (startup == NULL || strcmp(startup, value) != 0)
+                continue;
+        }
+
+        return o->itemGetArtArchivePath != NULL ?
+                   o->itemGetArtArchivePath(o, value, path, pathSize) :
+                   0;
+    }
+
+    return 0;
+}
+
 // Resolve an art-cache `value` (a source item's startup, or a VCD favourite's .VCD name /
 // strict PS1 id) to the favourite's SOURCE device mode, using the same matching favGetImage
 // uses to route the actual read. Lets texcache apply MMCE idle deferral, abort,
@@ -975,4 +1011,4 @@ item_list_t *favGetObject(int initOnly)
 static item_list_t favItemList = {
     FAV_MODE, -1, 0, 0, MENU_MIN_INACTIVE_FRAMES, FAV_MODE_UPDATE_DELAY, NULL, NULL, &favGetTextId, NULL, &favInit, &favNeedsUpdate, &favUpdateItemList,
     &favGetItemCount, NULL, &favGetItemName, &favGetItemNameLength, &favGetItemStartup, &favDeleteItem, &favRenameItem, &favLaunchItem,
-    &favGetConfig, &favGetImage, &favCleanUp, &favShutdown, &favCheckVMC, &favGetIconId};
+    &favGetConfig, &favGetImage, &favCleanUp, &favShutdown, &favCheckVMC, &favGetIconId, NULL, ITEM_VIEW_NATIVE, &favGetArtArchivePath};

--- a/src/gui.c
+++ b/src/gui.c
@@ -2144,8 +2144,10 @@ void guiShowArtworkConfig(void)
             // does nothing".
             int previousArtTar = gEnableArtTar;
             diaGetInt(diaArtworkConfig, UICFG_ENABLE_ART_TAR, &gEnableArtTar);
-            if (gEnableArtTar != previousArtTar)
+            if (gEnableArtTar != previousArtTar) {
                 tarInvalidate(TAR_KIND_ART);
+                tarInvalidate(TAR_KIND_HDD_ART);
+            }
         }
         int artDelayIdx = 0;
         diaGetInt(diaArtworkConfig, UICFG_ART_DELAY, &artDelayIdx);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -45,13 +45,10 @@ static unsigned char hddSupportModulesLoaded = 0;
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
-// Auto startup enqueues hddInitModules before the initial HDD list refresh. A PS2FS load can still
-// transiently fail on the first post-settle attempts while the other Auto transports are coming up,
-// then succeed on a queued refresh. Count consecutive failures and only toast code 222 once the
-// failure streak has survived multiple retries -- a single transient failure must not alarm the user
-// when the PFS stack recovers before the menu becomes usable.
-static unsigned char hddPfsLoadRetryCount = 0;
-#define HDD_PFS_LOAD_RETRY_TOAST_THRESHOLD 3
+// Deferred PFS failure state. Low-level boot/config probes may transiently fail to load PS2FS/PFS;
+// they set this flag instead of publishing a user-facing error. The final HDD list-refresh path
+// evaluates the flag after recovery has had a chance to succeed and only then emits code 222 once.
+static unsigned char hddPfsLoadFailed = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -533,17 +530,15 @@ static int hddLoadCoreSupportModules(void)
         ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: PFS support module failed to load.\n");
-            if (hddPfsLoadRetryCount < 0xFF)
-                hddPfsLoadRetryCount++;
-            if (hddPfsLoadRetryCount >= HDD_PFS_LOAD_RETRY_TOAST_THRESHOLD && !hddSupportErrToasted) {
-                setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
-                hddSupportErrToasted = 1;
-            }
+            // Do NOT toast here. Boot/config probes may fail transiently before the
+            // final list-refresh recovery has run. Record the failure and let
+            // hddUpdateGameList() decide whether to publish code 222 after recovery.
+            hddPfsLoadFailed = 1;
             return 0;
         }
 
         hddSupportModulesLoaded = 1;
-        hddPfsLoadRetryCount = 0;
+        hddPfsLoadFailed = 0;
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
@@ -878,6 +873,15 @@ static int hddNeedsUpdate(item_list_t *itemList)
 
 static int hddUpdateGameList(item_list_t *itemList)
 {
+    // hddInitModules() runs the ATA stack load (and its required ~1-second post-ATAD settle) on the
+    // IO worker. If the GUI update runs before that async init has even started,
+    // hddLoadModulesReady() would perform the first load -- including the DelayThread -- on the GUI
+    // thread and freeze the menu. Defer until the worker has at least begun (count != 0);
+    // hddLoadModulesReady() then only blocks if an attempt is already in progress and returns safely
+    // otherwise.
+    if (hddModulesLoadCount == 0)
+        return 0;
+
     // Self-heal (wLaunchELF-R3Z3N parity: latch only on success, retry per use): a boot-time first
     // touch that raced drive spin-up used to leave the APA page EMPTY for the whole session -- the
     // one-shot hddInitModules never retried, and nothing else reloads the support stack. Both calls
@@ -904,6 +908,17 @@ static int hddUpdateGameList(item_list_t *itemList)
     // fails harmlessly if hdd0: is not ready; the VCD builder likewise skips mounts it cannot open.
     if (!hddSupportModulesLoaded)
         LOG("HDDSUPPORT UpdateGameList: PFS support incomplete; attempting read-only APA enumeration anyway\n");
+
+    // After boot/config probes and the retry above have had their chance, publish a persistent PFS
+    // failure exactly once. A later successful load clears the deferred flag and retracts the error.
+    if (hddSupportModulesLoaded) {
+        hddPfsLoadFailed = 0;
+        hddSupportErrToasted = 0;
+        hddClearRecoveredErrors();
+    } else if (hddPfsLoadFailed && !hddSupportErrToasted) {
+        setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
+        hddSupportErrToasted = 1;
+    }
 
     if (vcdListViewActive(itemList))
         // Reuse the session's built list on view flips; hddBuildVcdGameList runs only when never
@@ -1849,7 +1864,7 @@ static void hddShutdown(item_list_t *itemList)
 {
     LOG("HDDSUPPORT Shutdown\n");
 
-    hddPfsLoadRetryCount = 0;
+    hddPfsLoadFailed = 0;
     hddSupportErrToasted = 0;
 
     if (hddGameList.enabled) {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -35,6 +35,11 @@ static unsigned char hddForceUpdate = 0;
 static unsigned char hddHDProKitDetected = 0;
 static unsigned char hddModulesLoadCount = 0;
 static unsigned char hddModulesLoaded = 0;
+// Residency is published before the one-second ATA settle so list retry can observe it, but PFS
+// must not start until the settle has completed. With every source on Auto another boot task can
+// otherwise see the resident latch mid-delay, start PS2FS too early, and leave a false code-222
+// notification behind even though the next retry mounts APA normally.
+static unsigned char hddModulesSettled = 0;
 static unsigned char hddSupportModulesLoaded = 0;
 // One toast per failure streak: hddUpdateGameList now RETRIES the support-module load every refresh
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
@@ -273,6 +278,7 @@ int hddLoadModules(void)
         // Increment the load count as soon as possible to prevent thread scheduling from allowing another thread to
         // call into here and try to double load modules.
         hddModulesLoadCount = 1;
+        hddModulesSettled = 0;
 
         // DEV9 must be loaded, as HDD.IRX depends on it. Even if not required by the I/F (i.e. HDPro)
         sysInitDev9();
@@ -314,6 +320,7 @@ int hddLoadModules(void)
             // arm did not, and rebuild-153's device-refresh bump made the retry more frequent.
             sysShutdownDev9();
             hddModulesLoadCount = 0;
+            hddModulesSettled = 0;
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;
             hddModulesLoaded = 1;
@@ -324,6 +331,7 @@ int hddLoadModules(void)
             // ATA_DEVCTL_READ_PARTITION_SECTOR probe / ps2hdd init can otherwise race a drive that is
             // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
             DelayThread(1000 * 1000);
+            hddModulesSettled = 1;
         }
     } else {
         hddModulesLoadCount++;
@@ -537,6 +545,12 @@ static int hddLoadCoreSupportModules(void)
 void hddLoadSupportModules(void)
 {
     int ret;
+
+    // Do not turn a concurrent Auto boot caller's mid-settle observation into a real PFS probe.
+    // The loader that owns the settle resumes into this function after the delay; if it is a
+    // BDM-only caller, the normal HDD list retry makes the first support attempt after it instead.
+    if (!hddModulesSettled)
+        return;
 
     if (!hddLoadCoreSupportModules())
         return;
@@ -1847,6 +1861,7 @@ static void hddShutdown(item_list_t *itemList)
             // DEV9 will remain active if ETH is in use, so put the HDD in IDLE state.
             // The HDD should still enter standby state after 21 minutes & 15 seconds, as per the ATAD defaults.
             hddSetIdleImmediate();
+            hddModulesSettled = 0;
         }
 
         // Only shut down dev9 from here, if it was initialized from here before -- and only on a
@@ -1977,7 +1992,23 @@ static char *hddGetPrefix(item_list_t *itemList)
     return gHDDPrefix;
 }
 
+// The persistent PFS mount is the session's sole APA data home. Keep packed artwork on that same
+// root: __common maps to pfs0:OPL/ART/art.tar, while +OPL maps to pfs0:ART/art.tar.
+static int hddGetArtArchivePath(item_list_t *itemList, const char *value, char *path, int pathSize)
+{
+    int len;
+
+    (void)itemList;
+    (void)value;
+
+    if (gHDDPrefix == NULL)
+        return -1;
+
+    len = snprintf(path, pathSize, "%sART/art.tar", gHDDPrefix);
+    return (len > 0 && len < pathSize) ? 1 : -1;
+}
+
 static item_list_t hddGameList = {
     HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, NULL, NULL, &hddGetTextId, &hddGetPrefix, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
     &hddGetGameCount, &hddGetGame, &hddGetGameName, &hddGetGameNameLength, &hddGetGameStartup, &hddDeleteGame, &hddRenameGame,
-    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId, &hddLaunchVcd};
+    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId, &hddLaunchVcd, ITEM_VIEW_NATIVE, &hddGetArtArchivePath};

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -46,10 +46,12 @@ static unsigned char hddSupportModulesLoaded = 0;
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
 // Auto startup enqueues hddInitModules before the initial HDD list refresh. A PS2FS load can still
-// transiently fail on that first post-settle attempt while the other Auto transports are coming up,
-// then succeed on the queued refresh. Keep that first failure pending so code 222 describes an
-// actually unavailable PFS stack, not a condition that already recovered before the menu is usable.
-static unsigned char hddPfsLoadRetryPending = 0;
+// transiently fail on the first post-settle attempts while the other Auto transports are coming up,
+// then succeed on a queued refresh. Count consecutive failures and only toast code 222 once the
+// failure streak has survived multiple retries -- a single transient failure must not alarm the user
+// when the PFS stack recovers before the menu becomes usable.
+static unsigned char hddPfsLoadRetryCount = 0;
+#define HDD_PFS_LOAD_RETRY_TOAST_THRESHOLD 3
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -531,16 +533,17 @@ static int hddLoadCoreSupportModules(void)
         ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: PFS support module failed to load.\n");
-            if (hddPfsLoadRetryPending && !hddSupportErrToasted) {
+            if (hddPfsLoadRetryCount < 0xFF)
+                hddPfsLoadRetryCount++;
+            if (hddPfsLoadRetryCount >= HDD_PFS_LOAD_RETRY_TOAST_THRESHOLD && !hddSupportErrToasted) {
                 setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
                 hddSupportErrToasted = 1;
             }
-            hddPfsLoadRetryPending = 1;
             return 0;
         }
 
         hddSupportModulesLoaded = 1;
-        hddPfsLoadRetryPending = 0;
+        hddPfsLoadRetryCount = 0;
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
@@ -1846,7 +1849,8 @@ static void hddShutdown(item_list_t *itemList)
 {
     LOG("HDDSUPPORT Shutdown\n");
 
-    hddPfsLoadRetryPending = 0;
+    hddPfsLoadRetryCount = 0;
+    hddSupportErrToasted = 0;
 
     if (hddGameList.enabled) {
         hddFreeHDLGamelist(&hddGames);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -45,6 +45,11 @@ static unsigned char hddSupportModulesLoaded = 0;
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
+// Auto startup enqueues hddInitModules before the initial HDD list refresh. A PS2FS load can still
+// transiently fail on that first post-settle attempt while the other Auto transports are coming up,
+// then succeed on the queued refresh. Keep that first failure pending so code 222 describes an
+// actually unavailable PFS stack, not a condition that already recovered before the menu is usable.
+static unsigned char hddPfsLoadRetryPending = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -526,14 +531,16 @@ static int hddLoadCoreSupportModules(void)
         ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: PFS support module failed to load.\n");
-            if (!hddSupportErrToasted) {
+            if (hddPfsLoadRetryPending && !hddSupportErrToasted) {
                 setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
                 hddSupportErrToasted = 1;
             }
+            hddPfsLoadRetryPending = 1;
             return 0;
         }
 
         hddSupportModulesLoaded = 1;
+        hddPfsLoadRetryPending = 0;
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
@@ -1838,6 +1845,8 @@ static int hddCheckVMC(item_list_t *itemList, char *name, int createSize)
 static void hddShutdown(item_list_t *itemList)
 {
     LOG("HDDSUPPORT Shutdown\n");
+
+    hddPfsLoadRetryPending = 0;
 
     if (hddGameList.enabled) {
         hddFreeHDLGamelist(&hddGames);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -57,9 +57,7 @@ hdd_pfs_state_t hddGetPfsState(void)
 
 void hddSetPfsFailedFinal(void)
 {
-    if (hddPfsState != HDD_PFS_READY) {
-        hddPfsState = HDD_PFS_FAILED_FINAL;
-    }
+    hddPfsState = HDD_PFS_FAILED_FINAL;
 }
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -98,23 +98,27 @@ static void hddInitModules(void)
 
     // Existing-partitions-only discovery may legitimately fail closed. Do not dereference a
     // missing data home, and do not create any folders until a PFS partition is actually mounted.
-    if (gHDDPrefix == NULL) {
+    if (gHDDPrefix != NULL) {
+        // update Themes
+        char path[256];
+        snprintf(path, sizeof(path), "%sTHM", gHDDPrefix);
+        thmAddElements(path, "/", 1);
+
+        snprintf(path, sizeof(path), "%sLNG", gHDDPrefix);
+        lngAddLanguages(path, "/", hddGameList.mode);
+
+        // Create normal OPL folders only inside the selected mounted PFS data home. A configured
+        // existing APA partition owns its root; the canonical __common fallback owns __common/OPL/.
+        // Never create an APA partition to obtain a home.
+        sbCreateFolders(gHDDPrefix, 0);
+    } else {
         LOG("HDDSUPPORT InitModules: no existing PFS data home mounted\n");
-        return;
     }
 
-    // update Themes
-    char path[256];
-    snprintf(path, sizeof(path), "%sTHM", gHDDPrefix);
-    thmAddElements(path, "/", 1);
-
-    snprintf(path, sizeof(path), "%sLNG", gHDDPrefix);
-    lngAddLanguages(path, "/", hddGameList.mode);
-
-    // Create normal OPL folders only inside the selected mounted PFS data home. A configured
-    // existing APA partition owns its root; the canonical __common fallback owns __common/OPL/.
-    // Never create an APA partition to obtain a home.
-    sbCreateFolders(gHDDPrefix, 0);
+    // Requeue the menu refresh now that the async ATA init/settle has completed. The GUI update
+    // that may have run earlier could have returned an empty list to avoid blocking on the GUI
+    // thread; this deferred update rebuilds the HDD page after the IO worker has finished.
+    ioPutRequest(IO_MENU_UPDATE_DEFFERED, &hddGameList.mode);
 }
 
 // HD Pro Kit is mapping the 1st word in ROM0 seg as a main ATA controller,
@@ -533,6 +537,9 @@ static int hddLoadCoreSupportModules(void)
             // Do NOT toast here. Boot/config probes may fail transiently before the
             // final list-refresh recovery has run. Record the failure and let
             // hddUpdateGameList() decide whether to publish code 222 after recovery.
+            // Clear the general support-error latch so a previous unrelated APA error
+            // does not suppress the deferred PFS notification.
+            hddSupportErrToasted = 0;
             hddPfsLoadFailed = 1;
             return 0;
         }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -45,10 +45,22 @@ static unsigned char hddSupportModulesLoaded = 0;
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
-// Deferred PFS failure state. Low-level boot/config probes may transiently fail to load PS2FS/PFS;
-// they set this flag instead of publishing a user-facing error. The final HDD list-refresh path
-// evaluates the flag after recovery has had a chance to succeed and only then emits code 222 once.
-static unsigned char hddPfsLoadFailed = 0;
+// Explicit PFS lifecycle state machine. Low-level boot/config probes may transiently fail to load PS2FS/PFS;
+// they enter RECOVERING instead of publishing a user-facing error. Only a settled, verified terminal failure
+// can transition to FAILED_FINAL and emit code 222.
+static hdd_pfs_state_t hddPfsState = HDD_PFS_UNKNOWN;
+
+hdd_pfs_state_t hddGetPfsState(void)
+{
+    return hddPfsState;
+}
+
+void hddSetPfsFailedFinal(void)
+{
+    if (hddPfsState != HDD_PFS_READY) {
+        hddPfsState = HDD_PFS_FAILED_FINAL;
+    }
+}
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -287,6 +299,7 @@ int hddLoadModules(void)
         // call into here and try to double load modules.
         hddModulesLoadCount = 1;
         hddModulesSettled = 0;
+        hddPfsState = HDD_PFS_SETTLING;
 
         // DEV9 must be loaded, as HDD.IRX depends on it. Even if not required by the I/F (i.e. HDPro)
         sysInitDev9();
@@ -329,6 +342,7 @@ int hddLoadModules(void)
             sysShutdownDev9();
             hddModulesLoadCount = 0;
             hddModulesSettled = 0;
+            hddPfsState = HDD_PFS_UNKNOWN;
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;
             hddModulesLoaded = 1;
@@ -340,6 +354,8 @@ int hddLoadModules(void)
             // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
             DelayThread(1000 * 1000);
             hddModulesSettled = 1;
+            if (hddPfsState == HDD_PFS_SETTLING)
+                hddPfsState = HDD_PFS_RECOVERING;
         }
     } else {
         hddModulesLoadCount++;
@@ -535,17 +551,15 @@ static int hddLoadCoreSupportModules(void)
         if (ret < 0) {
             LOG("HDD: PFS support module failed to load.\n");
             // Do NOT toast here. Boot/config probes may fail transiently before the
-            // final list-refresh recovery has run. Record the failure and let
-            // hddUpdateGameList() decide whether to publish code 222 after recovery.
-            // Clear the general support-error latch so a previous unrelated APA error
-            // does not suppress the deferred PFS notification.
+            // final list-refresh recovery has run. Mark as RECOVERING so subsequent
+            // attempts can retry without falsely emitting code 222 during boot.
             hddSupportErrToasted = 0;
-            hddPfsLoadFailed = 1;
+            hddPfsState = HDD_PFS_RECOVERING;
             return 0;
         }
 
         hddSupportModulesLoaded = 1;
-        hddPfsLoadFailed = 0;
+        hddPfsState = HDD_PFS_READY;
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
@@ -916,13 +930,13 @@ static int hddUpdateGameList(item_list_t *itemList)
     if (!hddSupportModulesLoaded)
         LOG("HDDSUPPORT UpdateGameList: PFS support incomplete; attempting read-only APA enumeration anyway\n");
 
-    // After boot/config probes and the retry above have had their chance, publish a persistent PFS
-    // failure exactly once. A later successful load clears the deferred flag and retracts the error.
+    // Check PFS state after recovery retry. A ready state clears errors; Code 222 is only
+    // published if an authoritative operation has confirmed a terminal failure (HDD_PFS_FAILED_FINAL).
     if (hddSupportModulesLoaded) {
-        hddPfsLoadFailed = 0;
+        hddPfsState = HDD_PFS_READY;
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
-    } else if (hddPfsLoadFailed && !hddSupportErrToasted) {
+    } else if (hddPfsState == HDD_PFS_FAILED_FINAL && !hddSupportErrToasted) {
         setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
         hddSupportErrToasted = 1;
     }
@@ -1081,14 +1095,20 @@ int hddStageOplHomeSelection(int selection)
     // of a module reference; hddLoadModulesReady() would retain one on every stage/save cycle.
     // Do not call hddLoadSupportModules here: its normal data-home recovery may mount pfs0: and
     // create OPL folders, neither of which belongs to a source selector proof.
-    if (!hddModulesAreLoaded())
+    if (!hddModulesAreLoaded()) {
+        hddSetPfsFailedFinal();
         return 0;
-    if (!hddLoadCoreSupportModules())
+    }
+    if (!hddLoadCoreSupportModules()) {
+        hddSetPfsFailedFinal();
         return 0;
+    }
 
     partition = selection == HDD_OPL_HOME_PLUS ? "hdd0:+OPL" : "hdd0:__common";
-    if (!hddPartitionMountableAt("pfs1:", partition, FIO_MT_RDONLY))
+    if (!hddPartitionMountableAt("pfs1:", partition, FIO_MT_RDONLY)) {
+        hddSetPfsFailedFinal();
         return 0;
+    }
 
     hddOplHomePending = selection;
     return 1;
@@ -1118,17 +1138,22 @@ int hddMountSelectedOplHome(char *prefix, int prefixLen)
     selection = hddGetOplHomeSelection();
     if (hddOplHomePending < 0 && hddOplHomeCommitted < 0)
         return 0;
-    if (!hddModulesAreLoaded() || !hddLoadCoreSupportModules())
+    if (!hddModulesAreLoaded() || !hddLoadCoreSupportModules()) {
+        hddSetPfsFailedFinal();
         return 0;
+    }
 
     partition = selection == HDD_OPL_HOME_PLUS ? "hdd0:+OPL" : "hdd0:__common";
     fileXioUmount("pfs1:");
-    if (fileXioMount("pfs1:", partition, FIO_MT_RDWR) < 0)
+    if (fileXioMount("pfs1:", partition, FIO_MT_RDWR) < 0) {
+        hddSetPfsFailedFinal();
         return 0;
+    }
 
     if (selection == HDD_OPL_HOME_COMMON) {
         if (!hddCheckOPLFolder("pfs1:")) {
             fileXioUmount("pfs1:");
+            hddSetPfsFailedFinal();
             return 0;
         }
         selectedPrefix = "pfs1:OPL/";
@@ -1140,6 +1165,7 @@ int hddMountSelectedOplHome(char *prefix, int prefixLen)
     if (n < 0 || n >= prefixLen) {
         fileXioUmount("pfs1:");
         prefix[0] = '\0';
+        hddSetPfsFailedFinal();
         return 0;
     }
 
@@ -1165,10 +1191,14 @@ int hddCommitOplHomeSelection(void)
     // An automatic +OPL home has no __common control file. The active pfs0: mount proves the
     // staged effective choice, so commit it as a fileless no-op without probing or writing
     // __common. This preserves the no-__common topology across ordinary Settings saves.
-    if (!hddModulesAreLoaded())
+    if (!hddModulesAreLoaded()) {
+        hddSetPfsFailedFinal();
         return 0;
-    if (!hddLoadCoreSupportModules())
+    }
+    if (!hddLoadCoreSupportModules()) {
+        hddSetPfsFailedFinal();
         return 0;
+    }
     if (hddOplHomePending == HDD_OPL_HOME_PLUS && hddOplHomeAutoPlus &&
         !strcmp(gOPLPart, "hdd0:+OPL") && gHDDPrefix != NULL) {
         hddOplHomeCommitted = hddOplHomePending;
@@ -1178,11 +1208,15 @@ int hddCommitOplHomeSelection(void)
 
     // Re-prove the common owner at commit time. No raw APA operation, partition creation, or pfs0:
     // remount is involved; this is only a bounded pfs1: read/write mount of an existing partition.
-    if (!hddPartitionMountableAt("pfs1:", "hdd0:__common", FIO_MT_RDWR))
+    if (!hddPartitionMountableAt("pfs1:", "hdd0:__common", FIO_MT_RDWR)) {
+        hddSetPfsFailedFinal();
         return 0;
+    }
 
-    if (fileXioMount("pfs1:", "hdd0:__common", FIO_MT_RDWR) < 0)
+    if (fileXioMount("pfs1:", "hdd0:__common", FIO_MT_RDWR) < 0) {
+        hddSetPfsFailedFinal();
         return 0;
+    }
 
     fd = open(path, O_RDONLY);
     exists = fd >= 0;
@@ -1871,7 +1905,7 @@ static void hddShutdown(item_list_t *itemList)
 {
     LOG("HDDSUPPORT Shutdown\n");
 
-    hddPfsLoadFailed = 0;
+    hddPfsState = HDD_PFS_UNKNOWN;
     hddSupportErrToasted = 0;
 
     if (hddGameList.enabled) {

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1013,6 +1013,11 @@ static void menuNextH()
 
     // If we found a valid menu transition to it.
     if (next != NULL) {
+        // A source switch can block the GUI thread (e.g. ATA page activation loads the APA/PFS
+        // stack), which stops readPads() and leaves a held-navigation rumble pulse latched on.
+        // Stop actuators synchronously before the switch so the motor never stays on during the
+        // freeze; padRumbleStopAll covers both native pads and PADEMU.
+        padRumbleStopAll();
         menuFolderResetLeaving(selected_item);
         selected_item = next;
         itemConfigId = -1;
@@ -1027,6 +1032,8 @@ static void menuPrevH()
         prev = prev->prev;
 
     if (prev != NULL) {
+        // See menuNextH(): stop any active rumble before a potentially blocking source switch.
+        padRumbleStopAll();
         menuFolderResetLeaving(selected_item);
         selected_item = prev;
         itemConfigId = -1;

--- a/src/opl.c
+++ b/src/opl.c
@@ -3396,6 +3396,7 @@ void applyConfig(int themeID, int langID, int skipDeviceRefresh)
     // so returning to List Mode does not re-probe USB 1.1 storage.
     if (skipDeviceRefresh == 0) {
         tarInvalidate(TAR_KIND_ART);
+        tarInvalidate(TAR_KIND_HDD_ART);
         cacheInvalidateFailMemo();
         artIndexInvalidate(); // a full settings apply is the user's own "I changed something, look again"
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -2932,6 +2932,7 @@ static int trySaveConfigHDD(int types)
         return configWriteMulti(types);
     }
 
+    hddSetPfsFailedFinal();
     return -ENOENT;
 }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -4286,7 +4286,7 @@ static void setDefaults(void)
     gMMCEAckWaitCycles = 5;
     gMMCEUseAlarms = 1;
 
-    gEnableUSB = 0; // USB block device is opt-in, like the other BDM transports
+    gEnableUSB = 1; // USB block device is part of the base BDM stack; the page toggle now only controls visibility/scans
     // Visual GameID barcode ships OFF, matching fork commit cc2cdfed ("GameID defaults OFF"): the
     // HDMI auto-profile latch is only verifiable on real GameID hardware, so it stays opt-in.
     gApplyGameID = 0;
@@ -4479,12 +4479,9 @@ static void miniInit(int mode)
         bdmInitSemaphore();
 
         // Force load all BDM modules.. we aren't using the gui so this is fine.
-        // gEnableUSB belongs in this list and was the one missing from it. Unlike the others it is a
-        // FORK INVENTION -- upstream loads USBMASS_BD unconditionally and has no such flag -- so the
-        // opt-in default of 0 that setDefaults() applies a few lines earlier (and which the GUI
-        // normally overrides from the saved config) had nothing to override it here: configReadMulti
-        // runs AFTER bdmLoadModules(). bdmLoadBlockDeviceModules gates the USB load on the flag, so
-        // an argv autolaunch from a USB stick loaded no USB block driver at all.
+        // USBMASS_BD is now loaded synchronously in bdmLoadCoreModules() regardless of
+        // gEnableUSB; these flags mainly ensure per-transport page/scan policy is enabled
+        // for the autolaunch path.
         gEnableUSB = 1;
         gEnableILK = 1; // iLink will break pcsx2 however.
         gEnableMX4SIO = 1;

--- a/src/opl.c
+++ b/src/opl.c
@@ -4051,6 +4051,10 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
 
+    // Stop before the I/O drain and before PADEMU is reset below. Port closure alone leaves a
+    // latched motor running through a slow launch or exit.
+    padRumbleStopAll();
+
     // Give up on the covers still QUEUED before draining. The drain waits on the ioman LIST, and the
     // worker keeps servicing it regardless of isIOBlocked, so without this the handoff pays for every
     // queued cover to be read off the game device first -- for a menu guiEnd() is about to destroy.
@@ -4108,6 +4112,9 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 void deinit(int exception, int modeSelected)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
+
+    // See deinitEx(): pulse shutdown must precede any blocking drain or PADEMU reset.
+    padRumbleStopAll();
 
     // Give up on the covers still QUEUED before draining. The drain waits on the ioman LIST, and the
     // worker keeps servicing it regardless of isIOBlocked, so without this the handoff pays for every
@@ -4845,6 +4852,11 @@ int main(int argc, char *argv[])
     // and it must not gate a boot that otherwise works fine.
     if (strchr(configGetDir(), '?') != NULL)
         guiWarning(_l(_STR_SETTINGS_NO_HOME), 6);
+
+    // guiIntroLoop handles input against a frozen pad snapshot. Do not send actuator RPCs until
+    // guiMainLoop is about to resume normal polling, otherwise a held boot button can race IOP loads.
+    padRumbleActivate();
+    padRumbleBump();
 
     guiMainLoop();
 

--- a/src/pad.c
+++ b/src/pad.c
@@ -570,19 +570,20 @@ void padRumbleStopAll(void)
 {
     int i;
 
+    if (!rumbleActive)
+        return;
+
     rumbleActive = 0;
     rumbleDurTicks = 0;
     rumbleLarge = 0;
     rumbleSmall = 0;
 
-    // Send native stops twice because freepad may drop an actuator command outside TASK_UPDATE_PAD.
+    // Send native stops: state transitioned ACTIVE -> IDLE, send OFF command once.
     // PADEMU uses its own command channel, so it needs an explicit stop as well once polling ends.
     for (i = 0; i < pad_count; ++i) {
         padPademuSetRumble(&pad_data[i], 0);
         padActSet(&pad_data[i], 0, 0);
     }
-    for (i = 0; i < pad_count; ++i)
-        padActSet(&pad_data[i], 0, 0);
 }
 
 /** Lets a decision bump complete before a caller starts work that will stop readPads(). */
@@ -641,13 +642,19 @@ static void padRumbleArm(int durationMs, int large, int small)
 
     rumbleStartTicks = nowTicks;
     rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
+
+    if (rumbleActive) {
+        // ACTIVE -> ACTIVE: pulse duration extended, actuator is already spinning.
+        // ZERO SIF RPCs issued.
+        return;
+    }
+
     rumbleActive = 1;
     rumbleLarge = large;
     rumbleSmall = small ? 1 : 0;
 
     for (i = 0; i < pad_count; ++i) {
-        // Native pads are kicked immediately and re-sent from readPads(); PADEMU gets the same
-        // immediate command so a confirm followed by blocking work still reaches a DS3/DS4/DS5.
+        // Native pads are kicked immediately (ON); PADEMU gets the same immediate command.
         padActSet(&pad_data[i], rumbleSmall, rumbleLarge);
         padPademuSetRumble(&pad_data[i], rumbleLarge);
     }
@@ -751,14 +758,10 @@ int readPads()
         }
     }
 
-    // Rumble decay + re-send. The native re-send is not redundant: freepad can drop a direct
-    // actuator command outside its update task, and PADEMU is kept in sync by readPad() above.
+    // Rumble decay. The pulse ends when duration expires; zero RPCs are sent while active.
     if (rumbleActive) {
         if (!gEnableRumble || (u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
             padRumbleStopAll();
-        } else {
-            for (i = 0; i < pad_count; ++i)
-                padActSet(&pad_data[i], rumbleSmall, rumbleLarge);
         }
     }
 

--- a/src/pad.c
+++ b/src/pad.c
@@ -497,8 +497,21 @@ pulse is timed against raw cpu_ticks() deltas so it remains correct across the 3
 // then killed rumble silently for the whole session.
 static void padRumbleRealign(struct pad_data_t *pad)
 {
-    if (pad->actAligned || pad->actuators == 0)
+    if (!rumbleLive || pad->actAligned)
         return;
+
+    // initializePad() deliberately clears this on every attempt: retaining a count across an
+    // unplug could drive a replacement digital pad. A bounded startup attempt can also return
+    // before padInfoAct() while the controller is already usable. Rumble is live only after boot,
+    // and padInfoAct() is an EE-local query, so recover the current controller's actuator count at
+    // the first real menu pulse instead of permanently sending through freepad's 0xff alignment.
+    if (pad->actuators == 0) {
+        pad->actuators = padInfoAct(pad->port, pad->slot, -1, 0);
+        if (pad->actuators <= 0) {
+            pad->actuators = 0;
+            return;
+        }
+    }
 
     pad->actAlign[0] = 0; // small engine -> byte 0 of padSetActDirect
     pad->actAlign[1] = 1; // big engine   -> byte 1

--- a/src/pad.c
+++ b/src/pad.c
@@ -640,15 +640,23 @@ static void padRumbleArm(int durationMs, int large, int small)
             durationMs = dutyMs;
     }
 
-    rumbleStartTicks = nowTicks;
-    rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
-
     if (rumbleActive) {
-        // ACTIVE -> ACTIVE: pulse duration extended, actuator is already spinning.
+        // ACTIVE -> ACTIVE: extend duration if requested deadline is further out; promote motor levels.
         // ZERO SIF RPCs issued.
+        u32 currentEnd = rumbleStartTicks + rumbleDurTicks;
+        u32 requestedEnd = nowTicks + (u32)durationMs * CLOCKS_PER_MILISEC;
+        if ((s32)(requestedEnd - currentEnd) > 0) {
+            rumbleDurTicks = requestedEnd - rumbleStartTicks;
+        }
+        if (large > rumbleLarge)
+            rumbleLarge = large;
+        if (small > rumbleSmall)
+            rumbleSmall = small ? 1 : 0;
         return;
     }
 
+    rumbleStartTicks = nowTicks;
+    rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
     rumbleActive = 1;
     rumbleLarge = large;
     rumbleSmall = small ? 1 : 0;
@@ -718,6 +726,15 @@ int readPads()
         rslt |= readPad(&pad_data[i], &pollClean);
     }
 
+    // Rumble decay. The pulse ends when duration expires; zero RPCs are sent while active.
+    // Processed before any deferred reconnect initialization to ensure reconnect polling delays
+    // cannot artificially prolong an active rumble pulse.
+    if (rumbleActive) {
+        if (!gEnableRumble || (u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
+            padRumbleStopAll();
+        }
+    }
+
     // Idle clock for the reconnect-edge self-heal gate (see PAD_SELF_HEAL_IDLE_MS). Only a clean,
     // zero-input, gap-free poll counts: misses and transitions are unknown, and an inter-poll gap
     // above the bound is unobserved time that must not be credited as a quiet user.
@@ -755,13 +772,6 @@ int readPads()
                 initializePad(&pad_data[i]);
                 break;
             }
-        }
-    }
-
-    // Rumble decay. The pulse ends when duration expires; zero RPCs are sent while active.
-    if (rumbleActive) {
-        if (!gEnableRumble || (u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
-            padRumbleStopAll();
         }
     }
 

--- a/src/pad.c
+++ b/src/pad.c
@@ -93,6 +93,26 @@ static u32 oldpaddata;
 static int delaycnt[16];
 static int paddelay[16];
 
+// Menu rumble is intentionally a short pulse, never sustained feedback. Navigation follows the
+// RETROLauncher timing model: a soft, long big-motor thump which gives the ERM time to spin up.
+#define RUMBLE_MAX_MS           500
+#define RUMBLE_TAP_MS           240
+#define RUMBLE_TAP_LEVEL        0x50
+#define RUMBLE_BUMP_MS          110
+#define RUMBLE_BUMP_LEVEL       0x60
+#define RUMBLE_REPEAT_WINDOW_MS 400
+#define RUMBLE_REPEAT_DUTY_PCT  45
+#define RUMBLE_REPEAT_FLOOR_MS  80
+
+static u32 rumbleStartTicks = 0;
+static u32 rumbleDurTicks = 0;
+static u32 rumbleLastTicks = 0;
+static int rumbleActive = 0;
+static int rumbleLarge = 0;
+static int rumbleSmall = 0;
+static int rumbleLive = 0;
+static int rumbleLastTicksValid = 0;
+
 // KEY_ to PAD_ conversion table
 static const int keyToPad[17] = {
     -1,
@@ -394,9 +414,14 @@ static int readPad(struct pad_data_t *pad, int *pollClean)
     }
 
 #ifdef PADEMU
+    // Unlike a native pad, a DS3/DS4/DS5 never passes through padSetActDirect(). Its motors are
+    // driven by this PADEMU path, so always sending zero here silently discards every menu pulse.
+    // Drive both motors together, matching the known-good RETROLauncher behavior.
+    u8 rumble = (gEnableRumble && rumbleActive) ? (u8)rumbleLarge : 0;
+
     if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING) {
         ret = ds34bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34bt_set_rumble(pad->port, 0, 0);
+        ds34bt_set_rumble(pad->port, rumble, rumble);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -405,7 +430,7 @@ static int readPad(struct pad_data_t *pad, int *pollClean)
 
     if (ds34usb_get_status(pad->port) & DS34USB_STATE_RUNNING) {
         ret = ds34usb_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34usb_set_rumble(pad->port, 0, 0);
+        ds34usb_set_rumble(pad->port, rumble, rumble);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -463,36 +488,9 @@ static int getKeyDelay(int id, int repeat)
 }
 
 /*--    Menu rumble    ------------------------------------------------------------------------------
-Opt-in (gEnableRumble). The pulse is timed against RAW cpu_ticks() elapsed since it started, and
-NOT against time_since_last below -- that value is the difference of two ALREADY divided cpu_ticks()
-readings, so it goes wild once every ~29.1 s when the 32-bit tick counter wraps. On a decrementing
-"milliseconds left" counter a single bad sample adds ~29 s to the pulse: a motor latched on. An
-elapsed comparison in raw ticks is correct across one wrap by ordinary unsigned arithmetic, and a
-pulse is capped below at a fraction of a second, so one wrap is the most that can occur inside it.
-This is why the feature needs none of the pad-clock rework it was originally blocked on.
+The native pad and PADEMU paths use distinct actuator APIs, but share the same pulse lifetime. The
+pulse is timed against raw cpu_ticks() deltas so it remains correct across the 32-bit tick wrap.
 ----------------------------------------------------------------------------------------------------*/
-static u32 rumbleStartTicks = 0;
-static u32 rumbleDurTicks = 0;
-static int rumbleActive = 0;
-static int rumbleLarge = 0;
-
-// Longest pulse we will ever hold a motor on for. Menu feedback, not a sustained buzz.
-#define RUMBLE_MAX_MS 500
-
-/* THE TWO THINGS THAT MAKE THIS SILENT ON REAL HARDWARE, both properties of freepad.irx -- which is
-   what we ship as padman (Makefile: asm/padman.c is built from $(PS2SDK)/iop/irx/freepad.irx):
-
-   1. freepad DROPS padSetActDirect unless its current task is TASK_UPDATE_PAD, and it still returns
-      1 when it does. Sending once per pulse means one unlucky frame eats the whole pulse. So the
-      command is RE-SENT every frame for the pulse's life. Do NOT "optimise" this back to send-once.
-
-   2. freepad fills its actuator alignment with 0xFF on padPortOpen, and padSetActAlign is the only
-      thing that overwrites it. padSetActDirect latches the bytes and returns 1 WITHOUT consulting
-      the alignment -- so if padSetActAlign never ran, every send reports success and drives actuator
-      index 0xFF, i.e. nothing at all. initializePad() has five bail-outs above padSetActAlign, so
-      this is reachable; padRumbleRealign() below retries it.
-
-   Neither shows up in a log or a return value. Both were found the expensive way. */
 
 // Alignment confirmed for this pad. Tracked so it can be RETRIED -- never used to veto a send: an
 // earlier fork revision gated sends on this and on a padInfoAct count, and any single init hiccup
@@ -520,7 +518,9 @@ static void padActSet(struct pad_data_t *pad, int small, int large)
 {
     char act[6];
 
-    if (pad->actuators == 0)
+    // A ready pad accepts the command; a digital-only controller ignores it. Do not let a transient
+    // padInfoAct failure permanently veto rumble for this session.
+    if (!isPadReadyState(pad->state))
         return;
 
     padRumbleRealign(pad);
@@ -533,38 +533,77 @@ static void padActSet(struct pad_data_t *pad, int small, int large)
     padSetActDirect(pad->port, pad->slot, act);
 }
 
-/** Stops any pulse in flight, on every pad.
- * The decay only runs from readPads(), so anything that can block the GUI thread for longer than a
- * pulse has to stop the motor on the way in or it buzzes for the whole operation.
- */
-void padRumbleFlush(void)
+static void padPademuSetRumble(struct pad_data_t *pad, int level)
+{
+#ifdef PADEMU
+    if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING)
+        ds34bt_set_rumble(pad->port, level, level);
+    if (ds34usb_get_status(pad->port) & DS34USB_STATE_RUNNING)
+        ds34usb_set_rumble(pad->port, level, level);
+#else
+    (void)pad;
+    (void)level;
+#endif
+}
+
+void padRumbleActivate(void)
+{
+    rumbleLive = 1;
+    rumbleLastTicksValid = 0;
+}
+
+/** Stops all actuators now. Closing pad ports does not clear a latched motor state. */
+void padRumbleStopAll(void)
 {
     int i;
-
-    if (!rumbleActive)
-        return;
 
     rumbleActive = 0;
     rumbleDurTicks = 0;
     rumbleLarge = 0;
-    // Sent twice: the IOP LATCHES the actuator state, so a dropped "off" leaves the motor spinning
-    // with nothing left to stop it. The "on" gets a re-send every frame; the "off" gets no frames.
-    for (i = 0; i < pad_count; ++i)
+    rumbleSmall = 0;
+
+    // Send native stops twice because freepad may drop an actuator command outside TASK_UPDATE_PAD.
+    // PADEMU uses its own command channel, so it needs an explicit stop as well once polling ends.
+    for (i = 0; i < pad_count; ++i) {
+        padPademuSetRumble(&pad_data[i], 0);
         padActSet(&pad_data[i], 0, 0);
+    }
     for (i = 0; i < pad_count; ++i)
         padActSet(&pad_data[i], 0, 0);
 }
 
-/** Starts a rumble pulse on every connected pad that has actuators.
- * @param durationMs pulse length, clamped to RUMBLE_MAX_MS
- * @param large      large (variable-speed) engine strength, 0..255; the small engine runs for the
- *                   whole pulse regardless, since it is the one that gives a crisp click
- */
-void padRumble(int durationMs, int large)
+/** Lets a decision bump complete before a caller starts work that will stop readPads(). */
+void padRumbleFlush(void)
+{
+    u32 elapsedTicks;
+    u32 remainingTicks;
+    int waitMs;
+
+    if (!rumbleActive)
+        return;
+
+    elapsedTicks = cpu_ticks() - rumbleStartTicks;
+    if (elapsedTicks < rumbleDurTicks) {
+        remainingTicks = rumbleDurTicks - elapsedTicks;
+        waitMs = (int)((remainingTicks + CLOCKS_PER_MILISEC - 1) / CLOCKS_PER_MILISEC);
+        if (waitMs > RUMBLE_BUMP_MS)
+            waitMs = RUMBLE_BUMP_MS;
+        if (waitMs > 0)
+            DelayThread(waitMs * 1000);
+    }
+
+    padRumbleStopAll();
+}
+
+static void padRumbleArm(int durationMs, int large, int small)
 {
     int i;
+    u32 nowTicks;
+    u32 intervalMs;
 
-    if (durationMs <= 0)
+    // guiIntroLoop can fire SFX_CURSOR against frozen pad data while the IOP is still loading modules.
+    // Keep every actuator RPC out of that window; main activates rumble just before guiMainLoop().
+    if (!rumbleLive || !gEnableRumble || durationMs <= 0)
         return;
     if (durationMs > RUMBLE_MAX_MS)
         durationMs = RUMBLE_MAX_MS;
@@ -573,13 +612,47 @@ void padRumble(int durationMs, int large)
     if (large > 255)
         large = 255;
 
-    rumbleStartTicks = cpu_ticks();
+    // RETROLauncher-style held navigation: first press gets the full thump, measured repeats ride
+    // at about 45 percent duty, and steps too fast for an ERM to spin up remain silent.
+    nowTicks = cpu_ticks();
+    intervalMs = rumbleLastTicksValid ? (nowTicks - rumbleLastTicks) / CLOCKS_PER_MILISEC : 0xffffffff;
+    rumbleLastTicks = nowTicks;
+    rumbleLastTicksValid = 1;
+    if (!small && intervalMs < RUMBLE_REPEAT_WINDOW_MS) {
+        int dutyMs = (int)(intervalMs * RUMBLE_REPEAT_DUTY_PCT / 100);
+        if (dutyMs < RUMBLE_REPEAT_FLOOR_MS)
+            return;
+        if (dutyMs < durationMs)
+            durationMs = dutyMs;
+    }
+
+    rumbleStartTicks = nowTicks;
     rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
     rumbleActive = 1;
     rumbleLarge = large;
+    rumbleSmall = small ? 1 : 0;
 
-    for (i = 0; i < pad_count; ++i)
-        padActSet(&pad_data[i], 1, large);
+    for (i = 0; i < pad_count; ++i) {
+        // Native pads are kicked immediately and re-sent from readPads(); PADEMU gets the same
+        // immediate command so a confirm followed by blocking work still reaches a DS3/DS4/DS5.
+        padActSet(&pad_data[i], rumbleSmall, rumbleLarge);
+        padPademuSetRumble(&pad_data[i], rumbleLarge);
+    }
+}
+
+void padRumbleTap(void)
+{
+    padRumbleArm(RUMBLE_TAP_MS, RUMBLE_TAP_LEVEL, 0);
+}
+
+void padRumbleTapList(void)
+{
+    padRumbleTap();
+}
+
+void padRumbleBump(void)
+{
+    padRumbleArm(RUMBLE_BUMP_MS, RUMBLE_BUMP_LEVEL, 1);
 }
 
 /* Screen-transition edge freeze. During the fade the main loop polls pads but dispatches no input,
@@ -665,15 +738,14 @@ int readPads()
         }
     }
 
-    // Rumble decay + re-send. Unsigned elapsed in RAW ticks -- see the note above padActSet().
-    // The re-send is not redundant: freepad drops padSetActDirect outside TASK_UPDATE_PAD and still
-    // reports success, so a pulse sent only once can be silently swallowed whole.
+    // Rumble decay + re-send. The native re-send is not redundant: freepad can drop a direct
+    // actuator command outside its update task, and PADEMU is kept in sync by readPad() above.
     if (rumbleActive) {
-        if ((u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
-            padRumbleFlush();
+        if (!gEnableRumble || (u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
+            padRumbleStopAll();
         } else {
             for (i = 0; i < pad_count; ++i)
-                padActSet(&pad_data[i], 1, rumbleLarge);
+                padActSet(&pad_data[i], rumbleSmall, rumbleLarge);
         }
     }
 
@@ -794,9 +866,9 @@ void unloadPads()
 {
     int i;
 
-    // Last chance to stop a motor. Closing the port does not clear the actuators, and OPL is on its
-    // way out here -- a pulse still in flight would keep buzzing into whatever we hand off to.
-    padRumbleFlush();
+    // Closing a port does not clear a latched motor. Do not wait here: the caller is dismantling the
+    // pad stack, so the immediate stop is the only safe behavior.
+    padRumbleStopAll();
 
     for (i = 0; i < pad_count; ++i)
         unloadPad(&pad_data[i]);

--- a/src/sound.c
+++ b/src/sound.c
@@ -283,38 +283,17 @@ void sfxGetDropDiag(unsigned int *staleDrops, unsigned int *fullDrops)
 
 static void sfxRumble(int id)
 {
-    if (!gEnableRumble)
-        return;
-
     switch (id) {
-        case SFX_CURSOR: {
-            // Cursor sounds are emitted for every navigation step, including held buttons. Keep the
-            // prompt responsive without turning a long scroll into a continuous motor buzz.
-            static u32 lastCursorRumbleTicks;
-            u32 now = cpu_ticks();
-            if (lastCursorRumbleTicks != 0 && (now - lastCursorRumbleTicks) / SFX_CLOCKS_PER_MS < 80)
-                return;
-            lastCursorRumbleTicks = now;
-            padRumble(35, 64);
+        case SFX_CURSOR:
+            padRumbleTap();
             break;
-        }
         case SFX_CONFIRM:
-            padRumble(120, 160);
-            break;
         case SFX_CANCEL:
-            padRumble(90, 96);
-            break;
         case SFX_MESSAGE:
-            padRumble(120, 160);
-            break;
         case SFX_TRANSITION:
-            padRumble(150, 200);
-            break;
         case SFX_BD_CONNECT:
-            padRumble(100, 128);
-            break;
         case SFX_BD_DISCONNECT:
-            padRumble(75, 96);
+            padRumbleBump();
             break;
         default:
             break;

--- a/src/system.c
+++ b/src/system.c
@@ -1359,9 +1359,17 @@ void sysLaunchNeutrino(const char *driver, const char *path, const char *startup
         snprintf(filePath, sizeof(filePath), "-dvd=%s%s", bsdfsDvdPrefix[fsOverride], path);
         if (argc < argvMax)
             argv[argc++] = filePath;
+
+        // USB diagnostic: current NHDDL uses quickboot for USB (and every backend except HDL).
+        // Neutrino's quickboot path keeps the inherited IOP environment (iomanX/fileXio/bdm/bdmfs_fatfs
+        // already resident from OPL) and skips the LE IOP reset. This is a controlled A/B test for
+        // USB only; do not enable it for other devices until hardware justifies it.
+        if (!strcmp(deviceName, "usb") && argc < argvMax &&
+            !neutrinoArgHasActiveFlag(gNeutrinoArgs, "-qb") && !neutrinoArgHasActiveFlag(extraArgs, "-qb"))
+            argv[argc++] = "-qb";
     }
 
-    // Everything up to and including -dvd is the boot-critical core: the pool-fit drop loop below
+    // Everything up to and including -dvd/-qb is the boot-critical core: the pool-fit drop loop below
     // must never shed these. A fixed floor of 3 silently stopped covering -dvd once the optional
     // -bsdfs slots in front of it (argv[3]) -- record the real core count instead.
     const int coreArgc = argc;

--- a/src/system.c
+++ b/src/system.c
@@ -38,6 +38,8 @@
 
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioInit, fileXioExit, fileXioDevctl
+#include <loadfile.h>
+#include <kernel.h>
 
 typedef struct
 {
@@ -1497,13 +1499,101 @@ void sysLaunchNeutrino(const char *driver, const char *path, const char *startup
             LOG("[NEUTRINO]   argv[%d]=%s\n", i, argv[i]);
     }
 
-    // Hand off WITHOUT the elf-loader IOP reset (NHDDL parity, vendored elfldr/): Neutrino reads
-    // its config/modules (-cwd) and opens the game ISO through OUR still-mounted devices, and only
-    // then does its own IOP reset -- the old resetting handoff left it a bare SIO2MAN/MCMAN/MCSERV
-    // IOP, so any USB/BDM-hosted neutrino.elf setup black-screened to OSDSYS. The callers keep both
-    // the game device and the neutrino.elf device mounted (deinitEx).
-    if (sysLoadELFKeepIOP(neutrinoPath, "", argc, argv) < 0)
-        LOG("[NEUTRINO] keep-IOP handoff failed for %s\n", neutrinoPath);
+    // Direct single protected transition into Neutrino (NHDDL parity): Neutrino reads its
+    // config/modules (-cwd) and opens the game ISO through OUR still-mounted devices pre-reset.
+    // Launch code and arguments reside in protected BRAM; ExecPS2 transitions directly.
+    sysLaunchNeutrinoDirect(neutrinoPath, argc, argv);
+}
+
+#define LAUNCH_ARGS_SIZE 4096
+
+__attribute__((section("._launch_args")))
+__attribute__((aligned(16))) static char launchArgs[LAUNCH_ARGS_SIZE];
+
+__attribute__((section("._launch_elf"), noinline)) void
+bramLaunchCore(const char *neutrinoPath, int argc, char *argv[])
+{
+    t_ExecData elfdata = {0};
+
+    // Phase 1: Wipe Neutrino ELF memory regions (0x01000000 -> GetMemorySize())
+    for (int i = 0x1000000; i < GetMemorySize(); i += 64) {
+        asm volatile("\tsq $0, 0(%0) \n"
+                     "\tsq $0, 16(%0) \n"
+                     "\tsq $0, 32(%0) \n"
+                     "\tsq $0, 48(%0) \n" ::"r"(i));
+    }
+
+    // Writeback data cache before loading ELF.
+    FlushCache(WRITEBACK_DCACHE);
+
+    // Load Neutrino ELF directly into memory
+    SifLoadFileInit();
+    int ret = SifLoadElf(neutrinoPath, &elfdata);
+    SifLoadFileExit();
+    if (!(ret == 0 && elfdata.epc != 0)) {
+        while (1) {
+            SleepThread();
+        }
+    }
+
+    // Copy launch arguments from user memory into protected kernel memory buffer
+    char **largv = (char **)launchArgs;
+    char *argStart = (char *)launchArgs + ((argc + 1) * sizeof(char *));
+    for (int i = 0; i < argc; i++) {
+        const char *src = argv[i];
+        int len = 0;
+        while (src[len] != '\0') {
+            len++;
+        }
+        if (argStart + len + 1 > launchArgs + LAUNCH_ARGS_SIZE) {
+            while (1) {
+                SleepThread();
+            }
+        }
+        for (int j = 0; j <= len; j++) {
+            argStart[j] = src[j];
+        }
+        largv[i] = argStart;
+        argStart += len + 1;
+    }
+    largv[argc] = NULL;
+
+    // The rest of the code doesn't use libc functions
+    // Phase 2: Wipe OPL launcher user memory (0x00100000 -> 0x01000000)
+    for (int i = 0x100000; i < 0x1000000; i += 64) {
+        asm volatile("\tsq $0, 0(%0) \n"
+                     "\tsq $0, 16(%0) \n"
+                     "\tsq $0, 32(%0) \n"
+                     "\tsq $0, 48(%0) \n" ::"r"(i));
+    }
+
+    FlushCache(WRITEBACK_DCACHE);
+    FlushCache(INVALIDATE_ICACHE);
+    TerminateLibrary();
+    _ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, largv);
+    while (1) {
+        SleepThread();
+    }
+}
+
+__attribute__((section("._launch_elf"), noreturn)) int
+sysLaunchNeutrinoDirect(const char *neutrinoPath, int argc, char *argv[])
+{
+    register const char *r_path asm("a0") = neutrinoPath;
+    register int r_argc asm("a1") = argc;
+    register char **r_argv asm("a2") = argv;
+
+    asm volatile(
+        "move $sp, %3\n\t"
+        "j bramLaunchCore\n\t"
+        "nop\n\t"
+        :
+        : "r"(r_path), "r"(r_argc), "r"(r_argv), "r"(0xffff0)
+        : "memory");
+
+    while (1) {
+        SleepThread();
+    }
 }
 
 // Hand off to an external POPSTARTER.ELF to boot a PS1 VCD. The caller resolves the per-device

--- a/src/tar.c
+++ b/src/tar.c
@@ -55,13 +55,18 @@ static const TarDevice gDevices[] = {
 static const TarKindInfo gTarInfo[TAR_KIND_MAX] = {
     {"ART/art.tar", "art_cache.bin", sizeof(TarEntryArt)},
     {"CFG/cfg.tar", "cfg_cache.bin", sizeof(TarEntryCfg)},
-    {"CHT/cht.tar", "cht_cache.bin", sizeof(TarEntryCht)}};
+    {"CHT/cht.tar", "cht_cache.bin", sizeof(TarEntryCht)},
+    {"ART/art.tar", "art_cache.bin", sizeof(TarEntryArt)}};
 
-static void *s_index[TAR_KIND_MAX] = {NULL, NULL, NULL};
-static u32 s_count[TAR_KIND_MAX] = {0, 0, 0};
-static u32 s_cap[TAR_KIND_MAX] = {0, 0, 0};
-static const TarDevice *s_dev[TAR_KIND_MAX] = {NULL, NULL, NULL};
-static int s_inactive[TAR_KIND_MAX] = {0, 0, 0};
+static void *s_index[TAR_KIND_MAX] = {0};
+static u32 s_count[TAR_KIND_MAX] = {0};
+static u32 s_cap[TAR_KIND_MAX] = {0};
+static const TarDevice *s_dev[TAR_KIND_MAX] = {0};
+static int s_inactive[TAR_KIND_MAX] = {0};
+// An exact archive path is intentionally separate from the device probe table. The HDD art path
+// is the PFS data home selected for this session, not an alternate source to discover.
+static char s_exactPath[TAR_KIND_MAX][256];
+static int s_hasExactPath[TAR_KIND_MAX] = {0};
 
 static const unsigned char s_zeroBlock[TAR_BLOCK_SIZE] __attribute__((aligned(64))) = {0};
 
@@ -91,6 +96,8 @@ static void tarCloseInternal(TarKind kind)
     s_count[kind] = 0;
     s_cap[kind] = 0;
     s_dev[kind] = NULL;
+    s_exactPath[kind][0] = '\0';
+    s_hasExactPath[kind] = 0;
 }
 
 static int buildTarPath(const TarDevice *dev, TarKind kind, char *out, int outSize)
@@ -378,16 +385,51 @@ fail:
     return -1;
 }
 
+static int tarLoadExactPath(TarKind kind, const char *path)
+{
+    int len;
+
+    if (path == NULL || path[0] == '\0')
+        return -1;
+
+    if (s_hasExactPath[kind] && strcmp(s_exactPath[kind], path) == 0)
+        return s_inactive[kind] ? -1 : 0;
+
+    tarCloseInternal(kind);
+    s_inactive[kind] = 0;
+
+    len = snprintf(s_exactPath[kind], sizeof(s_exactPath[kind]), "%s", path);
+    if (len <= 0 || len >= (int)sizeof(s_exactPath[kind])) {
+        s_exactPath[kind][0] = '\0';
+        return -1;
+    }
+    s_hasExactPath[kind] = 1;
+
+    if (tarParseFile(kind, s_exactPath[kind]) == 0)
+        return 0;
+
+    // A missing selected archive should cost one open, not one open per cover. Unlike the generic
+    // loader, this latch is scoped to the exact PFS home and therefore never falls through to a
+    // second APA partition or another device.
+    s_inactive[kind] = 1;
+    LOG("TAR no archive at selected path %s -- probing disabled for this path\n", s_exactPath[kind]);
+    return -1;
+}
+
 int tarLoadFile(TarKind kind, const char *path)
 {
-    s_dev[kind] = NULL;
-    return tarParseFile(kind, path);
+    return tarLoadExactPath(kind, path);
 }
 
 int tarLoadFromAnyDevice(TarKind kind)
 {
     if (s_inactive[kind])
         return -1;
+
+    // An exact-path caller owns this kind's archive location. Never replace it with the first
+    // archive found by the generic device scan.
+    if (s_hasExactPath[kind])
+        return 0;
 
     if (s_index[kind] && s_dev[kind]) {
         char tarPath[256];
@@ -449,9 +491,12 @@ TarEntryBase *tarFind(TarKind kind, const char *filename)
     if (s_inactive[kind])
         return NULL;
 
-    if (!s_index[kind] || s_count[kind] == 0)
+    if ((!s_index[kind] || s_count[kind] == 0) && !s_hasExactPath[kind])
         if (tarLoadFromAnyDevice(kind) < 0)
             return NULL;
+
+    if (!s_index[kind] || s_count[kind] == 0)
+        return NULL;
 
     const char *queryClean = filename;
     if (!strncasecmp(queryClean, "./", 2))
@@ -478,15 +523,8 @@ TarEntryBase *tarFind(TarKind kind, const char *filename)
     return NULL;
 }
 
-TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
+static TarEntryBase *tarFindPrefixLoaded(TarKind kind, const char *prefix)
 {
-    if (s_inactive[kind])
-        return NULL;
-
-    if (!s_index[kind] || s_count[kind] == 0)
-        if (tarLoadFromAnyDevice(kind) < 0)
-            return NULL;
-
     size_t prefixLen = strlen(prefix);
     u32 entrySize = gTarInfo[kind].entrySize;
     char *base = (char *)s_index[kind];
@@ -505,6 +543,29 @@ TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
     return NULL;
 }
 
+TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
+{
+    if (s_inactive[kind])
+        return NULL;
+
+    if ((!s_index[kind] || s_count[kind] == 0) && !s_hasExactPath[kind])
+        if (tarLoadFromAnyDevice(kind) < 0)
+            return NULL;
+
+    if (!s_index[kind] || s_count[kind] == 0)
+        return NULL;
+
+    return tarFindPrefixLoaded(kind, prefix);
+}
+
+TarEntryBase *tarFindPrefixFromPath(TarKind kind, const char *path, const char *prefix)
+{
+    if (tarLoadExactPath(kind, path) < 0 || !s_index[kind] || s_count[kind] == 0)
+        return NULL;
+
+    return tarFindPrefixLoaded(kind, prefix);
+}
+
 u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize)
 {
     if (s_inactive[kind])
@@ -514,8 +575,13 @@ u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize)
         return 0;
 
     char tarPath[256];
-    if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) < 0)
+    if (s_hasExactPath[kind]) {
+        int len = snprintf(tarPath, sizeof(tarPath), "%s", s_exactPath[kind]);
+        if (len < 0 || len >= (int)sizeof(tarPath))
+            return 0;
+    } else if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) < 0) {
         return 0;
+    }
 
     int fd = open(tarPath, O_RDONLY);
     if (fd < 0)
@@ -569,6 +635,9 @@ int tarEnsureLoaded(TarKind kind)
 {
     if (s_inactive[kind])
         return -1;
+
+    if (s_hasExactPath[kind])
+        return 0;
 
     if (!s_index[kind] || s_count[kind] == 0)
         return tarLoadFromAnyDevice(kind);

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -116,7 +116,7 @@ static void cacheWakeArtWorker(void);
 //       non-fatal (tarParseFile ignores the result) and happens only when the archive changes, but it
 //       is the thing to instrument first if a .tar-enabled build ever feels worse than a plain one.
 //   DEFAULT PATH: gEnableArtTar ships 0, so none of the above is reachable unless the user opts in.
-static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *texture)
+static int artTarLoadImage(TarKind kind, const char *archivePath, const char *value, const char *suffix, GSTEXTURE *texture)
 {
     char prefix[64];
     TarEntryBase *entry = NULL;
@@ -126,7 +126,7 @@ static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *tex
     if (snprintf(prefix, sizeof(prefix), "%s_%s.", value, suffix) >= (int)sizeof(prefix))
         return -1;
 
-    entry = tarFindPrefix(TAR_KIND_ART, prefix);
+    entry = archivePath != NULL ? tarFindPrefixFromPath(kind, archivePath, prefix) : tarFindPrefix(kind, prefix);
 
     if (entry == NULL) {
         LOG("ART TAR: '%s_%s' not in the archive index\n", value, suffix);
@@ -139,7 +139,7 @@ static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *tex
         return -1;
     }
 
-    if (tarRead(TAR_KIND_ART, entry, buffer, entry->rawSize) != entry->rawSize) {
+    if (tarRead(kind, entry, buffer, entry->rawSize) != entry->rawSize) {
         LOG("ART TAR: short read for '%s' (%u bytes expected)\n", prefix, entry->rawSize);
         free(buffer);
         return -1;
@@ -826,8 +826,21 @@ static void cacheLoadImage(load_image_request_t *req)
 
     texSetLoadAbortFlag(&req->abortRequested);
 
-    if (gEnableArtTar)
-        result = artTarLoadImage(req->value, req->cache->suffix, &staged);
+    if (gEnableArtTar) {
+        char archivePath[256];
+        int archivePathResult = 0;
+
+        // HDD artwork owns a single PFS data home for the session. Its callback supplies the exact
+        // ART/art.tar path, so this lookup cannot scan __common, +OPL, or another device. A negative
+        // result means that source has no mounted home and must not fall back to the generic probe.
+        if (req->cache->isPrefixRelative && handler->itemGetArtArchivePath != NULL)
+            archivePathResult = handler->itemGetArtArchivePath(handler, req->value, archivePath, sizeof(archivePath));
+
+        if (archivePathResult > 0)
+            result = artTarLoadImage(TAR_KIND_HDD_ART, archivePath, req->value, req->cache->suffix, &staged);
+        else if (archivePathResult == 0)
+            result = artTarLoadImage(TAR_KIND_ART, NULL, req->value, req->cache->suffix, &staged);
+    }
 
     // Fall through to the per-file lookup whenever the archive is off, absent, or lacks this key.
     if (result < 0)

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -245,6 +245,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     int EnablePS2Logo = 0;
     int result;
     char filename[32], partname[256];
+    char udpfsStartup[GAME_STARTUP_MAX + 1];
     base_game_info_t *game = &udpfsGames[id];
 
     // Folder browsing: a folder row is never launched (the dispatch descends first); guard defensively
@@ -344,11 +345,16 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     if (sysNeutrinoPreflight("udpfs", neutrinoPath) < 0)
         return;
     int neutrinoDevMode = oplPath2Mode(neutrinoPath);
+
+    // game->startup lives inside udpfsGames, which itemCleanUp frees below. Copy it before the teardown
+    // so sysLaunchNeutrino reads valid stack memory instead of freed heap (UAF).
+    snprintf(udpfsStartup, sizeof(udpfsStartup), "%s", game->startup);
+
     deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees udpfsGames/game
 
-    // Hand off to Neutrino with the udpfs driver token. `partname` (the filesystem game path) + the token
-    // survive the deinit above; `game` does not and is not used past this point.
-    sysLaunchNeutrino("udpfs", partname, game->startup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: udpfs is fileid, no fs layer */, &neutrinoVmc);
+    // Hand off to Neutrino with the udpfs driver token. `partname` and `udpfsStartup` (the filesystem
+    // game path + startup) survive the deinit above; `game` does not and is not used past this point.
+    sysLaunchNeutrino("udpfs", partname, udpfsStartup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: udpfs is fileid, no fs layer */, &neutrinoVmc);
 }
 
 static config_set_t *udpfsGetConfig(item_list_t *itemList, int id)


### PR DESCRIPTION
## Summary

This PR supersedes #533 and #534 and combines them into the single hardware-validation candidate, plus source-derived fixes for USB initialization, code-222 false positives, and the ATA-page transition freeze.

## Included work

### APA artwork/data-home correctness
- Artwork remains tied to the currently mounted OPL data home.
- `__common/OPL` uses `pfs0:OPL/ART/`.
- `+OPL` uses `pfs0:ART/`.
- HDD archive path gets its independent cache.
- No fallthrough to another APA home/device.
- HDD-backed Favourites and Apps preserve the same rule.

### APA startup/settle handling
- Auto-start PFS setup respects the ATA settle requirement.
- Low-level boot/config PS2FS probes now record a deferred `hddPfsLoadFailed` flag instead of immediately toasting code 222.
- `hddUpdateGameList()` evaluates the flag after recovery has had a chance to succeed and publishes code 222 once only if PFS remains unavailable.
- A later successful load clears the deferred flag and retracts/recovers the error.
- Real post-settle failures remain visible.

### Controller vibration fixes
- DS3/DS4/DS5 PADEMU motors receive active rumble.
- Navigation pulse behavior remains intact.
- Repeat duty control remains bounded.
- Rumble is kept out of intro/IOP-load phase.
- Motors explicitly stop before blocking teardown.
- Active actuators are stopped synchronously before potentially blocking source/page transitions so a held-navigation pulse cannot latch on while the GUI thread is blocked.

### ATA page transition freeze
- `hddUpdateGameList()` no longer initiates the first ATA module load from the GUI thread.
- The ATA stack load (and its required ~1-second post-ATAD settle) runs on the IO worker via `hddInitModules()`; the GUI refresh defers until the worker has started.
- This prevents the GUI thread from blocking inside `DelayThread()` when switching into the ATA page while the drive is still initializing.

### USB base-BDM initialization
- `USBMASS_BD` is now loaded synchronously inside `bdmLoadCoreModules()` as part of the base BDM stack, matching upstream OPL and Grimdoomer.
- USB is removed from the optional async transport retry machinery (`bdmLoadBlockDeviceModules()`, `bdmShouldQueueModuleLoad()`, `bdmEnsureTransportLoaded()`).
- `gEnableUSB` defaults to `1`; the UI flag now governs page/scan visibility rather than fundamental driver residency.

### Neutrino keep-IOP handoff
- `elfldr/loader.c` no longer calls `SifExitRpc()` before successful `ExecPS2()` on either the primary `SifLoadElf` path or the fileXio rescue path.
- Successful rescue load no longer tears down fileXio.
- The target intentionally inherits OPL's live IOP, mounts, SIF RPC, and fileXio environment before performing its own reset.

### USB Neutrino quickboot diagnostic
- `sysLaunchNeutrino()` appends `-qb` for USB Neutrino launches only.
- This is a controlled A/B diagnostic based on current NHDDL behavior (which uses `-qb` for every Neutrino backend except HDL) and current Neutrino's explicit quickboot support.
- `-qb` is **not required by Neutrino**; normal boot remains supported and is the path used by all other backends.
- All other backends remain on the normal Neutrino boot path pending hardware evidence.

### UDPFS lifetime fix
- `game->startup` is copied into stack storage before `deinitEx()` frees `udpfsGames`.
- The stack copy is passed to Neutrino after teardown.

## Important invariants

- Successful Neutrino/POPSTARTER handoff inherits the live RPC/IOP environment.
- Failure-only fileXio cleanup in `loadElfViaFileXio()`.
- `udpfsbd` remains an intentional RiptOPL extension (`bsd-udpfsbd.toml` / `udpfs_bd.irx`).
- USBMASS_BD is base BDM infrastructure, not an optional transport.
- USB Neutrino currently carries a USB-only `-qb` diagnostic based on NHDDL; all other backends remain on the normal Neutrino boot path pending hardware evidence.
- The selected APA data home remains authoritative.

## Validation

- `git diff --check` clean
- `clang-format` applied to touched files
- Local PS2DEV build not available in this environment
- Pushed; CI-format-check and four-flavour build running below

## Hardware validation required

1. USB → Neutrino (also validates USB enumeration fix; `-qb` still applied for comparison)
2. APA HDD → Neutrino
3. MMCE → Neutrino
4. MX4SIO
5. iLink
6. internal ATA/exFAT
7. UDPBD
8. UDPFS filesystem
9. UDPFSBD/UDPRDMA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved artwork discovery and loading for hard drive content, favorites, and exact archive locations.
  * Added richer controller rumble feedback for menu navigation, selections, and startup activity.
  * USB game launches can now use quick boot automatically when supported.
* **Bug Fixes**
  * Fixed potential launch failures when starting games through UDPFS.
  * Prevented rumble from remaining active during device switching or shutdown.
* **Improvements**
  * Improved hard drive initialization, recovery, refresh behavior, and preservation of working game lists during incomplete scans.
  * Improved system handoffs when launching games and applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->