### PR TITLE
fix(menu): serialize the hint list with its own lock, not guiLock

### DIFF
--- a/include/menusys.h
+++ b/include/menusys.h
@@ -145,6 +145,24 @@ void menuHandleInputAppMenu();
 // Sets the selected item if it is found in the menu list
 void menuSetSelectedItem(menu_item_t *item);
 
+/** Serialize menu_item_t::hints against the renderer.
+ *
+ * ⚠ EVERY toucher of a hint list must bracket itself with these -- readers included. The list is
+ * rebuilt on the IO WORKER (moduleUpdateMenuInternal) while the GUI thread walks it every frame in
+ * themes.c drawHintText(), twice per frame. Without this, a draw landing mid-rebuild follows a
+ * freed ->next.
+ *
+ * These are CALLER-LOCKED on purpose: menuAddHint()/menuRemoveHints() do not lock internally,
+ * because a rebuild is many calls that must be atomic as a whole and the semaphore is not
+ * recursive. Do not nest them.
+ *
+ * Not guiLock(): that is held across rmEndFrame()'s vsync wait, so borrowing it here stalls the IO
+ * worker for a whole frame on every device change. This lock is held only for the list work itself.
+ */
+void menuHintsLock(void);
+void menuHintsUnlock(void);
+
+// Call with menuHintsLock() held -- see above.
 void menuAddHint(menu_item_t *menu, int text_id, int icon_id);
 void menuRemoveHints(menu_item_t *menu);
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -3381,7 +3381,9 @@ static void guiHandleOp(struct gui_update_t *item)
 
         case GUI_OP_ADD_HINT:
             // append the hint list in the menu item
+            menuHintsLock();
             menuAddHint(item->menu.menu, item->hint.text_id, item->hint.icon_id);
+            menuHintsUnlock();
             break;
 
         default:

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -91,6 +91,45 @@ static submenu_list_t *appMenu;
 static submenu_list_t *appMenuCurrent;
 
 static s32 menuSemaId = -1;
+
+/* HINT-LIST LOCK. Deliberately its OWN semaphore, and deliberately not guiLock.
+ *
+ * menu_item_t::hints is a linked list that the IO WORKER rebuilds -- moduleUpdateMenuInternal()
+ * calls menuRemoveHints() to free every node and then menuAddHint() several times to malloc and
+ * relink -- while the GUI thread walks that same list every frame in themes.c drawHintText(), twice
+ * (guiAlignMenuHints() to align, then again to draw). Unserialized, a draw landing mid-rebuild
+ * follows a freed ->next into memory already handed back out.
+ *
+ * guiLock() is the WRONG lock for this even though it does exclude the renderer: guiStartFrame()
+ * takes it and guiEndFrame() releases it after rmEndFrame()'s vsync wait, so it is held for
+ * essentially a whole frame. Taking that on a per-device-update path stalls the io worker ~16 ms
+ * every time a device appears or vanishes, which measurably disturbed unrelated timing.
+ *
+ * This one is held only for the list work itself -- a few frees and mallocs, or one traversal --
+ * so the worst a waiter ever sees is microseconds.
+ *
+ * CALLER-LOCKED. menuAddHint()/menuRemoveHints() do NOT lock internally: a rebuild is many calls and
+ * must be atomic as a whole, and this semaphore is not recursive. Every caller brackets its own
+ * sequence with menuHintsLock()/menuHintsUnlock().
+ */
+static s32 menuHintSemaId = -1;
+static ee_sema_t menuHintSema;
+
+void menuHintsLock(void)
+{
+    // Not-ready guard, same shape as guiLock(): hints are built during init before menuInit() has
+    // created this, and everything is single-threaded until the GUI and IO threads exist.
+    if (menuHintSemaId < 0)
+        return;
+    WaitSema(menuHintSemaId);
+}
+
+void menuHintsUnlock(void)
+{
+    if (menuHintSemaId < 0)
+        return;
+    SignalSema(menuHintSemaId);
+}
 static s32 menuListSemaId = -1;
 static ee_sema_t menuSema;
 
@@ -669,6 +708,12 @@ void menuInit()
         menuSema.option = 0;
         menuSemaId = CreateSema(&menuSema);
     }
+    if (menuHintSemaId < 0) {
+        menuHintSema.init_count = 1;
+        menuHintSema.max_count = 1;
+        menuHintSema.option = 0;
+        menuHintSemaId = CreateSema(&menuHintSema);
+    }
     if (menuListSemaId < 0) {
         menuListSemaId = sbCreateSemaphore();
     }
@@ -686,7 +731,9 @@ void menuEnd()
         if (td->item)
             submenuDestroy(&(td->item->submenu));
 
+        menuHintsLock();
         menuRemoveHints(td->item);
+        menuHintsUnlock();
 
         free(td);
     }
@@ -702,6 +749,8 @@ void menuEnd()
 
     DeleteSema(menuSemaId);
     menuSemaId = -1;
+    DeleteSema(menuHintSemaId);
+    menuHintSemaId = -1;
     DeleteSema(menuListSemaId);
     menuListSemaId = -1;
 }

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -749,8 +749,24 @@ void menuEnd()
 
     DeleteSema(menuSemaId);
     menuSemaId = -1;
-    DeleteSema(menuHintSemaId);
-    menuHintSemaId = -1;
+
+    // PUBLISH "GONE" BEFORE DELETING, not after. ioEnd() only sets gIOTerminate and wakes the io
+    // worker -- it does not join it -- so a queued moduleUpdateMenuInternal() can still be running
+    // when we get here. Clearing the id first means such a caller either reads -1 and no-ops
+    // (menuHintsLock's not-ready guard) or has already sampled a live id; deleting first would
+    // additionally let it sample an id we are in the middle of destroying.
+    //
+    // This narrows the window rather than closing it, and the same race already exists for
+    // menuSemaId above -- which ioman handlers (_menuSaveConfig, _menuLoadConfig,
+    // _menuLoadConfigAsync) take directly with no not-ready guard at all. Closing it properly means
+    // joining the io worker before support cleanup, which is a shutdown-ordering change and does
+    // not belong in a hint-list lock.
+    {
+        s32 hintSema = menuHintSemaId;
+        menuHintSemaId = -1;
+        if (hintSema >= 0)
+            DeleteSema(hintSema);
+    }
     DeleteSema(menuListSemaId);
     menuListSemaId = -1;
 }

--- a/src/opl.c
+++ b/src/opl.c
@@ -299,6 +299,12 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         guiCheckNotifications(0, langChanged);
     }
 
+    /* One lock across the WHOLE rebuild, not per call. This runs on the io worker while the GUI
+       thread walks the same list twice a frame; a per-call lock would still let a draw land between
+       the free and the relink and render a half-built row. Cheap: a few frees and mallocs, no I/O,
+       nothing that can block -- so the renderer never waits more than microseconds for it. */
+    menuHintsLock();
+
     // refresh Hints
     menuRemoveHints(&mod->menuItem);
 
@@ -325,6 +331,8 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         if (vcdModeSupported(mod->support->mode) && gDefaultGameView == GAME_VIEW_BOTH)
             menuAddHint(&mod->menuItem, _STR_VCD, L3_ICON);
     }
+
+    menuHintsUnlock();
 
     // refresh Cache
     if (themeChanged) {

--- a/src/themes.c
+++ b/src/themes.c
@@ -1873,6 +1873,15 @@ static void drawHintText(struct menu_list *menu, struct submenu_list *item, conf
     if (thmElemSkipsDevice(elem, menu->item->icon_id))
         return; // devices= filter: not this page's element
 
+    /* HELD ACROSS BOTH WALKS, not just the draw loop. guiAlignMenuHints() traverses the list too, so
+       reading the head and then measuring it under one lock and drawing it under another would still
+       let the io worker free the chain in between. The rebuild that races this
+       (moduleUpdateMenuInternal, on the io worker) frees every node before relinking, so a stale
+       ->next points into memory already handed back out.
+       Cheap enough to sit on the per-frame draw path: uncontended almost always, and the only
+       holder on the other side does a handful of frees and mallocs with no I/O. */
+    menuHintsLock();
+
     menu_hint_item_t *hint = menu->item->hints;
     if (hint) {
         int x = elem->posX;
@@ -1885,6 +1894,8 @@ static void drawHintText(struct menu_list *menu, struct submenu_list *item, conf
             x += elem->width;
         }
     }
+
+    menuHintsUnlock();
 }
 
 static void drawInfoHintText(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)


### PR DESCRIPTION
Second attempt at a race found during the #536 freeze hunt. The first ([`e21f252c`](https://github.com/NathanNeurotic/Open-PS2-Loader/commit/e21f252c)) had the right diagnosis and the wrong lock, and was reverted before #536 merged.

## The race

`menu_item_t::hints` is rebuilt on the **IO worker** — `moduleUpdateMenuInternal()` frees every node via `menuRemoveHints()`, then mallocs and relinks three to seven more — while the **GUI thread** walks that same list every frame in `themes.c drawHintText()`, **twice**: once through `guiAlignMenuHints()` to measure and again to draw.

`bdmUpdateDeviceData()` calls `moduleUpdateMenu()` from four places as devices appear, vanish and re-identify, so browsing device pages is exactly what provokes it. A draw landing mid-rebuild follows a freed `->next` into memory already handed back out.

## Why not guiLock

It does exclude the renderer, but `guiStartFrame()` takes it and `guiEndFrame()` releases it only after `rmEndFrame()`'s **vsync wait** — so it is held for essentially a whole frame. Borrowing it on a per-device-update path stalled the IO worker ~16 ms on every device change, and that timing shift was enough to bring the deferred Code 222 back. That is what got the first attempt reverted.

This is its own semaphore, held only for the list work itself — a few frees and mallocs, or one traversal — so a waiter blocks for microseconds.

## Caller-locked, deliberately

A rebuild is many calls and must be atomic as a whole. Locking inside `menuAddHint()`/`menuRemoveHints()` would still let a draw land between the free and the relink and render a half-built row, and the semaphore is not recursive so an outer lock could not sit on top.

All four touchers bracket themselves: the rebuild (opl.c), the deferred `GUI_OP_ADD_HINT` (gui.c), the teardown (menusys.c), and the renderer (themes.c) — the last across **both** walks, since measuring and drawing under separate locks would leave the same window open between them.

**No deadlock:** the IO worker releases this before taking `guiLock` for the `themeChanged` cache rebuild further down, so the two are never held together and there is no ordering to invert.

## Honest scope

Whether this race ever bit on hardware is **unproven** — freezes stopped once the deferred-op leak was fixed in #536, and this may have been a second contributor or none at all. It is a real use-after-free either way.

## Validation

`clang-format` 12 clean; builds with zero errors and no new warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu hint handling during updates and rendering.
  * Prevented incomplete or inconsistent hint displays while hint lists are being rebuilt.
  * Added safer synchronization when adding, removing, or displaying menu hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->