### PR TITLE
fix: art delay back to the fork's 2; Code 222 on elapsed time

### DIFF
--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -3,6 +3,7 @@
 #include "include/lang.h"
 #include "include/gui.h"
 #include "include/supportbase.h"
+#include <time.h> // clock()/CLOCKS_PER_SEC -- the Code 222 grace window
 #include "include/hddsupport.h"
 #include "include/vcdsupport.h" // HDD VCD view: vcdScanDirRoot/vcdViewActive + vcd_entry_t
 #include "include/util.h"
@@ -47,8 +48,17 @@ static int hddRetryQueued = 0;
 // answers the ATA stack well before it will answer PS2FS, so a single refusal after the settle says
 // nothing -- hardware shows PFS declining a few of these and then mounting normally. Reset by
 // hddClearPfsDiagFailure() the moment the support stack latches.
-#define HDD_PFS_REPORT_AFTER_FAILURES 3
-static int hddPfsSettledFailures = 0;
+/* A COUNT WAS THE WRONG UNIT. Requiring 3 settled failures was the second attempt at this message
+   and it still fired on drives that mounted moments later -- because the retry cadence is not fixed,
+   so "3 retries" can elapse in well under the time a cold drive needs to answer PS2FS. Report on
+   TIME instead: the drive has had a real chance and still refuses. Same one variable, no extra
+   machinery, and the threshold now means what a reader assumes it means.
+
+   NOTE: this message is self-clearing (clearErrorMessageIf on recovery), which is the tell that it
+   describes a TRANSIENT. An error box a later success silently retracts is a notification wearing
+   the wrong clothes; whether it should be modal at all is a design call, not a tuning one. */
+#define HDD_PFS_REPORT_AFTER_MS 20000
+static clock_t hddPfsFirstSettledFailure = 0;
 
 typedef enum {
     HDD_PFS_DIAG_REASON_NONE = 0,
@@ -106,7 +116,7 @@ static void hddClearPfsDiagFailure(const char *why)
 {
     hddLogPfsDiagState("clear", why);
     hddPfsDeferredFailed = 0;
-    hddPfsSettledFailures = 0; // PFS came up: the retries that failed before it were spin-up, not fault
+    hddPfsFirstSettledFailure = 0; // PFS came up: the retries that failed before it were spin-up, not fault
     hddPfsDiagReason = HDD_PFS_DIAG_REASON_NONE;
     hddPfsDiagHddCheckResult = HDD_PFS_DIAG_NOT_RUN;
     hddPfsDiagPs2fsResult = HDD_PFS_DIAG_NOT_RUN;
@@ -1095,13 +1105,16 @@ static int hddUpdateGameList(item_list_t *itemList)
             // So require the failure to PERSIST across a few settled attempts. Each pass through
             // here is a genuine retry (hddLoadSupportModules ran and did not latch), and the success
             // arm above resets the count, so this only fires when PFS has really refused to come up.
-            if (++hddPfsSettledFailures >= HDD_PFS_REPORT_AFTER_FAILURES) {
+            if (hddPfsFirstSettledFailure == 0)
+                hddPfsFirstSettledFailure = clock();
+
+            if ((clock() - hddPfsFirstSettledFailure) >= (clock_t)HDD_PFS_REPORT_AFTER_MS * (CLOCKS_PER_SEC / 1000)) {
                 hddLogPfsDiagState("emit-code-222", "settled-retries-exhausted");
                 setErrorMessageWithCodeAndDetail(_STR_HDD_PFS_UNAVAILABLE_ERROR, ERROR_HDD_MODULE_PFS_FAILURE,
                                                  hddPfsDiagReasonName(hddPfsDiagReason));
                 hddSupportErrToasted = 1;
             } else {
-                hddLogPfsDiagState("defer-code-222", "settled-retry-failed-below-threshold");
+                hddLogPfsDiagState("defer-code-222", "settled-retry-failed-inside-grace");
             }
         }
     } else {

--- a/src/opl.c
+++ b/src/opl.c
@@ -2693,9 +2693,9 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_ART_DELAY, &gArtDelay);
             // Keep the stored domain identical to the Artwork page's enum {0,2,5,8} (item 45), so a
             // hand-edited or legacy value cannot render as a delay the UI is unable to express.
-            // An out-of-domain value falls back to 0, matching setDefaults().
+            // An out-of-domain value falls back to 2, matching setDefaults() and the fork.
             if (gArtDelay != 0 && gArtDelay != 2 && gArtDelay != 5 && gArtDelay != 8)
-                gArtDelay = 0;
+                gArtDelay = 2;
             configGetInt(configOPL, CONFIG_OPL_FOLDER_NAV, &gEnableFolderNav);
             configGetColor(configOPL, CONFIG_OPL_PLAS_BLEND_COLOR, gDefaultPlasBlendColor);
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, &gCoverflowCount);
@@ -4345,11 +4345,24 @@ static void setDefaults(void)
     // as much. The effect is that art will not begin loading until navigation has fully stopped and
     // stayed stopped, which reads as covers refusing to appear while browsing.
     //
-    // The reason to settle at all was to keep art reads off the bus while the user is moving, but
-    // that concern is device-specific and is already handled where it belongs: texcache gates SIO2
-    // devices (MMCE, MX4SIO) on real idleness because their reads contend with pad polling. Making
-    // every device wait for the worst device's constraint is not a trade worth a default.
-    gArtDelay = 0;
+    /* 2 IS THE FORK'S OWN VALUE, and it is the one number here that something has actually run.
+     *
+     * Three candidates existed and only one had a pedigree. The fork shipped 2. The rebuild changed
+     * it to 8 and called that "official-like". I then changed it to 0, which nothing had ever run,
+     * while quoting the very comment -- "the fork lands on 2, we land on 8" -- that named 2. Twice
+     * in one day I read the number that was known to work and picked one that was not.
+     *
+     * 0 is not merely untested, it is actively wrong for the non-SIO2 devices it was meant to help.
+     * The settle counts frames of NO INPUT before art may be REQUESTED, so at 0 every scrolled row
+     * enqueues a cover immediately and USB/ATA/network art reads run underneath the scroll itself.
+     * That is the "art isn't fluid like it was" report: the covers arrive sooner and the movement
+     * they arrive during is worse, which is a bad trade at any speed.
+     *
+     * 8 is not the answer either -- that is the delay that made art feel like it needed a settle
+     * before anything appeared. 2 is short enough that a pause of two frames releases the art, and
+     * long enough that a continuous scroll never asks. SIO2 keeps its own higher floor in texcache;
+     * this is only the default for everything else. */
+    gArtDelay = 2;
     gEnableFolderNav = 0;
     gDefaultPlasBlendColor[0] = 0x00;
     gDefaultPlasBlendColor[1] = 0x00;

--- a/src/themes.c
+++ b/src/themes.c
@@ -2545,13 +2545,30 @@ static int thmLoadResource(GSTEXTURE *texture, int texId, const char *themePath,
     return success;
 }
 
-static void thmSetColors(theme_t *theme)
+/* retintElements: also force every main element to the new textColor.
+ *
+ * THIS IS NOT A PALETTE OPERATION and the distinction is load-bearing. At theme-load time the
+ * element list is still empty when this runs, so the loop below is a no-op and the elements get
+ * their real colours moments later from the theme's own config (initBasic / the "color" key).
+ * Called again on a POPULATED theme, the same loop overwrites every one of those parsed colours
+ * with a single flat value.
+ *
+ * That is harmless for the built-in default theme, whose elements all use textColor anyway --
+ * which is why it went unnoticed for years while theme 0 was the only live caller. It is
+ * destructive for any theme that gives its elements distinct colours, and <Coverflow> is exactly
+ * such a theme: theme_coverflow_cfg sets them. Flattening them repaints the whole page in one
+ * colour, and any element whose text then matches its background simply stops being visible --
+ * a list that renders nothing while navigation still works perfectly. */
+static void thmSetColors(theme_t *theme, int retintElements)
 {
     memcpy(theme->bgColor, gDefaultBgColor, 3);
     memcpy(theme->plasBlendColor, gDefaultPlasBlendColor, 3);
     theme->textColor = GS_SETREG_RGBA(gDefaultTextColor[0], gDefaultTextColor[1], gDefaultTextColor[2], 0x80);
     theme->uiTextColor = GS_SETREG_RGBA(gDefaultUITextColor[0], gDefaultUITextColor[1], gDefaultUITextColor[2], 0x80);
     theme->selTextColor = GS_SETREG_RGBA(gDefaultSelTextColor[0], gDefaultSelTextColor[1], gDefaultSelTextColor[2], 0x80);
+
+    if (!retintElements)
+        return;
 
     theme_element_t *elem = theme->mainElems.first;
     while (elem) {
@@ -2616,7 +2633,7 @@ static int thmLoad(const char *themePath)
 
     newT->useDefault = 1;
     newT->usedHeight = 480;
-    thmSetColors(newT);
+    thmSetColors(newT, 1); // element list is still empty here; the retint is a no-op by construction
     newT->mainElems.first = NULL;
     newT->mainElems.last = NULL;
     newT->infoElems.first = NULL;
@@ -3062,8 +3079,15 @@ int thmSetGuiValue(int themeID, int reload)
 
                Disk themes stay excluded on purpose -- their colours come from the theme file, and
                overwriting them with the settings picker's values is what the read-only grey-out in
-               guiShowColorsConfig exists to prevent. (issue #537) */
-            thmSetColors(gTheme);
+               guiShowColorsConfig exists to prevent. (issue #537)
+
+               ONLY THEME 0 GETS THE ELEMENT RETINT. Extending this call to Coverflow without that
+               restriction repainted every Coverflow element in one flat colour on EVERY applyConfig
+               -- not just on a colour edit -- because the retint loop stomps the per-element colours
+               theme_coverflow_cfg had parsed. Elements whose text then matched their background
+               stopped drawing at all, which presents as broken visuals and vanishing game lists
+               while navigation stays perfectly responsive. Coverflow takes the palette only. */
+            thmSetColors(gTheme, guiThemeID == 0);
         }
     }
     return 0;


### PR DESCRIPTION
Two regressions of mine, both found by going back to what the code already said.

### `fix(art)` — art delay 0 → 2

**"Art isn't fluid like it was."** It isn't, and this is why.

Three values existed for `gArtDelay` and only one had ever run in the field:

| value | origin |
|---|---|
| **2** | what the **fork** shipped |
| 8 | the rebuild's "official-like" change |
| 0 | mine |

I picked 0 while quoting the comment that says, in as many words, *"the fork lands on 2, we land on 8."* I read the number that was known to work and chose one that wasn't — the same mistake as `ART_MIN_SETTLE_FRAMES`, the same day.

And 0 is not merely untested, it's wrong for the devices it was meant to help. The setting counts frames of **no input** before art may be **requested**, so at 0 every scrolled row enqueues a cover immediately and USB/ATA/network art reads run underneath the scroll itself. Covers arrive sooner and the movement they arrive during gets worse.

8 isn't the answer either — that's the delay that made art feel like it needed a settle before anything appeared. 2 releases art after a two-frame pause and never asks during a continuous scroll. SIO2 keeps its own higher floor in texcache.

### `fix(hdd)` — Code 222 on elapsed time

Still appearing on the APA page for drives that then mount fine.

Requiring 3 settled failures was the *second* attempt, and it fails for a reason a third threshold wouldn't fix: retry cadence isn't fixed, so "3 retries" can elapse in far less time than a cold drive needs to answer PS2FS. A count can't express *"the drive has had a fair chance"*, which is the only thing this message should assert. Now it's time-based — one variable, no new machinery.

Recording plainly rather than tuning again: this message is **self-clearing** (`clearErrorMessageIf` on recovery). An error box a later success silently retracts is describing a transient. Whether it should be modal at all is a design call, not a tuning one — it's now been tuned three times without becoming true.

---

Verified: clean ps2dev build `MAKE_EXIT=0`, clang-format 12 clean.

**Not fixed here — "VCD shows them and then they immediately vanish".** Traced the mechanism: `submenuAllocItem` does `it->item.text = text` — menu rows **alias** the support's game array rather than copying it. So when a support frees that array, every visible row dangles. MMCE frees **both** arrays the instant its prefix goes empty, and its Auto re-detect had no debounce, so one contended probe during USB churn wiped a populated list. That is the path fixed in `f77d942a` (already merged) — needs confirming against a build that contains it before I add anything further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HDD PFS diagnostic Code 222 now appears only after 20 seconds of continuous failure, reducing premature error reports.
  - Successful PFS checks reset the failure monitoring period.

- **Improvements**
  - Updated the default cover-art loading delay to 2 seconds.
  - Invalid cover-art delay settings now safely fall back to the 2-second default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->