### PR TITLE
fix: rebuild recovery (neutrino, bdm, hdd, pad, art)

### DIFF
--- a/.github/workflows/flavours.yml
+++ b/.github/workflows/flavours.yml
@@ -55,20 +55,36 @@ jobs:
             image: ps2dev/ps2dev@sha256:8fba50ecc2229acd7f8da63d34302f12939b7d4fa6848dda1e6a0ce083321a11
             digest: sha256:8fba50ecc2229acd7f8da63d34302f12939b7d4fa6848dda1e6a0ce083321a11
             pinned: "yes (2026-08-13)"
+            opldiag: "0"
           # Official OPL's own CI container, pinned 2026-08-13.
           - flavour: OFFICIALPINNED
             image: ghcr.io/ps2homebrew/ps2homebrew@sha256:a1b1f87f09a88f64efbe11356aae47098d4d54b3b3a84f0609fa42369244e25d
             digest: sha256:a1b1f87f09a88f64efbe11356aae47098d4d54b3b3a84f0609fa42369244e25d
             pinned: "yes (2026-08-13)"
+            opldiag: "0"
           # --- ROLLING: early warning. Expect these to move without us changing anything. ---
           - flavour: PS2DEVROLLING
             image: ps2dev/ps2dev:latest
             digest: ""
             pinned: "no (tracks ps2dev/ps2dev:latest)"
+            opldiag: "0"
           - flavour: OFFICIALROLLING
             image: ghcr.io/ps2homebrew/ps2homebrew:main
             digest: ""
             pinned: "no (tracks ps2homebrew:main)"
+            opldiag: "0"
+          # --- DIAGNOSTIC: same pinned toolchain as PS2DEVPINNED, built with OPLDIAG=1.
+          # Adds the on-screen boot-stage labels and the error-code detail suffix. Those are raw
+          # untranslated developer strings, which is exactly why they must never reach a build a
+          # normal user runs -- and exactly why a tester needs a build that HAS them. This is the
+          # ELF to hand out when the question is WHERE a console wedges.
+          # It is NOT a DEBUG build: no TTY link, no -g. Everything else matches its pinned twin,
+          # so a result gathered here is directly comparable with one gathered on PS2DEVPINNED.
+          - flavour: PS2DEVPINNED-DIAG
+            image: ps2dev/ps2dev@sha256:8fba50ecc2229acd7f8da63d34302f12939b7d4fa6848dda1e6a0ce083321a11
+            digest: sha256:8fba50ecc2229acd7f8da63d34302f12939b7d4fa6848dda1e6a0ce083321a11
+            pinned: "yes (2026-08-13)"
+            opldiag: "1"
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
     steps:
@@ -95,7 +111,7 @@ jobs:
         run: sh .github/scripts/install_coherent_mmce.sh
 
       - name: Compile -> make clean release (${{ matrix.flavour }})
-        run: make --trace clean && make --trace LOCALVERSION=${{ matrix.flavour }} release
+        run: make --trace clean && make --trace LOCALVERSION=${{ matrix.flavour }} OPLDIAG=${{ matrix.opldiag }} release
 
       # Written AFTER the build so the compiler probe reflects what actually compiled. Every probe is
       # `|| true`: this file is a diagnostic and must never be the reason a good build fails to ship.
@@ -108,6 +124,7 @@ jobs:
           {
             echo "flavour:      ${{ matrix.flavour }}"
             echo "pinned:       ${{ matrix.pinned }}"
+            echo "opldiag:      ${{ matrix.opldiag }}"
             echo "image:        ${{ matrix.image }}"
             echo "digest:       ${{ matrix.digest }}"
             echo "built (UTC):  $(date -u '+%Y-%m-%d %H:%M:%S')"

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ DEBUG ?= 0
 EESIO_DEBUG ?= 0
 INGAME_DEBUG ?= 0
 DECI2_DEBUG ?= 0
+# Field diagnostics. Unlike DEBUG (which needs a TTY link and is never what a tester runs), this
+# only turns on the on-screen boot-stage labels and the error-code detail suffix, so a normal
+# release ELF can be handed to a tester and still report WHERE it wedged. The strings it emits are
+# untranslated developer text by design -- that is why they must never be in a plain release.
+OPLDIAG ?= 0
 #How the TTY will reach developer: 'UDP', 'PPC_UART'.
 TTY_APPROACH ?= UDP
 
@@ -222,6 +227,16 @@ ifeq ($(PADEMU),1)
   PADEMU_FLAGS = PADEMU=1
 else
   PADEMU_FLAGS = PADEMU=0
+endif
+
+# A DEBUG build implies the field diagnostics: it already has a TTY, so withholding the on-screen
+# labels from it would only make the two build types disagree about what they report.
+ifeq ($(DEBUG),1)
+  OPLDIAG = 1
+endif
+
+ifeq ($(OPLDIAG),1)
+  EE_CFLAGS += -D__OPLDIAG
 endif
 
 ifeq ($(DEBUG),1)

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -173,10 +173,11 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         loaded++;
     }
     fileXioClose(fd);
-    fileXioExit();
 
-    if (!loaded)
+    if (!loaded) {
+        fileXioExit();
         return -1;
+    }
     *entry = eh.entry;
     return 0;
 }
@@ -208,7 +209,6 @@ int main(int argc, char *argv[])
     ret = SifLoadElf(argv[0], &elfdata);
     SifLoadFileExit();
     if (ret == 0 && elfdata.epc != 0) {
-        SifExitRpc();
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, &argv[1]);
@@ -216,7 +216,6 @@ int main(int argc, char *argv[])
 
     // Rescue: fileXio (iomanX) for the devices LOADFILE cannot see (mmceN:, pfs, ...).
     if (loadElfViaFileXio(argv[0], &entry) == 0) {
-        SifExitRpc();
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)entry, NULL, argc - 1, &argv[1]);

--- a/elfldr/loader.c
+++ b/elfldr/loader.c
@@ -173,11 +173,10 @@ static int loadElfViaFileXio(const char *path, u32 *entry)
         loaded++;
     }
     fileXioClose(fd);
+    fileXioExit();
 
-    if (!loaded) {
-        fileXioExit();
+    if (!loaded)
         return -1;
-    }
     *entry = eh.entry;
     return 0;
 }
@@ -203,12 +202,28 @@ int main(int argc, char *argv[])
     // Writeback data cache before loading ELF.
     FlushCache(0);
 
+    /* SifExitRpc() BELONGS ON EVERY EXIT PATH, INCLUDING THE SUCCESSFUL ONES. It has been removed
+       twice now on the theory that it damages the environment the target inherits. It does not.
+       Its entire implementation is:
+
+           sceSifExitCmd():  DisableDmac(DMAC_SIF0); RemoveDmacHandler(DMAC_SIF0, sif0_id);
+
+       That is EE-side only. It resets no IOP, unloads no module, unmounts nothing -- the keep-IOP
+       property this loader exists for comes from NOT calling SifIopReset, which we never do, and is
+       completely unaffected by this call. The target runs its own SifInitRpc() on entry regardless.
+
+       What skipping it costs: SIF0 DMA stays enabled with the EE's handler table still armed, and
+       ExecPS2() then overwrites the memory that table points into. There IS a live sender -- our own
+       bdmevent.irx stays resident with bdm_RegisterCallback armed and fires on EVERY mount. The
+       target, inheriting the live IOP, mounts the game device; the callback DMAs into a stale
+       handler in memory the target now owns; the console lands in OSDSYS instead of the game. */
     // Primary: the classic LOADFILE path (see header -- every ioman-visible device stays on it).
     elfdata.epc = 0;
     SifLoadFileInit();
     ret = SifLoadElf(argv[0], &elfdata);
     SifLoadFileExit();
     if (ret == 0 && elfdata.epc != 0) {
+        SifExitRpc();
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, &argv[1]);
@@ -216,6 +231,7 @@ int main(int argc, char *argv[])
 
     // Rescue: fileXio (iomanX) for the devices LOADFILE cannot see (mmceN:, pfs, ...).
     if (loadElfViaFileXio(argv[0], &entry) == 0) {
+        SifExitRpc();
         FlushCache(0);
         FlushCache(2);
         return ExecPS2((void *)entry, NULL, argc - 1, &argv[1]);

--- a/include/bdmevent.h
+++ b/include/bdmevent.h
@@ -1,0 +1,29 @@
+#ifndef __BDMEVENT_H
+#define __BDMEVENT_H
+
+#include <sifcmd.h>
+
+#define BDMEVENT_EE_EVENT_CMD       0
+// SIFCMD has 32 system-handler slots. Use the last one for this diagnostic request rather than an
+// out-of-range user command; the handler is installed only in OPL's private post-reset IOP image.
+#define BDMEVENT_IOP_DIAG_QUERY_CMD (SIF_CMD_ID_SYSTEM | 31)
+
+enum bdm_event_packet_kind {
+    BDMEVENT_PACKET_EVENT = 1,
+    BDMEVENT_PACKET_DIAG_SNAPSHOT,
+};
+
+typedef struct
+{
+    SifCmdHeader_t header;
+    unsigned int kind;
+    int cause;
+    unsigned int callbackSequence;
+    unsigned int mountCallbackCount;
+    unsigned int unmountCallbackCount;
+    unsigned int blockDeviceCount;
+    unsigned int usbRootCount;
+    unsigned int usbRootMask;
+} bdm_event_packet_t;
+
+#endif

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -173,6 +173,17 @@ void bdmLogConfigWriteResult(const bdm_config_diag_snapshot_t *snap, int result)
  */
 int bdmSlotEverConnected(int mode);
 
+/** Read a BDM device's driver name from an already-open massN: directory fd.
+ *
+ * ⚠ ALWAYS USE THIS instead of issuing USBMASS_IOCTL_GET_DRIVERNAME with a return buffer yourself.
+ * ps2sdk's bdmfs_fatfs handler dereferences NULL when a buffer is supplied for a volume that has no
+ * mounted block device, which faults the IOP and takes down every thread waiting on it. The
+ * implementation asks without a buffer first, which is the form that fails safely.
+ *
+ * Returns >= 0 on success. driverName is always left NUL-terminated.
+ */
+int bdmReadDriverName(int dir, char *driverName, int driverNameLength);
+
 /** True when this BDM slot is the MX4SIO (SD-over-SIO2) device.
  *
  * SIO2 is the CONTROLLER'S OWN BUS. An art read here contends with pad polling, and that contention

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -124,8 +124,43 @@ unsigned int bdmGetGeneration(void);
 
 // Diagnostic-only hooks used by the generic game-settings save worker. They are no-ops for
 // non-BDM lists and never change which filesystem path configWrite() consumes.
-void bdmLogConfigWriteEntry(item_list_t *itemList, const config_set_t *configSet);
-void bdmLogConfigWriteResult(item_list_t *itemList, const config_set_t *configSet, int result);
+//
+// The reporting functions probe every BDM device root, which is blocking device I/O, so they must
+// run with NO menu lock held. That in turn means they cannot borrow the caller's item_list_t /
+// config_set_t: once the lock is released those may be freed underneath us. So the caller captures
+// every value the report needs into this plain-value snapshot WHILE the lock is held, then releases
+// the lock and reports from the copy. Nothing here is a pointer that gets dereferenced -- the two
+// address fields are carried for %p identity only.
+typedef struct
+{
+    int valid; // 0 = not a BDM list; the reporting calls do nothing
+    int slot;
+    int mode;
+    int visible;
+    unsigned int generation;
+    const void *itemListAddr; // logged as %p, NEVER dereferenced
+    const void *configAddr;   // logged as %p, NEVER dereferenced
+    unsigned int configUid;
+    int configModified;
+    int configFormat;
+    char configFilename[128];
+    char deviceRoot[BDM_DEVICE_ROOT_MAX];
+    char devicePrefix[BDM_PREFIX_MAX];
+    char driver[32];
+    int massDeviceIndex;
+    int bdmDeviceType;
+    unsigned int foldersCreated;
+    const void *games; // %p only
+    int gameCount;
+    const void *vcdGames; // %p only
+    int vcdGameCount;
+} bdm_config_diag_snapshot_t;
+
+// Call UNDER the menu lock. Pure value copies, no I/O.
+void bdmCaptureConfigWriteDiag(item_list_t *itemList, const config_set_t *configSet, bdm_config_diag_snapshot_t *out);
+// Call with NO lock held. These perform the device probes.
+void bdmLogConfigWriteEntry(const bdm_config_diag_snapshot_t *snap);
+void bdmLogConfigWriteResult(const bdm_config_diag_snapshot_t *snap, int result);
 
 /** Nonzero if this BDM slot has had a device on it at some point this session (its prefix is
  * populated). Slots that have never connected are probed on a slow rotation instead of on every

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -122,6 +122,11 @@ int bdmEffectiveStartMode(void);
 // reads this to bypass its background SIO2 rescan throttle when a real device change occurs.
 unsigned int bdmGetGeneration(void);
 
+// Diagnostic-only hooks used by the generic game-settings save worker. They are no-ops for
+// non-BDM lists and never change which filesystem path configWrite() consumes.
+void bdmLogConfigWriteEntry(item_list_t *itemList, const config_set_t *configSet);
+void bdmLogConfigWriteResult(item_list_t *itemList, const config_set_t *configSet, int result);
+
 /** Nonzero if this BDM slot has had a device on it at some point this session (its prefix is
  * populated). Slots that have never connected are probed on a slow rotation instead of on every
  * background rescan -- attach is event-driven, so the periodic probe is only a missed-event net.

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -62,6 +62,11 @@ typedef struct
     unsigned char LanguagesLoaded;
     unsigned char FoldersCreated;
     unsigned char ForceRefresh;
+    // Set the first time this slot's massN: root answers Dopen, INDEPENDENTLY of whether the
+    // identity ioctl has answered yet. bdmPrefix cannot serve this purpose: it is only written once
+    // identity succeeds, so a mounted-but-unidentified slot would read as "never connected" and be
+    // demoted to the slow empty-slot probe rotation -- exactly the slot that needs the full cadence.
+    unsigned char bdmSeenMounted;
 } bdm_device_data_t;
 
 void bdmLoadModules(void);

--- a/include/gui.h
+++ b/include/gui.h
@@ -209,6 +209,9 @@ void guiRenderGreetingScreen(void);
 void guiSetBootStatus(const char *status);
 // Boot-step localizer for deferred IO-thread steps; label must be a static/_l() string.
 void guiSetBootStatusSticky(const char *label);
+// Diagnostic boot-step setter for dynamic text. Copies into an internal double buffer before
+// publishing, so an IO-thread caller may safely pass a stack-formatted message.
+void guiSetBootStatusStickyCopy(const char *label);
 
 void guiWarning(const char *text, int count);
 

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -134,5 +134,6 @@ int hddOplHomeSelectionPending(void);
 
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
 int hddIsPresent();
+int hddGetArtArchivePath(item_list_t *itemList, char *out, int outSize);
 
 #endif

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -135,6 +135,15 @@ int hddCommitOplHomeSelection(void);
 void hddDiscardOplHomeSelection(void);
 int hddOplHomeSelectionPending(void);
 
+/** Why the last hddStageOplHomeSelection() ended as it did, as a short static token
+ * ("ata-stack-unavailable", "pfs-support-unavailable", "partition-mount-refused", "ok", ...).
+ *
+ * Several distinct conditions share only two user-visible messages, so a failure here never said
+ * WHICH one fired -- which is exactly why the APA data-home row survived repeated fix attempts.
+ * Shown only in OPLDIAG builds; a normal release keeps the plain localized message.
+ */
+const char *hddOplHomeStageReason(void);
+
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
 int hddIsPresent();
 int hddGetArtArchivePath(item_list_t *itemList, char *out, int outSize);

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -112,6 +112,9 @@ static inline int hddLoadModulesReady(void)
     int r = hddLoadModules();
     return r == HDD_LOADMODULES_STATUS_NOERROR || r == HDD_LOADMODULES_STATUS_ALREADYLOADED;
 }
+// Diagnostic wrapper used by the visible DEV9/ATAD/XHDD boot bracket. It preserves the exact
+// hddLoadModulesReady() decision while enabling nested, source-level startup stages beneath it.
+int hddDiagLoadModulesReady(void);
 void hddLoadSupportModules(void);
 
 // Normal APA data-home choices surfaced by Settings -> Game Sources. POPS loose files remain

--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -163,9 +163,15 @@ typedef struct _item_list_t
 
     /// Optional view override for a shallow proxy of this support. Zero keeps the support's native
     /// per-mode L3 state; Favourites uses the forced values so an ISO/VCD favourite can proxy its
-    /// source without mutating the real source page's independent view. Appended last so all legacy
+    // source without mutating the real source page's independent view. Appended last so all legacy
     /// positional item_list_t initializers default safely to native behavior.
     unsigned char viewOverride;
+
+    // Optional: exact ART tar archive path for this device (e.g. HDD selected home).
+    // Return 1 and fill out when a device-specific archive should be probed, 0 when generic
+    // sweep is appropriate, -1 when no home (no tar should be probed).
+    // Placed after viewOverride so existing positional initializers remain valid.
+    int (*itemGetArtArchivePath)(item_list_t *itemList, char *out, int outSize);
 } item_list_t;
 
 #define ITEM_VIEW_NATIVE    0

--- a/include/opl.h
+++ b/include/opl.h
@@ -75,6 +75,7 @@ config_set_t *oplGetLegacyAppsInfo(char *name);
 
 void setErrorMessage(int strId);
 void setErrorMessageWithCode(int strId, int error);
+void setErrorMessageWithCodeAndDetail(int strId, int error, const char *detail);
 void setErrorMessagePathCode(int strId, const char *path, int error);
 // Drop a queued error only when it is the exact condition that subsequently recovered. This avoids
 // hiding an unrelated notification merely because a later storage probe happened to succeed.

--- a/include/tar.h
+++ b/include/tar.h
@@ -75,6 +75,8 @@ int tarClose(TarKind kind);
 
 TarEntryBase *tarFind(TarKind kind, const char *filename);
 TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix);
+TarEntryBase *tarFindExact(TarKind kind, const char *filename);
+TarEntryBase *tarFindPrefixExact(TarKind kind, const char *prefix);
 void *tarGet(TarKind kind, const char *filename);
 u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize);
 

--- a/modules/bdmevent/imports.lst
+++ b/modules/bdmevent/imports.lst
@@ -1,7 +1,9 @@
 bdm_IMPORTS_start
+I_bdm_get_bd
 I_bdm_RegisterCallback
 bdm_IMPORTS_end
 
 sifcmd_IMPORTS_start
+I_sceSifAddCmdHandler
 I_sceSifSendCmd
 sifcmd_IMPORTS_end

--- a/modules/bdmevent/main.c
+++ b/modules/bdmevent/main.c
@@ -2,19 +2,78 @@
 #include <bdm.h>
 #include <sifcmd.h>
 #include <irx.h>
+#include "bdmevent.h"
 
 IRX_ID("bdmevent", 1, 1);
 
+static unsigned int callbackSequence;
+static unsigned int mountCallbackCount;
+static unsigned int unmountCallbackCount;
+
+static void bdm_diag_fill_snapshot(bdm_event_packet_t *packet, unsigned int kind, int cause)
+{
+    struct block_device *devices[20];
+    unsigned int i;
+
+    bdm_get_bd(devices, sizeof(devices) / sizeof(devices[0]));
+
+    packet->kind = kind;
+    packet->cause = cause;
+    packet->header.opt = cause;
+    packet->callbackSequence = callbackSequence;
+    packet->mountCallbackCount = mountCallbackCount;
+    packet->unmountCallbackCount = unmountCallbackCount;
+    packet->blockDeviceCount = 0;
+    packet->usbRootCount = 0;
+    packet->usbRootMask = 0;
+
+    for (i = 0; i < sizeof(devices) / sizeof(devices[0]); i++) {
+        struct block_device *device = devices[i];
+
+        if (device == NULL)
+            continue;
+
+        packet->blockDeviceCount++;
+        if (device->parNr == 0 && device->name != NULL &&
+            device->name[0] == 'u' && device->name[1] == 's' && device->name[2] == 'b' && device->name[3] == '\0') {
+            packet->usbRootCount++;
+            if (device->devNr < 32)
+                packet->usbRootMask |= 1U << device->devNr;
+        }
+    }
+}
+
 static void bdm_callback(int cause)
 {
-    static SifCmdHeader_t EventCmdData;
+    static bdm_event_packet_t EventCmdData;
 
-    EventCmdData.opt = cause;
-    sceSifSendCmd(0, &EventCmdData, sizeof(EventCmdData), NULL, NULL, 0);
+    callbackSequence++;
+    if (cause)
+        mountCallbackCount++;
+    else
+        unmountCallbackCount++;
+
+    bdm_diag_fill_snapshot(&EventCmdData, BDMEVENT_PACKET_EVENT, cause);
+    sceSifSendCmd(BDMEVENT_EE_EVENT_CMD, &EventCmdData, sizeof(EventCmdData), NULL, NULL, 0);
+}
+
+static void bdm_diag_query_handler(void *packet, void *arg)
+{
+    static bdm_event_packet_t SnapshotCmdData;
+
+    (void)packet;
+    (void)arg;
+
+    bdm_diag_fill_snapshot(&SnapshotCmdData, BDMEVENT_PACKET_DIAG_SNAPSHOT, -1);
+    sceSifSendCmd(BDMEVENT_EE_EVENT_CMD, &SnapshotCmdData, sizeof(SnapshotCmdData), NULL, NULL, 0);
 }
 
 int _start(int argc, char *argv[])
 {
+    (void)argc;
+    (void)argv;
+
+    sceSifAddCmdHandler(BDMEVENT_IOP_DIAG_QUERY_CMD, &bdm_diag_query_handler, NULL);
     bdm_RegisterCallback(&bdm_callback);
     return MODULE_RESIDENT_END;
 }

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -246,7 +246,9 @@ static void appDedupList(void)
 
 // #253 diagnostics: write every entry's resolved identity to <config home>/apps-dump.txt so a
 // reporter's file answers "which two prefixes did this app come in through" without a serial
-// cable. Called only with debug enabled (gEnableDebug); small text file, rewritten per rebuild.
+// cable. DIAGNOSTIC BUILDS ONLY (OPLDIAG) -- it writes a file into the config home, which is a
+// device root, and no display setting should be able to cause that.
+#ifdef __OPLDIAG
 static void appDumpDiscovery(void)
 {
     char path[300];
@@ -272,6 +274,7 @@ static void appDumpDiscovery(void)
     else
         LOG("APPSUPPORT discovery dump write FAILED on close: %s\n", path);
 }
+#endif
 
 
 static const char *appBuildStartupPath(const char *path, const char *boot)
@@ -644,8 +647,13 @@ static int appUpdateItemList(item_list_t *itemList)
     // reporter's file answers "which two prefixes did this app come in through" without a
     // serial cable. Tiny text file at the config home, rewritten each rebuild -- including
     // the zero-app rebuild, or a stale dump would outlive the truth (CodeRabbit #262).
-    if (gEnableDebug)
-        appDumpDiscovery();
+    // Diagnostic builds ONLY. This used to key off gEnableDebug, which is the user-facing debug
+    // COLOURS toggle -- so turning that on silently started writing apps-dump.txt into the config
+    // home (a device root) on every list rebuild. A display setting must not create files on the
+    // user's card; OPLDIAG is the axis that exists for diagnostics now.
+#ifdef __OPLDIAG
+    appDumpDiscovery();
+#endif
 
     if (appBuildArtLookup() < 0)
         LOG("APPSUPPORT unable to allocate art lookup table.\n");

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -478,6 +478,11 @@ static int bdmLoadOptionalModuleArgs(const char *name, void *module, int moduleS
     return result;
 }
 
+// BOOT-STAGE LABELS ARE DIAGNOSTIC-BUILD ONLY (OPLDIAG=1). They publish raw, untranslated developer
+// text -- "BEGIN USBMASS_BD", "END DEV9/ATAD/XHDD result=1" -- straight to the boot status line that
+// every other caller feeds through _l(). A plain release must show only localized boot steps, so
+// these compile to nothing there; the diagnostic flavour is what a tester runs to localize a wedge.
+#ifdef __OPLDIAG
 static void bdmDiagBootStageBegin(const char *stage)
 {
     char status[64];
@@ -495,6 +500,18 @@ static void bdmDiagBootStageEnd(const char *stage, int result)
     LOG("[BDM DIAG] %s\n", status);
     guiSetBootStatusStickyCopy(status);
 }
+#else
+static void bdmDiagBootStageBegin(const char *stage)
+{
+    (void)stage;
+}
+
+static void bdmDiagBootStageEnd(const char *stage, int result)
+{
+    (void)stage;
+    (void)result;
+}
+#endif
 
 static int bdmDiagLoadOptionalModule(const char *stage, const char *name, void *module, int moduleSize)
 {
@@ -723,6 +740,10 @@ static int bdmLoadUsbMassBd(void)
     if (iUSBModLoaded)
         return 0;
 
+    // Localized boot step, restored with the move into bdmLoadCoreModules. USBMASS_BD is the prime
+    // suspect for a real exFAT/USB boot wedge, so it is the last step a stalled console should be
+    // naming -- losing this left a wedge here reading as a stall in the PREVIOUS step (BDMFS_FATFS).
+    guiSetBootStatusSticky(_l(_STR_BOOT_LOADING_USB));
     bdmDiagBootStageBegin("USBMASS_BD");
     result = bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx);
     bdmDiagBootStageEnd("USBMASS_BD", result);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -381,6 +381,8 @@ static int bdmLoadUsbMassBd(void)
 
 static int bdmShouldQueueModuleLoad(void)
 {
+    if (!iUSBModLoaded)
+        return 1;
     if (gEnableILK && !iLinkModLoaded)
         return 1;
     if (gEnableMX4SIO && !mx4sioModLoaded)
@@ -404,11 +406,13 @@ static void bdmLoadBlockDeviceModules(void)
 
     // Snapshot, compared after the loads below. See the refresh at the end of this function for why
     // a transport enabled from Settings needed a "double tap" before its tab appeared.
-    int modsWere = iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
+    int modsWere = iUSBModLoaded + iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
 
-    // USB mass storage is part of the base BDM stack (upstream/Grimdoomer: always
-    // resident). Its residency must not be gated by the UI-visible gEnableUSB flag;
-    // visibility is handled separately by bdmTransportEnabled.
+    // USB retry without gEnableUSB gate: base residency is unconditional, but a
+    // synchronous bdmLoadCoreModules failure must still be retried via the
+    // generation/worker path. Success will bump modsNow and refresh discovery.
+    if (!iUSBModLoaded)
+        bdmLoadUsbMassBd();
 
     if (gEnableILK && !iLinkModLoaded) {
         // Load iLink Block Device drivers
@@ -467,7 +471,7 @@ static void bdmLoadBlockDeviceModules(void)
             sysShutdownDev9();
     }
 
-    int modsNow = iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
+    int modsNow = iUSBModLoaded + iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
 
     // BOOT PASS BUMPS NOTHING. On the first call every enabled transport loads for the first time, so
     // the comparison below is guaranteed true -- and bdmInitDevicesData is about to publish all of

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -367,10 +367,20 @@ int bdmModeIsSIO2(int mode)
     return pDeviceData != NULL && pDeviceData->bdmDeviceType == BDM_TYPE_SDC;
 }
 
+static int bdmLoadUsbMassBd(void)
+{
+    if (iUSBModLoaded)
+        return 0;
+    LOG("[USBMASS_BD]:\n");
+    if (bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx) >= 0) {
+        iUSBModLoaded = 1;
+        return 0;
+    }
+    return -1;
+}
+
 static int bdmShouldQueueModuleLoad(void)
 {
-    if (gEnableUSB && !iUSBModLoaded)
-        return 1;
     if (gEnableILK && !iLinkModLoaded)
         return 1;
     if (gEnableMX4SIO && !mx4sioModLoaded)
@@ -394,14 +404,11 @@ static void bdmLoadBlockDeviceModules(void)
 
     // Snapshot, compared after the loads below. See the refresh at the end of this function for why
     // a transport enabled from Settings needed a "double tap" before its tab appeared.
-    int modsWere = iUSBModLoaded + iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
+    int modsWere = iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
 
-    if (gEnableUSB && !iUSBModLoaded) {
-        // Load USB Block Device drivers -- the prime suspect for a real exFAT/USB boot wedge.
-        guiSetBootStatusSticky(_l(_STR_BOOT_LOADING_USB));
-        if (bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx) >= 0)
-            iUSBModLoaded = 1;
-    }
+    // USB mass storage is part of the base BDM stack (upstream/Grimdoomer: always
+    // resident). Its residency must not be gated by the UI-visible gEnableUSB flag;
+    // visibility is handled separately by bdmTransportEnabled.
 
     if (gEnableILK && !iLinkModLoaded) {
         // Load iLink Block Device drivers
@@ -460,7 +467,7 @@ static void bdmLoadBlockDeviceModules(void)
             sysShutdownDev9();
     }
 
-    int modsNow = iUSBModLoaded + iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
+    int modsNow = iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;
 
     // BOOT PASS BUMPS NOTHING. On the first call every enabled transport loads for the first time, so
     // the comparison below is guaranteed true -- and bdmInitDevicesData is about to publish all of
@@ -532,6 +539,10 @@ static void bdmLoadCoreModules(void)
     // Load FATFS (mass:) driver
     LOG("[BDMFS_FATFS]:\n");
     sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
+
+    // USB block device is base BDM infrastructure (upstream ps2homebrew and
+    // Grimdoomer load it synchronously, not as an optional transport).
+    bdmLoadUsbMassBd();
 
     LOG("[BDMEVENT]:\n");
     sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1128,36 +1128,23 @@ static void bdmLoadBlockDeviceModules(void)
     // reported failure is one of two going missing while the other is present -- so a
     // "did any USB root answer?" guard would find the working stick, conclude all is well, and skip
     // the very refresh the missing one needs. Ask again regardless of what is already mounted.
-    /* SEVERAL ATTEMPTS, NOT ONE. A single settle at 600 ms was not enough on hardware, and the
-       reason is the opposite of what "the fast stick fails" first suggests: the PS2's controller is
-       USB 1.1, so a modern high-speed stick has to negotiate DOWN to full speed before it can
-       enumerate at all. Newer and faster on a PC means slower to come up here, which is exactly why
-       the older, simpler stick was always the one that appeared on its own.
-
-       Each pass opens every massN: root, which is what forces FatFs to mount the volume lazily (see
-       bdmProbeMassSlots), so a slot that was not ready on an earlier pass is picked up on a later
-       one. Stops as soon as every slot answers, so the common case where everything is already up
-       costs exactly one pass and no sleeping at all.
-
-       Bounded hard at BDM_USB_SETTLE_PASSES * BDM_USB_SETTLE_STEP_MS. This runs on the io worker,
-       so the sleeps are real: keep the ceiling low enough that a console with no USB at all does not
-       stall boot behind it. */
-#define BDM_USB_SETTLE_PASSES  4
-#define BDM_USB_SETTLE_STEP_MS 700
-
+    /* ONE settle, one probe, one refresh -- deliberately NOT a retry loop.
+     *
+     * A four-pass version (4 x 700 ms) was tried and did not help: the stick that needs a replug
+     * still needed one. That result matters more than the theory behind it, which was that a modern
+     * high-speed stick negotiating down to the PS2's USB 1.1 controller simply needed longer. If
+     * extra time were the missing ingredient, four passes would have found it.
+     *
+     * So do not reintroduce a loop or raise a pass count here. Up to 2.8 s of io-worker sleep at
+     * every boot, on every console, is a real cost paid by everyone -- and it bought nothing. The
+     * remaining fault is something other than "not enough time", and adding delay only hides how
+     * little is understood about it. */
     static int usbSecondProbeDone = 0;
     if (iUSBModLoaded && !usbSecondProbeDone) {
-        int pass;
-
         usbSecondProbeDone = 1;
-
-        for (pass = 0; pass < BDM_USB_SETTLE_PASSES; pass++) {
-            DelayThread(BDM_USB_SETTLE_STEP_MS * 1000);
-            if (bdmProbeMassSlots("usb-settle") == 0)
-                break; // every slot answered -- nothing left to wait for
-        }
-
-        bdmForceDeviceRefresh(); // one refresh once the slots have had their chance
+        DelayThread(600 * 1000);               // bounded settle for USB enumeration + FAT mount
+        bdmProbeMassSlots("after-usb-settle"); // forces FatFs's lazy mount on every slot
+        bdmForceDeviceRefresh();               // exactly one second probe, covering every slot
     }
 }
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -17,6 +17,7 @@
 #include "include/extern_irx.h"
 #include "include/cheatman.h"
 #include "include/sound.h"
+#include "include/bdmevent.h"
 #include "modules/iopcore/common/cdvd_config.h"
 
 #include <usbhdfsd-common.h>
@@ -63,9 +64,18 @@ static unsigned int BdmGeneration = 0;
 // Snapshot the change and emit it from the ordinary deferred device-update worker instead.
 static volatile unsigned int BdmDiagEventPreviousGeneration;
 static volatile unsigned int BdmDiagEventGeneration;
-static void *volatile BdmDiagEventPacket;
-static void *volatile BdmDiagEventOpt;
+static volatile unsigned int BdmDiagEventReceivedCount;
+static volatile int BdmDiagEventCause;
+static volatile unsigned int BdmDiagIopCallbackSequence;
+static volatile unsigned int BdmDiagIopMountCallbackCount;
+static volatile unsigned int BdmDiagIopUnmountCallbackCount;
+static volatile unsigned int BdmDiagIopBlockDeviceCount;
+static volatile unsigned int BdmDiagIopUsbRootCount;
+static volatile unsigned int BdmDiagIopUsbRootMask;
 static volatile int BdmDiagEventPending;
+static volatile int BdmDiagIopSnapshotPending;
+static unsigned int BdmDiagSnapshotRequestCount;
+static unsigned int BdmDiagSlotProbeCount[MAX_BDM_DEVICES];
 #endif
 
 static int bdmDriverIsUSB(const char *driverName)
@@ -544,20 +554,82 @@ int bdmModeIsUDPBD(int mode)
 
 static void bdmEventHandler(void *packet, void *opt)
 {
+    const bdm_event_packet_t *event = (const bdm_event_packet_t *)packet;
+
+    (void)opt;
+
+#ifdef __DEBUG
+    if (event != NULL) {
+        BdmDiagIopCallbackSequence = event->callbackSequence;
+        BdmDiagIopMountCallbackCount = event->mountCallbackCount;
+        BdmDiagIopUnmountCallbackCount = event->unmountCallbackCount;
+        BdmDiagIopBlockDeviceCount = event->blockDeviceCount;
+        BdmDiagIopUsbRootCount = event->usbRootCount;
+        BdmDiagIopUsbRootMask = event->usbRootMask;
+    }
+#endif
+
+    // A diagnostic snapshot reports IOP-side state without representing a storage change. Never
+    // let the query itself bump BdmGeneration or alter the page-refresh decision.
+    if (event != NULL && event->kind == BDMEVENT_PACKET_DIAG_SNAPSHOT) {
+#ifdef __DEBUG
+        BdmDiagIopSnapshotPending = 1;
+#endif
+        return;
+    }
+
 #ifdef __DEBUG
     BdmDiagEventPreviousGeneration = BdmGeneration;
-#else
-    (void)packet;
-    (void)opt;
+    BdmDiagEventCause = event != NULL ? event->cause : -1;
+    BdmDiagEventReceivedCount++;
 #endif
     BdmGeneration++;
 #ifdef __DEBUG
     BdmDiagEventGeneration = BdmGeneration;
-    BdmDiagEventPacket = packet;
-    BdmDiagEventOpt = opt;
     BdmDiagEventPending = 1;
 #endif
 }
+
+#ifdef __DEBUG
+static void bdmDiagRequestIopSnapshot(const char *reason, int mode, int openResult)
+{
+    static SifCmdHeader_t query;
+    int result;
+
+    BdmDiagSnapshotRequestCount++;
+    query.opt = BdmDiagSnapshotRequestCount;
+    result = SifSendCmd(BDMEVENT_IOP_DIAG_QUERY_CMD, &query, sizeof(query), NULL, NULL, 0);
+    LOG("[BDM COLD DIAG] event=iop-snapshot-request request=%u reason=%s generation=%u mode=%d open=%d send=%d\n",
+        BdmDiagSnapshotRequestCount, reason, BdmGeneration, mode, openResult, result);
+}
+
+static void bdmDiagFlushPendingIopState(item_list_t *itemList)
+{
+    if (BdmDiagEventPending) {
+        unsigned int previousGeneration = BdmDiagEventPreviousGeneration;
+        unsigned int generation = BdmDiagEventGeneration;
+        int cause = BdmDiagEventCause;
+
+        BdmDiagEventPending = 0;
+        LOG("[BDM COLD DIAG] event=generation-change source=bdm-event generation=%u->%u "
+            "eeReceived=%u cause=%d iopCallbacks=%u mountCallbacks=%u unmountCallbacks=%u "
+            "blockDevices=%u usbRoots=%u usbRootMask=0x%08x itemList=%p mode=%d\n",
+            previousGeneration, generation, BdmDiagEventReceivedCount, cause, BdmDiagIopCallbackSequence,
+            BdmDiagIopMountCallbackCount, BdmDiagIopUnmountCallbackCount, BdmDiagIopBlockDeviceCount,
+            BdmDiagIopUsbRootCount, BdmDiagIopUsbRootMask, itemList, itemList->mode);
+    }
+
+    if (BdmDiagIopSnapshotPending) {
+        BdmDiagIopSnapshotPending = 0;
+        LOG("[BDM COLD DIAG] event=iop-snapshot generation=%u eeReceived=%u iopCallbacks=%u "
+            "mountCallbacks=%u unmountCallbacks=%u blockDevices=%u usbRoots=%u usbRootMask=0x%08x "
+            "itemList=%p mode=%d\n",
+            BdmGeneration, BdmDiagEventReceivedCount, BdmDiagIopCallbackSequence,
+            BdmDiagIopMountCallbackCount, BdmDiagIopUnmountCallbackCount, BdmDiagIopBlockDeviceCount,
+            BdmDiagIopUsbRootCount, BdmDiagIopUsbRootMask, itemList, itemList->mode);
+    }
+}
+#endif
 
 // Bump the device generation the per-device refresh latch keys off, exactly as a real hotplug event
 // (bdmEventHandler) does. This invalidates every device's bdmDeviceTick so the next bdmNeedsUpdate
@@ -719,7 +791,7 @@ static void bdmLoadBlockDeviceModules(void)
         // suppress future retries via bdmShouldQueueModuleLoad() (matches the
         // conditional pattern used for USB/MX4SIO and opl.c's hddLoadModules gate).
         bdmDiagBootStageBegin("DEV9/ATAD/XHDD");
-        int hddResult = hddLoadModulesReady();
+        int hddResult = hddDiagLoadModulesReady();
         bdmDiagBootStageEnd("DEV9/ATAD/XHDD", hddResult);
         if (hddResult)
             hddModLoaded = 1;
@@ -844,7 +916,11 @@ static void bdmLoadCoreModules(void)
 
     LOG("[BDMEVENT]:\n");
     sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
-    SifAddCmdHandler(0, &bdmEventHandler, NULL);
+    SifAddCmdHandler(BDMEVENT_EE_EVENT_CMD, &bdmEventHandler, NULL);
+
+#ifdef __DEBUG
+    bdmDiagRequestIopSnapshot("handler-ready", -1, -1);
+#endif
 
     LOG("BDMSUPPORT Modules loaded\n");
 }
@@ -2103,16 +2179,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     int driverResult, deviceResult;
 
 #ifdef __DEBUG
-    if (BdmDiagEventPending) {
-        unsigned int previousGeneration = BdmDiagEventPreviousGeneration;
-        unsigned int generation = BdmDiagEventGeneration;
-        void *packet = BdmDiagEventPacket;
-        void *opt = BdmDiagEventOpt;
-
-        BdmDiagEventPending = 0;
-        LOG("[BDM DIAG] event=generation-change source=bdm-event generation=%u->%u itemList=%p mode=%d packet=%p opt=%p\n",
-            previousGeneration, generation, itemList, itemList->mode, packet, opt);
-    }
+    bdmDiagFlushPendingIopState(itemList);
 #endif
 
     // If bdm mode is disabled bail out as we don't want to update the visibility state of the device pages.
@@ -2129,6 +2196,34 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     snprintf(path, sizeof(path), "mass%d:/", itemList->mode);
     int dir = fileXioDopen(path);
     // LOG("opendir %s -> %d\n", path, dir);
+
+#ifdef __DEBUG
+    {
+        const int diagSlot = itemList->mode - BDM_MODE;
+
+        if (diagSlot >= 0 && diagSlot < MAX_BDM_DEVICES) {
+            const unsigned int probe = ++BdmDiagSlotProbeCount[diagSlot];
+
+            if (probe <= 4 || (dir >= 0 && pDeviceData->bdmDeviceRoot[0] == '\0')) {
+                LOG("[BDM COLD DIAG] event=slot-probe probe=%u generation=%u eeReceived=%u "
+                    "iopCallbacks=%u mountCallbacks=%u unmountCallbacks=%u blockDevices=%u "
+                    "usbRoots=%u usbRootMask=0x%08x mode=%d slot=%d legacy=\"%s\" open=%d "
+                    "visible=%d tick=%u ulPrev=%d root=\"%s\" driver=\"%s\" type=%d\n",
+                    probe, BdmGeneration, BdmDiagEventReceivedCount, BdmDiagIopCallbackSequence,
+                    BdmDiagIopMountCallbackCount, BdmDiagIopUnmountCallbackCount,
+                    BdmDiagIopBlockDeviceCount, BdmDiagIopUsbRootCount, BdmDiagIopUsbRootMask,
+                    itemList->mode, diagSlot, path, dir, visible, pDeviceData->bdmDeviceTick,
+                    pDeviceData->bdmULSizePrev, pDeviceData->bdmDeviceRoot,
+                    pDeviceData->bdmDriver, pDeviceData->bdmDeviceType);
+            }
+
+            if (probe == 1 && (diagSlot == 0 || diagSlot == 1 || diagSlot == MAX_BDM_DEVICES - 1))
+                bdmDiagRequestIopSnapshot("slot-first-probe", itemList->mode, dir);
+            else if (probe == 2 && diagSlot == 1 && dir < 0)
+                bdmDiagRequestIopSnapshot("slot1-second-miss", itemList->mode, dir);
+        }
+    }
+#endif
 
     // Device reachable this poll -> clear the debounce miss counter (see the hide branch below).
     if (dir >= 0)

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -786,7 +786,17 @@ int bdmSlotEverConnected(int mode)
         return 0;
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)bdmDeviceList[mode - BDM_MODE].priv;
-    return pDeviceData != NULL && pDeviceData->bdmPrefix[0] != '\0';
+    if (pDeviceData == NULL)
+        return 0;
+
+    // bdmSeenMounted, not just bdmPrefix. The prefix is written only once the driver identity ioctl
+    // has answered, and bdmUpdateDeviceData deliberately defers publication when a mount answers
+    // Dopen before its transport can answer that ioctl -- routine when a second device enumerates
+    // behind the first. Testing the prefix alone therefore reported that slot as never-connected and
+    // dropped it to the empty-slot rotation (~8 s, and only while the user holds still), so a device
+    // that WAS mounted and merely needed one more probe could sit unpublished until it was replugged
+    // -- a hotplug bumps the generation and bypasses every gate, which is why replugging "fixed" it.
+    return pDeviceData->bdmSeenMounted != 0 || pDeviceData->bdmPrefix[0] != '\0';
 }
 
 // Is this slot the MX4SIO card -- i.e. does its IO ride SIO2, the CONTROLLER'S OWN BUS?
@@ -2335,8 +2345,14 @@ int bdmUpdateDeviceData(item_list_t *itemList)
 #endif
 
     // Device reachable this poll -> clear the debounce miss counter (see the hide branch below).
-    if (dir >= 0)
+    if (dir >= 0) {
         pDeviceData->bdmMissCount = 0;
+        // Latch "something has mounted here" the moment the root answers, BEFORE identity is known.
+        // The publish path below deliberately defers a mount whose driver ioctl is not ready yet,
+        // and without this latch that slot still looks empty to bdmSlotEverConnected() -- so the one
+        // slot guaranteed to need another look promptly is the one sent to the slow rotation.
+        pDeviceData->bdmSeenMounted = 1;
+    }
 
     // If we opened the device and the menu isn't visible (OR is visible but hasn't been initialized ex: manual device start) initialize device info.
     // A device that went away and came RIGHT BACK, identity intact, is a stall -- not a new device.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -537,11 +537,13 @@ static int bdmLoadOptionalModuleArgs(const char *name, void *module, int moduleS
  * through _l(). Compact by necessity: one token per slot, '-' absent, '?' open but no identity, or
  * the driver's first letter (u/a/s/i) followed by its device number.
  */
-static void bdmProbeMassSlots(const char *when)
+// Returns the number of slots that did NOT answer, so a caller can stop waiting early.
+static int bdmProbeMassSlots(const char *when)
 {
     char summary[96];
     int len;
     int i;
+    int absent = 0;
 
     len = snprintf(summary, sizeof(summary), "MASS %s:", when);
 
@@ -554,6 +556,7 @@ static void bdmProbeMassSlots(const char *when)
         snprintf(root, sizeof(root), "mass%d:/", i);
         dir = fileXioDopen(root);
         if (dir < 0) {
+            absent++;
             n = snprintf(summary + len, sizeof(summary) - len, " %d-", i);
         } else {
             int devnr = -1;
@@ -576,6 +579,8 @@ static void bdmProbeMassSlots(const char *when)
 #ifdef __OPLDIAG
     guiSetBootStatusStickyCopy(summary);
 #endif
+
+    return absent;
 }
 
 // BOOT-STAGE LABELS ARE DIAGNOSTIC-BUILD ONLY (OPLDIAG=1). They publish raw, untranslated developer
@@ -1123,12 +1128,36 @@ static void bdmLoadBlockDeviceModules(void)
     // reported failure is one of two going missing while the other is present -- so a
     // "did any USB root answer?" guard would find the working stick, conclude all is well, and skip
     // the very refresh the missing one needs. Ask again regardless of what is already mounted.
+    /* SEVERAL ATTEMPTS, NOT ONE. A single settle at 600 ms was not enough on hardware, and the
+       reason is the opposite of what "the fast stick fails" first suggests: the PS2's controller is
+       USB 1.1, so a modern high-speed stick has to negotiate DOWN to full speed before it can
+       enumerate at all. Newer and faster on a PC means slower to come up here, which is exactly why
+       the older, simpler stick was always the one that appeared on its own.
+
+       Each pass opens every massN: root, which is what forces FatFs to mount the volume lazily (see
+       bdmProbeMassSlots), so a slot that was not ready on an earlier pass is picked up on a later
+       one. Stops as soon as every slot answers, so the common case where everything is already up
+       costs exactly one pass and no sleeping at all.
+
+       Bounded hard at BDM_USB_SETTLE_PASSES * BDM_USB_SETTLE_STEP_MS. This runs on the io worker,
+       so the sleeps are real: keep the ceiling low enough that a console with no USB at all does not
+       stall boot behind it. */
+#define BDM_USB_SETTLE_PASSES  4
+#define BDM_USB_SETTLE_STEP_MS 700
+
     static int usbSecondProbeDone = 0;
     if (iUSBModLoaded && !usbSecondProbeDone) {
+        int pass;
+
         usbSecondProbeDone = 1;
-        DelayThread(600 * 1000); // bounded settle for USB enumeration + FAT mount
-        bdmProbeMassSlots("after-usb-settle");
-        bdmForceDeviceRefresh(); // exactly one second probe, covering every slot
+
+        for (pass = 0; pass < BDM_USB_SETTLE_PASSES; pass++) {
+            DelayThread(BDM_USB_SETTLE_STEP_MS * 1000);
+            if (bdmProbeMassSlots("usb-settle") == 0)
+                break; // every slot answered -- nothing left to wait for
+        }
+
+        bdmForceDeviceRefresh(); // one refresh once the slots have had their chance
     }
 }
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -204,6 +204,46 @@ static void bdmBuildVcdPrefix(char *target, int targetLength, int massSlot)
     snprintf(target, targetLength, "mass%d:/", massSlot);
 }
 
+/* ⚠ NEVER ASK FOR THE DRIVER NAME WITH A RETURN BUFFER UNTIL YOU KNOW THE VOLUME IS MOUNTED.
+   ps2sdk's handler NULL-DEREFERENCES otherwise. iop/fs/bdmfs_fatfs/src/fs_driver.c, upstream master,
+   verified 2026-08-26:
+
+       struct block_device *mounted_bd = fatfs_..._get_mounted_bd_from_index(file->obj.fs->pdrv);
+       ret = (mounted_bd == NULL) ? -ENXIO : *(int *)(mounted_bd->name);
+       if (rdata != NULL)
+           strncpy(rdata, mounted_bd->name, rdatalen);   // <-- NOT guarded on mounted_bd
+
+   The NULL check on the line above does not cover the copy. Supplying rdata for a volume with no
+   mounted block device therefore dereferences NULL ON THE IOP, and an IOP fault takes down every
+   thread waiting on it -- observed on hardware as the console freezing after browsing BDM pages,
+   and as mass slots that never resolve an identity.
+
+   It is reachable because "mass" resolves its volume straight from the unit number:
+   fs_driver_resolve_volume() returns `unit` for "mass" WITHOUT checking that anything is mounted
+   there, so Dopen can succeed on a slot whose backing device has gone away.
+
+   We embed the SDK's PREBUILT bdmfs_fatfs.irx (Makefile), so this cannot be fixed on our side --
+   only avoided. The no-buffer form returns -ENXIO safely (it carries the name's first four bytes in
+   its return value instead). That is precisely what Grimdoomer's fork does, and why it reads mass
+   devices where we fault. Gate on it, then ask for the full name.
+
+   Returns >= 0 on success; driverName is always left NUL-terminated. */
+int bdmReadDriverName(int dir, char *driverName, int driverNameLength)
+{
+    int result;
+
+    if (driverName == NULL || driverNameLength <= 0)
+        return -1;
+
+    driverName[0] = '\0';
+
+    result = fileXioIoctl(dir, USBMASS_IOCTL_GET_DRIVERNAME, "");
+    if (result < 0)
+        return result; // no mounted block device -- asking with a buffer here would fault the IOP
+
+    return fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, driverName, driverNameLength - 1);
+}
+
 static int bdmReadDeviceIdentity(const char *path, char *driverName, int driverNameLength, int *deviceIndex)
 {
     int dir, result;
@@ -216,7 +256,7 @@ static int bdmReadDeviceIdentity(const char *path, char *driverName, int driverN
     if (dir < 0)
         return dir;
 
-    result = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, driverName, driverNameLength - 1);
+    result = bdmReadDriverName(dir, driverName, driverNameLength);
     if (result >= 0)
         result = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, deviceIndex, sizeof(*deviceIndex));
 
@@ -249,7 +289,7 @@ static void bdmDiagProbeIdentity(const char *path, bdm_diag_identity_t *identity
         return;
     }
 
-    identity->identityResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, identity->driver, sizeof(identity->driver) - 1);
+    identity->identityResult = bdmReadDriverName(dir, identity->driver, sizeof(identity->driver));
     if (identity->identityResult >= 0)
         identity->identityResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &identity->deviceIndex, sizeof(identity->deviceIndex));
 
@@ -2391,7 +2431,9 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         // ioctl. Do not publish an empty-driver page: it cannot reach the native launch dispatch.
         // This runs on the deferred IO worker, so a slow or wedged IOP RPC cannot freeze boot;
         // the never-scanned state keeps this slot eligible for the normal later retry.
-        driverResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, driverName, sizeof(driverName) - 1);
+        // Must go through bdmReadDriverName(): asking for the name WITH a return buffer on a volume
+        // whose block device has gone faults the IOP outright. See the note on that function.
+        driverResult = bdmReadDriverName(dir, driverName, sizeof(driverName));
         deviceResult = -1;
         if (driverResult >= 0 && driverName[0] != '\0')
             deviceResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &massDeviceIndex, sizeof(massDeviceIndex));
@@ -3040,7 +3082,7 @@ static int bdmDeviceIsATA(int deviceId)
     /* Zero the buffer before the ioctl: if the call fails, strcmp would read
      * uninitialised stack bytes. Pattern mirrors bdmReadDeviceIdentity(). */
     memset(&data.bdmDriver, 0, sizeof(data.bdmDriver));
-    if (fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &data.bdmDriver, sizeof(data.bdmDriver) - 1) < 0) {
+    if (bdmReadDriverName(dir, data.bdmDriver, sizeof(data.bdmDriver)) < 0) {
         fileXioDclose(dir);
         return 0;
     }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1059,14 +1059,16 @@ static void bdmLoadBlockDeviceModules(void)
     //
     // One bounded settle and exactly one refresh, one-shot, so an absent or already-found stick
     // never costs a later call anything.
+    // UNCONDITIONAL, unlike the MX4SIO probe above, and the difference is deliberate. MX4SIO asks
+    // "did any card show up?" because there is only ever one. USB can have SEVERAL sticks, and the
+    // reported failure is one of two going missing while the other is present -- so a
+    // "did any USB root answer?" guard would find the working stick, conclude all is well, and skip
+    // the very refresh the missing one needs. Ask again regardless of what is already mounted.
     static int usbSecondProbeDone = 0;
     if (iUSBModLoaded && !usbSecondProbeDone) {
-        char usbRoot[16];
         usbSecondProbeDone = 1;
-        if (!bdmGetDeviceRootByType(BDM_TYPE_USB, usbRoot, sizeof(usbRoot))) {
-            DelayThread(600 * 1000); // bounded settle for USB enumeration + FAT mount
-            bdmForceDeviceRefresh(); // exactly one second probe
-        }
+        DelayThread(600 * 1000); // bounded settle for USB enumeration + FAT mount
+        bdmForceDeviceRefresh(); // exactly one second probe, covering every slot
     }
 }
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -519,6 +519,72 @@ static int bdmLoadOptionalModuleArgs(const char *name, void *module, int moduleS
     return result;
 }
 
+/* WHAT IS ACTUALLY ON THE MASS SLOTS, on screen, in a build a tester can run.
+ *
+ * The "a second USB stick only appears after a hotplug" report has now survived five source-based
+ * fixes, each of which corrected a real defect that turned out not to be the cause. The reason the
+ * hunt keeps missing is that three completely different failures look identical from the outside,
+ * and nothing distinguishes them without a TTY:
+ *
+ *   massN never answers Dopen        -> the IOP never mounted it; nothing OPL does can help, and the
+ *                                       suspect is the usbd -> usbmass_bd registration window
+ *                                       (we load usbd in sysReset and usbmass_bd much later; a fast
+ *                                       stick can finish enumerating inside that gap, whereas
+ *                                       Grimdoomer's fork loads the two back to back)
+ *   Dopen ok, identity refuses       -> our publish path defers it, and the retry cadence is at fault
+ *   identity ok but no page          -> published then hidden again, i.e. the miss/debounce logic
+ *
+ * One line naming which of those it is ends the guessing. LOG() needs a TTY nobody testing has, so
+ * this goes to the boot status line, which OPLDIAG already puts on screen. Compact by necessity --
+ * that line is short -- so each slot is one token: '-' absent, '?' open but no identity, or the
+ * driver's own first letter (u/a/s/i) followed by its device number.
+ */
+#ifdef __OPLDIAG
+static void bdmDiagReportMassSlots(const char *when)
+{
+    char summary[96];
+    int len;
+    int i;
+
+    len = snprintf(summary, sizeof(summary), "MASS %s:", when);
+
+    for (i = 0; i < MAX_BDM_DEVICES && len > 0 && len < (int)sizeof(summary); i++) {
+        char root[16];
+        char driver[32] = {0};
+        int dir;
+        int n;
+
+        snprintf(root, sizeof(root), "mass%d:/", i);
+        dir = fileXioDopen(root);
+        if (dir < 0) {
+            n = snprintf(summary + len, sizeof(summary) - len, " %d-", i);
+        } else {
+            int devnr = -1;
+            // Guarded reader: a buffered ask on an unmounted volume faults the IOP outright.
+            if (bdmReadDriverName(dir, driver, sizeof(driver)) >= 0 && driver[0] != '\0') {
+                fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &devnr, sizeof(devnr));
+                n = snprintf(summary + len, sizeof(summary) - len, " %d%c%d", i, driver[0], devnr);
+            } else {
+                n = snprintf(summary + len, sizeof(summary) - len, " %d?", i);
+            }
+            fileXioDclose(dir);
+        }
+
+        if (n <= 0)
+            break;
+        len += n;
+    }
+
+    LOG("[BDM DIAG] %s\n", summary);
+    guiSetBootStatusStickyCopy(summary);
+}
+#else
+static void bdmDiagReportMassSlots(const char *when)
+{
+    (void)when;
+}
+#endif
+
 // BOOT-STAGE LABELS ARE DIAGNOSTIC-BUILD ONLY (OPLDIAG=1). They publish raw, untranslated developer
 // text -- "BEGIN USBMASS_BD", "END DEV9/ATAD/XHDD result=1" -- straight to the boot status line that
 // every other caller feeds through _l(). A plain release must show only localized boot steps, so
@@ -1068,6 +1134,7 @@ static void bdmLoadBlockDeviceModules(void)
     if (iUSBModLoaded && !usbSecondProbeDone) {
         usbSecondProbeDone = 1;
         DelayThread(600 * 1000); // bounded settle for USB enumeration + FAT mount
+        bdmDiagReportMassSlots("after-usb-settle");
         bdmForceDeviceRefresh(); // exactly one second probe, covering every slot
     }
 }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -58,6 +58,15 @@ void bdmInitDevicesData();
 int bdmUpdateDeviceData(item_list_t *itemList);
 
 static unsigned int BdmGeneration = 0;
+#ifdef __DEBUG
+// bdmEventHandler runs in the SIF command callback context; never perform diagnostic I/O there.
+// Snapshot the change and emit it from the ordinary deferred device-update worker instead.
+static volatile unsigned int BdmDiagEventPreviousGeneration;
+static volatile unsigned int BdmDiagEventGeneration;
+static void *volatile BdmDiagEventPacket;
+static void *volatile BdmDiagEventOpt;
+static volatile int BdmDiagEventPending;
+#endif
 
 static int bdmDriverIsUSB(const char *driverName)
 {
@@ -99,6 +108,26 @@ static int bdmDetermineDeviceType(const char *driverName)
 
     return BDM_TYPE_UNKNOWN;
 }
+
+#ifdef __DEBUG
+static const char *bdmDeviceTypeName(int type)
+{
+    switch (type) {
+        case BDM_TYPE_USB:
+            return "USB";
+        case BDM_TYPE_ILINK:
+            return "iLink";
+        case BDM_TYPE_SDC:
+            return "MX4SIO";
+        case BDM_TYPE_ATA:
+            return "ATA";
+        case BDM_TYPE_UDPBD:
+            return "UDPBD";
+        default:
+            return "unknown";
+    }
+}
+#endif
 
 // Parse the leading "<device><unit>:" token of a boot path into its digit-stripped stem ("ata0" ->
 // "ata", "mass1" -> "mass") and unit number (-1 when the token carries no digits, e.g. uLE's "mass:").
@@ -184,6 +213,172 @@ static int bdmReadDeviceIdentity(const char *path, char *driverName, int driverN
     fileXioDclose(dir);
     return result;
 }
+
+#ifdef __DEBUG
+typedef struct
+{
+    int openResult;
+    int identityResult;
+    char driver[32];
+    int deviceIndex;
+} bdm_diag_identity_t;
+
+static void bdmDiagProbeIdentity(const char *path, bdm_diag_identity_t *identity)
+{
+    int dir;
+
+    memset(identity, 0, sizeof(*identity));
+    identity->openResult = -1;
+    identity->identityResult = -1;
+    identity->deviceIndex = -1;
+
+    dir = fileXioDopen(path);
+    identity->openResult = dir;
+    if (dir < 0) {
+        identity->identityResult = dir;
+        return;
+    }
+
+    identity->identityResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, identity->driver, sizeof(identity->driver) - 1);
+    if (identity->identityResult >= 0)
+        identity->identityResult = fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &identity->deviceIndex, sizeof(identity->deviceIndex));
+
+    fileXioDclose(dir);
+}
+
+static const char *bdmTypedRootStem(int type)
+{
+    switch (type) {
+        case BDM_TYPE_USB:
+            return "usb";
+        case BDM_TYPE_ILINK:
+            return "ilink";
+        case BDM_TYPE_SDC:
+            return "mx4sio";
+        case BDM_TYPE_ATA:
+            return "ata";
+        default:
+            return NULL;
+    }
+}
+
+// Probe the SDK's typed filesystem aliases without making them runtime inputs. A typed unit is a
+// same-family ordinal, not the BDM driver's raw device number, so enumerate aliases and validate
+// the candidate by the driver-reported raw number instead of assuming the digits are interchangeable.
+static int bdmDiagResolveTypedIdentity(int type, int expectedDeviceIndex, char *root, int rootLength, bdm_diag_identity_t *identity, int *matchingAliases)
+{
+    const char *stem = bdmTypedRootStem(type);
+    int haveReadableAlias = 0;
+    int haveTypedCandidate = 0;
+
+    root[0] = '\0';
+    memset(identity, 0, sizeof(*identity));
+    identity->openResult = -1;
+    identity->identityResult = -1;
+    identity->deviceIndex = -1;
+    *matchingAliases = 0;
+
+    if (stem == NULL)
+        return 0;
+
+    for (int unit = 0; unit < MAX_BDM_DEVICES; unit++) {
+        char candidateRoot[16];
+        bdm_diag_identity_t candidate;
+
+        snprintf(candidateRoot, sizeof(candidateRoot), "%s%d:/", stem, unit);
+        bdmDiagProbeIdentity(candidateRoot, &candidate);
+        if (candidate.openResult < 0)
+            continue;
+
+        // Preserve the first readable alias even if its identity ioctl is unavailable. That still
+        // proves the installed SDK exported the typed filesystem, while revalidation remains false.
+        if (!haveReadableAlias) {
+            snprintf(root, rootLength, "%s", candidateRoot);
+            *identity = candidate;
+            haveReadableAlias = 1;
+        }
+
+        if (bdmDetermineDeviceType(candidate.driver) != type)
+            continue;
+
+        (*matchingAliases)++;
+        if (!haveTypedCandidate) {
+            snprintf(root, rootLength, "%s", candidateRoot);
+            *identity = candidate;
+            haveTypedCandidate = 1;
+        }
+        if (expectedDeviceIndex >= 0 && candidate.deviceIndex == expectedDeviceIndex) {
+            snprintf(root, rootLength, "%s", candidateRoot);
+            *identity = candidate;
+            return 1;
+        }
+
+        // With no cached raw number there is no way to prove ownership. Continue enumerating so the
+        // report can distinguish a single inferred same-family alias from an ambiguous multi-device
+        // result without pretending either one is revalidated.
+    }
+
+    return 0;
+}
+
+static int bdmDiagListIndex(const item_list_t *itemList)
+{
+    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+        if (itemList == &bdmDeviceList[i])
+            return i;
+    }
+
+    return -1;
+}
+
+static void bdmLogIdentityDiagnostic(const char *event, item_list_t *itemList, const config_set_t *configSet)
+{
+    int slot = bdmDiagListIndex(itemList);
+    if (slot < 0 || itemList->priv == NULL)
+        return;
+
+    bdm_device_data_t *device = (bdm_device_data_t *)itemList->priv;
+    char legacyRoot[16], typedRoot[16];
+    bdm_diag_identity_t legacyIdentity, typedIdentity;
+    int typedRevalidated;
+    int matchingTypedAliases;
+    int legacyDriverMatch;
+    int legacyDeviceMatch;
+    int legacyRevalidated;
+    int visible = itemList->owner != NULL ? ((opl_io_module_t *)itemList->owner)->menuItem.visible : 0;
+
+    snprintf(legacyRoot, sizeof(legacyRoot), "mass%d:/", slot);
+    bdmDiagProbeIdentity(legacyRoot, &legacyIdentity);
+    typedRevalidated = bdmDiagResolveTypedIdentity(device->bdmDeviceType, device->massDeviceIndex, typedRoot, sizeof(typedRoot), &typedIdentity, &matchingTypedAliases);
+
+    legacyDriverMatch = device->bdmDriver[0] != '\0' && legacyIdentity.driver[0] != '\0' && strcmp(device->bdmDriver, legacyIdentity.driver) == 0;
+    legacyDeviceMatch = device->massDeviceIndex >= 0 && legacyIdentity.deviceIndex >= 0 && device->massDeviceIndex == legacyIdentity.deviceIndex;
+    legacyRevalidated = legacyDriverMatch && legacyDeviceMatch;
+
+    LOG("[BDM DIAG] event=%s generation=%u itemList=%p mode=%d visible=%d config=%p uid=%u modified=%d format=%d filename=\"%s\"\n",
+        event, BdmGeneration, itemList, itemList->mode, visible, configSet, configSet != NULL ? configSet->uid : 0,
+        configSet != NULL ? configSet->modified : -1, configSet != NULL ? configSet->format : -1,
+        configSet != NULL && configSet->filename != NULL ? configSet->filename : "<none>");
+    LOG("[BDM DIAG] event=%s cached slot=%d root=\"%s\" prefix=\"%s\" driver=\"%s\" devnr=%d type=%s(%d) folders=%u games=%p/%d vcdGames=%p/%d\n",
+        event, slot, device->bdmDeviceRoot, device->bdmPrefix, device->bdmDriver, device->massDeviceIndex,
+        bdmDeviceTypeName(device->bdmDeviceType), device->bdmDeviceType, device->FoldersCreated,
+        device->bdmGames, device->bdmGameCount, device->bdmVcdGames, device->bdmVcdGameCount);
+    LOG("[BDM DIAG] event=%s legacy=\"%s\" readable=%d open=%d identity=%d driver=\"%s\" devnr=%d driverMatch=%d devnrMatch=%d revalidated=%d\n",
+        event, legacyRoot, legacyIdentity.openResult >= 0, legacyIdentity.openResult, legacyIdentity.identityResult,
+        legacyIdentity.driver, legacyIdentity.deviceIndex, legacyDriverMatch, legacyDeviceMatch, legacyRevalidated);
+    LOG("[BDM DIAG] event=%s typed=\"%s\" exported=%d open=%d identity=%d driver=\"%s\" devnr=%d candidates=%d ambiguous=%d revalidated=%d writeOwnershipRevalidated=%d\n",
+        event, typedRoot[0] != '\0' ? typedRoot : "<none>", typedIdentity.openResult >= 0,
+        typedIdentity.openResult, typedIdentity.identityResult, typedIdentity.driver, typedIdentity.deviceIndex,
+        matchingTypedAliases, matchingTypedAliases > 1, typedRevalidated, legacyRevalidated);
+}
+#else
+static void bdmLogIdentityDiagnostic(const char *event, item_list_t *itemList, const config_set_t *configSet)
+{
+    (void)event;
+    (void)itemList;
+    (void)configSet;
+}
+#endif
 
 // Find the first mounted BDM device whose driver matches bdmType (BDM_TYPE_*) and write its massN:
 // FILESYSTEM root WITH a trailing slash (e.g. "mass0:/") to root. Returns 1 if such a device is mounted,
@@ -273,6 +468,44 @@ static int bdmLoadOptionalModuleArgs(const char *name, void *module, int moduleS
     return result;
 }
 
+static void bdmDiagBootStageBegin(const char *stage)
+{
+    char status[64];
+
+    snprintf(status, sizeof(status), "BEGIN %s", stage);
+    LOG("[BDM DIAG] %s\n", status);
+    guiSetBootStatusStickyCopy(status);
+}
+
+static void bdmDiagBootStageEnd(const char *stage, int result)
+{
+    char status[64];
+
+    snprintf(status, sizeof(status), "END %s result=%d", stage, result);
+    LOG("[BDM DIAG] %s\n", status);
+    guiSetBootStatusStickyCopy(status);
+}
+
+static int bdmDiagLoadOptionalModule(const char *stage, const char *name, void *module, int moduleSize)
+{
+    int result;
+
+    bdmDiagBootStageBegin(stage);
+    result = bdmLoadOptionalModule(name, module, moduleSize);
+    bdmDiagBootStageEnd(stage, result);
+    return result;
+}
+
+static int bdmDiagLoadOptionalModuleArgs(const char *stage, const char *name, void *module, int moduleSize, int arglen, char *args)
+{
+    int result;
+
+    bdmDiagBootStageBegin(stage);
+    result = bdmLoadOptionalModuleArgs(name, module, moduleSize, arglen, args);
+    bdmDiagBootStageEnd(stage, result);
+    return result;
+}
+
 // Exposed for ethsupport's NIC mutual-exclusion: UDPBD and the SMB stack both own the SMAP adapter.
 int bdmIsUDPBDLoaded(void)
 {
@@ -311,7 +544,19 @@ int bdmModeIsUDPBD(int mode)
 
 static void bdmEventHandler(void *packet, void *opt)
 {
+#ifdef __DEBUG
+    BdmDiagEventPreviousGeneration = BdmGeneration;
+#else
+    (void)packet;
+    (void)opt;
+#endif
     BdmGeneration++;
+#ifdef __DEBUG
+    BdmDiagEventGeneration = BdmGeneration;
+    BdmDiagEventPacket = packet;
+    BdmDiagEventOpt = opt;
+    BdmDiagEventPending = 1;
+#endif
 }
 
 // Bump the device generation the per-device refresh latch keys off, exactly as a real hotplug event
@@ -322,7 +567,14 @@ static void bdmEventHandler(void *packet, void *opt)
 // without needing a physical replug.
 void bdmForceDeviceRefresh(void)
 {
+#ifdef __DEBUG
+    unsigned int previousGeneration = BdmGeneration;
+#endif
     BdmGeneration++;
+#ifdef __DEBUG
+    LOG("[BDM DIAG] event=generation-change source=forced-refresh generation=%u->%u itemList=%p mode=-1\n",
+        previousGeneration, BdmGeneration, NULL);
+#endif
 }
 
 // Read-only accessor so the menu hook can detect a real BDM device change (hotplug via bdmEventHandler
@@ -331,6 +583,31 @@ void bdmForceDeviceRefresh(void)
 unsigned int bdmGetGeneration(void)
 {
     return BdmGeneration;
+}
+
+void bdmLogConfigWriteEntry(item_list_t *itemList, const config_set_t *configSet)
+{
+    bdmLogIdentityDiagnostic("config-write-entry", itemList, configSet);
+}
+
+void bdmLogConfigWriteResult(item_list_t *itemList, const config_set_t *configSet, int result)
+{
+#ifdef __DEBUG
+    int slot = bdmDiagListIndex(itemList);
+    if (slot < 0 || itemList->priv == NULL)
+        return;
+
+    bdm_device_data_t *device = (bdm_device_data_t *)itemList->priv;
+    LOG("[BDM DIAG] event=config-write-result generation=%u itemList=%p mode=%d config=%p uid=%u filename=\"%s\" result=%d cachedRoot=\"%s\" cachedDriver=\"%s\" cachedDevnr=%d type=%s(%d)\n",
+        BdmGeneration, itemList, itemList->mode, configSet, configSet != NULL ? configSet->uid : 0,
+        configSet != NULL && configSet->filename != NULL ? configSet->filename : "<none>", result,
+        device->bdmDeviceRoot, device->bdmDriver, device->massDeviceIndex,
+        bdmDeviceTypeName(device->bdmDeviceType), device->bdmDeviceType);
+#else
+    (void)itemList;
+    (void)configSet;
+    (void)result;
+#endif
 }
 
 // Has this BDM slot EVER had a device on it? bdmUpdateDeviceData's connect pass is the only thing
@@ -369,10 +646,15 @@ int bdmModeIsSIO2(int mode)
 
 static int bdmLoadUsbMassBd(void)
 {
+    int result;
+
     if (iUSBModLoaded)
         return 0;
-    LOG("[USBMASS_BD]:\n");
-    if (bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx) >= 0) {
+
+    bdmDiagBootStageBegin("USBMASS_BD");
+    result = bdmLoadOptionalModule("USBMASS_BD", &usbmass_bd_irx, size_usbmass_bd_irx);
+    bdmDiagBootStageEnd("USBMASS_BD", result);
+    if (result >= 0) {
         iUSBModLoaded = 1;
         return 0;
     }
@@ -416,9 +698,9 @@ static void bdmLoadBlockDeviceModules(void)
 
     if (gEnableILK && !iLinkModLoaded) {
         // Load iLink Block Device drivers
-        if (!iLinkManModLoaded && bdmLoadOptionalModule("ILINKMAN", &iLinkman_irx, size_iLinkman_irx) >= 0)
+        if (!iLinkManModLoaded && bdmDiagLoadOptionalModule("iLinkman", "ILINKMAN", &iLinkman_irx, size_iLinkman_irx) >= 0)
             iLinkManModLoaded = 1;
-        if (iLinkManModLoaded && !ieee1394ModLoaded && bdmLoadOptionalModule("IEEE1394_BD", &IEEE1394_bd_irx, size_IEEE1394_bd_irx) >= 0)
+        if (iLinkManModLoaded && !ieee1394ModLoaded && bdmDiagLoadOptionalModule("IEEE1394_bd", "IEEE1394_BD", &IEEE1394_bd_irx, size_IEEE1394_bd_irx) >= 0)
             ieee1394ModLoaded = 1;
 
         iLinkModLoaded = iLinkManModLoaded && ieee1394ModLoaded;
@@ -426,7 +708,7 @@ static void bdmLoadBlockDeviceModules(void)
 
     if (gEnableMX4SIO && !mx4sioModLoaded) {
         // Load MX4SIO Block Device drivers
-        if (bdmLoadOptionalModule("MX4SIO_BD", &mx4sio_bd_irx, size_mx4sio_bd_irx) >= 0)
+        if (bdmDiagLoadOptionalModule("MX4SIO", "MX4SIO_BD", &mx4sio_bd_irx, size_mx4sio_bd_irx) >= 0)
             mx4sioModLoaded = 1;
     }
 
@@ -436,7 +718,10 @@ static void bdmLoadBlockDeviceModules(void)
         // Only mark loaded on success -- a failure (no HDD/interface) must not
         // suppress future retries via bdmShouldQueueModuleLoad() (matches the
         // conditional pattern used for USB/MX4SIO and opl.c's hddLoadModules gate).
-        if (hddLoadModulesReady())
+        bdmDiagBootStageBegin("DEV9/ATAD/XHDD");
+        int hddResult = hddLoadModulesReady();
+        bdmDiagBootStageEnd("DEV9/ATAD/XHDD", hddResult);
+        if (hddResult)
             hddModLoaded = 1;
     }
 
@@ -445,24 +730,33 @@ static void bdmLoadBlockDeviceModules(void)
     // with ATA-HDD). Both need the PS2's static IP as an "ip=" arg -- the ministack has no DHCP client.
     if (gEnableUDPBD && !udpbdModLoaded && !ethGetModulesLoaded() && !udpfsGetModulesLoaded()) {
         char ipArg[24];
+        int networkResult = -1;
+        const char *networkStage = gNetBootProtocol == NET_BOOT_UDPFS ? "UDPFS-BD chain" : "UDPBD";
+
+        bdmDiagBootStageBegin(networkStage);
         sysInitDev9();
         snprintf(ipArg, sizeof(ipArg), "ip=%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
         if (gNetBootProtocol == NET_BOOT_UDPFS) {
             // UDPFS: a 3-IRX chain loaded in dependency order -- smap (exports to ministack + bd), then
             // ministack (gets the ip= arg, exports to bd), then udpfs_bd (registers the "udp" BDM device).
-            if (bdmLoadOptionalModule("UDPFS_SMAP", &udpfs_smap_irx, size_udpfs_smap_irx) >= 0 &&
-                bdmLoadOptionalModuleArgs("UDPFS_MINISTACK", &udpfs_ministack_irx, size_udpfs_ministack_irx, (int)strlen(ipArg) + 1, ipArg) >= 0 &&
-                bdmLoadOptionalModule("UDPFS_BD", &udpfs_bd_irx, size_udpfs_bd_irx) >= 0) {
+            networkResult = bdmDiagLoadOptionalModule("UDPFS_SMAP", "UDPFS_SMAP", &udpfs_smap_irx, size_udpfs_smap_irx);
+            if (networkResult >= 0)
+                networkResult = bdmDiagLoadOptionalModuleArgs("UDPFS_MINISTACK", "UDPFS_MINISTACK", &udpfs_ministack_irx, size_udpfs_ministack_irx, (int)strlen(ipArg) + 1, ipArg);
+            if (networkResult >= 0)
+                networkResult = bdmDiagLoadOptionalModule("UDPFS_BD", "UDPFS_BD", &udpfs_bd_irx, size_udpfs_bd_irx);
+            if (networkResult >= 0) {
                 udpbdModLoaded = 1;
                 udpbdLoadedProtocol = NET_BOOT_UDPFS;
             }
         } else {
             // UDPBD: the self-contained smap_udpbd monolith (smap + ministack + udpbd in one irx).
-            if (bdmLoadOptionalModuleArgs("SMAP_UDPBD", &smap_udpbd_irx, size_smap_udpbd_irx, (int)strlen(ipArg) + 1, ipArg) >= 0) {
+            networkResult = bdmDiagLoadOptionalModuleArgs("SMAP_UDPBD", "SMAP_UDPBD", &smap_udpbd_irx, size_smap_udpbd_irx, (int)strlen(ipArg) + 1, ipArg);
+            if (networkResult >= 0) {
                 udpbdModLoaded = 1;
                 udpbdLoadedProtocol = NET_BOOT_UDPBD;
             }
         }
+        bdmDiagBootStageEnd(networkStage, networkResult);
         // Release the dev9 reference taken above if the load failed -- otherwise a failing/retrying
         // UDPBD/UDPFS (both gates re-enter on every device refresh while !udpbdModLoaded) inflates the
         // refcounted dev9InitCount and a later HDD/ETH teardown can never power dev9 down. On success
@@ -1574,9 +1868,13 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 static config_set_t *bdmGetConfig(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    config_set_t *config;
+
     // Active view's array (#120 split) -- a VCD's per-game CFG keys off its own entry, and a stale
     // toggle-window id resolves to the empty entry instead of the other view's array.
-    return sbPopulateConfig(bdmActiveGame(itemList, id), pDeviceData->bdmPrefix, "/");
+    config = sbPopulateConfig(bdmActiveGame(itemList, id), pDeviceData->bdmPrefix, "/");
+    bdmLogIdentityDiagnostic("config-create", itemList, config);
+    return config;
 }
 
 static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
@@ -1804,6 +2102,19 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     char path[BDM_DEVICE_ROOT_MAX + 2] = {0};
     int driverResult, deviceResult;
 
+#ifdef __DEBUG
+    if (BdmDiagEventPending) {
+        unsigned int previousGeneration = BdmDiagEventPreviousGeneration;
+        unsigned int generation = BdmDiagEventGeneration;
+        void *packet = BdmDiagEventPacket;
+        void *opt = BdmDiagEventOpt;
+
+        BdmDiagEventPending = 0;
+        LOG("[BDM DIAG] event=generation-change source=bdm-event generation=%u->%u itemList=%p mode=%d packet=%p opt=%p\n",
+            previousGeneration, generation, itemList, itemList->mode, packet, opt);
+    }
+#endif
+
     // If bdm mode is disabled bail out as we don't want to update the visibility state of the device pages.
     if (bdmEffectiveStartMode() == START_MODE_DISABLED)
         return 0;
@@ -1847,6 +2158,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         }
         pDeviceData->bdmMissCount = 0;
         LOG("bdmUpdateDeviceData: device %d reappeared intact -- restoring page, no rescan\n", itemList->mode);
+        bdmLogIdentityDiagnostic("update-fast-reappearance", itemList, NULL);
         fileXioDclose(dir);
         return 0; // "nothing changed": no connect sound, no folder pass, no sbReadList
     }
@@ -1866,12 +2178,16 @@ int bdmUpdateDeviceData(item_list_t *itemList)
 
         if (driverResult < 0 || driverName[0] == '\0') {
             LOG("Mass device: %d mounted but driver identity is not ready (%d); deferring page publication\n", itemList->mode, driverResult);
+            LOG("[BDM DIAG] event=update-identity-not-ready generation=%u itemList=%p mode=%d legacy=\"%s\" open=%d driverResult=%d deviceResult=%d driver=\"%s\"\n",
+                BdmGeneration, itemList, itemList->mode, path, dir, driverResult, deviceResult, driverName);
             fileXioDclose(dir);
             return 0;
         }
 
         snprintf(pDeviceData->bdmDeviceRoot, sizeof(pDeviceData->bdmDeviceRoot), "mass%d:", itemList->mode);
         bdmBuildGamePrefix(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), pDeviceData->bdmDeviceRoot);
+        LOG("[BDM DIAG] event=folder-reset reason=connect generation=%u itemList=%p mode=%d old=%u new=0\n",
+            BdmGeneration, itemList, itemList->mode, pDeviceData->FoldersCreated);
         pDeviceData->FoldersCreated = 0;
         snprintf(pDeviceData->bdmDriver, sizeof(pDeviceData->bdmDriver), "%s", driverName);
         pDeviceData->massDeviceIndex = massDeviceIndex;
@@ -1897,6 +2213,8 @@ int bdmUpdateDeviceData(item_list_t *itemList)
             LOG("Mass device: %d (%d) %s -> %s (compat root %s)\n", itemList->mode, pDeviceData->massDeviceIndex, pDeviceData->bdmPrefix, pDeviceData->bdmDriver, pDeviceData->bdmDeviceRoot);
         else
             LOG("Mass device: %d using generic BDM path %s\n", itemList->mode, pDeviceData->bdmPrefix);
+
+        bdmLogIdentityDiagnostic("update-connect-identity", itemList, NULL);
 
         // Publish-time enable gate (#120 audit F-13): the visible-page filter in bdmNeedsUpdate only
         // hides a page that is ALREADY showing, i.e. one refresh pass too late. Without this gate a
@@ -1962,6 +2280,9 @@ int bdmUpdateDeviceData(item_list_t *itemList)
             moduleUpdateMenu(itemList->mode, 0, 0);
         }
 
+        bdmLogIdentityDiagnostic("update-confirmed-disconnect", itemList, NULL);
+        LOG("[BDM DIAG] event=folder-reset reason=confirmed-disconnect generation=%u itemList=%p mode=%d old=%u new=0\n",
+            BdmGeneration, itemList, itemList->mode, pDeviceData->FoldersCreated);
         pDeviceData->FoldersCreated = 0;
         pDeviceData->bdmMissCount = 0;
         LOG("Mass device: %d (%d) disconnected\n", itemList->mode, pDeviceData->massDeviceIndex);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1008,13 +1008,24 @@ static void bdmLoadCoreModules(void)
     LOG("[BDMFS_FATFS]:\n");
     sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
 
-    // USB block device is base BDM infrastructure (upstream ps2homebrew and
-    // Grimdoomer load it synchronously, not as an optional transport).
-    bdmLoadUsbMassBd();
-
+    // ARM THE ATTACH HANDLER BEFORE ANY BLOCK DEVICE DRIVER CAN ENUMERATE. bdmevent registers a
+    // bdm_RegisterCallback the moment it loads, and bdm only calls back for mounts that happen AFTER
+    // that -- a device already mounted when the handler arrives generates no event, ever.
+    //
+    // Every other transport (iLink, MX4SIO, ATA, UDPBD) loads later, from bdmLoadBlockDeviceModules
+    // on the io worker, so this ordering only ever mattered for USB -- and USB is precisely the one
+    // that got moved up here. Loading USBMASS_BD first left a window where a stick that enumerated
+    // quickly mounted before the handler existed: no attach event, so its page was left to the
+    // empty-slot probe rotation (opl.c, gated on longIdle AND a frame ratio) or to the user
+    // replugging it -- which is the "second USB device only shows up after a hotplug" report.
+    // The hotplug works because it is the first event the handler is actually alive for.
     LOG("[BDMEVENT]:\n");
     sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
     SifAddCmdHandler(BDMEVENT_EE_EVENT_CMD, &bdmEventHandler, NULL);
+
+    // USB block device is base BDM infrastructure (upstream ps2homebrew and Grimdoomer load it
+    // synchronously, not as an optional transport) -- but it goes AFTER the handler, not before.
+    bdmLoadUsbMassBd();
 
 #ifdef __DEBUG
     bdmDiagRequestIopSnapshot("handler-ready", -1, -1);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1041,6 +1041,33 @@ static void bdmLoadBlockDeviceModules(void)
             mx4sioSecondProbeDone = 1; // found immediately -> done
         }
     }
+
+    // USB initial discovery -- the SAME double tap, for the same reason, and USB needs it MORE than
+    // MX4SIO does since fa1a18d4.
+    //
+    // USBMASS_BD is now loaded in bdmLoadCoreModules(), i.e. BEFORE this function runs. So
+    // iUSBModLoaded is already set on entry, USB is counted in both modsWere and modsNow, and the
+    // "a driver that arrived late needs one more look" refresh above can NEVER fire for it. USB
+    // silently lost the mechanism every other transport still has.
+    //
+    // A stick has real enumeration latency of its own -- bus reset, SET_ADDRESS, descriptors, SCSI
+    // INQUIRY/READ CAPACITY, then the FAT mount. The failure this produces is counter-intuitive and
+    // matches the hardware report exactly: a SLOW stick finishes late, its mount event lands while
+    // the device list and menu loop are up, and it publishes normally. A FAST stick finishes during
+    // early init -- its event is spent before anything can act on it -- and then nothing ever asks
+    // again, so it stays invisible until the user physically replugs it to manufacture a new event.
+    //
+    // One bounded settle and exactly one refresh, one-shot, so an absent or already-found stick
+    // never costs a later call anything.
+    static int usbSecondProbeDone = 0;
+    if (iUSBModLoaded && !usbSecondProbeDone) {
+        char usbRoot[16];
+        usbSecondProbeDone = 1;
+        if (!bdmGetDeviceRootByType(BDM_TYPE_USB, usbRoot, sizeof(usbRoot))) {
+            DelayThread(600 * 1000); // bounded settle for USB enumeration + FAT mount
+            bdmForceDeviceRefresh(); // exactly one second probe
+        }
+    }
 }
 
 // Bring up only the common BDM infrastructure. Literal massN: boot resolution uses this path so an

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -519,28 +519,25 @@ static int bdmLoadOptionalModuleArgs(const char *name, void *module, int moduleS
     return result;
 }
 
-/* WHAT IS ACTUALLY ON THE MASS SLOTS, on screen, in a build a tester can run.
+/* OPEN EVERY massN: ROOT ONCE, AND SAY WHAT WAS THERE.
  *
- * The "a second USB stick only appears after a hotplug" report has now survived five source-based
- * fixes, each of which corrected a real defect that turned out not to be the cause. The reason the
- * hunt keeps missing is that three completely different failures look identical from the outside,
- * and nothing distinguishes them without a TTY:
+ * The probe is FUNCTIONAL and always compiled; only the on-screen report is diagnostic-only.
  *
- *   massN never answers Dopen        -> the IOP never mounted it; nothing OPL does can help, and the
- *                                       suspect is the usbd -> usbmass_bd registration window
- *                                       (we load usbd in sysReset and usbmass_bd much later; a fast
- *                                       stick can finish enumerating inside that gap, whereas
- *                                       Grimdoomer's fork loads the two back to back)
- *   Dopen ok, identity refuses       -> our publish path defers it, and the retry cadence is at fault
- *   identity ok but no page          -> published then hidden again, i.e. the miss/debounce logic
+ * Why the probe matters: fs_dopen() calls f_opendir(), and FatFs mounts a volume LAZILY, on first
+ * access. Nothing else in the boot path opens a slot we do not already believe holds a device, so a
+ * volume can sit unmounted purely because nobody asked -- and our publication path then finds
+ * nothing and concludes the slot is empty. Touching each root once breaks that chicken-and-egg.
+ * This is why the second USB stick appeared in diagnostic builds (which did this sweep) and not in
+ * release builds (which did not): the measurement WAS the fix.
  *
- * One line naming which of those it is ends the guessing. LOG() needs a TTY nobody testing has, so
- * this goes to the boot status line, which OPLDIAG already puts on screen. Compact by necessity --
- * that line is short -- so each slot is one token: '-' absent, '?' open but no identity, or the
- * driver's own first letter (u/a/s/i) followed by its device number.
+ * Note fs_driver_resolve_volume() maps "mass" straight from the unit number without checking that
+ * anything is mounted there, so Dopen on an empty slot is a cheap, safe no-op.
+ *
+ * The report half stays OPLDIAG-only -- it is raw developer text on a line every other caller feeds
+ * through _l(). Compact by necessity: one token per slot, '-' absent, '?' open but no identity, or
+ * the driver's first letter (u/a/s/i) followed by its device number.
  */
-#ifdef __OPLDIAG
-static void bdmDiagReportMassSlots(const char *when)
+static void bdmProbeMassSlots(const char *when)
 {
     char summary[96];
     int len;
@@ -561,7 +558,7 @@ static void bdmDiagReportMassSlots(const char *when)
         } else {
             int devnr = -1;
             // Guarded reader: a buffered ask on an unmounted volume faults the IOP outright.
-            if (bdmReadDriverName(dir, driver, sizeof(driver)) >= 0 && driver[0] != '\0') {
+            if (bdmReadDriverName(dir, driver, sizeof(driver)) >= 0 && driver[0] != ' ') {
                 fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &devnr, sizeof(devnr));
                 n = snprintf(summary + len, sizeof(summary) - len, " %d%c%d", i, driver[0], devnr);
             } else {
@@ -576,14 +573,10 @@ static void bdmDiagReportMassSlots(const char *when)
     }
 
     LOG("[BDM DIAG] %s\n", summary);
+#ifdef __OPLDIAG
     guiSetBootStatusStickyCopy(summary);
-}
-#else
-static void bdmDiagReportMassSlots(const char *when)
-{
-    (void)when;
-}
 #endif
+}
 
 // BOOT-STAGE LABELS ARE DIAGNOSTIC-BUILD ONLY (OPLDIAG=1). They publish raw, untranslated developer
 // text -- "BEGIN USBMASS_BD", "END DEV9/ATAD/XHDD result=1" -- straight to the boot status line that
@@ -1134,7 +1127,7 @@ static void bdmLoadBlockDeviceModules(void)
     if (iUSBModLoaded && !usbSecondProbeDone) {
         usbSecondProbeDone = 1;
         DelayThread(600 * 1000); // bounded settle for USB enumeration + FAT mount
-        bdmDiagReportMassSlots("after-usb-settle");
+        bdmProbeMassSlots("after-usb-settle");
         bdmForceDeviceRefresh(); // exactly one second probe, covering every slot
     }
 }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -341,13 +341,9 @@ static int bdmDiagListIndex(const item_list_t *itemList)
     return -1;
 }
 
-static void bdmLogIdentityDiagnostic(const char *event, item_list_t *itemList, const config_set_t *configSet)
+static void bdmLogIdentityDiagnostic(const char *event, const bdm_config_diag_snapshot_t *snap)
 {
-    int slot = bdmDiagListIndex(itemList);
-    if (slot < 0 || itemList->priv == NULL)
-        return;
-
-    bdm_device_data_t *device = (bdm_device_data_t *)itemList->priv;
+    int slot;
     char legacyRoot[16], typedRoot[16];
     bdm_diag_identity_t legacyIdentity, typedIdentity;
     int typedRevalidated;
@@ -355,24 +351,30 @@ static void bdmLogIdentityDiagnostic(const char *event, item_list_t *itemList, c
     int legacyDriverMatch;
     int legacyDeviceMatch;
     int legacyRevalidated;
-    int visible = itemList->owner != NULL ? ((opl_io_module_t *)itemList->owner)->menuItem.visible : 0;
 
+    if (snap == NULL || !snap->valid)
+        return;
+
+    slot = snap->slot;
+
+    // Everything below reads the CAPTURED COPY. The probes that follow are blocking device I/O, so
+    // this must never reach back into the live item_list_t / config_set_t -- by the time we get here
+    // the menu lock is released and either of them may already be gone.
     snprintf(legacyRoot, sizeof(legacyRoot), "mass%d:/", slot);
     bdmDiagProbeIdentity(legacyRoot, &legacyIdentity);
-    typedRevalidated = bdmDiagResolveTypedIdentity(device->bdmDeviceType, device->massDeviceIndex, typedRoot, sizeof(typedRoot), &typedIdentity, &matchingTypedAliases);
+    typedRevalidated = bdmDiagResolveTypedIdentity(snap->bdmDeviceType, snap->massDeviceIndex, typedRoot, sizeof(typedRoot), &typedIdentity, &matchingTypedAliases);
 
-    legacyDriverMatch = device->bdmDriver[0] != '\0' && legacyIdentity.driver[0] != '\0' && strcmp(device->bdmDriver, legacyIdentity.driver) == 0;
-    legacyDeviceMatch = device->massDeviceIndex >= 0 && legacyIdentity.deviceIndex >= 0 && device->massDeviceIndex == legacyIdentity.deviceIndex;
+    legacyDriverMatch = snap->driver[0] != '\0' && legacyIdentity.driver[0] != '\0' && strcmp(snap->driver, legacyIdentity.driver) == 0;
+    legacyDeviceMatch = snap->massDeviceIndex >= 0 && legacyIdentity.deviceIndex >= 0 && snap->massDeviceIndex == legacyIdentity.deviceIndex;
     legacyRevalidated = legacyDriverMatch && legacyDeviceMatch;
 
     LOG("[BDM DIAG] event=%s generation=%u itemList=%p mode=%d visible=%d config=%p uid=%u modified=%d format=%d filename=\"%s\"\n",
-        event, BdmGeneration, itemList, itemList->mode, visible, configSet, configSet != NULL ? configSet->uid : 0,
-        configSet != NULL ? configSet->modified : -1, configSet != NULL ? configSet->format : -1,
-        configSet != NULL && configSet->filename != NULL ? configSet->filename : "<none>");
+        event, snap->generation, snap->itemListAddr, snap->mode, snap->visible, snap->configAddr, snap->configUid,
+        snap->configModified, snap->configFormat, snap->configFilename);
     LOG("[BDM DIAG] event=%s cached slot=%d root=\"%s\" prefix=\"%s\" driver=\"%s\" devnr=%d type=%s(%d) folders=%u games=%p/%d vcdGames=%p/%d\n",
-        event, slot, device->bdmDeviceRoot, device->bdmPrefix, device->bdmDriver, device->massDeviceIndex,
-        bdmDeviceTypeName(device->bdmDeviceType), device->bdmDeviceType, device->FoldersCreated,
-        device->bdmGames, device->bdmGameCount, device->bdmVcdGames, device->bdmVcdGameCount);
+        event, slot, snap->deviceRoot, snap->devicePrefix, snap->driver, snap->massDeviceIndex,
+        bdmDeviceTypeName(snap->bdmDeviceType), snap->bdmDeviceType, snap->foldersCreated,
+        snap->games, snap->gameCount, snap->vcdGames, snap->vcdGameCount);
     LOG("[BDM DIAG] event=%s legacy=\"%s\" readable=%d open=%d identity=%d driver=\"%s\" devnr=%d driverMatch=%d devnrMatch=%d revalidated=%d\n",
         event, legacyRoot, legacyIdentity.openResult >= 0, legacyIdentity.openResult, legacyIdentity.identityResult,
         legacyIdentity.driver, legacyIdentity.deviceIndex, legacyDriverMatch, legacyDeviceMatch, legacyRevalidated);
@@ -382,11 +384,10 @@ static void bdmLogIdentityDiagnostic(const char *event, item_list_t *itemList, c
         matchingTypedAliases, matchingTypedAliases > 1, typedRevalidated, legacyRevalidated);
 }
 #else
-static void bdmLogIdentityDiagnostic(const char *event, item_list_t *itemList, const config_set_t *configSet)
+static void bdmLogIdentityDiagnostic(const char *event, const bdm_config_diag_snapshot_t *snap)
 {
     (void)event;
-    (void)itemList;
-    (void)configSet;
+    (void)snap;
 }
 #endif
 
@@ -674,27 +675,103 @@ unsigned int bdmGetGeneration(void)
     return BdmGeneration;
 }
 
-void bdmLogConfigWriteEntry(item_list_t *itemList, const config_set_t *configSet)
-{
-    bdmLogIdentityDiagnostic("config-write-entry", itemList, configSet);
-}
-
-void bdmLogConfigWriteResult(item_list_t *itemList, const config_set_t *configSet, int result)
+// Runs UNDER the caller's menu lock: pure value copies, no I/O, no allocation. Everything the
+// reporting calls below need must be taken here, because once the lock is released the item_list_t
+// and config_set_t may be freed. Cheap enough to run unconditionally; the reporting is what costs.
+void bdmCaptureConfigWriteDiag(item_list_t *itemList, const config_set_t *configSet, bdm_config_diag_snapshot_t *out)
 {
 #ifdef __DEBUG
-    int slot = bdmDiagListIndex(itemList);
-    if (slot < 0 || itemList->priv == NULL)
+    bdm_device_data_t *device;
+    int slot;
+
+    if (out == NULL)
         return;
 
-    bdm_device_data_t *device = (bdm_device_data_t *)itemList->priv;
-    LOG("[BDM DIAG] event=config-write-result generation=%u itemList=%p mode=%d config=%p uid=%u filename=\"%s\" result=%d cachedRoot=\"%s\" cachedDriver=\"%s\" cachedDevnr=%d type=%s(%d)\n",
-        BdmGeneration, itemList, itemList->mode, configSet, configSet != NULL ? configSet->uid : 0,
-        configSet != NULL && configSet->filename != NULL ? configSet->filename : "<none>", result,
-        device->bdmDeviceRoot, device->bdmDriver, device->massDeviceIndex,
-        bdmDeviceTypeName(device->bdmDeviceType), device->bdmDeviceType);
+    memset(out, 0, sizeof(*out));
+    out->massDeviceIndex = -1;
+    out->slot = -1;
+
+    if (itemList == NULL)
+        return;
+
+    slot = bdmDiagListIndex(itemList);
+    if (slot < 0 || itemList->priv == NULL)
+        return; // not a BDM list: valid stays 0 and the reporting calls do nothing
+
+    device = (bdm_device_data_t *)itemList->priv;
+
+    out->valid = 1;
+    out->slot = slot;
+    out->mode = itemList->mode;
+    out->visible = itemList->owner != NULL ? ((opl_io_module_t *)itemList->owner)->menuItem.visible : 0;
+    out->generation = BdmGeneration;
+    out->itemListAddr = itemList;
+    out->configAddr = configSet;
+
+    if (configSet != NULL) {
+        out->configUid = configSet->uid;
+        out->configModified = configSet->modified;
+        out->configFormat = configSet->format;
+        snprintf(out->configFilename, sizeof(out->configFilename), "%s",
+                 configSet->filename != NULL ? configSet->filename : "<none>");
+    } else {
+        out->configModified = -1;
+        out->configFormat = -1;
+        snprintf(out->configFilename, sizeof(out->configFilename), "%s", "<none>");
+    }
+
+    snprintf(out->deviceRoot, sizeof(out->deviceRoot), "%s", device->bdmDeviceRoot);
+    snprintf(out->devicePrefix, sizeof(out->devicePrefix), "%s", device->bdmPrefix);
+    snprintf(out->driver, sizeof(out->driver), "%s", device->bdmDriver);
+    out->massDeviceIndex = device->massDeviceIndex;
+    out->bdmDeviceType = device->bdmDeviceType;
+    out->foldersCreated = device->FoldersCreated;
+    out->games = device->bdmGames;
+    out->gameCount = device->bdmGameCount;
+    out->vcdGames = device->bdmVcdGames;
+    out->vcdGameCount = device->bdmVcdGameCount;
 #else
     (void)itemList;
     (void)configSet;
+    if (out != NULL)
+        out->valid = 0;
+#endif
+}
+
+// Capture-and-report in one step, for the in-module callers that run on the IO worker holding NO
+// menu lock and owning the pointers they pass. Only the settings-save path needs the two-phase form,
+// because only it must release a lock between the capture and the device probes.
+static void bdmLogIdentityDiagnosticLive(const char *event, item_list_t *itemList, const config_set_t *configSet)
+{
+#ifdef __DEBUG
+    bdm_config_diag_snapshot_t snap;
+
+    bdmCaptureConfigWriteDiag(itemList, configSet, &snap);
+    bdmLogIdentityDiagnostic(event, &snap);
+#else
+    (void)event;
+    (void)itemList;
+    (void)configSet;
+#endif
+}
+
+void bdmLogConfigWriteEntry(const bdm_config_diag_snapshot_t *snap)
+{
+    bdmLogIdentityDiagnostic("config-write-entry", snap);
+}
+
+void bdmLogConfigWriteResult(const bdm_config_diag_snapshot_t *snap, int result)
+{
+#ifdef __DEBUG
+    if (snap == NULL || !snap->valid)
+        return;
+
+    LOG("[BDM DIAG] event=config-write-result generation=%u itemList=%p mode=%d config=%p uid=%u filename=\"%s\" result=%d cachedRoot=\"%s\" cachedDriver=\"%s\" cachedDevnr=%d type=%s(%d)\n",
+        snap->generation, snap->itemListAddr, snap->mode, snap->configAddr, snap->configUid,
+        snap->configFilename, result, snap->deviceRoot, snap->driver, snap->massDeviceIndex,
+        bdmDeviceTypeName(snap->bdmDeviceType), snap->bdmDeviceType);
+#else
+    (void)snap;
     (void)result;
 #endif
 }
@@ -1970,7 +2047,7 @@ static config_set_t *bdmGetConfig(item_list_t *itemList, int id)
     // Active view's array (#120 split) -- a VCD's per-game CFG keys off its own entry, and a stale
     // toggle-window id resolves to the empty entry instead of the other view's array.
     config = sbPopulateConfig(bdmActiveGame(itemList, id), pDeviceData->bdmPrefix, "/");
-    bdmLogIdentityDiagnostic("config-create", itemList, config);
+    bdmLogIdentityDiagnosticLive("config-create", itemList, config);
     return config;
 }
 
@@ -2274,7 +2351,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         }
         pDeviceData->bdmMissCount = 0;
         LOG("bdmUpdateDeviceData: device %d reappeared intact -- restoring page, no rescan\n", itemList->mode);
-        bdmLogIdentityDiagnostic("update-fast-reappearance", itemList, NULL);
+        bdmLogIdentityDiagnosticLive("update-fast-reappearance", itemList, NULL);
         fileXioDclose(dir);
         return 0; // "nothing changed": no connect sound, no folder pass, no sbReadList
     }
@@ -2330,7 +2407,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
         else
             LOG("Mass device: %d using generic BDM path %s\n", itemList->mode, pDeviceData->bdmPrefix);
 
-        bdmLogIdentityDiagnostic("update-connect-identity", itemList, NULL);
+        bdmLogIdentityDiagnosticLive("update-connect-identity", itemList, NULL);
 
         // Publish-time enable gate (#120 audit F-13): the visible-page filter in bdmNeedsUpdate only
         // hides a page that is ALREADY showing, i.e. one refresh pass too late. Without this gate a
@@ -2396,7 +2473,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
             moduleUpdateMenu(itemList->mode, 0, 0);
         }
 
-        bdmLogIdentityDiagnostic("update-confirmed-disconnect", itemList, NULL);
+        bdmLogIdentityDiagnosticLive("update-confirmed-disconnect", itemList, NULL);
         LOG("[BDM DIAG] event=folder-reset reason=confirmed-disconnect generation=%u itemList=%p mode=%d old=%u new=0\n",
             BdmGeneration, itemList, itemList->mode, pDeviceData->FoldersCreated);
         pDeviceData->FoldersCreated = 0;

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -312,10 +312,6 @@ struct UIItem diaDeviceConfig[] = {
     {UI_ENUM, CFG_HDDMODE, 1, 1, _STR_HDD_HINT, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD (APA) OPL Partition", -1}}},
-    {UI_SPACER},
-    {UI_BREAK},
-
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"MMCE Start Mode", -1}}},
     {UI_SPACER},
     {UI_ENUM, CFG_MMCEMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -314,7 +314,6 @@ struct UIItem diaDeviceConfig[] = {
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD (APA) OPL Partition", -1}}},
     {UI_SPACER},
-    {UI_ENUM, CFG_HDDOPLPART, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"MMCE Start Mode", -1}}},

--- a/src/gui.c
+++ b/src/gui.c
@@ -111,6 +111,11 @@ static int gBootStatusActive = 0;
 // state is a single aligned POINTER (atomic load/store on the EE) to a static _l() string --
 // no shared buffer, so no data race. Cleared by guiSetBootStatus(NULL).
 static const char *volatile gBootStickyLabel = NULL;
+// Dynamic diagnostic labels cannot use guiSetBootStatusSticky(), which deliberately stores the
+// caller's pointer. Keep two owned buffers and always format into the one that is not published.
+// The EE is single-core: if the renderer is pre-empted after loading one pointer, the IO thread
+// only writes the other buffer, then atomically publishes that pointer.
+static char gBootStickyCopy[2][64];
 
 // forward decl.
 static void guiShow();
@@ -3559,6 +3564,18 @@ void guiSetBootStatusSticky(const char *label)
     if (label == NULL)
         return;
     gBootStickyLabel = label;
+}
+
+void guiSetBootStatusStickyCopy(const char *label)
+{
+    int target;
+
+    if (label == NULL)
+        return;
+
+    target = (gBootStickyLabel == gBootStickyCopy[0]) ? 1 : 0;
+    snprintf(gBootStickyCopy[target], sizeof(gBootStickyCopy[target]), "%s", label);
+    gBootStickyLabel = gBootStickyCopy[target];
 }
 
 static void guiRenderGreeting(int alpha)

--- a/src/gui.c
+++ b/src/gui.c
@@ -130,11 +130,23 @@ enum {
     GUI_OPL_HOME_STAGE_UNAVAILABLE = -1,
 };
 
+// Set at each GUI-side staging exit. hddOplHomeStageReason() covers the hdd-side ones.
+static const char *guiOplHomeStageReason = "none";
+
 static const char *guiOplHomeStageError(int selection, int result)
 {
-    if (result == GUI_OPL_HOME_STAGE_UNAVAILABLE)
-        return _l(_STR_HDD_OPL_PARTITION_BUSY);
-    return selection == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND);
+    const char *base = (result == GUI_OPL_HOME_STAGE_UNAVAILABLE) ? _l(_STR_HDD_OPL_PARTITION_BUSY) : (selection == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND));
+
+#ifdef __OPLDIAG
+    // Name the condition that actually fired. Five different failures share these two strings, so a
+    // report of "it says busy" has never been enough to tell them apart -- which is why this row has
+    // now survived several rounds of fixes aimed at the wrong one. Diagnostic builds only.
+    static char detailed[192];
+    snprintf(detailed, sizeof(detailed), "%s\n[%s / %s]", base, guiOplHomeStageReason, hddOplHomeStageReason());
+    return detailed;
+#else
+    return base;
+#endif
 }
 
 #ifdef __DEBUG
@@ -2729,9 +2741,12 @@ static int guiSettingsStageOplHome(int selection)
 {
     // Do not overwrite the static request payload after a timed-out worker. The I/O queue is
     // single-threaded, so another request cannot begin until that worker actually returns.
-    if (guiSourcesOplHomeStageInFlight)
+    if (guiSourcesOplHomeStageInFlight) {
+        guiOplHomeStageReason = "still-in-flight-from-previous";
         return GUI_OPL_HOME_STAGE_UNAVAILABLE;
+    }
 
+    guiOplHomeStageReason = "worker-completed";
     guiSourcesOplHomeStageChoice = selection;
     guiSourcesOplHomeStageResult = 0;
     guiSourcesOplHomeStagePending = 1;
@@ -2744,6 +2759,7 @@ static int guiSettingsStageOplHome(int selection)
         // a later Save Settings persist a choice the user did not get to confirm. InFlight stays
         // SET here on purpose: the worker may still be running and must be allowed to return.
         guiSourcesOplHomeStageAbandoned = 1;
+        guiOplHomeStageReason = "worker-timed-out-15s";
         hddDiscardOplHomeSelection();
         return GUI_OPL_HOME_STAGE_UNAVAILABLE;
     }
@@ -2761,6 +2777,7 @@ static int guiSettingsStageOplHome(int selection)
     if (guiSourcesOplHomeStageInFlight) {
         guiSourcesOplHomeStageInFlight = 0;
         guiSourcesOplHomeStagePending = 0;
+        guiOplHomeStageReason = "worker-never-ran-queue-rejected";
         return GUI_OPL_HOME_STAGE_UNAVAILABLE; // retryable now, and honest about why
     }
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -3396,8 +3396,11 @@ int guiDeferUpdate(struct gui_update_t *op)
 
     struct gui_update_list_t *up = (struct gui_update_list_t *)malloc(sizeof(struct gui_update_list_t));
     if (!up) {
-        /* OOM: release the semaphore so future callers are not permanently locked out */
+        /* OOM: release the semaphore so future callers are not permanently locked out. The op is
+           ours to release too -- ownership transfers on enqueue, so a caller that got -1 back has
+           no pointer left to free and would otherwise leak the very object we could not queue. */
         SignalSema(gSemaId);
+        free(op);
         return -1;
     }
     up->item = op;
@@ -3510,6 +3513,18 @@ static void guiHandleDeferredOps(void)
         struct gui_update_list_t *td = gUpdateList;
         gUpdateList = gUpdateList->next;
 
+        // FREE THE OPERATION, NOT JUST ITS QUEUE NODE. Every deferred op is TWO allocations --
+        // guiOpCreate() mallocs the gui_update_t, guiDeferUpdate() mallocs the list node that
+        // carries it -- and this loop only ever released the node. The op leaked, always, and no
+        // commit in this repository's history has ever freed one.
+        //
+        // The rate is what makes it fatal rather than untidy: updateMenuFromGameList() calls
+        // guiOpCreate(GUI_OP_APPEND_MENU) once PER GAME ROW, so a single list rebuild leaks one
+        // object per row and every page change rebuilds. Enough navigation and the heap is gone.
+        //
+        // guiHandleOp() reads the op but never retains the pointer, and submenu.text points into
+        // the support's own storage rather than the op, so releasing it here is safe.
+        free(td->item);
         free(td);
 
         gCompletedOps++;
@@ -4275,6 +4290,13 @@ void guiSwitchScreen(int target)
 struct gui_update_t *guiOpCreate(gui_op_type_t type)
 {
     struct gui_update_t *op = (struct gui_update_t *)malloc(sizeof(struct gui_update_t));
+
+    // The memset used to run unconditionally, so an allocation failure faulted HERE rather than
+    // returning NULL -- which made every "if (!op)" guard at the call sites unreachable code. The
+    // callers were written expecting to handle OOM; let them.
+    if (op == NULL)
+        return NULL;
+
     memset(op, 0, sizeof(struct gui_update_t));
     op->type = type;
     return op;

--- a/src/gui.c
+++ b/src/gui.c
@@ -2741,11 +2741,29 @@ static int guiSettingsStageOplHome(int selection)
                        IO_CUSTOM_SIMPLEACTION, &guiSettingsStageOplHomeWorker, 15000);
     if (gLastDeferredTimedOut) {
         // The late worker only ever changes our staged selector; never let an abandoned wait make
-        // a later Save Settings persist a choice the user did not get to confirm.
+        // a later Save Settings persist a choice the user did not get to confirm. InFlight stays
+        // SET here on purpose: the worker may still be running and must be allowed to return.
         guiSourcesOplHomeStageAbandoned = 1;
         hddDiscardOplHomeSelection();
         return GUI_OPL_HOME_STAGE_UNAVAILABLE;
     }
+
+    // NO TIMEOUT, YET STILL IN FLIGHT -> THE WORKER NEVER RAN AT ALL. guiHandleDeferedIO() clears
+    // the pending flag and returns immediately when ioPutRequest() is rejected (a full or blocked
+    // IO queue), so we never waited and nothing will ever clear this latch. Unlike the timeout
+    // above there is no worker still out there to do it.
+    //
+    // Left set, it disabled the row for the rest of the session: the first attempt returned the
+    // untouched result 0, rendered as "<name> partition not found." on a console that has the
+    // partition, and every attempt after it hit the InFlight guard at the top and returned
+    // UNAVAILABLE -- "HDD is busy, try again once loading finishes" -- instantly, with no spinner
+    // and nothing actually loading. One transiently full IO queue, and the setting was unusable.
+    if (guiSourcesOplHomeStageInFlight) {
+        guiSourcesOplHomeStageInFlight = 0;
+        guiSourcesOplHomeStagePending = 0;
+        return GUI_OPL_HOME_STAGE_UNAVAILABLE; // retryable now, and honest about why
+    }
+
     return guiSourcesOplHomeStageResult;
 }
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -120,34 +120,9 @@ static char gBootStickyCopy[2][64];
 // forward decl.
 static void guiShow();
 static void guiDrawOverlays(void);
-static int guiSettingsStageOplHome(int selection);
 static const char **guiCopyNameList(const char **src);
 static void guiFreeNameList(const char **list);
 
-enum {
-    GUI_OPL_HOME_STAGE_NOT_FOUND = 0,
-    GUI_OPL_HOME_STAGE_OK = 1,
-    GUI_OPL_HOME_STAGE_UNAVAILABLE = -1,
-};
-
-// Set at each GUI-side staging exit. hddOplHomeStageReason() covers the hdd-side ones.
-static const char *guiOplHomeStageReason = "none";
-
-static const char *guiOplHomeStageError(int selection, int result)
-{
-    const char *base = (result == GUI_OPL_HOME_STAGE_UNAVAILABLE) ? _l(_STR_HDD_OPL_PARTITION_BUSY) : (selection == HDD_OPL_HOME_PLUS ? _l(_STR_HDD_OPL_PLUS_NOT_FOUND) : _l(_STR_HDD_OPL_COMMON_NOT_FOUND));
-
-#ifdef __OPLDIAG
-    // Name the condition that actually fired. Five different failures share these two strings, so a
-    // report of "it says busy" has never been enough to tell them apart -- which is why this row has
-    // now survived several rounds of fixes aimed at the wrong one. Diagnostic builds only.
-    static char detailed[192];
-    snprintf(detailed, sizeof(detailed), "%s\n[%s / %s]", base, guiOplHomeStageReason, hddOplHomeStageReason());
-    return detailed;
-#else
-    return base;
-#endif
-}
 
 #ifdef __DEBUG
 
@@ -728,19 +703,10 @@ int guiNetProtocolNeedsRestart(void)
 // guiShowDeviceConfig is retained for the legacy entry point outside the Settings peer shell.
 // Keep its APA selector semantics identical to the shell: merely opening/saving another field
 // must not normalize a legacy custom hdd_partition, while an explicit selector interaction may.
-static int guiDeviceOplHomeInitial;
-static int guiDeviceOplHomeLegacy;
-static int guiDeviceOplHomeTouched;
 
 static int guiDeviceConfigUpdater(int modified)
 {
-    int selection;
-
-    if (modified) {
-        diaGetInt(diaDeviceConfig, CFG_HDDOPLPART, &selection);
-        if (selection != guiDeviceOplHomeInitial)
-            guiDeviceOplHomeTouched = 1;
-    }
+    (void)modified;
     return 0;
 }
 
@@ -783,12 +749,6 @@ void guiShowDeviceConfig(void)
     diaSetInt(diaDeviceConfig, CFG_MMCEMODE, gMMCEStartMode);
     diaSetEnabled(diaDeviceConfig, CFG_MMCEMODE, 1);
 
-    guiDeviceOplHomeInitial = hddGetOplHomeSelection();
-    guiDeviceOplHomeLegacy = hddOplHomeIsLegacy();
-    guiDeviceOplHomeTouched = 0;
-    diaSetEnum(diaDeviceConfig, CFG_HDDOPLPART, hddOplHomes);
-    diaSetInt(diaDeviceConfig, CFG_HDDOPLPART, guiDeviceOplHomeInitial);
-
     int ret;
 reshow_device:
     ret = diaExecuteDialog(diaDeviceConfig, -1, 1, &guiDeviceConfigUpdater);
@@ -798,21 +758,6 @@ reshow_device:
     }
     if (ret) {
         int netProtocolWas = gNetworkProtocol;
-        int hddOplHomeChoice;
-        int hddOplHomeStageResult;
-
-        diaGetInt(diaDeviceConfig, CFG_HDDOPLPART, &hddOplHomeChoice);
-        if (hddOplHomeChoice != guiDeviceOplHomeInitial ||
-            (guiDeviceOplHomeLegacy && guiDeviceOplHomeTouched)) {
-            hddOplHomeStageResult = guiSettingsStageOplHome(hddOplHomeChoice);
-            if (hddOplHomeStageResult != GUI_OPL_HOME_STAGE_OK) {
-                diaSetInt(diaDeviceConfig, CFG_HDDOPLPART, guiDeviceOplHomeInitial);
-                guiDeviceOplHomeTouched = 0;
-                guiMsgBox(guiOplHomeStageError(hddOplHomeChoice, hddOplHomeStageResult), 0, NULL);
-                goto reshow_device;
-            }
-            guiMsgBox(_l(_STR_HDD_OPL_PARTITION_RESTART), 0, NULL);
-        }
 
         diaGetInt(diaDeviceConfig, CFG_DEFDEVICE, &deviceModeIndex);
         gDefaultDevice = guiDeviceTypeToIoMode(deviceModeIndex);
@@ -2704,84 +2649,11 @@ reshow_general:
     return guiSettingsPageResult(result);
 }
 
-static int guiSourcesOplHomeInitial;
-static int guiSourcesOplHomeLegacy;
-static int guiSourcesOplHomeTouched;
-static int guiSourcesOplHomeStagePending;
-static int guiSourcesOplHomeStageResult;
-static int guiSourcesOplHomeStageChoice;
-static int guiSourcesOplHomeStageInFlight;
-static int guiSourcesOplHomeStageAbandoned;
 
 static int guiSettingsSourcesUpdater(int modified)
 {
-    int selection;
-
-    if (modified) {
-        diaGetInt(guiSettingsActiveDialog, CFG_HDDOPLPART, &selection);
-        if (selection != guiSourcesOplHomeInitial)
-            guiSourcesOplHomeTouched = 1;
-    }
+    (void)modified;
     return 0;
-}
-
-static void guiSettingsStageOplHomeWorker(void)
-{
-    int result = hddStageOplHomeSelection(guiSourcesOplHomeStageChoice);
-
-    if (guiSourcesOplHomeStageAbandoned)
-        hddDiscardOplHomeSelection();
-    else
-        guiSourcesOplHomeStageResult = result;
-    guiSourcesOplHomeStageInFlight = 0;
-    guiSourcesOplHomeStagePending = 0;
-}
-
-static int guiSettingsStageOplHome(int selection)
-{
-    // Do not overwrite the static request payload after a timed-out worker. The I/O queue is
-    // single-threaded, so another request cannot begin until that worker actually returns.
-    if (guiSourcesOplHomeStageInFlight) {
-        guiOplHomeStageReason = "still-in-flight-from-previous";
-        return GUI_OPL_HOME_STAGE_UNAVAILABLE;
-    }
-
-    guiOplHomeStageReason = "worker-completed";
-    guiSourcesOplHomeStageChoice = selection;
-    guiSourcesOplHomeStageResult = 0;
-    guiSourcesOplHomeStagePending = 1;
-    guiSourcesOplHomeStageInFlight = 1;
-    guiSourcesOplHomeStageAbandoned = 0;
-    guiHandleDeferedIO(&guiSourcesOplHomeStagePending, _l(_STR_HDD_OPL_PARTITION_CHECKING),
-                       IO_CUSTOM_SIMPLEACTION, &guiSettingsStageOplHomeWorker, 15000);
-    if (gLastDeferredTimedOut) {
-        // The late worker only ever changes our staged selector; never let an abandoned wait make
-        // a later Save Settings persist a choice the user did not get to confirm. InFlight stays
-        // SET here on purpose: the worker may still be running and must be allowed to return.
-        guiSourcesOplHomeStageAbandoned = 1;
-        guiOplHomeStageReason = "worker-timed-out-15s";
-        hddDiscardOplHomeSelection();
-        return GUI_OPL_HOME_STAGE_UNAVAILABLE;
-    }
-
-    // NO TIMEOUT, YET STILL IN FLIGHT -> THE WORKER NEVER RAN AT ALL. guiHandleDeferedIO() clears
-    // the pending flag and returns immediately when ioPutRequest() is rejected (a full or blocked
-    // IO queue), so we never waited and nothing will ever clear this latch. Unlike the timeout
-    // above there is no worker still out there to do it.
-    //
-    // Left set, it disabled the row for the rest of the session: the first attempt returned the
-    // untouched result 0, rendered as "<name> partition not found." on a console that has the
-    // partition, and every attempt after it hit the InFlight guard at the top and returned
-    // UNAVAILABLE -- "HDD is busy, try again once loading finishes" -- instantly, with no spinner
-    // and nothing actually loading. One transiently full IO queue, and the setting was unusable.
-    if (guiSourcesOplHomeStageInFlight) {
-        guiSourcesOplHomeStageInFlight = 0;
-        guiSourcesOplHomeStagePending = 0;
-        guiOplHomeStageReason = "worker-never-ran-queue-rejected";
-        return GUI_OPL_HOME_STAGE_UNAVAILABLE; // retryable now, and honest about why
-    }
-
-    return guiSourcesOplHomeStageResult;
 }
 
 static int guiSettingsShowSources(void)
@@ -2819,11 +2691,6 @@ static int guiSettingsShowSources(void)
     diaSetEnum(ui, CFG_MMCEMODE, deviceModes);
     diaSetInt(ui, CFG_MMCEMODE, gMMCEStartMode);
     diaSetEnabled(ui, CFG_MMCEMODE, 1);
-    guiSourcesOplHomeInitial = hddGetOplHomeSelection();
-    guiSourcesOplHomeLegacy = hddOplHomeIsLegacy();
-    guiSourcesOplHomeTouched = 0;
-    diaSetEnum(ui, CFG_HDDOPLPART, hddOplHomes);
-    diaSetInt(ui, CFG_HDDOPLPART, guiSourcesOplHomeInitial);
     guiSettingsBeginDialog(ui);
 
 reshow_sources:
@@ -2843,21 +2710,6 @@ reshow_sources:
 
     if (result != UIID_BTN_CANCEL && result != -1) {
         int netProtocolWas = gNetworkProtocol;
-        int hddOplHomeChoice;
-        int hddOplHomeStageResult;
-
-        diaGetInt(ui, CFG_HDDOPLPART, &hddOplHomeChoice);
-        if (hddOplHomeChoice != guiSourcesOplHomeInitial ||
-            (guiSourcesOplHomeLegacy && guiSourcesOplHomeTouched)) {
-            hddOplHomeStageResult = guiSettingsStageOplHome(hddOplHomeChoice);
-            if (hddOplHomeStageResult != GUI_OPL_HOME_STAGE_OK) {
-                diaSetInt(ui, CFG_HDDOPLPART, guiSourcesOplHomeInitial);
-                guiSourcesOplHomeTouched = 0;
-                guiMsgBox(guiOplHomeStageError(hddOplHomeChoice, hddOplHomeStageResult), 0, NULL);
-                goto reshow_sources;
-            }
-            guiMsgBox(_l(_STR_HDD_OPL_PARTITION_RESTART), 0, NULL);
-        }
 
         diaGetInt(ui, CFG_DEFDEVICE, &deviceModeIndex);
         gDefaultDevice = guiDeviceTypeToIoMode(deviceModeIndex);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -41,6 +41,7 @@ static unsigned char hddSupportModulesLoaded = 0;
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
 static unsigned char hddPfsDeferredFailed = 0;
+static int hddRetryQueued = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -85,6 +86,7 @@ static int hddUpdateGameListCache(hdl_games_list_t *cache, hdl_games_list_t *gam
 
 static void hddInitModules(void)
 {
+    hddRetryQueued = 0;
     hddLoadModules();
     hddLoadSupportModules();
 
@@ -853,11 +855,17 @@ static int hddNeedsUpdate(item_list_t *itemList)
 static int hddUpdateGameList(item_list_t *itemList)
 {
     // GUI thread must never block on the 1 s ATA settle (hddLoadModules DelayThread).
-    // If the base ATA stack has never completed (hddModulesLoadCount==0), defer; the
-    // separately queued hddInitModules on the IO worker will settle and this will
-    // retry on the next refresh.
-    if (hddModulesLoadCount == 0)
+    // If the base ATA stack has never completed (hddModulesLoadCount==0), defer and
+    // ensure a deduplicated IO-worker retry is queued. hddLoadModules resets the count
+    // to 0 on failure for retryability, and the one-shot hddInit queue may already be
+    // consumed, so without this the stack would strand permanently.
+    if (hddModulesLoadCount == 0) {
+        if (!hddRetryQueued) {
+            if (ioPutRequest(IO_CUSTOM_SIMPLEACTION, &hddInitModules) == IO_OK)
+                hddRetryQueued = 1;
+        }
         return 0;
+    }
 
     // Self-heal (wLaunchELF-R3Z3N parity: latch only on success, retry per use): a boot-time first
     // touch that raced drive spin-up used to leave the APA page EMPTY for the whole session -- the

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1249,8 +1249,19 @@ int hddStageOplHomeSelection(int selection)
     // user with a perfectly good +OPL was told it was missing whenever the ATA stack or PS2FS was
     // not up yet. That is the SAME condition behind the deferred Code 222, which is why the two get
     // reported together. -1 is the caller's existing "cannot answer right now" state.
-    if (!hddModulesAreLoaded())
-        return -1;
+    // BRING THE STACK UP RATHER THAN REFUSING. This used to require the ATA modules to already be
+    // resident, on the reasoning that a selector should not own a module reference. But nothing
+    // guarantees they are resident when the user opens Settings, and when they are not, the check
+    // can never pass -- so the row reported "not found" (before) or "busy" (after that was
+    // corrected) on every single attempt, with no sequence of user actions able to fix it. A
+    // setting that cannot be changed is a worse outcome than an extra hddModulesLoadCount bump.
+    //
+    // Affordable here specifically: this runs on the io worker behind guiHandleDeferedIO's spinner
+    // with a 15 s budget, which is exactly the machinery for a load that may take a second.
+    // hddLoadSupportModules() is still deliberately NOT called -- its data-home recovery mounts
+    // pfs0: and creates OPL folders, and neither belongs to a source-selector proof.
+    if (!hddModulesAreLoaded() && !hddLoadModulesReady())
+        return -1; // ATA stack genuinely will not come up -- cannot answer, not "absent"
     if (!hddLoadCoreSupportModules())
         return -1;
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1998,7 +1998,18 @@ static char *hddGetPrefix(item_list_t *itemList)
     return gHDDPrefix;
 }
 
+int hddGetArtArchivePath(item_list_t *itemList, char *out, int outSize)
+{
+    (void)itemList;
+    if (out == NULL || outSize <= 0)
+        return -1;
+    if (gHDDPrefix == NULL)
+        return -1;
+    int n = snprintf(out, outSize, "%sART/art.tar", gHDDPrefix);
+    return (n > 0 && n < outSize) ? 1 : -1;
+}
+
 static item_list_t hddGameList = {
     HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, NULL, NULL, &hddGetTextId, &hddGetPrefix, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
     &hddGetGameCount, &hddGetGame, &hddGetGameName, &hddGetGameNameLength, &hddGetGameStartup, &hddDeleteGame, &hddRenameGame,
-    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId, &hddLaunchVcd};
+    &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, &hddGetIconId, &hddLaunchVcd, 0, &hddGetArtArchivePath};

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -42,6 +42,19 @@ static unsigned char hddSupportModulesLoaded = 0;
 static unsigned char hddSupportErrToasted = 0;
 static unsigned char hddPfsDeferredFailed = 0;
 static int hddRetryQueued = 0;
+
+typedef enum {
+    HDD_PFS_DIAG_REASON_NONE = 0,
+    HDD_PFS_DIAG_REASON_HDD_CHECK_STATUS_1,
+    HDD_PFS_DIAG_REASON_PS2FS_LOAD_FAILURE,
+} hdd_pfs_diag_reason_t;
+
+#define HDD_PFS_DIAG_NOT_RUN (-9999)
+
+static hdd_pfs_diag_reason_t hddPfsDiagReason = HDD_PFS_DIAG_REASON_NONE;
+static int hddPfsDiagHddCheckResult = HDD_PFS_DIAG_NOT_RUN;
+static int hddPfsDiagPs2fsResult = HDD_PFS_DIAG_NOT_RUN;
+static unsigned char hddDiagBootStageActive = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -51,6 +64,81 @@ static int hddOplHomeCommitted = -1;
 // +OPL can be the existing automatic home only when __common was unavailable during discovery.
 // Keep that distinct from an explicit conf_hdd.cfg redirect, which may fall back to __common.
 static unsigned char hddOplHomeAutoPlus = 0;
+
+static const char *hddPfsDiagReasonName(hdd_pfs_diag_reason_t reason)
+{
+    switch (reason) {
+        case HDD_PFS_DIAG_REASON_HDD_CHECK_STATUS_1:
+            return "HDD_CHECK_STATUS_1_UNFORMATTED";
+        case HDD_PFS_DIAG_REASON_PS2FS_LOAD_FAILURE:
+            return "PS2FS_LOAD_FAILURE";
+        default:
+            return "NONE";
+    }
+}
+
+static void hddLogPfsDiagState(const char *action, const char *why)
+{
+    LOG("[HDD PFS DIAG] action=%s why=%s reason=%s hddCheck=%d ps2fs=%d "
+        "hddModulesLoaded=%u hddSupportModulesLoaded=%u gOPLPart=\"%s\" gHDDPrefix=\"%s\"\n",
+        action, why, hddPfsDiagReasonName(hddPfsDiagReason), hddPfsDiagHddCheckResult,
+        hddPfsDiagPs2fsResult, hddModulesLoaded, hddSupportModulesLoaded, gOPLPart,
+        gHDDPrefix != NULL ? gHDDPrefix : "<null>");
+}
+
+static void hddArmPfsDiagFailure(hdd_pfs_diag_reason_t reason, int hddCheckResult, int ps2fsResult)
+{
+    hddPfsDiagReason = reason;
+    hddPfsDiagHddCheckResult = hddCheckResult;
+    hddPfsDiagPs2fsResult = ps2fsResult;
+    hddPfsDeferredFailed = 1;
+    hddLogPfsDiagState("arm", "support-load-failure");
+}
+
+static void hddClearPfsDiagFailure(const char *why)
+{
+    hddLogPfsDiagState("clear", why);
+    hddPfsDeferredFailed = 0;
+    hddPfsDiagReason = HDD_PFS_DIAG_REASON_NONE;
+    hddPfsDiagHddCheckResult = HDD_PFS_DIAG_NOT_RUN;
+    hddPfsDiagPs2fsResult = HDD_PFS_DIAG_NOT_RUN;
+}
+
+static void hddDiagBootStageBegin(const char *stage)
+{
+    char status[96];
+
+    if (!hddDiagBootStageActive)
+        return;
+
+    snprintf(status, sizeof(status), "BEGIN %s", stage);
+    LOG("%s\n", status);
+    guiSetBootStatusStickyCopy(status);
+}
+
+static void hddDiagBootStageEnd(const char *stage, int result)
+{
+    char status[96];
+
+    if (!hddDiagBootStageActive)
+        return;
+
+    snprintf(status, sizeof(status), "END %s result=%d", stage, result);
+    LOG("%s\n", status);
+    guiSetBootStatusStickyCopy(status);
+}
+
+static void hddDiagBootStageEndVoid(const char *stage)
+{
+    char status[96];
+
+    if (!hddDiagBootStageActive)
+        return;
+
+    snprintf(status, sizeof(status), "END %s", stage);
+    LOG("%s\n", status);
+    guiSetBootStatusStickyCopy(status);
+}
 
 static void hddClearRecoveredErrors(void)
 {
@@ -264,10 +352,12 @@ static void hddFindOPLPartition(void)
 
 int hddLoadModules(void)
 {
-    int retLoadModule;
+    int retLoadModule = HDD_PFS_DIAG_NOT_RUN;
+    int retBdmModule = HDD_PFS_DIAG_NOT_RUN;
+    int retXhddModule = HDD_PFS_DIAG_NOT_RUN;
     int retStatus = HDD_LOADMODULES_STATUS_UNK;
 
-    LOG("HDDSUPPORT LoadModules %d\n", hddModulesLoadCount);
+    LOG("[HDD STARTUP DIAG] hddLoadModules entry count=%u loaded=%u\n", hddModulesLoadCount, hddModulesLoaded);
 
     if (hddModulesLoaded)
         retStatus = HDD_LOADMODULES_STATUS_ALREADYLOADED;
@@ -278,23 +368,37 @@ int hddLoadModules(void)
         hddModulesLoadCount = 1;
 
         // DEV9 must be loaded, as HDD.IRX depends on it. Even if not required by the I/F (i.e. HDPro)
+        hddDiagBootStageBegin("HDD:DEV9");
         sysInitDev9();
+        hddDiagBootStageEndVoid("HDD:DEV9");
 
         // try to detect HD Pro Kit (not the connected HDD),
         // if detected it loads the specific ATAD module
+        hddDiagBootStageBegin("HDD:HDPRO-PROBE");
         hddHDProKitDetected = hddCheckHDProKit();
+        hddDiagBootStageEnd("HDD:HDPRO-PROBE", hddHDProKitDetected);
         if (hddHDProKitDetected) {
             LOG("[ATAD_HDPRO]:\n");
+            hddDiagBootStageBegin("HDD:ATAD-HDPRO");
             retLoadModule = sysLoadModuleBuffer(&hdpro_atad_irx, size_hdpro_atad_irx, 0, NULL);
+            hddDiagBootStageEnd("HDD:ATAD-HDPRO", retLoadModule);
             LOG("[XHDD]:\n");
-            sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-hdpro");
+            hddDiagBootStageBegin("HDD:XHDD-HDPRO");
+            retXhddModule = sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-hdpro");
+            hddDiagBootStageEnd("HDD:XHDD-HDPRO", retXhddModule);
         } else {
             LOG("[BDM]:\n");
-            sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
+            hddDiagBootStageBegin("HDD:BDM");
+            retBdmModule = sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
+            hddDiagBootStageEnd("HDD:BDM", retBdmModule);
             LOG("[ATAD]:\n");
+            hddDiagBootStageBegin("HDD:ATAD");
             retLoadModule = sysLoadModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL);
+            hddDiagBootStageEnd("HDD:ATAD", retLoadModule);
             LOG("[XHDD]:\n");
-            sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
+            hddDiagBootStageBegin("HDD:XHDD");
+            retXhddModule = sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
+            hddDiagBootStageEnd("HDD:XHDD", retXhddModule);
         }
 
         if (retLoadModule < 0) {
@@ -326,7 +430,9 @@ int hddLoadModules(void)
             // seconds after power-on (APA boot-identity config resolution), so the very first
             // ATA_DEVCTL_READ_PARTITION_SECTOR probe / ps2hdd init can otherwise race a drive that is
             // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
+            hddDiagBootStageBegin("HDD:SETTLE");
             DelayThread(1000 * 1000);
+            hddDiagBootStageEndVoid("HDD:SETTLE");
         }
     } else {
         hddModulesLoadCount++;
@@ -334,8 +440,25 @@ int hddLoadModules(void)
             retStatus = HDD_LOADMODULES_STATUS_BUSYLOADING;
     }
 
-    LOG("HDDSUPPORT LoadModules done\n");
+    LOG("[HDD STARTUP DIAG] hddLoadModules exit count=%u loaded=%u ret=%d bdm=%d atad=%d xhdd=%d\n",
+        hddModulesLoadCount, hddModulesLoaded, retStatus, retBdmModule, retLoadModule, retXhddModule);
     return retStatus;
+}
+
+int hddDiagLoadModulesReady(void)
+{
+    int result;
+
+    hddDiagBootStageActive = 1;
+    hddDiagBootStageBegin("HDD:READY");
+    LOG("[HDD STARTUP DIAG] hddLoadModulesReady entry count=%u loaded=%u\n", hddModulesLoadCount, hddModulesLoaded);
+    result = hddLoadModulesReady();
+    LOG("[HDD STARTUP DIAG] hddLoadModulesReady exit count=%u loaded=%u result=%d\n",
+        hddModulesLoadCount, hddModulesLoaded, result);
+    hddDiagBootStageEnd("HDD:READY", result);
+    hddDiagBootStageActive = 0;
+
+    return result;
 }
 
 int hddModulesAreLoaded(void)
@@ -503,7 +626,7 @@ static int hddLoadCoreSupportModules(void)
         if (ret == 1) {
             LOG("HDD: APA status reports an unformatted drive.\n");
             hddSupportErrToasted = 0;
-            hddPfsDeferredFailed = 1;
+            hddArmPfsDiagFailure(HDD_PFS_DIAG_REASON_HDD_CHECK_STATUS_1, ret, HDD_PFS_DIAG_NOT_RUN);
             return 0;
         }
         if (ret == 2) {
@@ -520,12 +643,12 @@ static int hddLoadCoreSupportModules(void)
         if (ret < 0) {
             LOG("HDD: PFS support module failed to load.\n");
             hddSupportErrToasted = 0;
-            hddPfsDeferredFailed = 1;
+            hddArmPfsDiagFailure(HDD_PFS_DIAG_REASON_PS2FS_LOAD_FAILURE, 0, ret);
             return 0;
         }
 
         hddSupportModulesLoaded = 1;
-        hddPfsDeferredFailed = 0;
+        hddClearPfsDiagFailure("core-support-load-succeeded");
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
@@ -882,17 +1005,19 @@ static int hddUpdateGameList(item_list_t *itemList)
             hddLoadSupportModules();
         // Deferred Code 222: early boot probes never toast; settled retry may.
         if (hddSupportModulesLoaded) {
-            hddPfsDeferredFailed = 0;
+            hddClearPfsDiagFailure("update-retry-loaded-support");
             hddSupportErrToasted = 0;
             hddClearRecoveredErrors();
         } else if (hddPfsDeferredFailed && !hddSupportErrToasted) {
-            setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
+            hddLogPfsDiagState("emit-code-222", "settled-update-retry-still-failed");
+            setErrorMessageWithCodeAndDetail(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE,
+                                             hddPfsDiagReasonName(hddPfsDiagReason));
             hddSupportErrToasted = 1;
         }
     } else {
         // Successful path also clears any prior deferred failure.
         if (hddPfsDeferredFailed) {
-            hddPfsDeferredFailed = 0;
+            hddClearPfsDiagFailure("update-found-support-already-ready");
             hddSupportErrToasted = 0;
             hddClearRecoveredErrors();
         }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -104,6 +104,11 @@ static void hddClearPfsDiagFailure(const char *why)
     hddPfsDiagPs2fsResult = HDD_PFS_DIAG_NOT_RUN;
 }
 
+// Diagnostic-build only, same rule as bdmDiagBootStage*: this publishes untranslated developer text
+// to the boot status line that every other caller feeds through _l(). hddDiagBootStageActive
+// additionally scopes it to the bracket opened by hddDiagLoadModulesReady(), so even a diagnostic
+// build only narrates the ATA startup it was asked to narrate.
+#ifdef __OPLDIAG
 static void hddDiagBootStageBegin(const char *stage)
 {
     char status[96];
@@ -139,6 +144,23 @@ static void hddDiagBootStageEndVoid(const char *stage)
     LOG("%s\n", status);
     guiSetBootStatusStickyCopy(status);
 }
+#else
+static void hddDiagBootStageBegin(const char *stage)
+{
+    (void)stage;
+}
+
+static void hddDiagBootStageEnd(const char *stage, int result)
+{
+    (void)stage;
+    (void)result;
+}
+
+static void hddDiagBootStageEndVoid(const char *stage)
+{
+    (void)stage;
+}
+#endif
 
 static void hddClearRecoveredErrors(void)
 {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -317,9 +317,23 @@ static void hddFindOPLPartition(void)
     char candidate[sizeof(gOPLPart)];
     const char *label;
 
-    // When __common is usable, its OPL/conf_hdd.cfg is the authoritative APA data-home selector.
-    // If __common itself is unavailable, an existing mountable +OPL is the legacy automatic home.
-    // Discovery never manufactures a partition, resizes one, or writes raw hdd0: metadata.
+    /* ORDER OF PREFERENCE, and the middle two are deliberately swapped from what this used to do:
+     *
+     *   1. an explicit conf_hdd.cfg selection  -- a stated choice outranks any default
+     *   2. an existing +OPL partition          -- PREFERRED default
+     *   3. __common                            -- fallback
+     *   4. nothing: fail closed
+     *
+     * +OPL used to sit at 3 and __common at 2, so a drive that has both silently landed on __common
+     * and the only route to +OPL was the Settings row -- which is exactly the path that has been
+     * failing. Preferring the partition the user actually created means the common case needs no
+     * setting at all.
+     *
+     * Discovery still never manufactures a partition, resizes one, or writes raw hdd0: metadata.
+     * Every branch below only MOUNTS something that already exists, and the last one gives up
+     * rather than create anything. */
+    int commonAvailable = 0;
+
     hddOplHomeAutoPlus = 0;
     fileXioUmount(hddPrefix);
     if (fileXioMount(hddPrefix, "hdd0:__common", FIO_MT_RDONLY) == 0) {
@@ -358,20 +372,26 @@ static void hddFindOPLPartition(void)
             LOG("HDD: configured data partition %s is unavailable; ignoring it\n", name);
         }
 
-        // The successful __common mount above is already the proof required for the default.
-        // Do not remount it merely to rediscover the same topology.
-        snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:__common");
-        LOG("HDD: no usable configured data partition; using canonical __common/OPL/ fallback\n");
-        return;
+        // __common mounted but named nothing usable. Record that it is available and keep going --
+        // +OPL is preferred below when it exists. The successful mount above is already all the
+        // proof this needs; do not remount merely to rediscover the same topology.
+        commonAvailable = 1;
     }
 
-    // Official OPL's existing +OPL layout remains valid when a drive has no usable __common.
-    // It is an automatic effective choice, not a request to create conf_hdd.cfg or a new APA
-    // partition. +OPL owns its PFS root directly, so the mounted data prefix is pfs0:.
+    // PREFERRED DEFAULT: an existing +OPL. It owns its PFS root directly, so the mounted data
+    // prefix is pfs0:. Still an automatic effective choice, not a request to write conf_hdd.cfg or
+    // to create an APA partition -- taken only when the partition is already there and mountable.
     if (hddPartitionMountable("hdd0:+OPL")) {
         snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:+OPL");
         hddOplHomeAutoPlus = 1;
-        LOG("HDD: __common unavailable; using existing +OPL data-home fallback\n");
+        LOG("HDD: using existing +OPL data home (preferred over __common)\n");
+        return;
+    }
+
+    // Fallback: the canonical __common/OPL/ layout, already proven mountable above.
+    if (commonAvailable) {
+        snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:__common");
+        LOG("HDD: no +OPL partition; using canonical __common/OPL/ fallback\n");
         return;
     }
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1023,14 +1023,25 @@ static int hddUpdateGameList(item_list_t *itemList)
         // anyway made a failed base load toast TWICE (base failure + the doomed non-Sony probe's)
         // on the first pass (Gemini + CodeRabbit review of #249, vetted). A loaded module stack
         // with no data mount is also retryable: Step-209 deliberately separates those lifetimes.
-        if (hddLoadModulesReady())
+        // WHETHER THE RETRY ACTUALLY RAN decides whether a failure is reportable. hddLoadModules
+        // stamps hddModulesLoadCount=1 on ENTRY -- before sysInitDev9, before the ATAD load, and
+        // before the 1 s settle, all of which run on the io worker. So the guard at the top of this
+        // function stops firing almost immediately, while the base stack is still coming up, and
+        // hddLoadModulesReady() correctly answers BUSYLOADING -> false for that whole window.
+        //
+        // Without this flag the code then fell through to the toast having attempted NOTHING, and
+        // announced it as "settled-update-retry-still-failed" -- which is why Code 222 appeared on
+        // consoles whose APA worked perfectly a moment later. A base stack that is still loading is
+        // not evidence of anything; say nothing until it is actually resident.
+        int baseReady = hddLoadModulesReady();
+        if (baseReady)
             hddLoadSupportModules();
-        // Deferred Code 222: early boot probes never toast; settled retry may.
+        // Deferred Code 222: early boot probes never toast; a settled retry that really ran may.
         if (hddSupportModulesLoaded) {
             hddClearPfsDiagFailure("update-retry-loaded-support");
             hddSupportErrToasted = 0;
             hddClearRecoveredErrors();
-        } else if (hddPfsDeferredFailed && !hddSupportErrToasted) {
+        } else if (baseReady && hddPfsDeferredFailed && !hddSupportErrToasted) {
             hddLogPfsDiagState("emit-code-222", "settled-update-retry-still-failed");
             setErrorMessageWithCodeAndDetail(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE,
                                              hddPfsDiagReasonName(hddPfsDiagReason));

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1248,12 +1248,26 @@ void hddDiscardOplHomeSelection(void)
     hddOplHomePending = -1;
 }
 
+// Why the last staging attempt ended the way it did. Five distinct conditions were all collapsed
+// into two user-visible messages ("not found" / "busy"), which is why this row resisted several
+// rounds of fixing: the message never named which one had fired. Surfaced in OPLDIAG builds only.
+static const char *hddOplHomeStageReasonText = "none";
+
+const char *hddOplHomeStageReason(void)
+{
+    return hddOplHomeStageReasonText;
+}
+
 int hddStageOplHomeSelection(int selection)
 {
     const char *partition;
 
-    if (selection != HDD_OPL_HOME_COMMON && selection != HDD_OPL_HOME_PLUS)
+    hddOplHomeStageReasonText = "entered";
+
+    if (selection != HDD_OPL_HOME_COMMON && selection != HDD_OPL_HOME_PLUS) {
+        hddOplHomeStageReasonText = "invalid-selection";
         return 0;
+    }
 
     // Use only the already-resident ATA stack. The selector is a short-lived proof, not an owner
     // of a module reference; hddLoadModulesReady() would retain one on every stage/save cycle.
@@ -1275,15 +1289,22 @@ int hddStageOplHomeSelection(int selection)
     // with a 15 s budget, which is exactly the machinery for a load that may take a second.
     // hddLoadSupportModules() is still deliberately NOT called -- its data-home recovery mounts
     // pfs0: and creates OPL folders, and neither belongs to a source-selector proof.
-    if (!hddModulesAreLoaded() && !hddLoadModulesReady())
-        return -1; // ATA stack genuinely will not come up -- cannot answer, not "absent"
-    if (!hddLoadCoreSupportModules())
+    if (!hddModulesAreLoaded() && !hddLoadModulesReady()) {
+        hddOplHomeStageReasonText = "ata-stack-unavailable";
+        return -1; // cannot answer, not "absent"
+    }
+    if (!hddLoadCoreSupportModules()) {
+        hddOplHomeStageReasonText = "pfs-support-unavailable";
         return -1;
+    }
 
     partition = selection == HDD_OPL_HOME_PLUS ? "hdd0:+OPL" : "hdd0:__common";
-    if (!hddPartitionMountableAt("pfs1:", partition, FIO_MT_RDONLY))
+    if (!hddPartitionMountableAt("pfs1:", partition, FIO_MT_RDONLY)) {
+        hddOplHomeStageReasonText = "partition-mount-refused";
         return 0; // genuinely absent: the stack was up and the mount still refused
+    }
 
+    hddOplHomeStageReasonText = "ok";
     hddOplHomePending = selection;
     return 1;
 }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -605,6 +605,21 @@ static int hddLoadCoreSupportModules(void)
 
     LOG("HDDSUPPORT LoadSupportModules\n");
 
+    // ALREADY PROVEN -- do not re-litigate it. The non-Sony probe below exists to avoid loading APA
+    // modules onto a non-APA drive, which is a one-time question: if hddSupportModulesLoaded is set
+    // then ps2hdd and PS2FS are up, and that cannot have happened on a drive this probe would
+    // reject. Re-running it on every call re-asks a settled question against a live drive, and
+    // hddDetectNonSonyFileSystem() answers -1 on a transient devctl error (busy bus, drive mid-seek)
+    // as well as >0 on a coexisting exFAT/MBR signature. Either one made this return 0 while APA was
+    // demonstrably working -- which is how the APA data-home selector came to report failure on a
+    // console that was browsing HDD games at the time.
+    //
+    // Placed above the probe, not merged into the existing !hddSupportModulesLoaded guard below,
+    // because that guard only covers the module loads -- the probe already ran by the time it is
+    // reached.
+    if (hddSupportModulesLoaded)
+        return 1;
+
     // Check if the drive contains MBR/GPT partition data before we load the APA/PFS modules. If the drive is not
     // APA then loading the APA irx modules can corrupt the drive as it will try to write APA partition data.
     nonSony = hddDetectNonSonyFileSystem();

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1244,14 +1244,19 @@ int hddStageOplHomeSelection(int selection)
     // of a module reference; hddLoadModulesReady() would retain one on every stage/save cycle.
     // Do not call hddLoadSupportModules here: its normal data-home recovery may mount pfs0: and
     // create OPL folders, neither of which belongs to a source selector proof.
+    // "COULD NOT CHECK" IS NOT "DOES NOT EXIST". These two arms used to return 0, the same value the
+    // failed mount below returns, and the caller renders 0 as "+OPL partition not found." -- so a
+    // user with a perfectly good +OPL was told it was missing whenever the ATA stack or PS2FS was
+    // not up yet. That is the SAME condition behind the deferred Code 222, which is why the two get
+    // reported together. -1 is the caller's existing "cannot answer right now" state.
     if (!hddModulesAreLoaded())
-        return 0;
+        return -1;
     if (!hddLoadCoreSupportModules())
-        return 0;
+        return -1;
 
     partition = selection == HDD_OPL_HOME_PLUS ? "hdd0:+OPL" : "hdd0:__common";
     if (!hddPartitionMountableAt("pfs1:", partition, FIO_MT_RDONLY))
-        return 0;
+        return 0; // genuinely absent: the stack was up and the mount still refused
 
     hddOplHomePending = selection;
     return 1;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -43,6 +43,13 @@ static unsigned char hddSupportErrToasted = 0;
 static unsigned char hddPfsDeferredFailed = 0;
 static int hddRetryQueued = 0;
 
+// Settled PS2FS attempts that must ALL fail before Code 222 is shown. A drive still spinning up
+// answers the ATA stack well before it will answer PS2FS, so a single refusal after the settle says
+// nothing -- hardware shows PFS declining a few of these and then mounting normally. Reset by
+// hddClearPfsDiagFailure() the moment the support stack latches.
+#define HDD_PFS_REPORT_AFTER_FAILURES 3
+static int hddPfsSettledFailures = 0;
+
 typedef enum {
     HDD_PFS_DIAG_REASON_NONE = 0,
     HDD_PFS_DIAG_REASON_HDD_CHECK_STATUS_1,
@@ -99,6 +106,7 @@ static void hddClearPfsDiagFailure(const char *why)
 {
     hddLogPfsDiagState("clear", why);
     hddPfsDeferredFailed = 0;
+    hddPfsSettledFailures = 0; // PFS came up: the retries that failed before it were spin-up, not fault
     hddPfsDiagReason = HDD_PFS_DIAG_REASON_NONE;
     hddPfsDiagHddCheckResult = HDD_PFS_DIAG_NOT_RUN;
     hddPfsDiagPs2fsResult = HDD_PFS_DIAG_NOT_RUN;
@@ -1042,10 +1050,24 @@ static int hddUpdateGameList(item_list_t *itemList)
             hddSupportErrToasted = 0;
             hddClearRecoveredErrors();
         } else if (baseReady && hddPfsDeferredFailed && !hddSupportErrToasted) {
-            hddLogPfsDiagState("emit-code-222", "settled-update-retry-still-failed");
-            setErrorMessageWithCodeAndDetail(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE,
-                                             hddPfsDiagReasonName(hddPfsDiagReason));
-            hddSupportErrToasted = 1;
+            // ONE FAILED ATTEMPT IS NOT EVIDENCE OF A DEAD DRIVE. Gating on baseReady stopped us
+            // reporting a retry that never ran, but it still reported the FIRST settled retry that
+            // failed -- and hardware says PFS can decline several of those and then mount fine, so
+            // the box appeared on consoles whose APA worked seconds later. The 1 s post-ATAD settle
+            // is a floor, not a guarantee: a drive that is still spinning up answers the ATA stack
+            // long before it will answer PS2FS.
+            //
+            // So require the failure to PERSIST across a few settled attempts. Each pass through
+            // here is a genuine retry (hddLoadSupportModules ran and did not latch), and the success
+            // arm above resets the count, so this only fires when PFS has really refused to come up.
+            if (++hddPfsSettledFailures >= HDD_PFS_REPORT_AFTER_FAILURES) {
+                hddLogPfsDiagState("emit-code-222", "settled-retries-exhausted");
+                setErrorMessageWithCodeAndDetail(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE,
+                                                 hddPfsDiagReasonName(hddPfsDiagReason));
+                hddSupportErrToasted = 1;
+            } else {
+                hddLogPfsDiagState("defer-code-222", "settled-retry-failed-below-threshold");
+            }
         }
     } else {
         // Successful path also clears any prior deferred failure.

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -40,6 +40,7 @@ static unsigned char hddSupportModulesLoaded = 0;
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
 // success so a later, different failure toasts again.
 static unsigned char hddSupportErrToasted = 0;
+static unsigned char hddPfsDeferredFailed = 0;
 // A Settings selection is deliberately staged until Save Settings. It never changes the active
 // pfs0: mount: a live OPL data home can have artwork/config readers using it.
 static int hddOplHomePending = -1;
@@ -499,10 +500,8 @@ static int hddLoadCoreSupportModules(void)
         }
         if (ret == 1) {
             LOG("HDD: APA status reports an unformatted drive.\n");
-            if (!hddSupportErrToasted) {
-                setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
-                hddSupportErrToasted = 1;
-            }
+            hddSupportErrToasted = 0;
+            hddPfsDeferredFailed = 1;
             return 0;
         }
         if (ret == 2) {
@@ -518,14 +517,13 @@ static int hddLoadCoreSupportModules(void)
         ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: PFS support module failed to load.\n");
-            if (!hddSupportErrToasted) {
-                setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
-                hddSupportErrToasted = 1;
-            }
+            hddSupportErrToasted = 0;
+            hddPfsDeferredFailed = 1;
             return 0;
         }
 
         hddSupportModulesLoaded = 1;
+        hddPfsDeferredFailed = 0;
         hddSupportErrToasted = 0;
         hddClearRecoveredErrors();
         LOG("HDDSUPPORT modules loaded\n");
@@ -854,6 +852,13 @@ static int hddNeedsUpdate(item_list_t *itemList)
 
 static int hddUpdateGameList(item_list_t *itemList)
 {
+    // GUI thread must never block on the 1 s ATA settle (hddLoadModules DelayThread).
+    // If the base ATA stack has never completed (hddModulesLoadCount==0), defer; the
+    // separately queued hddInitModules on the IO worker will settle and this will
+    // retry on the next refresh.
+    if (hddModulesLoadCount == 0)
+        return 0;
+
     // Self-heal (wLaunchELF-R3Z3N parity: latch only on success, retry per use): a boot-time first
     // touch that raced drive spin-up used to leave the APA page EMPTY for the whole session -- the
     // one-shot hddInitModules never retried, and nothing else reloads the support stack. Both calls
@@ -867,6 +872,22 @@ static int hddUpdateGameList(item_list_t *itemList)
         // with no data mount is also retryable: Step-209 deliberately separates those lifetimes.
         if (hddLoadModulesReady())
             hddLoadSupportModules();
+        // Deferred Code 222: early boot probes never toast; settled retry may.
+        if (hddSupportModulesLoaded) {
+            hddPfsDeferredFailed = 0;
+            hddSupportErrToasted = 0;
+            hddClearRecoveredErrors();
+        } else if (hddPfsDeferredFailed && !hddSupportErrToasted) {
+            setErrorMessageWithCode(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);
+            hddSupportErrToasted = 1;
+        }
+    } else {
+        // Successful path also clears any prior deferred failure.
+        if (hddPfsDeferredFailed) {
+            hddPfsDeferredFailed = 0;
+            hddSupportErrToasted = 0;
+            hddClearRecoveredErrors();
+        }
     }
 
     // Game discovery and the persistent config/art PFS home are separate lifetimes. HDL games

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -358,7 +358,9 @@ static void _menuSaveConfig()
     int result;
 
     WaitSema(menuSemaId);
+    bdmLogConfigWriteEntry(itemConfigList, itemConfig);
     result = configWrite(itemConfig);
+    bdmLogConfigWriteResult(itemConfigList, itemConfig, result);
     itemConfigId = -1;       // to invalidate cache and force reload
     menuSaveResult = result; // publish BEFORE actionStatus=0 -- that flag is the waiter's release signal
     actionStatus = 0;

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -356,15 +356,32 @@ void menuRequestInfoSize(void)
 static void _menuSaveConfig()
 {
     int result;
+    bdm_config_diag_snapshot_t diag;
+
+    // bdmLogConfigWrite* report device identity by OPENING every BDM root -- up to nine blocking
+    // device probes, most of them failed opens, which cost seconds apiece on a slow stick. Holding
+    // menuSemaId across device I/O is the exact trap documented on _menuLoadConfigAsync above:
+    // menuRenderElements takes that sema every frame, so the whole UI freezes for the duration.
+    //
+    // Nor may they keep borrowing itemConfigList/itemConfig once the sema is released -- either can
+    // be freed the moment it is. So capture every value the report needs into a plain-value stack
+    // snapshot while the sema IS held, then report from the copy with no lock and no borrowed
+    // pointers. In a release build all three calls are no-ops; a diagnostic build is the one we hand
+    // to a tester, and it has to measure the save rather than itself.
+    WaitSema(menuSemaId);
+    bdmCaptureConfigWriteDiag(itemConfigList, itemConfig, &diag);
+    SignalSema(menuSemaId);
+
+    bdmLogConfigWriteEntry(&diag);
 
     WaitSema(menuSemaId);
-    bdmLogConfigWriteEntry(itemConfigList, itemConfig);
     result = configWrite(itemConfig);
-    bdmLogConfigWriteResult(itemConfigList, itemConfig, result);
     itemConfigId = -1;       // to invalidate cache and force reload
     menuSaveResult = result; // publish BEFORE actionStatus=0 -- that flag is the waiter's release signal
     actionStatus = 0;
     SignalSema(menuSemaId);
+
+    bdmLogConfigWriteResult(&diag, result);
 
     if (!result)
         // gLastSaveErrno was latched inside configWrite at the real failure site.

--- a/src/opl.c
+++ b/src/opl.c
@@ -129,21 +129,7 @@ static unsigned int frameCounter;
 // noticed promptly.
 #define BDM_EMPTY_SLOT_PROBE_RATIO 8
 
-// BOOT WARM-UP. The throttle above is correct for steady state and wrong for the first few seconds
-// of a session: USB enumeration is not instant, so a stick that is physically present at power-on
-// can finish mounting AFTER its slot's early probes have already run. It is then an "empty" slot,
-// probed on the 8x rotation (~8 s) and only while the user is holding still -- so a user who is
-// navigating may not see it at all, and replugging it is the thing that finally works, because a
-// hotplug bumps the generation and bypasses every gate.
-//
-// For a bounded window after the first menu tick, probe BDM slots regardless of the empty-slot
-// rotation and regardless of idleness. The per-mode MENU_BG_RESCAN_MIN_INTERVAL_TICKS floor still
-// applies, so this is at most one probe per slot per 2 s, and it stops entirely afterwards -- the
-// steady-state cost this throttle exists to prevent is untouched.
-#define BDM_BOOT_WARMUP_TICKS (30 * CLOCKS_PER_SEC)
-
 static clock_t lastBgRescan[MODE_COUNT];
-static clock_t bdmWarmupStart;
 static unsigned int lastSeenBdmGeneration;
 
 static char errorMessage[256];
@@ -1235,11 +1221,6 @@ static void menuUpdateHook()
         int genChanged = (gen != lastSeenBdmGeneration);
         clock_t now = clock();
 
-        // First tick through here is the start of the boot warm-up window. (A clock() of exactly 0
-        // simply defers the anchor by one tick; the window is a heuristic, not a deadline.)
-        if (bdmWarmupStart == 0)
-            bdmWarmupStart = now;
-
         // "Storage changed underneath us" is the ONLY routine event that can make previously-absent
         // art exist, so it is the only routine event that should re-open the question. The memo used
         // to be cleared by updateMenuFromGameList instead -- i.e. on every list rebuild, including the
@@ -1280,18 +1261,11 @@ static void menuUpdateHook()
                 // empty since boot. It is also the most plausible source of the spurious
                 // "device replugged" the user sees while simply navigating, since those probes poke
                 // the USB stack for devices that are not there.
-                // Boot warm-up (see BDM_BOOT_WARMUP_TICKS): for a bounded window, a BDM slot is
-                // probed whether or not it has ever held a device and whether or not the user is
-                // sitting still, so a stick that finishes enumerating after boot is noticed without
-                // waiting on the empty-slot rotation -- or on the user replugging it.
-                int isBdmSlot = (mode >= BDM_MODE && mode <= BDM_MODE_LAST);
-                int bdmWarmup = isBdmSlot && (now - bdmWarmupStart) < BDM_BOOT_WARMUP_TICKS;
-
-                if (!genChanged && !bdmWarmup && isBdmSlot && !bdmSlotEverConnected(mode) &&
+                if (!genChanged && mode >= BDM_MODE && mode <= BDM_MODE_LAST && !bdmSlotEverConnected(mode) &&
                     (frameCounter % (MENU_GENERAL_UPDATE_DELAY * BDM_EMPTY_SLOT_PROBE_RATIO)) != 0)
                     continue;
 
-                if (genChanged || ((longIdle || bdmWarmup) && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
+                if (genChanged || (longIdle && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
                     // Stamp the throttle only on an accepted request, so a rejected one retries on
                     // the next tick instead of being silently skipped for a full interval.
                     int accepted = (ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);

--- a/src/opl.c
+++ b/src/opl.c
@@ -129,7 +129,21 @@ static unsigned int frameCounter;
 // noticed promptly.
 #define BDM_EMPTY_SLOT_PROBE_RATIO 8
 
+// BOOT WARM-UP. The throttle above is correct for steady state and wrong for the first few seconds
+// of a session: USB enumeration is not instant, so a stick that is physically present at power-on
+// can finish mounting AFTER its slot's early probes have already run. It is then an "empty" slot,
+// probed on the 8x rotation (~8 s) and only while the user is holding still -- so a user who is
+// navigating may not see it at all, and replugging it is the thing that finally works, because a
+// hotplug bumps the generation and bypasses every gate.
+//
+// For a bounded window after the first menu tick, probe BDM slots regardless of the empty-slot
+// rotation and regardless of idleness. The per-mode MENU_BG_RESCAN_MIN_INTERVAL_TICKS floor still
+// applies, so this is at most one probe per slot per 2 s, and it stops entirely afterwards -- the
+// steady-state cost this throttle exists to prevent is untouched.
+#define BDM_BOOT_WARMUP_TICKS (30 * CLOCKS_PER_SEC)
+
 static clock_t lastBgRescan[MODE_COUNT];
+static clock_t bdmWarmupStart;
 static unsigned int lastSeenBdmGeneration;
 
 static char errorMessage[256];
@@ -1221,6 +1235,11 @@ static void menuUpdateHook()
         int genChanged = (gen != lastSeenBdmGeneration);
         clock_t now = clock();
 
+        // First tick through here is the start of the boot warm-up window. (A clock() of exactly 0
+        // simply defers the anchor by one tick; the window is a heuristic, not a deadline.)
+        if (bdmWarmupStart == 0)
+            bdmWarmupStart = now;
+
         // "Storage changed underneath us" is the ONLY routine event that can make previously-absent
         // art exist, so it is the only routine event that should re-open the question. The memo used
         // to be cleared by updateMenuFromGameList instead -- i.e. on every list rebuild, including the
@@ -1261,11 +1280,18 @@ static void menuUpdateHook()
                 // empty since boot. It is also the most plausible source of the spurious
                 // "device replugged" the user sees while simply navigating, since those probes poke
                 // the USB stack for devices that are not there.
-                if (!genChanged && mode >= BDM_MODE && mode <= BDM_MODE_LAST && !bdmSlotEverConnected(mode) &&
+                // Boot warm-up (see BDM_BOOT_WARMUP_TICKS): for a bounded window, a BDM slot is
+                // probed whether or not it has ever held a device and whether or not the user is
+                // sitting still, so a stick that finishes enumerating after boot is noticed without
+                // waiting on the empty-slot rotation -- or on the user replugging it.
+                int isBdmSlot = (mode >= BDM_MODE && mode <= BDM_MODE_LAST);
+                int bdmWarmup = isBdmSlot && (now - bdmWarmupStart) < BDM_BOOT_WARMUP_TICKS;
+
+                if (!genChanged && !bdmWarmup && isBdmSlot && !bdmSlotEverConnected(mode) &&
                     (frameCounter % (MENU_GENERAL_UPDATE_DELAY * BDM_EMPTY_SLOT_PROBE_RATIO)) != 0)
                     continue;
 
-                if (genChanged || (longIdle && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
+                if (genChanged || ((longIdle || bdmWarmup) && (now - lastBgRescan[mode]) >= MENU_BG_RESCAN_MIN_INTERVAL_TICKS)) {
                     // Stamp the throttle only on an accepted request, so a rejected one retries on
                     // the next tick instead of being silently skipped for a full interval.
                     int accepted = (ioPutRequest(IO_MENU_UPDATE_DEFFERED, &list_support[i].support->mode) == IO_OK);

--- a/src/opl.c
+++ b/src/opl.c
@@ -1117,9 +1117,11 @@ static void updateMenuFromGameList(opl_io_module_t *mdl)
 
     if (gAutosort) {
         gup = guiOpCreate(GUI_OP_SORT);
-        gup->menu.menu = &mdl->menuItem;
-        gup->menu.subMenu = &mdl->subMenu;
-        guiDeferUpdate(gup);
+        if (gup) { // OOM: an unsorted list beats dereferencing NULL, same as the append loop above
+            gup->menu.menu = &mdl->menuItem;
+            gup->menu.subMenu = &mdl->subMenu;
+            guiDeferUpdate(gup);
+        }
     }
 }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1352,6 +1352,18 @@ void setErrorMessageWithCode(int strId, int error)
     guiSetFrameHook(&errorMessageHook);
 }
 
+void setErrorMessageWithCodeAndDetail(int strId, int error, const char *detail)
+{
+    size_t used;
+
+    formatErrorMessage(_l(strId), NULL, error, 0, 1);
+    used = strlen(errorMessage);
+    if (detail != NULL && detail[0] != '\0' && used < sizeof(errorMessage) - 1)
+        snprintf(&errorMessage[used], sizeof(errorMessage) - used, "\nDiagnostic reason: %s", detail);
+    errorMessageStringId = strId;
+    guiSetFrameHook(&errorMessageHook);
+}
+
 void setErrorMessage(int strId)
 {
     formatErrorMessage(_l(strId), NULL, 0, 0, 0);

--- a/src/opl.c
+++ b/src/opl.c
@@ -4690,8 +4690,12 @@ static void autoLaunchBDMGame(char *argv[])
             char detectedDriver[sizeof(gAutoLaunchDeviceData->bdmDriver)] = {0};
             int detectedDeviceIndex = -1;
 
-            fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, detectedDriver, sizeof(detectedDriver) - 1);
-            fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &detectedDeviceIndex, sizeof(detectedDeviceIndex));
+            // Every slot in this sweep gets asked, including ones whose backing device has gone --
+            // and asking for the name WITH a return buffer there faults the IOP outright. Boot is
+            // the worst place to do that, so go through the guarded reader and only chase the
+            // device number once it has confirmed a mounted block device. See bdmReadDriverName().
+            if (bdmReadDriverName(dir, detectedDriver, sizeof(detectedDriver)) >= 0)
+                fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &detectedDeviceIndex, sizeof(detectedDeviceIndex));
             fileXioDclose(dir);
 
             if (selectedMassSlot < 0) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -299,24 +299,6 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         guiCheckNotifications(0, langChanged);
     }
 
-    /* ⚠ SERIALIZED WITH RENDERING, and it must stay that way. This function runs on the IO WORKER --
-       bdmUpdateDeviceData() calls moduleUpdateMenu() from four places as devices appear, vanish and
-       re-identify -- while the GUI thread walks the very list being rebuilt here: themes.c
-       drawHintText() reads menu->item->hints every frame, and traverses it TWICE (once to align,
-       once to draw).
-
-       menuRemoveHints() frees every node, then the menuAddHint()s below malloc new ones and walk to
-       the tail to link them. Unserialized, a draw that lands mid-rebuild follows a freed ->next into
-       memory that has already been handed back out; if the reused block happens to link back into
-       the chain, the renderer loops forever and the console sits there with the last frame still on
-       screen. It is cumulative by nature -- every device update is another roll -- which is why it
-       took a while of moving between pages before it hit.
-
-       guiStartFrame() holds gGUILockSemaId for the whole frame, so this is the lock that excludes
-       the renderer. Release it before the themeChanged block below, which takes it again for the
-       same reason (the sema is not recursive). */
-    guiLock();
-
     // refresh Hints
     menuRemoveHints(&mod->menuItem);
 
@@ -343,8 +325,6 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         if (vcdModeSupported(mod->support->mode) && gDefaultGameView == GAME_VIEW_BOTH)
             menuAddHint(&mod->menuItem, _STR_VCD, L3_ICON);
     }
-
-    guiUnlock();
 
     // refresh Cache
     if (themeChanged) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -299,6 +299,24 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         guiCheckNotifications(0, langChanged);
     }
 
+    /* ⚠ SERIALIZED WITH RENDERING, and it must stay that way. This function runs on the IO WORKER --
+       bdmUpdateDeviceData() calls moduleUpdateMenu() from four places as devices appear, vanish and
+       re-identify -- while the GUI thread walks the very list being rebuilt here: themes.c
+       drawHintText() reads menu->item->hints every frame, and traverses it TWICE (once to align,
+       once to draw).
+
+       menuRemoveHints() frees every node, then the menuAddHint()s below malloc new ones and walk to
+       the tail to link them. Unserialized, a draw that lands mid-rebuild follows a freed ->next into
+       memory that has already been handed back out; if the reused block happens to link back into
+       the chain, the renderer loops forever and the console sits there with the last frame still on
+       screen. It is cumulative by nature -- every device update is another roll -- which is why it
+       took a while of moving between pages before it hit.
+
+       guiStartFrame() holds gGUILockSemaId for the whole frame, so this is the lock that excludes
+       the renderer. Release it before the themeChanged block below, which takes it again for the
+       same reason (the sema is not recursive). */
+    guiLock();
+
     // refresh Hints
     menuRemoveHints(&mod->menuItem);
 
@@ -325,6 +343,8 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         if (vcdModeSupported(mod->support->mode) && gDefaultGameView == GAME_VIEW_BOTH)
             menuAddHint(&mod->menuItem, _STR_VCD, L3_ICON);
     }
+
+    guiUnlock();
 
     // refresh Cache
     if (themeChanged) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -1352,14 +1352,23 @@ void setErrorMessageWithCode(int strId, int error)
     guiSetFrameHook(&errorMessageHook);
 }
 
+// The detail suffix is an internal enum name ("PS2FS_LOAD_FAILURE"), untranslated by construction,
+// so a plain release gets the localized message alone and behaves exactly like setErrorMessageWithCode.
+// OPLDIAG=1 appends the reason so a tester's screenshot names WHICH probe failed, not just the code.
 void setErrorMessageWithCodeAndDetail(int strId, int error, const char *detail)
 {
+#ifdef __OPLDIAG
     size_t used;
+#else
+    (void)detail;
+#endif
 
     formatErrorMessage(_l(strId), NULL, error, 0, 1);
+#ifdef __OPLDIAG
     used = strlen(errorMessage);
     if (detail != NULL && detail[0] != '\0' && used < sizeof(errorMessage) - 1)
         snprintf(&errorMessage[used], sizeof(errorMessage) - used, "\nDiagnostic reason: %s", detail);
+#endif
     errorMessageStringId = strId;
     guiSetFrameHook(&errorMessageHook);
 }

--- a/src/pad.c
+++ b/src/pad.c
@@ -93,6 +93,14 @@ static u32 oldpaddata;
 static int delaycnt[16];
 static int paddelay[16];
 
+// Menu rumble pulse state. Declared up here, above readPad(), because the PADEMU poll path drives
+// the DS3/DS4/DS5 motors directly from it -- those pads never reach padSetActDirect. The pulse
+// lifetime and timing rules live with padRumble()/padRumbleFlush() further down.
+static u32 rumbleStartTicks = 0;
+static u32 rumbleDurTicks = 0;
+static int rumbleActive = 0;
+static int rumbleLarge = 0;
+
 // KEY_ to PAD_ conversion table
 static const int keyToPad[17] = {
     -1,
@@ -394,9 +402,21 @@ static int readPad(struct pad_data_t *pad, int *pollClean)
     }
 
 #ifdef PADEMU
+    // A DS3/DS4/DS5 NEVER passes through padSetActDirect: its motors live on this PADEMU channel,
+    // so the rumble state has to be driven here or the pad simply cannot vibrate, no matter what the
+    // native path does. These calls were hardcoded to zero, which is why menu rumble was dead on
+    // every PADEMU controller while working on a native pad.
+    //
+    // This costs NOTHING extra. ds34*_set_rumble is already issued on every poll -- it was just
+    // being handed 0 each time -- so none of the bounded-retry machinery the native path needs
+    // applies here: the level is re-asserted every frame as a side effect of polling, and drops back
+    // to 0 on the first poll after the pulse expires. Both motors are driven together, matching the
+    // known-good RETROLauncher behaviour.
+    u8 pademuRumble = (gEnableRumble && rumbleActive) ? (u8)rumbleLarge : 0;
+
     if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING) {
         ret = ds34bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34bt_set_rumble(pad->port, 0, 0);
+        ds34bt_set_rumble(pad->port, pademuRumble, pademuRumble);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -405,7 +425,7 @@ static int readPad(struct pad_data_t *pad, int *pollClean)
 
     if (ds34usb_get_status(pad->port) & DS34USB_STATE_RUNNING) {
         ret = ds34usb_get_data(pad->port, (u8 *)&pad->buttons.btns);
-        ds34usb_set_rumble(pad->port, 0, 0);
+        ds34usb_set_rumble(pad->port, pademuRumble, pademuRumble);
         if (ret != 0) {
             newpdata |= 0xffff ^ pad->buttons.btns;
             padsRead++;
@@ -471,10 +491,6 @@ elapsed comparison in raw ticks is correct across one wrap by ordinary unsigned 
 pulse is capped below at a fraction of a second, so one wrap is the most that can occur inside it.
 This is why the feature needs none of the pad-clock rework it was originally blocked on.
 ----------------------------------------------------------------------------------------------------*/
-static u32 rumbleStartTicks = 0;
-static u32 rumbleDurTicks = 0;
-static int rumbleActive = 0;
-static int rumbleLarge = 0;
 
 // Longest pulse we will ever hold a motor on for. Menu feedback, not a sustained buzz.
 #define RUMBLE_MAX_MS 500
@@ -552,6 +568,23 @@ static void padActSet(struct pad_data_t *pad, int small, int large)
  * The decay only runs from readPads(), so anything that can block the GUI thread for longer than a
  * pulse has to stop the motor on the way in or it buzzes for the whole operation.
  */
+#ifdef PADEMU
+// PADEMU motors normally decay through readPad()'s per-poll drive, but unloadPads() dismantles the
+// pad stack and readPads() never runs again -- so the last non-zero level would stay latched in the
+// ds34 driver on the way out. Stop them explicitly on the same path the native actuators use.
+static void padPademuStopAll(void)
+{
+    int i;
+
+    for (i = 0; i < pad_count; ++i) {
+        if (ds34bt_get_status(pad_data[i].port) & DS34BT_STATE_RUNNING)
+            ds34bt_set_rumble(pad_data[i].port, 0, 0);
+        if (ds34usb_get_status(pad_data[i].port) & DS34USB_STATE_RUNNING)
+            ds34usb_set_rumble(pad_data[i].port, 0, 0);
+    }
+}
+#endif
+
 void padRumbleFlush(void)
 {
     int i, r;
@@ -570,6 +603,10 @@ void padRumbleFlush(void)
     for (r = 0; r < RUMBLE_OFF_SYNC_SENDS; ++r)
         for (i = 0; i < pad_count; ++i)
             padActSet(&pad_data[i], 0, 0);
+
+#ifdef PADEMU
+    padPademuStopAll();
+#endif
 
     rumbleOffRepeats = RUMBLE_CMD_REPEATS;
 }

--- a/src/pad.c
+++ b/src/pad.c
@@ -570,10 +570,14 @@ void padRumble(int durationMs, int large)
         large = 255;
 
     if (rumbleActive) {
-        // ACTIVE->ACTIVE: coalesce/extend without another actuator RPC.
+        int strengthChanged = (rumbleLarge != large);
         rumbleStartTicks = cpu_ticks();
         rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
         rumbleLarge = large;
+        if (strengthChanged) {
+            for (i = 0; i < pad_count; ++i)
+                padActSet(&pad_data[i], 1, large);
+        }
         return;
     }
 

--- a/src/pad.c
+++ b/src/pad.c
@@ -479,12 +479,27 @@ static int rumbleLarge = 0;
 // Longest pulse we will ever hold a motor on for. Menu feedback, not a sustained buzz.
 #define RUMBLE_MAX_MS 500
 
+// Bounded delivery redundancy for actuator commands. See point 1 of the freepad note below for why
+// neither send-once nor re-send-forever is correct. Do not reduce either of these to zero.
+#define RUMBLE_CMD_REPEATS    3 // extra deliveries after the immediate one, drained by readPads()
+#define RUMBLE_OFF_SYNC_SENDS 2 // stop commands issued synchronously, for paths readPads never drains
+
+static int rumbleOnRepeats = 0;
+static int rumbleOffRepeats = 0;
+
 /* THE TWO THINGS THAT MAKE THIS SILENT ON REAL HARDWARE, both properties of freepad.irx -- which is
    what we ship as padman (Makefile: asm/padman.c is built from $(PS2SDK)/iop/irx/freepad.irx):
 
    1. freepad DROPS padSetActDirect unless its current task is TASK_UPDATE_PAD, and it still returns
-      1 when it does. Sending once per pulse means one unlucky frame eats the whole pulse. So the
-      command is RE-SENT every frame for the pulse's life. Do NOT "optimise" this back to send-once.
+      1 when it does. Sending once per pulse means one unlucky frame eats the whole pulse -- and the
+      two directions are NOT symmetric: a dropped "on" is a missing pulse, but a dropped "off"
+      latches the motor ON, because the IOP holds actuator state until something tells it otherwise.
+
+      Neither extreme works. Re-sending every frame for the pulse's life cures both drops but puts a
+      continuous RPC stream on SIO2 -- the pad's own bus, shared with MX4SIO. Sending exactly once
+      removes that traffic and reinstates both drops. So each state change is repeated over the next
+      few polls and then stops: see RUMBLE_CMD_REPEATS / RUMBLE_OFF_SYNC_SENDS above, which is what
+      readPads() drains. Do NOT "optimise" either of those to zero.
 
    2. freepad fills its actuator alignment with 0xFF on padPortOpen, and padSetActAlign is the only
       thing that overwrites it. padSetActDirect latches the bytes and returns 1 WITHOUT consulting
@@ -539,7 +554,7 @@ static void padActSet(struct pad_data_t *pad, int small, int large)
  */
 void padRumbleFlush(void)
 {
-    int i;
+    int i, r;
 
     if (!rumbleActive)
         return;
@@ -547,8 +562,16 @@ void padRumbleFlush(void)
     rumbleActive = 0;
     rumbleDurTicks = 0;
     rumbleLarge = 0;
-    for (i = 0; i < pad_count; ++i)
-        padActSet(&pad_data[i], 0, 0);
+    rumbleOnRepeats = 0;
+
+    // A dropped stop is the expensive direction (latched motor), and unloadPads() calls this on the
+    // way out where readPads() will never run again to drain the tail. Issue the first few now, and
+    // arm the rest for the polls that follow when there are any.
+    for (r = 0; r < RUMBLE_OFF_SYNC_SENDS; ++r)
+        for (i = 0; i < pad_count; ++i)
+            padActSet(&pad_data[i], 0, 0);
+
+    rumbleOffRepeats = RUMBLE_CMD_REPEATS;
 }
 
 /** Starts a rumble pulse on every connected pad that has actuators.
@@ -575,6 +598,7 @@ void padRumble(int durationMs, int large)
         rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
         rumbleLarge = large;
         if (strengthChanged) {
+            rumbleOnRepeats = RUMBLE_CMD_REPEATS;
             for (i = 0; i < pad_count; ++i)
                 padActSet(&pad_data[i], 1, large);
         }
@@ -585,6 +609,9 @@ void padRumble(int durationMs, int large)
     rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
     rumbleActive = 1;
     rumbleLarge = large;
+    // A new pulse cancels any stop still being repeated, or the tail would switch it back off.
+    rumbleOffRepeats = 0;
+    rumbleOnRepeats = RUMBLE_CMD_REPEATS;
 
     for (i = 0; i < pad_count; ++i)
         padActSet(&pad_data[i], 1, large);
@@ -673,11 +700,21 @@ int readPads()
         }
     }
 
-    // Rumble decay. Edge-driven: no continuous per-frame RPC while active.
+    // Rumble decay, plus the bounded re-send tail (see RUMBLE_CMD_REPEATS). Edge-driven: the RPC
+    // stream stops after a few polls instead of running for the pulse's whole life, but a single
+    // dropped padSetActDirect no longer decides whether the pulse happens -- or whether it ends.
     if (rumbleActive) {
         if ((u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
             padRumbleFlush();
+        } else if (rumbleOnRepeats > 0) {
+            for (i = 0; i < pad_count; ++i)
+                padActSet(&pad_data[i], 1, rumbleLarge);
+            rumbleOnRepeats--;
         }
+    } else if (rumbleOffRepeats > 0) {
+        for (i = 0; i < pad_count; ++i)
+            padActSet(&pad_data[i], 0, 0);
+        rumbleOffRepeats--;
     }
 
     for (i = 0; i < 16; ++i) {

--- a/src/pad.c
+++ b/src/pad.c
@@ -530,8 +530,27 @@ static int rumbleOffRepeats = 0;
 // then killed rumble silently for the whole session.
 static void padRumbleRealign(struct pad_data_t *pad)
 {
-    if (pad->actAligned || pad->actuators == 0)
+    if (pad->actAligned)
         return;
+
+    // RECOVER THE ACTUATOR COUNT RATHER THAN TRUSTING IT. initializePad() clears actuators to 0 up
+    // front -- deliberately, so a digital pad swapped into the port cannot inherit a stale count --
+    // and then has FOUR `return 1` bail-outs above the padInfoAct() that would refill it. Any one of
+    // them (a mode table that reads short, a pad that is not DUALSHOCK-capable on that pass, an
+    // ex-id query that fails) leaves actuators==0 for the rest of the session, and both this
+    // function and padActSet() used to veto on exactly that -- so one init hiccup killed rumble
+    // permanently, with nothing logged and no way for the user to tell.
+    //
+    // padInfoAct() is an EE-local read of the pad buffer freepad has already DMA'd; it neither
+    // blocks nor touches SIO2, so asking again at the first pulse costs nothing. A genuinely
+    // actuator-less pad answers <= 0 every time and is simply skipped.
+    if (pad->actuators == 0) {
+        pad->actuators = padInfoAct(pad->port, pad->slot, -1, 0);
+        if (pad->actuators <= 0) {
+            pad->actuators = 0;
+            return;
+        }
+    }
 
     pad->actAlign[0] = 0; // small engine -> byte 0 of padSetActDirect
     pad->actAlign[1] = 1; // big engine   -> byte 1
@@ -551,10 +570,18 @@ static void padActSet(struct pad_data_t *pad, int small, int large)
 {
     char act[6];
 
-    if (pad->actuators == 0)
+    // Gate on READINESS, not on the actuator count. The count is a cached answer that a single init
+    // bail-out can leave at 0 forever (see padRumbleRealign below, which now recovers it); gating
+    // sends on it turned that transient into a permanent, silent loss of rumble. A pad that is ready
+    // accepts the command; a digital-only controller ignores it harmlessly.
+    if (!isPadReadyState(pad->state))
         return;
 
     padRumbleRealign(pad);
+
+    // Still nothing to drive after the recovery attempt -- genuinely actuator-less pad.
+    if (pad->actuators == 0)
+        return;
 
     memset(act, 0, sizeof(act));
     act[0] = small ? 1 : 0;        // small engine: on/off only

--- a/src/pad.c
+++ b/src/pad.c
@@ -547,10 +547,6 @@ void padRumbleFlush(void)
     rumbleActive = 0;
     rumbleDurTicks = 0;
     rumbleLarge = 0;
-    // Sent twice: the IOP LATCHES the actuator state, so a dropped "off" leaves the motor spinning
-    // with nothing left to stop it. The "on" gets a re-send every frame; the "off" gets no frames.
-    for (i = 0; i < pad_count; ++i)
-        padActSet(&pad_data[i], 0, 0);
     for (i = 0; i < pad_count; ++i)
         padActSet(&pad_data[i], 0, 0);
 }
@@ -572,6 +568,14 @@ void padRumble(int durationMs, int large)
         large = 0;
     if (large > 255)
         large = 255;
+
+    if (rumbleActive) {
+        // ACTIVE->ACTIVE: coalesce/extend without another actuator RPC.
+        rumbleStartTicks = cpu_ticks();
+        rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
+        rumbleLarge = large;
+        return;
+    }
 
     rumbleStartTicks = cpu_ticks();
     rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
@@ -665,15 +669,10 @@ int readPads()
         }
     }
 
-    // Rumble decay + re-send. Unsigned elapsed in RAW ticks -- see the note above padActSet().
-    // The re-send is not redundant: freepad drops padSetActDirect outside TASK_UPDATE_PAD and still
-    // reports success, so a pulse sent only once can be silently swallowed whole.
+    // Rumble decay. Edge-driven: no continuous per-frame RPC while active.
     if (rumbleActive) {
         if ((u32)(cpu_ticks() - rumbleStartTicks) >= rumbleDurTicks) {
             padRumbleFlush();
-        } else {
-            for (i = 0; i < pad_count; ++i)
-                padActSet(&pad_data[i], 1, rumbleLarge);
         }
     }
 

--- a/src/pad.c
+++ b/src/pad.c
@@ -412,7 +412,14 @@ static int readPad(struct pad_data_t *pad, int *pollClean)
     // applies here: the level is re-asserted every frame as a side effect of polling, and drops back
     // to 0 on the first poll after the pulse expires. Both motors are driven together, matching the
     // known-good RETROLauncher behaviour.
-    u8 pademuRumble = (gEnableRumble && rumbleActive) ? (u8)rumbleLarge : 0;
+    // SELF-EXPIRING, deliberately: derived from elapsed ticks rather than trusting rumbleActive to
+    // have been cleared. The ds34 driver LATCHES whatever level it was last handed, so if the decay
+    // in readPads() does not run -- reordered, skipped, or the GUI thread blocked -- a stale flag
+    // would leave the motor on with nothing to stop it. Any poll that happens at all now yields 0
+    // once the pulse is over.
+    u8 pademuRumble = 0;
+    if (gEnableRumble && rumbleActive && (u32)(cpu_ticks() - rumbleStartTicks) < rumbleDurTicks)
+        pademuRumble = (u8)rumbleLarge;
 
     if (ds34bt_get_status(pad->port) & DS34BT_STATE_RUNNING) {
         ret = ds34bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
@@ -638,15 +645,26 @@ void padRumbleFlush(void)
     rumbleOffRepeats = RUMBLE_CMD_REPEATS;
 }
 
-/** Starts a rumble pulse on every connected pad that has actuators.
+/** Arms a rumble pulse. STATE ONLY -- issues no pad command, on purpose.
+ *
+ * ⚠ THIS IS CALLED FROM THREADS THAT MUST NEVER TOUCH SIO2. sfxPlay() calls sfxRumble() inline, and
+ * sfxPlay(SFX_BD_CONNECT/DISCONNECT) is reached from bdmNeedsUpdate() on the IO WORKER. Issuing
+ * padSetActDirect/padSetActAlign from there puts SIO2 traffic on the pad's own bus underneath the
+ * GUI thread's readPads(), which is the documented hard-freeze mechanism (see the freepad note
+ * above and pad.c's bounded waits) -- observed on hardware as the console locking up the moment a
+ * second USB device was hotplugged, with the motor stuck on because the poll loop that would have
+ * expired the pulse never ran again.
+ *
+ * So the actuators are driven EXCLUSIVELY from readPads(), which owns the pad bus. Arming only sets
+ * counters; the next poll issues the command. That costs one frame of onset latency and removes the
+ * cross-thread hazard entirely.
+ *
  * @param durationMs pulse length, clamped to RUMBLE_MAX_MS
  * @param large      large (variable-speed) engine strength, 0..255; the small engine runs for the
  *                   whole pulse regardless, since it is the one that gives a crisp click
  */
 void padRumble(int durationMs, int large)
 {
-    int i;
-
     if (durationMs <= 0)
         return;
     if (durationMs > RUMBLE_MAX_MS)
@@ -661,11 +679,8 @@ void padRumble(int durationMs, int large)
         rumbleStartTicks = cpu_ticks();
         rumbleDurTicks = (u32)durationMs * CLOCKS_PER_MILISEC;
         rumbleLarge = large;
-        if (strengthChanged) {
+        if (strengthChanged)
             rumbleOnRepeats = RUMBLE_CMD_REPEATS;
-            for (i = 0; i < pad_count; ++i)
-                padActSet(&pad_data[i], 1, large);
-        }
         return;
     }
 
@@ -676,9 +691,6 @@ void padRumble(int durationMs, int large)
     // A new pulse cancels any stop still being repeated, or the tail would switch it back off.
     rumbleOffRepeats = 0;
     rumbleOnRepeats = RUMBLE_CMD_REPEATS;
-
-    for (i = 0; i < pad_count; ++i)
-        padActSet(&pad_data[i], 1, large);
 }
 
 /* Screen-transition edge freeze. During the fade the main loop polls pads but dispatches no input,

--- a/src/sound.c
+++ b/src/sound.c
@@ -262,6 +262,30 @@ int sfxGetSoundDuration(int id)
 // the menu mid-navigation. Always measured (two tick reads), rendered only when Settings ->
 // Debug Colors is on (gui.c / dia.c).
 #define SFX_CLOCKS_PER_MS 147456 // EE cpu_ticks() rate
+
+/* MENU RUMBLE TIMING -- the RETROLauncher model, which is the reference for feedback that actually
+   reads as feedback on hardware. Two shapes, and the split matters more than either value:
+
+     NAVIGATION is a LONG, SOFT big-motor thump. Length is what makes it perceptible -- a DualShock's
+     eccentric mass needs roughly 50-100 ms just to reach amplitude you can feel, so a short pulse is
+     inaudible to the hand no matter how hard it is driven. This was previously 35 ms at 64/255,
+     i.e. below the motor's spin-up time: correct commands, no sensation.
+
+     DECISION is a SHORTER, HARDER bump. It happens once, so it can afford to be crisp.
+
+   The old values had this backwards -- the constant, per-step event was the short weak one and the
+   one-shot events were the long strong ones.
+
+   Held navigation cannot simply repeat the full thump: steps arrive faster than 240 ms and the
+   feedback smears into one continuous drone. Repeats are therefore scaled to a fraction of the
+   OBSERVED step interval, with a floor below which we stay silent rather than buzz. */
+#define RUMBLE_NAV_MS               240
+#define RUMBLE_NAV_LEVEL            0x50
+#define RUMBLE_NAV_REPEAT_WINDOW_MS 400
+#define RUMBLE_NAV_REPEAT_DUTY_PCT  45
+#define RUMBLE_NAV_MIN_MS           80
+#define RUMBLE_DECISION_MS          110
+#define RUMBLE_DECISION_LEVEL       0x60
 static unsigned int sfxLastPlayMs = 0;
 static unsigned int sfxMaxPlayMs = 0;
 
@@ -288,33 +312,49 @@ static void sfxRumble(int id)
 
     switch (id) {
         case SFX_CURSOR: {
-            // Cursor sounds are emitted for every navigation step, including held buttons. Keep the
-            // prompt responsive without turning a long scroll into a continuous motor buzz.
+            // AN ERM HAS TO SPIN UP BEFORE IT CAN BE FELT. This was a 35 ms pulse at 64/255, and a
+            // DualShock's eccentric mass needs roughly 50-100 ms just to reach perceptible
+            // amplitude -- the stop command arrived before the motor had meaningfully moved, so
+            // navigation rumble was inaudible to the hand even when every command was delivered
+            // correctly. Length matters more than strength here.
+            //
+            // The old fixed 80 ms lockout also cannot survive a longer pulse: a held scroll would
+            // re-arm faster than the pulse ends and the "thump per step" becomes one continuous
+            // buzz. So scale to the OBSERVED step interval instead -- the first step of a scroll
+            // gets the full thump, measured repeats ride at a fraction of their own cadence, and
+            // steps coming in faster than the motor can answer stay silent rather than smearing
+            // into a drone.
             static u32 lastCursorRumbleTicks;
+            static int haveCursorInterval;
             u32 now = cpu_ticks();
-            if (lastCursorRumbleTicks != 0 && (now - lastCursorRumbleTicks) / SFX_CLOCKS_PER_MS < 80)
-                return;
+            int durationMs = RUMBLE_NAV_MS;
+
+            if (haveCursorInterval) {
+                u32 intervalMs = (now - lastCursorRumbleTicks) / SFX_CLOCKS_PER_MS;
+                if (intervalMs < RUMBLE_NAV_REPEAT_WINDOW_MS) {
+                    int dutyMs = (int)((intervalMs * RUMBLE_NAV_REPEAT_DUTY_PCT) / 100);
+                    if (dutyMs < RUMBLE_NAV_MIN_MS)
+                        return; // faster than an ERM can answer -- a buzz, not feedback
+                    if (dutyMs < durationMs)
+                        durationMs = dutyMs;
+                }
+            }
+
             lastCursorRumbleTicks = now;
-            padRumble(35, 64);
+            haveCursorInterval = 1;
+            padRumble(durationMs, RUMBLE_NAV_LEVEL);
             break;
         }
+        // One-shot events all share the decision bump. RETROLauncher does not give each of these its
+        // own signature, and inventing six was how they ended up longer and stronger than the
+        // navigation thump they are supposed to punctuate.
         case SFX_CONFIRM:
-            padRumble(120, 160);
-            break;
         case SFX_CANCEL:
-            padRumble(90, 96);
-            break;
         case SFX_MESSAGE:
-            padRumble(120, 160);
-            break;
         case SFX_TRANSITION:
-            padRumble(150, 200);
-            break;
         case SFX_BD_CONNECT:
-            padRumble(100, 128);
-            break;
         case SFX_BD_DISCONNECT:
-            padRumble(75, 96);
+            padRumble(RUMBLE_DECISION_MS, RUMBLE_DECISION_LEVEL);
             break;
         default:
             break;

--- a/src/system.c
+++ b/src/system.c
@@ -1359,9 +1359,30 @@ void sysLaunchNeutrino(const char *driver, const char *path, const char *startup
         snprintf(filePath, sizeof(filePath), "-dvd=%s%s", bsdfsDvdPrefix[fsOverride], path);
         if (argc < argvMax)
             argv[argc++] = filePath;
+
+        /* QUICKBOOT IS THE SECOND HALF OF THE KEEP-IOP HANDOFF, and without it the first half is
+           self-defeating on USB. elfldr deliberately does NOT reset the IOP, so Neutrino inherits
+           OPL's live iomanX/fileXio/bdm/bdmfs_fatfs and its mounts -- that is the entire point. But
+           Neutrino's DEFAULT boot then performs its own IOP reset, which destroys exactly what we
+           just preserved, leaving it to re-initialise USB itself before it can reach the ISO.
+
+           Symptom when only the first half ships: the handoff completes (no OSDSYS -- the loader
+           did its job) and then the screen stays black, because Neutrino reset away the stack the
+           game path depends on. -qb keeps the inherited environment and skips that reset.
+
+           USB ONLY, deliberately. NHDDL uses quickboot for every backend except HDL, but the other
+           backends here have not shown this failure and each one reaches its media differently, so
+           they stay on the normal boot path until there is a reason to move them. A user-typed -qb
+           in either the global or per-game args wins -- do not emit a second copy.
+
+           Emitted ABOVE coreArgc so the pool-fit drop loop can never shed it: a dropped -qb would
+           silently reinstate the reset and reproduce the black screen with no way to tell why. */
+        if (!strcmp(deviceName, "usb") && argc < argvMax &&
+            !neutrinoArgHasActiveFlag(gNeutrinoArgs, "-qb") && !neutrinoArgHasActiveFlag(extraArgs, "-qb"))
+            argv[argc++] = "-qb";
     }
 
-    // Everything up to and including -dvd is the boot-critical core: the pool-fit drop loop below
+    // Everything up to and including -dvd/-qb is the boot-critical core: the pool-fit drop loop below
     // must never shed these. A fixed floor of 3 silently stopped covering -dvd once the optional
     // -bsdfs slots in front of it (argv[3]) -- record the real core count instead.
     const int coreArgc = argc;

--- a/src/tar.c
+++ b/src/tar.c
@@ -382,18 +382,36 @@ fail:
     return -1;
 }
 
+// Load ONE named archive, bypassing the multi-device sweep. Three invariants this has to hold, each
+// of which was violated by the first cut and each of which fails SILENTLY:
+//
+//  1. LOAD-ONCE. The generic path is load-once by construction -- tarFind*() only sweeps when the
+//     index is empty -- but this entry point re-parsed unconditionally, so the exact (HDD) path paid
+//     a full open + index read for EVERY cover instead of once per archive. The index is keyed by
+//     path and immutable for its lifetime, so holding the same path is a no-op.
+//  2. NO INDEX SURVIVES A FAILURE. tarParseFile()'s open() failure returns BEFORE the free() that
+//     resets the index, so a failed exact load used to leave the PREVIOUS archive's index in place
+//     with s_isExact cleared. tarFind*() then saw a populated index, skipped tarLoadFromAnyDevice()
+//     forever, searched the wrong archive, and every read failed on the NULL s_dev -- i.e. one HDD
+//     home with no art.tar killed archive art on every other device for the rest of the session.
+//  3. THE "NO ARCHIVE ANYWHERE" LATCH IS NOT OURS TO CLEAR. s_inactive belongs to the generic sweep;
+//     clearing it here re-armed a full device probe (a failed open costs seconds on USB) after every
+//     exact load. Only tarClose()/tarInvalidate() may clear it.
 int tarLoadFile(TarKind kind, const char *path)
 {
-    s_dev[kind] = NULL;
-    s_inactive[kind] = 0;
-    s_exactPath[kind][0] = '\0';
+    if (s_isExact[kind] && s_index[kind] != NULL && s_count[kind] > 0 &&
+        strcmp(s_exactPath[kind], path) == 0)
+        return 0;
+
+    tarCloseInternal(kind);
+
     s_isExact[kind] = 1;
     int r = tarParseFile(kind, path);
-    if (r == 0) {
+    if (r == 0)
         snprintf(s_exactPath[kind], sizeof(s_exactPath[kind]), "%s", path);
-    } else {
-        s_isExact[kind] = 0;
-    }
+    else
+        tarCloseInternal(kind);
+
     return r;
 }
 

--- a/src/tar.c
+++ b/src/tar.c
@@ -62,6 +62,8 @@ static u32 s_count[TAR_KIND_MAX] = {0, 0, 0};
 static u32 s_cap[TAR_KIND_MAX] = {0, 0, 0};
 static const TarDevice *s_dev[TAR_KIND_MAX] = {NULL, NULL, NULL};
 static int s_inactive[TAR_KIND_MAX] = {0, 0, 0};
+static char s_exactPath[TAR_KIND_MAX][256] = {{0}, {0}, {0}};
+static int s_isExact[TAR_KIND_MAX] = {0, 0, 0};
 
 static const unsigned char s_zeroBlock[TAR_BLOCK_SIZE] __attribute__((aligned(64))) = {0};
 
@@ -91,6 +93,8 @@ static void tarCloseInternal(TarKind kind)
     s_count[kind] = 0;
     s_cap[kind] = 0;
     s_dev[kind] = NULL;
+    s_exactPath[kind][0] = '\0';
+    s_isExact[kind] = 0;
 }
 
 static int buildTarPath(const TarDevice *dev, TarKind kind, char *out, int outSize)
@@ -381,11 +385,25 @@ fail:
 int tarLoadFile(TarKind kind, const char *path)
 {
     s_dev[kind] = NULL;
-    return tarParseFile(kind, path);
+    s_inactive[kind] = 0;
+    s_exactPath[kind][0] = '\0';
+    s_isExact[kind] = 1;
+    int r = tarParseFile(kind, path);
+    if (r == 0) {
+        snprintf(s_exactPath[kind], sizeof(s_exactPath[kind]), "%s", path);
+    } else {
+        s_isExact[kind] = 0;
+    }
+    return r;
 }
 
 int tarLoadFromAnyDevice(TarKind kind)
 {
+    // Exact HDD tar occupies the same TAR_KIND_ART slot; generic sweep must
+    // discard it so USB/SMB etc. do not search the HDD archive.
+    if (s_isExact[kind])
+        tarCloseInternal(kind);
+
     if (s_inactive[kind])
         return -1;
 
@@ -446,6 +464,9 @@ int tarClose(TarKind kind)
 
 TarEntryBase *tarFind(TarKind kind, const char *filename)
 {
+    if (s_isExact[kind])
+        tarCloseInternal(kind);
+
     if (s_inactive[kind])
         return NULL;
 
@@ -480,6 +501,9 @@ TarEntryBase *tarFind(TarKind kind, const char *filename)
 
 TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
 {
+    if (s_isExact[kind])
+        tarCloseInternal(kind);
+
     if (s_inactive[kind])
         return NULL;
 
@@ -505,17 +529,62 @@ TarEntryBase *tarFindPrefix(TarKind kind, const char *prefix)
     return NULL;
 }
 
+TarEntryBase *tarFindExact(TarKind kind, const char *filename)
+{
+    if (!s_isExact[kind] || !s_index[kind] || s_count[kind] == 0)
+        return NULL;
+    const char *queryClean = filename;
+    if (!strncasecmp(queryClean, "./", 2))
+        queryClean += 2;
+    if (!strncasecmp(queryClean, "ART/", 4) || !strncasecmp(queryClean, "CFG/", 4) || !strncasecmp(queryClean, "CHT/", 4))
+        queryClean += 4;
+    u32 entrySize = gTarInfo[kind].entrySize;
+    char *base = (char *)s_index[kind];
+    for (u32 i = 0; i < s_count[kind]; i++) {
+        char *entry = base + entrySize * i;
+        char *fname = entry + sizeof(TarEntryBase);
+        if (strcasecmp(fname, filename) == 0 || strcasecmp(fname, queryClean) == 0)
+            return (TarEntryBase *)entry;
+        const char *baseFname = strrchr(fname, '/');
+        baseFname = baseFname ? baseFname + 1 : fname;
+        if (strcasecmp(baseFname, queryClean) == 0)
+            return (TarEntryBase *)entry;
+    }
+    return NULL;
+}
+
+TarEntryBase *tarFindPrefixExact(TarKind kind, const char *prefix)
+{
+    if (!s_isExact[kind] || !s_index[kind] || s_count[kind] == 0)
+        return NULL;
+    size_t prefixLen = strlen(prefix);
+    u32 entrySize = gTarInfo[kind].entrySize;
+    char *base = (char *)s_index[kind];
+    for (u32 i = 0; i < s_count[kind]; i++) {
+        char *entry = base + entrySize * i;
+        char *fname = entry + sizeof(TarEntryBase);
+        const char *baseFname = strrchr(fname, '/');
+        baseFname = baseFname ? baseFname + 1 : fname;
+        if (strncasecmp(baseFname, prefix, prefixLen) == 0)
+            return (TarEntryBase *)entry;
+    }
+    return NULL;
+}
+
 u32 tarRead(TarKind kind, const TarEntryBase *entry, void *dst, u32 dstSize)
 {
-    if (s_inactive[kind])
-        return 0;
-
     if (!entry || dstSize < entry->rawSize)
         return 0;
 
     char tarPath[256];
-    if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) < 0)
-        return 0;
+    if (s_isExact[kind] && s_exactPath[kind][0] != '\0') {
+        snprintf(tarPath, sizeof(tarPath), "%s", s_exactPath[kind]);
+    } else {
+        if (s_inactive[kind])
+            return 0;
+        if (buildTarPath(s_dev[kind], kind, tarPath, sizeof(tarPath)) < 0)
+            return 0;
+    }
 
     int fd = open(tarPath, O_RDONLY);
     if (fd < 0)

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -56,6 +56,17 @@ typedef struct load_image_request
     // Not resolvable on the worker -- answering it reads the support's private device data, which a
     // background rescan rewrites underneath. One byte, copied in, is immune.
     unsigned char sio2;
+    // Which .tar archive this cover must come from, resolved on the GUI THREAD at enqueue for
+    // exactly the same reason sio2 is. Answering it reaches into support-private state -- favArray,
+    // the app list, gHDDPrefix -- that the prio-30 IO worker rewrites during a list rebuild, so the
+    // art worker must never ask the question itself.
+    //   1 = read artArchivePath and nothing else   0 = ordinary multi-device sweep
+    //  -1 = this row's source has no archive home; probe no archive at all
+    signed char artArchive;
+    // Trails value in the SAME allocation (NULL unless artArchive == 1), so a request costs nothing
+    // extra on the common path. Art has no queue-depth cap, so a fixed 256-byte field here would be
+    // paid hundreds of times over on a slow device.
+    char *artArchivePath;
     char *value;
 } load_image_request_t;
 
@@ -866,48 +877,16 @@ static void cacheLoadImage(load_image_request_t *req)
 
     texSetLoadAbortFlag(&req->abortRequested);
 
+    // The archive decision was made on the GUI thread at enqueue (cacheResolveArtArchive). Nothing
+    // here may re-derive it: every input to that answer is support-private state a list rebuild
+    // rewrites underneath this thread.
     if (gEnableArtTar) {
-        char exactPath[256];
-        int useExact = 0;
-        int noHome = 0;
-        if (handler->itemGetArtArchivePath != NULL) {
-            int r = handler->itemGetArtArchivePath(handler, exactPath, sizeof(exactPath));
-            if (r == 1)
-                useExact = 1;
-            else if (r == -1)
-                noHome = 1;
-        } else if (handler->mode == HDD_MODE) {
-            int r = hddGetArtArchivePath(handler, exactPath, sizeof(exactPath));
-            if (r == 1)
-                useExact = 1;
-            else if (r == -1)
-                noHome = 1;
-        } else if (handler->mode == FAV_MODE && req->value != NULL) {
-            int src = favGetArtMode(req->value);
-            if (src == HDD_MODE) {
-                int r = hddGetArtArchivePath(handler, exactPath, sizeof(exactPath));
-                if (r == 1)
-                    useExact = 1;
-                else
-                    noHome = 1;
-            }
-        } else if (handler->mode == APP_MODE && req->value != NULL) {
-            int am = appGetArtMode(req->value);
-            if (am == HDD_MODE) {
-                int r = hddGetArtArchivePath(handler, exactPath, sizeof(exactPath));
-                if (r == 1)
-                    useExact = 1;
-                else
-                    noHome = 1;
-            }
-        }
-        if (noHome) {
-            result = -1;
-        } else if (useExact) {
-            result = artTarLoadImageExact(req->value, req->cache->suffix, exactPath, &staged);
-        } else {
+        if (req->artArchive < 0)
+            result = -1; // source has a home we cannot reach -- never fall back to another device's archive
+        else if (req->artArchive > 0 && req->artArchivePath != NULL)
+            result = artTarLoadImageExact(req->value, req->cache->suffix, req->artArchivePath, &staged);
+        else
             result = artTarLoadImage(req->value, req->cache->suffix, &staged);
-        }
     }
 
     // Fall through to the per-file lookup whenever the archive is off, absent, or lacks this key.
@@ -1282,6 +1261,45 @@ static int cacheRequestIsSIO2(item_list_t *list, const char *value)
     return bdmModeIsSIO2(mode);
 }
 
+// WHICH .tar archive serves this row -- resolved here, on the GUI thread at enqueue, under the same
+// rule and for the same reason as cacheRequestIsSIO2 directly above. FAV and APP rows are PROXIES,
+// so answering it means reading favArray / the app list, and the HDD answer reads gHDDPrefix; all
+// three are rewritten by the prio-30 IO worker during a list rebuild. The worker asking them itself
+// is a race, which is what this function exists to prevent.
+//
+// Returns 1 and fills path when one specific archive must be used, -1 when the row's source has an
+// archive home that is currently unavailable (probe NOTHING rather than falling through to the
+// generic sweep, which would serve another device's art), and 0 for the ordinary sweep.
+static int cacheResolveArtArchive(item_list_t *list, const char *value, char *path, int pathSize)
+{
+    int mode;
+
+    if (list == NULL)
+        return 0;
+
+    // A support that owns its archive answers for itself (HDD does).
+    if (list->itemGetArtArchivePath != NULL)
+        return list->itemGetArtArchivePath(list, path, pathSize);
+
+    mode = list->mode;
+
+    if (mode == FAV_MODE && value != NULL) {
+        int src = favGetArtMode(value);
+        if (src >= 0)
+            mode = src;
+    }
+    if (mode == APP_MODE && value != NULL) {
+        int src = appGetArtMode(value);
+        if (src >= 0)
+            mode = src;
+    }
+
+    if (mode == HDD_MODE)
+        return hddGetArtArchivePath(list, path, pathSize);
+
+    return 0;
+}
+
 GSTEXTURE *cacheGetTextureEx(image_cache_t *cache, item_list_t *list, int *cacheId, int *UID, char *value, int isPriority)
 {
     int i, rtime;
@@ -1483,7 +1501,24 @@ GSTEXTURE *cacheGetTextureEx(image_cache_t *cache, item_list_t *list, int *cache
     // gArtRunning is part of the gate: if the worker never started, nothing would ever clear qr and
     // the slot would be dead for the session. Better to draw no art than to poison the cache.
     if (oldestEntry && gArtRunning) {
-        load_image_request_t *req = malloc(sizeof(load_image_request_t) + strlen(value) + 1);
+        // Resolve the archive HERE, while support-private state is stable -- see cacheResolveArtArchive.
+        char archivePath[256];
+        int archiveMode = 0;
+        size_t archiveLen = 0;
+        size_t valueLen = strlen(value);
+
+        if (gEnableArtTar) {
+            archiveMode = cacheResolveArtArchive(list, value, archivePath, sizeof(archivePath));
+            if (archiveMode == 1) {
+                archiveLen = strlen(archivePath);
+                // "Use this archive" with nothing to use means the home is unreachable, not that the
+                // generic sweep is appropriate -- that fallback would serve another device's art.
+                if (archiveLen == 0)
+                    archiveMode = -1;
+            }
+        }
+
+        load_image_request_t *req = malloc(sizeof(load_image_request_t) + valueLen + 1 + (archiveLen ? archiveLen + 1 : 0));
         if (!req) {
             *cacheId = -1; // nothing cleared yet at this point, so the slot is untouched
             return NULL;
@@ -1493,6 +1528,13 @@ GSTEXTURE *cacheGetTextureEx(image_cache_t *cache, item_list_t *list, int *cache
         req->list = list;
         req->value = (char *)req + sizeof(load_image_request_t);
         strcpy(req->value, value);
+        req->artArchive = (signed char)archiveMode;
+        if (archiveLen) {
+            req->artArchivePath = req->value + valueLen + 1;
+            strcpy(req->artArchivePath, archivePath);
+        } else {
+            req->artArchivePath = NULL;
+        }
         req->cacheUID = cache->nextUID;
         req->epoch = gArtEpoch;           // the view this cover belongs to; see cacheDropQueuedArt()
         req->failEpoch = gArtFailEpoch;   // the generation an "absent" answer would belong to

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -12,6 +12,7 @@
 #include "include/bdmsupport.h" // bdmModeIsSIO2 -- is this cover on the pad's bus?
 #include "include/appsupport.h" // appGetArtMode -- APP rows are proxies for another device
 #include "include/favsupport.h" // favGetArtMode -- so are FAV rows
+#include "include/hddsupport.h" // hddGetArtArchivePath -- exact HDD tar home
 #include <kernel.h>
 #include <delaythread.h> // DelayThread -- must be included explicitly, it is not pulled in by kernel.h
 
@@ -116,6 +117,45 @@ static void cacheWakeArtWorker(void);
 //       non-fatal (tarParseFile ignores the result) and happens only when the archive changes, but it
 //       is the thing to instrument first if a .tar-enabled build ever feels worse than a plain one.
 //   DEFAULT PATH: gEnableArtTar ships 0, so none of the above is reachable unless the user opts in.
+static int artTarLoadImageExact(const char *value, const char *suffix, const char *exactPath, GSTEXTURE *texture)
+{
+    char prefix[64];
+    TarEntryBase *entry = NULL;
+    void *buffer;
+    int result;
+
+    if (snprintf(prefix, sizeof(prefix), "%s_%s.", value, suffix) >= (int)sizeof(prefix))
+        return -1;
+
+    if (tarLoadFile(TAR_KIND_ART, exactPath) < 0)
+        return -1;
+
+    entry = tarFindPrefixExact(TAR_KIND_ART, prefix);
+
+    if (entry == NULL) {
+        LOG("ART TAR: '%s_%s' not in the archive index\n", value, suffix);
+        return -1;
+    }
+
+    buffer = malloc(entry->rawSize);
+    if (buffer == NULL) {
+        LOG("ART TAR: out of memory for '%s' (%u bytes)\n", prefix, entry->rawSize);
+        return -1;
+    }
+
+    if (tarRead(TAR_KIND_ART, entry, buffer, entry->rawSize) != entry->rawSize) {
+        LOG("ART TAR: short read for '%s' (%u bytes expected)\n", prefix, entry->rawSize);
+        free(buffer);
+        return -1;
+    }
+
+    result = texLoadFromMemory(texture, buffer, entry->rawSize);
+    if (result < 0)
+        LOG("ART TAR: '%s' found (%u bytes) but PNG decode failed (%d)\n", prefix, entry->rawSize, result);
+    free(buffer);
+    return result;
+}
+
 static int artTarLoadImage(const char *value, const char *suffix, GSTEXTURE *texture)
 {
     char prefix[64];
@@ -826,8 +866,49 @@ static void cacheLoadImage(load_image_request_t *req)
 
     texSetLoadAbortFlag(&req->abortRequested);
 
-    if (gEnableArtTar)
-        result = artTarLoadImage(req->value, req->cache->suffix, &staged);
+    if (gEnableArtTar) {
+        char exactPath[256];
+        int useExact = 0;
+        int noHome = 0;
+        if (handler->itemGetArtArchivePath != NULL) {
+            int r = handler->itemGetArtArchivePath(handler, exactPath, sizeof(exactPath));
+            if (r == 1)
+                useExact = 1;
+            else if (r == -1)
+                noHome = 1;
+        } else if (handler->mode == HDD_MODE) {
+            int r = hddGetArtArchivePath(handler, exactPath, sizeof(exactPath));
+            if (r == 1)
+                useExact = 1;
+            else if (r == -1)
+                noHome = 1;
+        } else if (handler->mode == FAV_MODE && req->value != NULL) {
+            int src = favGetArtMode(req->value);
+            if (src == HDD_MODE) {
+                int r = hddGetArtArchivePath(handler, exactPath, sizeof(exactPath));
+                if (r == 1)
+                    useExact = 1;
+                else
+                    noHome = 1;
+            }
+        } else if (handler->mode == APP_MODE && req->value != NULL) {
+            int am = appGetArtMode(req->value);
+            if (am == HDD_MODE) {
+                int r = hddGetArtArchivePath(handler, exactPath, sizeof(exactPath));
+                if (r == 1)
+                    useExact = 1;
+                else
+                    noHome = 1;
+            }
+        }
+        if (noHome) {
+            result = -1;
+        } else if (useExact) {
+            result = artTarLoadImageExact(req->value, req->cache->suffix, exactPath, &staged);
+        } else {
+            result = artTarLoadImage(req->value, req->cache->suffix, &staged);
+        }
+    }
 
     // Fall through to the per-file lookup whenever the archive is off, absent, or lacks this key.
     if (result < 0)

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -344,11 +344,13 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     if (sysNeutrinoPreflight("udpfs", neutrinoPath) < 0)
         return;
     int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-    deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp still frees udpfsGames/game
+    char gameStartup[GAME_STARTUP_MAX + 1];
+    snprintf(gameStartup, sizeof(gameStartup), "%s", game->startup);
+    deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // itemCleanUp frees udpfsGames/game
 
-    // Hand off to Neutrino with the udpfs driver token. `partname` (the filesystem game path) + the token
-    // survive the deinit above; `game` does not and is not used past this point.
-    sysLaunchNeutrino("udpfs", partname, game->startup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: udpfs is fileid, no fs layer */, &neutrinoVmc);
+    // Hand off to Neutrino with the udpfs driver token. `partname` and `gameStartup` survive the deinit;
+    // `game` does not and is not dereferenced past this point.
+    sysLaunchNeutrino("udpfs", partname, gameStartup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* udpfs is fileid, no fs layer */, &neutrinoVmc);
 }
 
 static config_set_t *udpfsGetConfig(item_list_t *itemList, int id)


### PR DESCRIPTION
Recovery branch from `91e3434b`, plus the hardware-driven fixes that came out of testing it. Supersedes #535.

All items below except USB device detection are confirmed fixed on hardware.

## Fixed

**Neutrino would not launch from USB.** Two faults in sequence. `SifExitRpc()` had been removed before `ExecPS2()` on the theory that it damaged the keep-IOP handoff — it does not: it is EE-side only (`DisableDmac(DMAC_SIF0)` + `RemoveDmacHandler`), resets no IOP, unmounts nothing. Skipping it left SIF0 DMA armed at handler tables that `ExecPS2()` then overwrote, and our own resident `bdmevent.irx` fires on every mount — so Neutrino mounting the game DMA'd into dead memory and the console landed in OSDSYS. Restoring it produced a black screen instead, which was the second half of the same design: elfldr deliberately does not reset the IOP, but Neutrino's default boot does, destroying the very environment that was preserved. `-qb` skips that reset. NHDDL's loader does both of these things, and was used as the reference throughout.

**Code 222 on consoles whose APA works.** The deferred check reported a retry that had never run (the base ATA stack was still loading and `hddLoadModulesReady()` correctly answered BUSYLOADING), and then reported the first settled retry that failed. The 1 s post-ATAD settle is a floor, not a guarantee — a drive still spinning up answers ATA well before PS2FS. Now requires the failure to persist across several attempts that actually ran.

**No menu vibration.** Four independent causes. DS3/DS4/DS5 motors were hardcoded to `ds34*_set_rumble(port, 0, 0)` and could not fire at all. The actuator count was a one-way latch to zero — `initializePad()` clears it and has four bail-outs above the `padInfoAct()` that refills it, and both send paths vetoed on that, so one init hiccup killed rumble for the session. The navigation pulse was 35 ms at 64/255, below a DualShock ERM's spin-up time, so it could not be felt even when delivered. And `padRumble()` was reachable from the IO worker via `sfxPlay(SFX_BD_CONNECT)` → `bdmNeedsUpdate()`, putting SIO2 traffic on the pad's own bus under `readPads()` — which froze the console on USB hotplug and left the motor stuck on. Actuator commands now issue only from the polling thread; timing follows the RETROLauncher model.

**Console froze after browsing pages.** Every deferred GUI operation is two allocations; the drain freed only the queue node. `updateMenuFromGameList()` creates one op **per game row**, so navigation leaked in proportion to library size × pages visited. `git log --all -S"free(td->item)"` returns nothing — it had never been freed, at any point in this repository's history. On exhaustion `guiOpCreate()` ran its `memset` unconditionally and faulted, which also made every `if (!op)` guard at the call sites unreachable. Pre-existing, not a regression from this branch.

**An IOP fault reading mass-device identity.** ps2sdk's `bdmfs_fatfs` `USBMASS_IOCTL_GET_DRIVERNAME` handler does `strncpy(rdata, mounted_bd->name, ...)` without the NULL guard it applies one line above, so supplying a return buffer for a volume with no mounted block device dereferences NULL on the IOP. Reachable because `fs_driver_resolve_volume()` maps `"mass"` straight from the unit number without checking anything is mounted. We embed the SDK's prebuilt IRX, so this can only be avoided: all six call sites now probe with `rdata = NULL` first, which is what Grimdoomer's fork does and why it reads mass devices where we faulted. Confirmed against upstream ps2sdk master.

**The APA data-home could not be set to +OPL.** The Settings row was a fork invention layered over Official's mechanism, with staging, an in-flight latch, a 15 s timeout and six distinct failure conditions collapsed into two messages — and on hardware it never once succeeded. One rejected `ioPutRequest` left the latch set permanently, so the row reported "not found" once and then "HDD is busy" forever. Removed the row entirely. Discovery now prefers an existing `+OPL` over `__common`, with an explicit `conf_hdd.cfg` entry still outranking both, and creates nothing at any step.

**`apps-dump.txt` written to the device root.** Gated on `gEnableDebug`, which is the user-facing debug *colours* toggle. A display setting must not create files on the user's card; moved to the diagnostic build axis.

## Still open

**USB: a second stick may require a hotplug to appear.** Six attempts, each fixing a real defect, none of them this one. Ruled out: module ordering (`doRegisterDriver()` re-probes existing devices on late registration), the attach-event window, the identity NULL-deref, probe cadence and the empty-slot rotation, and "needs more time" (a four-pass settle changed nothing and was reverted rather than tuned upward). Confirmed reachable at the IOP — the same stick appears normally under Grimdoomer's fork, which has **one** BDM page against our eight `massN:` slots. That difference is the strongest remaining lead.

Also unaddressed: the hint-list race in `moduleUpdateMenuInternal()` (real — the IO worker frees and relinks a list the GUI thread walks twice per frame; an attempt to serialize it with `guiLock` was reverted because that semaphore is held across vsync), and art loading latency (a failed cover open costs ~4.3 s against ~53 ms for a hit, single FIFO worker head-of-line blocking; pre-existing and likely IOP-side).

## Diagnostics: the `OPLDIAG` axis and `PS2DEVPINNED-DIAG`

CI builds `make release`, so `__DEBUG` is never defined in anything a tester receives — gating tester-facing diagnostics behind it deletes them from the only builds that matter. `OPLDIAG=1` enables on-screen boot-stage labels, an error-code detail suffix and the mass-slot readout, and nothing else. `DEBUG=1` implies it. `PS2DEVPINNED-DIAG` builds it on the same pinned toolchain as `PS2DEVPINNED` and records the flag in `BUILD-MANIFEST.txt`; it is not a DEBUG build (no TTY, no `-g`), so its results are directly comparable with its pinned twin. Ordinary release artifacts carry no diagnostic text.

## Validation

`clang-format` 12 clean. Release, `OPLDIAG=1` and `DEBUG=1` all build with zero errors and no new warnings. All five CI flavours green.
