### PR TITLE
fix: restore MMCE VCD and DEV9 startup

### DIFF
--- a/.github/scripts/test-vcd-directory.py
+++ b/.github/scripts/test-vcd-directory.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Exercise the real VCD scanner with controlled directory replies, without PS2 IO.
+
+MMCE's error-at-EOF fixture follows sd2psXtd/firmware commit
+8a20bd991b43ac731882f5f85030b19e94c23a3b:
+  src/ps2/mmceman/ps2_mmceman_fs.c: MMCEMAN_FS_DREAD
+  src/ps2/mmceman/ps2_mmceman_commands.c: ps2_mmceman_cmd_fs_dread
+Exhausted iteration sets rv=-1, sent as status 1. Our pinned mmceman
+db3e93f0fdbcf882f88da110cbd9b7db188ec17a returns -1 for that status.
+PS2SDK's fileXio/libcglue path consequently presents readdir(NULL) + errno.
+This is a source-contract test, not a hardware or timing simulation.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def function(source, signature):
+    start = source.index(signature)
+    return source[start:source.index("\n}", start) + 2]
+
+
+STUBS = r"""
+#define _POSIX_C_SOURCE 200112L
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#define memalign(alignment, size) malloc(size)
+#define LOG(...) ((void)0)
+#define VCD_MAX_ITEMS 2048
+#define VCD_NAME_MAX 256
+#define ISO_GAME_NAME_MAX 160
+#define GAME_FORMAT_ISO 1
+#define POPS_FOLDER "POPS"
+typedef struct { char name[VCD_NAME_MAX]; } vcd_entry_t;
+typedef struct {
+    char name[ISO_GAME_NAME_MAX + 1], startup[ISO_GAME_NAME_MAX + 1];
+    char extension[5];
+    int parts, format;
+} base_game_info_t;
+typedef struct { int offset; } DIR;
+struct dirent { char d_name[256]; };
+static DIR stream;
+static const char *const *entries;
+static int entryCount, endError, openError, bodyError, openCount, closeCount;
+static int gAutosort = 1, gVcdFirstDiscOnly = 0;
+static char openedPath[256];
+static DIR *opendir(const char *path) {
+    snprintf(openedPath, sizeof(openedPath), "%s", path);
+    if (openError) { errno = openError; return NULL; }
+    stream.offset = 0;
+    openCount++;
+    return &stream;
+}
+static struct dirent *readdir(DIR *dir) {
+    static struct dirent entry;
+    if (dir->offset == entryCount) {
+        if (endError) errno = endError;
+        return NULL;
+    }
+    snprintf(entry.d_name, sizeof(entry.d_name), "%s", entries[dir->offset++]);
+    return &entry;
+}
+static int closedir(DIR *dir) { (void)dir; closeCount++; return 0; }
+static void vcdNoteScanDir(const char *name, const char *path) {
+    (void)name; (void)path;
+    if (bodyError) errno = bodyError;
+}
+static void cacheInvalidateFailMemo(void) {}
+static int vcdIsHiddenDisc(const char *name) { (void)name; return 0; }
+static int vcdEntryCmp(const void *a, const void *b) {
+    return strcasecmp(((const vcd_entry_t *)a)->name, ((const vcd_entry_t *)b)->name);
+}
+static void fixture(const char *const *names, int count, int error) {
+    entries = names; entryCount = count; endError = error;
+    openError = bodyError = openCount = closeCount = 0;
+}
+"""
+
+TESTS = r"""
+static const char *const names[] = {".", "..", "Zebra.VCD", "Alpha.vcd", "POPSTARTER.VCD", "cover.png"};
+static void check_list(base_game_info_t *games, int count) {
+    assert(count == 2);
+    assert(games != NULL);
+    assert(strcmp(games[0].name, "Alpha") == 0);
+    assert(strcmp(games[1].name, "Zebra") == 0);
+    assert(strcmp(games[0].extension, ".VCD") == 0);
+    assert(openCount == 1 && closeCount == 1);
+}
+static void mmce_tests(void) {
+    const char *const roots[] = {"mmce0:/", "mmce1:/OPL/"};
+    for (int i = 0; i < 2; ++i) {
+        base_game_info_t *games = NULL;
+        fixture(names, 6, EPERM);
+        int count = vcdFillGameList(roots[i], &games);
+        printf("MMCE error-at-EOF %s: count=%d (expected 2)\n", roots[i], count);
+        fflush(stdout);
+        check_list(games, count);
+
+        fixture(names, 6, EPERM);
+        count = vcdFillGameList(roots[i], &games);
+        check_list(games, count); // repeated refresh must retain the visible games
+        free(games);
+
+        fixture(NULL, 0, EPERM);
+        games = NULL;
+        assert(vcdFillGameList(roots[i], &games) == 0); // master's empty-directory contract
+        assert(games == NULL && openCount == closeCount);
+    }
+}
+static void portable_tests(void) {
+    const char *const roots[] = {"mass0:/", "smb0:\\", "pfs0:/", "notmmce0:/"};
+    for (int i = 0; i < 4; ++i) {
+        base_game_info_t *games = NULL;
+        fixture(names, 6, 0);
+        int count = vcdFillGameList(roots[i], &games);
+        check_list(games, count);
+        base_game_info_t *previous = games;
+
+        fixture(names, 4, EIO); // a failed partial walk must not replace last-good
+        assert(vcdFillGameList(roots[i], &games) == -1);
+        assert(games == previous && strcmp(games[1].name, "Zebra") == 0);
+
+        fixture(names, 6, 0);
+        bodyError = ENOMEM; // best-effort metadata failure is NOT a directory failure
+        count = vcdFillGameList(roots[i], &games);
+        check_list(games, count);
+
+        fixture(NULL, 0, 0);
+        assert(vcdFillGameList(roots[i], &games) == 0);
+        assert(games == NULL);
+    }
+
+    base_game_info_t *games = NULL;
+    fixture(names, 6, 0);
+    int count = vcdFillGameList("mmce0:/", &games);
+    check_list(games, count);
+    base_game_info_t *previous = games;
+    fixture(NULL, 0, 0);
+    openError = EIO;
+    assert(vcdFillGameList("mmce0:/", &games) == -1);
+    assert(games == previous); // MMCE opendir failures still preserve the old list
+    openError = ENOENT;
+    assert(vcdFillGameList("mmce0:/", &games) == 0 && games == NULL);
+}
+int main(int argc, char **argv) {
+    assert(argc == 2);
+    if (strcmp(argv[1], "portable")) mmce_tests();
+    if (strcmp(argv[1], "mmce")) portable_tests();
+    puts("PASS: VCD directory contract");
+    return 0;
+}
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ref", help="Read scanner from this git ref, not the worktree")
+    parser.add_argument("--case", choices=("mmce", "portable", "all"), default="all")
+    parser.add_argument("--cc", default=os.environ.get("CC", "cc"))
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[2]
+    if args.ref:
+        source = subprocess.check_output(
+            ["git", "show", f"{args.ref}:src/vcdsupport.c"], cwd=root, text=True)
+    else:
+        source = (root / "src/vcdsupport.c").read_text(encoding="utf-8")
+    code = STUBS + "\n" + "\n".join(function(source, signature) for signature in (
+        "static int vcdScanOpenDir(", "int vcdScanDir(", "int vcdFillGameList(")) + TESTS
+    with tempfile.TemporaryDirectory(prefix="opl-vcd-scan-") as directory:
+        cfile = Path(directory) / "test.c"
+        binary = Path(directory) / ("test.exe" if os.name == "nt" else "test")
+        cfile.write_text(code, encoding="utf-8")
+        subprocess.run([args.cc, "-std=c99", "-Wall", "-Wextra", "-Werror",
+                        "-Wno-unused-function", "-Wno-format-truncation",
+                        str(cfile), "-o", str(binary)], check=True)
+        subprocess.run([str(binary), args.case], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/flavours.yml
+++ b/.github/workflows/flavours.yml
@@ -100,6 +100,16 @@ jobs:
             apt-get update -qq && apt-get install -y -qq bash make git zip unzip python3 python3-yaml gawk || true
           fi
 
+      - name: Provide PS2SDK iopfixup compatibility name
+        run: |
+          sdk_bin="${PS2SDK:-/usr/local/ps2dev/ps2sdk}/bin"
+          if [ -x "$sdk_bin/srxfixup" ]; then
+            echo "$sdk_bin" >> "$GITHUB_PATH"
+            # New PS2SDK images ship srxfixup under its canonical name, while the
+            # inherited module makefiles still invoke the compatible iopfixup alias.
+            [ -e "$sdk_bin/iopfixup" ] || ln -s srxfixup "$sdk_bin/iopfixup"
+          fi
+
       - name: git checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/flavours.yml
+++ b/.github/workflows/flavours.yml
@@ -1,5 +1,8 @@
 name: build-flavours
 
+permissions:
+  contents: read
+
 # FOUR FLAVOURS, along two independent axes: WHICH toolchain, and PINNED vs ROLLING.
 #
 #                      pinned (reproducible)          rolling (early warning)

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -99,6 +99,14 @@ jobs:
               diffutils
           fi
 
+      - name: Provide PS2SDK iopfixup compatibility name
+        run: |
+          sdk_bin="${PS2SDK:-/usr/local/ps2dev/ps2sdk}/bin"
+          if [ -x "$sdk_bin/srxfixup" ]; then
+            echo "$sdk_bin" >> "$GITHUB_PATH"
+            [ -e "$sdk_bin/iopfixup" ] || ln -s srxfixup "$sdk_bin/iopfixup"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -204,6 +212,14 @@ jobs:
               sed \
               gawk \
               diffutils
+          fi
+
+      - name: Provide PS2SDK iopfixup compatibility name
+        run: |
+          sdk_bin="${PS2SDK:-/usr/local/ps2dev/ps2sdk}/bin"
+          if [ -x "$sdk_bin/srxfixup" ]; then
+            echo "$sdk_bin" >> "$GITHUB_PATH"
+            [ -e "$sdk_bin/iopfixup" ] || ln -s srxfixup "$sdk_bin/iopfixup"
           fi
 
       - name: Checkout

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -50,7 +50,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 # Per-ref: master pushes still supersede each other (rolling), but a v* tag release runs in its
 # own group, so a new master push can't cancel an in-flight release cut (or vice versa).

--- a/.github/workflows/scanner-tests.yml
+++ b/.github/workflows/scanner-tests.yml
@@ -1,0 +1,24 @@
+name: VCD scanner contract
+
+on:
+  push:
+    paths:
+      - 'src/vcdsupport.c'
+      - '.github/scripts/test-vcd-directory.py'
+      - '.github/workflows/scanner-tests.yml'
+  pull_request:
+    paths:
+      - 'src/vcdsupport.c'
+      - '.github/scripts/test-vcd-directory.py'
+      - '.github/workflows/scanner-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  scanner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check MMCE EOF compatibility and other-device error preservation
+        run: python3 .github/scripts/test-vcd-directory.py --cc gcc

--- a/include/ethsupport.h
+++ b/include/ethsupport.h
@@ -17,8 +17,9 @@ typedef struct
 
 void ethInit(item_list_t *itemList); // Full initialization (Start ETH + SMB and apply configuration). GUI must be already initialized, used by GUI to start SMB mode.
 void ethDeinitModules(void);         // Module-only deinitialization, without the GUI's knowledge (for specific reasons, otherwise unused).
+void ethReleaseDev9(void);           // Release ETH's DEV9/NIC ownership after module teardown.
 int ethLoadInitModules(void);        // Initializes Ethernet and applies configuration.
-int ethGetModulesLoaded(void);       // 1 if the SMB NIC stack is loaded (UDPBD must not load on top).
+int ethGetModulesLoaded(void);       // 1 if ETH fully loaded or owns a partial SMB NIC claim (UDPBD must not load on top).
 // True only after OPENSHARE succeeded and the active smb0: prefix is usable. This is deliberately
 // stronger than "Network Protocol == SMB": callers must not turn a read-only import into a long
 // connection attempt or consume stale saved values.

--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -16,7 +16,8 @@ typedef struct
 
 void mmceInit(item_list_t *itemList);
 item_list_t *mmceGetObject(int initOnly);
-void mmceLoadModules(void);
+// Load the singleton MMCE driver. Returns 0 when resident, <0 when the load failed.
+int mmceLoadModules(void);
 void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
 // Push the selected game's disc id to a present MMCE card (SD2PSX/MemCard PRO2) for per-game folder
 // switching. Self-probes mmce0:/mmce1: when no MMCE-tab prefix is set, so it works on ALL launch

--- a/include/system.h
+++ b/include/system.h
@@ -9,7 +9,9 @@
 
 unsigned int USBA_crc32(const char *string);
 int sysGetDiscID(char *discID);
-void sysInitDev9(void);
+// Acquire one shared DEV9 reference. Returns 0 when DEV9 is ready, <0 when its
+// module could not be loaded; callers must only release the reference on success.
+int sysInitDev9(void);
 void sysShutdownDev9(void);
 void sysReset(int modload_mask);
 void sysExecExit(void);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1035,9 +1035,9 @@ static void bdmLoadBlockDeviceModules(void)
         const char *networkStage = gNetBootProtocol == NET_BOOT_UDPFS ? "UDPFS-BD chain" : "UDPBD";
 
         bdmDiagBootStageBegin(networkStage);
-        sysInitDev9();
+        int dev9Ready = sysInitDev9() == 0;
         snprintf(ipArg, sizeof(ipArg), "ip=%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
-        if (gNetBootProtocol == NET_BOOT_UDPFS) {
+        if (dev9Ready && gNetBootProtocol == NET_BOOT_UDPFS) {
             // UDPFS: a 3-IRX chain loaded in dependency order -- smap (exports to ministack + bd), then
             // ministack (gets the ip= arg, exports to bd), then udpfs_bd (registers the "udp" BDM device).
             networkResult = bdmDiagLoadOptionalModule("UDPFS_SMAP", "UDPFS_SMAP", &udpfs_smap_irx, size_udpfs_smap_irx);
@@ -1049,7 +1049,7 @@ static void bdmLoadBlockDeviceModules(void)
                 udpbdModLoaded = 1;
                 udpbdLoadedProtocol = NET_BOOT_UDPFS;
             }
-        } else {
+        } else if (dev9Ready) {
             // UDPBD: the self-contained smap_udpbd monolith (smap + ministack + udpbd in one irx).
             networkResult = bdmDiagLoadOptionalModuleArgs("SMAP_UDPBD", "SMAP_UDPBD", &smap_udpbd_irx, size_smap_udpbd_irx, (int)strlen(ipArg) + 1, ipArg);
             if (networkResult >= 0) {
@@ -1062,7 +1062,7 @@ static void bdmLoadBlockDeviceModules(void)
         // UDPBD/UDPFS (both gates re-enter on every device refresh while !udpbdModLoaded) inflates the
         // refcounted dev9InitCount and a later HDD/ETH teardown can never power dev9 down. On success
         // the reference is intentionally kept (the device stays mounted). Mirrors ETH/HDD pairing.
-        if (!udpbdModLoaded)
+        if (dev9Ready && !udpbdModLoaded)
             sysShutdownDev9();
     }
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -35,6 +35,10 @@ static int ieee1394ModLoaded = 0;
 static int mx4sioModLoaded = 0;
 static int hddModLoaded = 0;
 static int udpbdModLoaded = 0;
+// Keep one DEV9 reference while a UDPBD/UDPFS-BD dependency chain is incomplete. The lower-layer
+// SMAP module can already be resident when the final module fails; releasing DEV9 then powers off
+// the adapter and prevents a later retry from restoring it because module loading is deduplicated.
+static unsigned char udpbdDev9RefHeld = 0;
 /*
   WHICH network block transport is actually resident, as NET_BOOT_UDPBD / NET_BOOT_UDPFS, or -1
   when none is loaded.
@@ -657,7 +661,7 @@ static int bdmDiagLoadOptionalModuleArgs(const char *stage, const char *name, vo
 // Exposed for ethsupport's NIC mutual-exclusion: UDPBD and the SMB stack both own the SMAP adapter.
 int bdmIsUDPBDLoaded(void)
 {
-    return udpbdModLoaded;
+    return udpbdModLoaded || udpbdDev9RefHeld;
 }
 
 /*
@@ -1035,7 +1039,14 @@ static void bdmLoadBlockDeviceModules(void)
         const char *networkStage = gNetBootProtocol == NET_BOOT_UDPFS ? "UDPFS-BD chain" : "UDPBD";
 
         bdmDiagBootStageBegin(networkStage);
-        int dev9Ready = sysInitDev9() == 0;
+        int dev9Ready;
+        if (udpbdDev9RefHeld)
+            dev9Ready = 1;
+        else {
+            dev9Ready = sysInitDev9() == 0;
+            if (dev9Ready)
+                udpbdDev9RefHeld = 1;
+        }
         snprintf(ipArg, sizeof(ipArg), "ip=%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
         if (dev9Ready && gNetBootProtocol == NET_BOOT_UDPFS) {
             // UDPFS: a 3-IRX chain loaded in dependency order -- smap (exports to ministack + bd), then
@@ -1058,12 +1069,9 @@ static void bdmLoadBlockDeviceModules(void)
             }
         }
         bdmDiagBootStageEnd(networkStage, networkResult);
-        // Release the dev9 reference taken above if the load failed -- otherwise a failing/retrying
-        // UDPBD/UDPFS (both gates re-enter on every device refresh while !udpbdModLoaded) inflates the
-        // refcounted dev9InitCount and a later HDD/ETH teardown can never power dev9 down. On success
-        // the reference is intentionally kept (the device stays mounted). Mirrors ETH/HDD pairing.
-        if (dev9Ready && !udpbdModLoaded)
-            sysShutdownDev9();
+        // Keep the single DEV9 reference on failure so a retry can complete the dependency chain
+        // against the already-resident lower layers. It remains held for the life of the boot once
+        // the UDPBD/UDPFS-BD transport has claimed the adapter.
     }
 
     int modsNow = iUSBModLoaded + iLinkModLoaded + mx4sioModLoaded + hddModLoaded + udpbdModLoaded;

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -577,7 +577,7 @@ static int bdmProbeMassSlots(const char *when)
         } else {
             int devnr = -1;
             // Guarded reader: a buffered ask on an unmounted volume faults the IOP outright.
-            if (bdmReadDriverName(dir, driver, sizeof(driver)) >= 0 && driver[0] != ' ') {
+            if (bdmReadDriverName(dir, driver, sizeof(driver)) >= 0 && driver[0] != '\0') {
                 fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &devnr, sizeof(devnr));
                 n = snprintf(summary + len, sizeof(summary) - len, " %d%c%d", i, driver[0], devnr);
             } else {

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -323,35 +323,59 @@ static int ethLoadModules(void)
     }
 
     if (!ethModulesLoaded) {
-        ethModulesLoaded = 1;
+        int dev9Ready;
+        int netmanInitialized = 0;
+        int httpInitialized = 0;
 
-        sysInitDev9();
+        dev9Ready = sysInitDev9();
+        if (dev9Ready < 0) {
+            gNetworkStartup = ERROR_ETH_MODULE_NETIF_FAILURE;
+            LOG("ETHSUPPORT: DEV9 initialization failed (%d); network setup remains retryable\n", dev9Ready);
+            return -1;
+        }
 
         LOG("[NETMAN]:\n");
-        if (sysLoadModuleBuffer(&netman_irx, size_netman_irx, 0, NULL) >= 0) {
-            NetManInit();
-            LOG("[SMSUTILS]:\n");
-            sysLoadModuleBuffer(&smsutils_irx, size_smsutils_irx, 0, NULL);
-            LOG("[SMAP]:\n");
-            if (sysLoadModuleBuffer(&smap_irx, size_smap_irx, 0, NULL) >= 0) {
-                // Before the network stack is loaded, attempt to set the link settings in order to avoid needing double-initialization of the IF.
-                // But do not fail here because there is currently no way to re-start initialization.
-                ethApplyNetIFConfig();
-                LOG("[PS2IP]:\n");
-                if (sysLoadModuleBuffer(&ps2ip_irx, size_ps2ip_irx, 0, NULL) >= 0) {
-                    LOG("[PS2IPS]:\n");
-                    sysLoadModuleBuffer(&ps2ips_irx, size_ps2ips_irx, 0, NULL);
-                    LOG("[HTTPCLIENT]:\n");
-                    if (sysLoadModuleBuffer(&httpclient_irx, size_httpclient_irx, 0, NULL) >= 0) {
-                        if (HttpInit() < 0)
-                            LOG("ETHSUPPORT: httpclient RPC bind failed; compat update unavailable\n");
-                    }
-                    ps2ip_init();
-                    LOG("ETHSUPPORT Modules loaded\n");
-                    return 0;
-                }
-            }
+        if (sysLoadModuleBuffer(&netman_irx, size_netman_irx, 0, NULL) < 0)
+            goto load_failed;
+
+        NetManInit();
+        netmanInitialized = 1;
+        LOG("[SMSUTILS]:\n");
+        sysLoadModuleBuffer(&smsutils_irx, size_smsutils_irx, 0, NULL);
+        LOG("[SMAP]:\n");
+        if (sysLoadModuleBuffer(&smap_irx, size_smap_irx, 0, NULL) < 0)
+            goto load_failed;
+
+        // Before the network stack is loaded, attempt to set the link settings in order to avoid
+        // needing double-initialization of the IF. A failed dependency remains retryable now.
+        ethApplyNetIFConfig();
+        LOG("[PS2IP]:\n");
+        if (sysLoadModuleBuffer(&ps2ip_irx, size_ps2ip_irx, 0, NULL) < 0)
+            goto load_failed;
+
+        LOG("[PS2IPS]:\n");
+        sysLoadModuleBuffer(&ps2ips_irx, size_ps2ips_irx, 0, NULL);
+        LOG("[HTTPCLIENT]:\n");
+        if (sysLoadModuleBuffer(&httpclient_irx, size_httpclient_irx, 0, NULL) >= 0) {
+            if (HttpInit() < 0)
+                LOG("ETHSUPPORT: httpclient RPC bind failed; compat update unavailable\n");
+            else
+                httpInitialized = 1;
         }
+
+        ps2ip_init();
+        ethModulesLoaded = 1;
+        LOG("ETHSUPPORT Modules loaded\n");
+        return 0;
+
+    load_failed:
+        if (httpInitialized)
+            HttpDeinit();
+        if (netmanInitialized)
+            NetManDeinit();
+        sysShutdownDev9();
+        ethModulesLoaded = 0;
+        LOG("ETHSUPPORT: network module chain failed; setup remains retryable\n");
 
         gNetworkStartup = ERROR_ETH_MODULE_NETIF_FAILURE;
         return -1;
@@ -511,7 +535,7 @@ void ethInit(item_list_t *itemList)
 
     ethInvalidateFavIsoBacking();
 
-    if (gNetworkStartup >= ERROR_ETH_SMB_CONN) {
+    if (gNetworkStartup >= ERROR_ETH_MODULE_NETIF_FAILURE) {
         LOG("ETHSUPPORT Re-Init\n");
         thmReinit(ethBase);
         ethULSizePrev = -2;

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -463,7 +463,6 @@ void ethDeinitModules(void)
             DeleteSema(ethInitSemaID);
             ethInitSemaID = -1;
         }
-
     }
 }
 

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -540,7 +540,15 @@ void ethInit(item_list_t *itemList)
         thmReinit(ethBase);
         ethULSizePrev = -2;
         ethGameCount = 0;
-        ioPutRequest(IO_CUSTOM_SIMPLEACTION, &ethInitSMB);
+        // Code 200 means the base DEV9/SMAP/PS2IP chain never became resident. Re-entering
+        // ethInitSMB() alone only retries IP/SMB configuration against missing devices, so the
+        // original startup race remained a permanent "no network adapter" state. Re-run the full
+        // loader while the failed latch is clear; once the base chain is resident, a 300+ error
+        // needs only the cheaper config/share reconnect path.
+        if (!ethModulesLoaded || gNetworkStartup <= ERROR_ETH_MODULE_SMBMAN_FAILURE)
+            ioPutRequest(IO_CUSTOM_SIMPLEACTION, &smbLoadModules);
+        else
+            ioPutRequest(IO_CUSTOM_SIMPLEACTION, &ethInitSMB);
     } else {
         LOG("ETHSUPPORT Init\n");
         ethBase = "smb0:";

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -31,6 +31,17 @@ static time_t ethModifiedCDPrev;
 static time_t ethModifiedDVDPrev;
 static int ethGameCount = 0;
 static unsigned char ethModulesLoaded = 0;
+// Keep the DEV9/NIC ownership state separate from the fully usable SMB state. A dependency can
+// fail after NetMan/SMAP has claimed the adapter; dropping the DEV9 reference in that window powers
+// the adapter off while sysLoadModuleBuffer still considers its IRXs resident, and another transport
+// can then try to claim the same SMAP driver. The claim remains until the ETH stack is explicitly
+// torn down, while a retry reuses the one DEV9 reference instead of incrementing it again.
+static unsigned char ethNetworkClaimed = 0;
+static unsigned char ethDev9RefHeld = 0;
+static unsigned char ethNetmanInitialized = 0;
+static unsigned char ethPs2ipInitialized = 0;
+static unsigned char ethHttpInitialized = 0;
+static unsigned char ethNbnsInitialized = 0;
 static base_game_info_t *ethGames = NULL;
 
 // Favourites needs to validate an ISO record even when the live ETH page currently owns the VCD
@@ -295,7 +306,7 @@ static void ethInitSMB(void)
 
 int ethGetModulesLoaded(void)
 {
-    return ethModulesLoaded;
+    return ethModulesLoaded || ethNetworkClaimed;
 }
 
 int ethIsSMBShareConnected(void)
@@ -323,15 +334,14 @@ static int ethLoadModules(void)
     }
 
     if (!ethModulesLoaded) {
-        int dev9Ready;
-        int netmanInitialized = 0;
-        int httpInitialized = 0;
-
-        dev9Ready = sysInitDev9();
-        if (dev9Ready < 0) {
-            gNetworkStartup = ERROR_ETH_MODULE_NETIF_FAILURE;
-            LOG("ETHSUPPORT: DEV9 initialization failed (%d); network setup remains retryable\n", dev9Ready);
-            return -1;
+        if (!ethDev9RefHeld) {
+            int dev9Ready = sysInitDev9();
+            if (dev9Ready < 0) {
+                gNetworkStartup = ERROR_ETH_MODULE_NETIF_FAILURE;
+                LOG("ETHSUPPORT: DEV9 initialization failed (%d); network setup remains retryable\n", dev9Ready);
+                return -1;
+            }
+            ethDev9RefHeld = 1;
         }
 
         LOG("[NETMAN]:\n");
@@ -339,12 +349,13 @@ static int ethLoadModules(void)
             goto load_failed;
 
         NetManInit();
-        netmanInitialized = 1;
+        ethNetmanInitialized = 1;
         LOG("[SMSUTILS]:\n");
         sysLoadModuleBuffer(&smsutils_irx, size_smsutils_irx, 0, NULL);
         LOG("[SMAP]:\n");
         if (sysLoadModuleBuffer(&smap_irx, size_smap_irx, 0, NULL) < 0)
             goto load_failed;
+        ethNetworkClaimed = 1;
 
         // Before the network stack is loaded, attempt to set the link settings in order to avoid
         // needing double-initialization of the IF. A failed dependency remains retryable now.
@@ -359,21 +370,28 @@ static int ethLoadModules(void)
         if (sysLoadModuleBuffer(&httpclient_irx, size_httpclient_irx, 0, NULL) >= 0) {
             if (HttpInit() < 0)
                 LOG("ETHSUPPORT: httpclient RPC bind failed; compat update unavailable\n");
-            else
-                httpInitialized = 1;
+            else {
+                ethHttpInitialized = 1;
+            }
         }
 
         ps2ip_init();
+        ethPs2ipInitialized = 1;
         ethModulesLoaded = 1;
         LOG("ETHSUPPORT Modules loaded\n");
         return 0;
 
     load_failed:
-        if (httpInitialized)
+        if (ethHttpInitialized)
             HttpDeinit();
-        if (netmanInitialized)
+        if (ethNetmanInitialized)
             NetManDeinit();
-        sysShutdownDev9();
+        ethHttpInitialized = 0;
+        ethPs2ipInitialized = 0;
+        ethNetmanInitialized = 0;
+        // Keep the DEV9 reference and any claimed NIC ownership. The next invocation retries the
+        // missing dependency against the already-resident lower layers; releasing here would issue
+        // DDIOC_OFF while dev9Initialized/module-buffer tracking still says the stack is present.
         ethModulesLoaded = 0;
         LOG("ETHSUPPORT: network module chain failed; setup remains retryable\n");
 
@@ -392,7 +410,9 @@ static int ethLoadModules(void)
 
 void ethDeinitModules(void)
 {
-    if (ethModulesLoaded) {
+    if (ethModulesLoaded || ethNetworkClaimed || ethDev9RefHeld) {
+        int wasModulesLoaded = ethModulesLoaded;
+        int wasPs2ipInitialized = ethPs2ipInitialized;
         // BOUNDED ACQUIRE, was an unbounded WaitSema. deinit runs this while a game launch is in
         // flight, and anything still holding this lock -- an in-progress SMB reconnect, a network
         // read that will not return because the link is already going away -- used to stop the exit
@@ -415,10 +435,26 @@ void ethDeinitModules(void)
                 LOG("ETH: deinit could not take the init lock -- tearing down anyway\n");
         }
 
-        HttpDeinit();
-        nbnsDeinit();
-        NetManDeinit();
+        if (ethHttpInitialized)
+            HttpDeinit();
+        if (ethNbnsInitialized)
+            nbnsDeinit();
+        if (ethNetmanInitialized) {
+            NetManDeinit();
+            ethNetmanInitialized = 0;
+        }
+        // To allow the configuration to be read later on, read the latest version while PS2IP is
+        // still available. Preserve the old full-stack behavior, but skip it for a partial claim.
+        if (wasModulesLoaded)
+            ethReadNetConfig();
+        if (wasPs2ipInitialized)
+            ps2ip_deinit();
+
         ethModulesLoaded = 0;
+        ethHttpInitialized = 0;
+        ethPs2ipInitialized = 0;
+        ethNetmanInitialized = 0;
+        ethNbnsInitialized = 0;
         gNetworkStartup = ERROR_ETH_NOT_STARTED;
 
         if (ethInitSemaID >= 0) {
@@ -428,9 +464,17 @@ void ethDeinitModules(void)
             ethInitSemaID = -1;
         }
 
-        // To allow the configuration to be read later on, read the latest version now.
-        ethReadNetConfig();
-        ps2ip_deinit();
+    }
+}
+
+void ethReleaseDev9(void)
+{
+    // Deinit and DEV9 release are separate because the launch cleanup path must leave DEV9 powered
+    // for the handoff ELF, while terminal shutdown and the NBD preflight explicitly return it.
+    ethNetworkClaimed = 0;
+    if (ethDev9RefHeld) {
+        sysShutdownDev9();
+        ethDev9RefHeld = 0;
     }
 }
 
@@ -518,6 +562,7 @@ static void smbLoadModules(void)
             LOG("[NBNS]:\n");
             sysLoadModuleBuffer(&nbns_irx, size_nbns_irx, 0, NULL);
             nbnsInit();
+            ethNbnsInitialized = 1;
 
             LOG("SMBSUPPORT Modules loaded\n");
             ethInitSMB();
@@ -1082,6 +1127,8 @@ static void ethCleanUp(item_list_t *itemList, int exception)
 
     // UI may have initialized modules outside of ETH mode, so deinitialize regardless of the enabled status.
     ethDeinitModules();
+    if (gDeinitTerminal)
+        ethReleaseDev9();
 }
 
 // This may be called, even if ethInit() was not.
@@ -1099,12 +1146,8 @@ static void ethShutdown(item_list_t *itemList)
     }
 
     // UI may have initialized modules outside of ETH mode, so deinitialize regardless of the enabled status.
-    int ethWasLoaded = ethModulesLoaded; // capture BEFORE ethDeinitModules() clears ethModulesLoaded
     ethDeinitModules();
-
-    // Only shut down dev9 from here, if it was initialized from here before.
-    if (ethWasLoaded)
-        sysShutdownDev9();
+    ethReleaseDev9();
 }
 
 static int ethCheckVMC(item_list_t *itemList, char *name, int createSize)

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -36,6 +36,11 @@ static unsigned char hddHDProKitDetected = 0;
 static unsigned char hddModulesLoadCount = 0;
 static unsigned char hddModulesLoaded = 0;
 static unsigned char hddSupportModulesLoaded = 0;
+// A failed ATA dependency load must keep the DEV9 reference across retries. Releasing it powers
+// the card off while sysLoadModuleBuffer still remembers the resident DEV9 IRX, so a later retry
+// skips the load and probes a stopped adapter. This flag owns exactly one reference for the ATA
+// stack and is released only by terminal teardown.
+static unsigned char hddDev9RefHeld = 0;
 // The generic ATA block-device path does not need the APA settle. Keep one bounded gap between
 // the shared ATAD/XHDD stack and the APA/PFS stack, where the first hdd0:/ps2fs probe can race the
 // same physical drive. This avoids adding the APA-only delay to the single-partition ATA VCD path.
@@ -424,7 +429,13 @@ int hddLoadModules(void)
 
         // DEV9 must be loaded, as HDD.IRX depends on it. Even if not required by the I/F (i.e. HDPro)
         hddDiagBootStageBegin("HDD:DEV9");
-        dev9Ready = sysInitDev9() == 0;
+        if (hddDev9RefHeld)
+            dev9Ready = 1;
+        else {
+            dev9Ready = sysInitDev9() == 0;
+            if (dev9Ready)
+                hddDev9RefHeld = 1;
+        }
         hddDiagBootStageEndVoid("HDD:DEV9");
 
         if (!dev9Ready) {
@@ -476,13 +487,9 @@ int hddLoadModules(void)
             // power-on). sysInitDev9/sysLoadModuleBuffer are safe to re-run; a later caller (e.g. the
             // HDD tab) now gets a real second attempt instead of a poisoned latch.
             //
-            // Release the dev9 reference taken above before clearing the count, or the retry that this
-            // line exists to permit takes a SECOND one and never gives either back. dev9 is refcounted
-            // and shared with ETH/UDPBD, so an inflated count means a later teardown can never power
-            // dev9 down. The UDPBD arm in bdmsupport.c already pairs its init/shutdown this way; this
-            // arm did not, and rebuild-153's device-refresh bump made the retry more frequent.
-            if (dev9Ready)
-                sysShutdownDev9();
+            // Keep the single DEV9 reference for a retry. Releasing it here can power the card off
+            // while the resident-module tracker still makes the next sysInitDev9() skip loading it.
+            // Terminal teardown releases hddDev9RefHeld exactly once.
             hddModulesLoadCount = 0;
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;
@@ -2152,8 +2159,10 @@ static void hddShutdown(item_list_t *itemList)
         // emulated DEV9 power-off is inert). ee_core/POPSTARTER reset the IOP right after, so the
         // launch path needs no power-off. Note the refcount asymmetry this also softens: N
         // hddLoadModules calls take ONE dev9 reference, but every hddShutdown used to drop it.
-        if (gDeinitTerminal)
-            sysShutdownDev9();
+    }
+    if (gDeinitTerminal && hddDev9RefHeld) {
+        sysShutdownDev9();
+        hddDev9RefHeld = 0;
     }
     hddApaSettled = 0;
 }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -402,6 +402,7 @@ static void hddFindOPLPartition(void)
 
 int hddLoadModules(void)
 {
+    int dev9Ready = 0;
     int retLoadModule = HDD_PFS_DIAG_NOT_RUN;
     int retBdmModule = HDD_PFS_DIAG_NOT_RUN;
     int retXhddModule = HDD_PFS_DIAG_NOT_RUN;
@@ -419,15 +420,22 @@ int hddLoadModules(void)
 
         // DEV9 must be loaded, as HDD.IRX depends on it. Even if not required by the I/F (i.e. HDPro)
         hddDiagBootStageBegin("HDD:DEV9");
-        sysInitDev9();
+        dev9Ready = sysInitDev9() == 0;
         hddDiagBootStageEndVoid("HDD:DEV9");
+
+        if (!dev9Ready) {
+            LOG("HDD: DEV9 initialization failed; ATA setup remains retryable\n");
+            retLoadModule = -1;
+        }
 
         // try to detect HD Pro Kit (not the connected HDD),
         // if detected it loads the specific ATAD module
-        hddDiagBootStageBegin("HDD:HDPRO-PROBE");
-        hddHDProKitDetected = hddCheckHDProKit();
-        hddDiagBootStageEnd("HDD:HDPRO-PROBE", hddHDProKitDetected);
-        if (hddHDProKitDetected) {
+        if (dev9Ready) {
+            hddDiagBootStageBegin("HDD:HDPRO-PROBE");
+            hddHDProKitDetected = hddCheckHDProKit();
+            hddDiagBootStageEnd("HDD:HDPRO-PROBE", hddHDProKitDetected);
+        }
+        if (dev9Ready && hddHDProKitDetected) {
             LOG("[ATAD_HDPRO]:\n");
             hddDiagBootStageBegin("HDD:ATAD-HDPRO");
             retLoadModule = sysLoadModuleBuffer(&hdpro_atad_irx, size_hdpro_atad_irx, 0, NULL);
@@ -436,7 +444,7 @@ int hddLoadModules(void)
             hddDiagBootStageBegin("HDD:XHDD-HDPRO");
             retXhddModule = sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-hdpro");
             hddDiagBootStageEnd("HDD:XHDD-HDPRO", retXhddModule);
-        } else {
+        } else if (dev9Ready) {
             LOG("[BDM]:\n");
             hddDiagBootStageBegin("HDD:BDM");
             retBdmModule = sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
@@ -469,7 +477,8 @@ int hddLoadModules(void)
             // and shared with ETH/UDPBD, so an inflated count means a later teardown can never power
             // dev9 down. The UDPBD arm in bdmsupport.c already pairs its init/shutdown this way; this
             // arm did not, and rebuild-153's device-refresh bump made the retry more frequent.
-            sysShutdownDev9();
+            if (dev9Ready)
+                sysShutdownDev9();
             hddModulesLoadCount = 0;
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -21,7 +21,7 @@
 #include <io_common.h>   // FIO_MT_RDWR
 
 #include <hdd-ioctl.h>
-#include <delaythread.h> // DelayThread for the post-ATAD settle in hddLoadModules
+#include <delaythread.h> // DelayThread for the APA/ATA handoff settle
 
 #define OPL_HDD_MODE_PS2LOGO_OFFSET 0x17F8
 
@@ -36,6 +36,10 @@ static unsigned char hddHDProKitDetected = 0;
 static unsigned char hddModulesLoadCount = 0;
 static unsigned char hddModulesLoaded = 0;
 static unsigned char hddSupportModulesLoaded = 0;
+// The generic ATA block-device path does not need the APA settle. Keep one bounded gap between
+// the shared ATAD/XHDD stack and the APA/PFS stack, where the first hdd0:/ps2fs probe can race the
+// same physical drive. This avoids adding the APA-only delay to the single-partition ATA VCD path.
+static unsigned char hddApaSettled = 0;
 // One toast per failure streak: hddUpdateGameList now RETRIES the support-module load every refresh
 // while it keeps failing, and re-toasting the same error box each pass would bury the UI. Reset on
 // success so a later, different failure toasts again.
@@ -483,15 +487,6 @@ int hddLoadModules(void)
         } else {
             retStatus = HDD_LOADMODULES_STATUS_NOERROR;
             hddModulesLoaded = 1;
-            // Settle ~1 s after a FRESH ATA-stack load before anyone probes xhdd0: or loads ps2hdd.
-            // Every working reference does this: NHDDL sleeps 1 s after ata_bd ("prevents ps2hdd from
-            // hanging") and POPSLoader settles 1 s around ata_bd as well. Our earliest callers run
-            // seconds after power-on (APA boot-identity config resolution), so the very first
-            // ATA_DEVCTL_READ_PARTITION_SECTOR probe / ps2hdd init can otherwise race a drive that is
-            // still spinning up. Runs once per load generation: the dedupe branch above never gets here.
-            hddDiagBootStageBegin("HDD:SETTLE");
-            DelayThread(1000 * 1000);
-            hddDiagBootStageEndVoid("HDD:SETTLE");
         }
     } else {
         hddModulesLoadCount++;
@@ -651,6 +646,14 @@ static int hddLoadCoreSupportModules(void)
 
     // Check if the drive contains MBR/GPT partition data before we load the APA/PFS modules. If the drive is not
     // APA then loading the APA irx modules can corrupt the drive as it will try to write APA partition data.
+    // ATA-only BDM users do not need this gap. It belongs immediately before the APA probe/modules,
+    // so an APA page and the single-partition ATA page cannot cross the shared drive transition.
+    if (!hddApaSettled) {
+        hddDiagBootStageBegin("HDD:APA-SETTLE");
+        DelayThread(1000 * 1000);
+        hddDiagBootStageEndVoid("HDD:APA-SETTLE");
+        hddApaSettled = 1;
+    }
     nonSony = hddDetectNonSonyFileSystem();
     if (nonSony != 0) {
         // Drive is MBR/GPT style, or unknown, bail out or risk corrupting the drive.
@@ -2084,6 +2087,7 @@ static void hddCleanUp(item_list_t *itemList, int exception)
             hddFreeHDLGamelist(&hddGames);
             hddFreeVcdGameList();
         }
+        hddApaSettled = 0;
         return;
     }
 
@@ -2103,6 +2107,7 @@ static void hddCleanUp(item_list_t *itemList, int exception)
         hddSupportModulesLoaded = 0;
         gHDDPrefix = NULL; // pfs0: is no longer a valid persistent data-home mount marker
     }
+    hddApaSettled = 0;
 }
 
 static int hddCheckVMC(item_list_t *itemList, char *name, int createSize)
@@ -2150,6 +2155,7 @@ static void hddShutdown(item_list_t *itemList)
         if (gDeinitTerminal)
             sysShutdownDev9();
     }
+    hddApaSettled = 0;
 }
 
 static int hddLoadGameListCache(hdl_games_list_t *cache)

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <delaythread.h>
 #include <kernel.h>
 #include <sifrpc.h>
 
@@ -9,14 +10,25 @@ static SifRpcClientData_t SifRpcClient;
 static unsigned char RpcTxBuffer[256] ALIGNED(64);
 static unsigned char RpcRxBuffer[64] ALIGNED(64);
 
+// HTTP is optional compatibility-update support. A missing or late httpclient RPC server must not
+// hold the shared network worker forever, so give the server a short startup window and let ETH
+// continue without update support if it never appears.
+#define HTTP_INIT_RETRIES 30
+
 int HttpInit(void)
 {
-    while (SifBindRpc(&SifRpcClient, 0x00001B14, 0) < 0 || SifRpcClient.server == NULL) {
+    int retry;
+
+    for (retry = 0; retry < HTTP_INIT_RETRIES; retry++) {
+        if (SifBindRpc(&SifRpcClient, 0x00001B14, 0) >= 0 && SifRpcClient.server != NULL)
+            return 0;
+
         LOG("libhttpclient: bind failed\n");
-        nopdelay();
+        DelayThread(10000);
     }
 
-    return 0;
+    HttpDeinit();
+    return -1;
 }
 
 void HttpDeinit(void)

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -94,7 +94,8 @@ static unsigned char mmceEverResolved = 0;
 // forward declaration
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
-static int mmceModLoaded = 0;          // latched by mmceLoadModules; read by mmceSendGameID's arm check
+static int mmceModLoaded = 0;          // latched only after mmceLoadModules succeeds
+static int mmceModLoading = 0;         // prevents concurrent callers from issuing a second singleton load
 static char mmceGameIdTarget[8] = {0}; // last device a GameID 0x8 switch was SENT to (mmceGameIdSettle polls it)
 
 int mmceSendGameID(const char *startup, const char *protectMcPath, int vmcSlotMask)
@@ -390,17 +391,28 @@ void mmceSetPrefix(void)
     mmceRefreshArtRoots();
 }
 
-void mmceLoadModules(void)
+int mmceLoadModules(void)
 {
     // mmceman is a singleton -- loading the IRX buffer twice creates a 2nd instance. Guard so this is
     // idempotent: mmceInit calls it, and the BDMA equip now also calls it (to wake an MMCE source when
-    // MMCE games are off / Manual-not-started). Set the flag first so a partial load can't double-load.
+    // MMCE games are off / Manual-not-started). Do not mark it resident until the load succeeds: a
+    // transient IOP/module-resource failure must remain retryable for the VCD page.
     if (mmceModLoaded)
-        return;
-    mmceModLoaded = 1;
+        return 0;
+    if (mmceModLoading)
+        return -1;
+
+    mmceModLoading = 1;
     LOG("MMCESUPPORT LoadModules\n");
     LOG("[MMCEMAN]:\n");
-    sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
+    int ret = sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
+    mmceModLoading = 0;
+    if (ret < 0) {
+        LOG("MMCESUPPORT: mmceman load failed (%d); retry remains armed\n", ret);
+        return ret;
+    }
+    mmceModLoaded = 1;
+    return 0;
 }
 
 // Δ4 (NHDDL parity): arm the GameID transport OUTSIDE the launch path. NHDDL loads mmceman once at
@@ -414,7 +426,8 @@ void mmceArmGameIDTransport(void)
         return;
 
     guiSetBootStatusSticky(_l(_STR_BOOT_ARMING_MMCE)); // boot-step localizer (IO thread) -- see gui.c
-    mmceLoadModules();
+    if (mmceLoadModules() < 0)
+        return;
     // Post-load marker (#254): the boot arm runs right after GUI_INIT_DONE; a serial log that
     // shows the arm begin without this completion line localizes a wedge to the mmceman load.
     LOG("MMCESUPPORT GameID transport armed\n");
@@ -460,6 +473,15 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     char path[256];
     int result = 0;
     struct stat st;
+
+    // A failed menu-time mmceman load must not strand the MMCE page against a dead filesystem for the
+    // whole session. Retry through the same deferred refresh worker that already owns the MMCE I/O.
+    if (!mmceModLoaded) {
+        if (mmceLoadModules() < 0) {
+            mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
+            return 1;
+        }
+    }
 
     // Hacky: check if slot was changed, update prefix if needed
     mmceSetPrefix();

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -445,6 +445,9 @@ void mmceInit(item_list_t *itemList)
     mmceGames = NULL;
     mmceVcdGameCount = 0;
     mmceVcdGames = NULL;
+    mmceVcdScanned = 0;
+    mmceVcdScanFailed = 0;
+    mmceVcdScanRetries = 0;
     mmceResolvedDevice = -1; // re-detect the Auto slot on a fresh init (tab re-enable / settings apply)
     mmceFoldersCreatedFor[0] = '\0';
     mmceFolderRetries = 0;
@@ -1199,6 +1202,10 @@ static void mmceCleanUp(item_list_t *itemList, int exception)
         mmceGames = NULL;
         free(mmceVcdGames); // #120: free the separate VCD array too; NULL both (CleanUp + Shutdown both run)
         mmceVcdGames = NULL;
+        mmceVcdGameCount = 0;
+        mmceVcdScanned = 0;
+        mmceVcdScanFailed = 0;
+        mmceVcdScanRetries = 0;
 
         //      if ((exception & UNMOUNT_EXCEPTION) == 0)
         //          ...
@@ -1215,6 +1222,10 @@ static void mmceShutdown(item_list_t *itemList)
         mmceGames = NULL;
         free(mmceVcdGames);
         mmceVcdGames = NULL;
+        mmceVcdGameCount = 0;
+        mmceVcdScanned = 0;
+        mmceVcdScanFailed = 0;
+        mmceVcdScanRetries = 0;
     }
 
     // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -632,7 +632,9 @@ static int mmceUpdateGameList(item_list_t *itemList)
     // Each view scans into its OWN array (#120): a failed rescan preserves only that view's last-good and
     // can never resurrect the other view's list (see the mmceVcdGames comment at the declarations).
     if (vcdViewActive(itemList->mode)) {
-        int r = vcdFillGameList(mmcePrefix, &mmceVcdGames);
+        char vcdPrefix[sizeof(mmcePrefix)];
+        mmceGetDeviceRoot(vcdPrefix, sizeof(vcdPrefix));
+        int r = vcdFillGameList(vcdPrefix, &mmceVcdGames);
         if (r >= 0) { // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
             mmceVcdScanned = 1;
             mmceVcdGameCount = r;
@@ -705,10 +707,12 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
 {
     if (vcdViewActive(itemList->mode)) {
         base_game_info_t *game = mmceActiveGame(itemList, id);
+        char vcdPrefix[sizeof(mmcePrefix)];
 
         if (game == &mmceEmptyGame)
             return; // stale id in the VCD->ISO toggle window
-        if (vcdRenameFile(mmcePrefix, game->name, newName) == 0) {
+        mmceGetDeviceRoot(vcdPrefix, sizeof(vcdPrefix));
+        if (vcdRenameFile(vcdPrefix, game->name, newName) == 0) {
             // MMCE normally latches a successful VCD scan under NOUPDATE. Re-arm its normal scan
             // path so the deferred menu update publishes the new filename immediately.
             mmceVcdScanned = 0;
@@ -731,9 +735,14 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
 static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_t *configSet)
 {
     char vcdElf[256], vcdSelector[320];
+    char vcdPrefix[sizeof(mmcePrefix)];
+
+    (void)configSet;
 
     if (vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
         return;
+
+    mmceGetDeviceRoot(vcdPrefix, sizeof(vcdPrefix));
 
     // Present preparation indicator before potentially expensive memory-card file IO
     guiRenderTextScreen(_l(_STR_PLEASE_WAIT));
@@ -744,20 +753,20 @@ static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set
         return;
     }
 
-    if (!vcdResolvePopstarter(mmcePrefix, vcdElf, sizeof(vcdElf))) {
+    if (!vcdResolvePopstarter(vcdPrefix, vcdElf, sizeof(vcdElf))) {
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
         return;
     }
-    vcdBuildSelector(mmcePrefix, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
+    vcdBuildSelector(vcdPrefix, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
 
     // Source MC-side externals from this MMCE card's direct POPS/ folder; never overwrite card files.
-    (void)vcdInstallPopstarterMc(mmcePrefix);
+    (void)vcdInstallPopstarterMc(vcdPrefix);
 
     // Best-effort card prep: BDMA prep is card preparation, never a POPSTARTER launch gate.
     vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MMCE, VCD_BDMA_MMCE);
 
     char vcdFullPath[256];
-    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS/%s.VCD", mmcePrefix, vcdName);
+    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS/%s.VCD", vcdPrefix, vcdName);
     vcdPrepareRetroGemBarcode(vcdFullPath);
     deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the MMCE device mounted across the IOP reset
     sysLaunchPopstarter(vcdElf, vcdSelector);
@@ -1122,14 +1131,25 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
     // Config (CFG + #Format/#System/#DiscType badges) comes from the ACTIVE view's array; mmceActiveGame
     // picks it (VCD keys off the basename) and returns a safe empty entry for a stale id during the toggle
     // window -- so this can never index the wrong/NULL array out of range.
+    if (vcdViewActive(itemList->mode)) {
+        char vcdPrefix[sizeof(mmcePrefix)];
+        mmceGetDeviceRoot(vcdPrefix, sizeof(vcdPrefix));
+        return sbPopulateConfig(mmceActiveGame(itemList, id), vcdPrefix, "/");
+    }
     return sbPopulateConfig(mmceActiveGame(itemList, id), mmcePrefix, "/");
 }
 
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
-    int r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
+    char vcdPrefix[sizeof(mmcePrefix)];
+    const char *imagePrefix = mmceArtPrimary;
+    if (vcdViewActive(itemList->mode)) {
+        mmceGetDeviceRoot(vcdPrefix, sizeof(vcdPrefix));
+        imagePrefix = vcdPrefix;
+    }
+    int r = mmceTryLoadImage(imagePrefix, folder, isRelative, value, suffix, resultTex);
     if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode))
-        r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
+        r = vcdLoadPopsCover(imagePrefix, value, suffix, resultTex);
     return r;
 }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -537,7 +537,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     if (folderConsumeDirty(itemList->mode))
         return 1;
     if (vcdViewActive(itemList->mode)) {
-        if (!mmceVcdScanned) {
+        if (!mmceVcdScanned && !mmceVcdScanFailed) {
             mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
             return 1;
         }

--- a/src/opl.c
+++ b/src/opl.c
@@ -3828,13 +3828,9 @@ int oplUpdateGameCompatSingle(int id, item_list_t *support, config_set_t *config
 
 static void shutdownLwnbdNetwork(void)
 {
-    // The loaded-check mirrors ethShutdown: DEV9's refcount is shared with BDM/HDD, so only
-    // release it when the eth path actually holds it.
-    int ethWasLoaded = ethGetModulesLoaded();
-
+    // ETH owns its DEV9 reference, including partial dependency-load state, through teardown.
     ethDeinitModules();
-    if (ethWasLoaded)
-        sysShutdownDev9();
+    ethReleaseDev9();
 }
 
 static int loadLwnbdSvr(int *teardownStarted)

--- a/src/opl.c
+++ b/src/opl.c
@@ -739,7 +739,9 @@ static void initAllSupport(int force_reinit)
     guiSetBootStatus(_l(_STR_BOOT_SCANNING_NET));
     if (gBootInProgress)
         guiRenderGreetingScreen();
-    initSupport(ethGetObject(0), ETH_MODE, force_reinit || (gNetworkStartup >= ERROR_ETH_SMB_CONN));
+    // A module-level failure (code 200) is retryable too. The ETH loader clears its failed latch,
+    // so the next support pass must re-enter itemInit and retry the dependency chain.
+    initSupport(ethGetObject(0), ETH_MODE, force_reinit || (gNetworkStartup >= ERROR_ETH_MODULE_NETIF_FAILURE));
     // UDPFS filesystem shares the single NIC with SMB/UDPBD; its start-mode gate (initSupport) is live
     // only when gNetworkProtocol == NET_PROTO_UDPFS, so exactly one network tab is ever enabled.
     initSupport(udpfsGetObject(0), UDPFS_MODE, force_reinit);

--- a/src/opl.c
+++ b/src/opl.c
@@ -2695,9 +2695,9 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_ART_DELAY, &gArtDelay);
             // Keep the stored domain identical to the Artwork page's enum {0,2,5,8} (item 45), so a
             // hand-edited or legacy value cannot render as a delay the UI is unable to express.
-            // An out-of-domain value falls back to 0, matching setDefaults().
+            // An out-of-domain value falls back to 2, matching setDefaults() and the fork.
             if (gArtDelay != 0 && gArtDelay != 2 && gArtDelay != 5 && gArtDelay != 8)
-                gArtDelay = 0;
+                gArtDelay = 2;
             configGetInt(configOPL, CONFIG_OPL_FOLDER_NAV, &gEnableFolderNav);
             configGetColor(configOPL, CONFIG_OPL_PLAS_BLEND_COLOR, gDefaultPlasBlendColor);
             configGetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, &gCoverflowCount);
@@ -4341,17 +4341,10 @@ static void setDefaults(void)
     // setBootDir() already zeroes the buffer at its own entry, so nothing needs a reset here.
     gEnableBGArt = 1; // fork parity; gEnableArt is 1 above, so this is live
     gEnableArtTar = 0;
-    // NO SETTLE BY DEFAULT. This is the number of INACTIVE frames the menu must see before art is
-    // even asked for, and it shipped at 8 -- the slowest of the four values the UI offers {0,2,5,8}
-    // -- as a placeholder pending a decision that never happened; the comment here previously said
-    // as much. The effect is that art will not begin loading until navigation has fully stopped and
-    // stayed stopped, which reads as covers refusing to appear while browsing.
-    //
-    // The reason to settle at all was to keep art reads off the bus while the user is moving, but
-    // that concern is device-specific and is already handled where it belongs: texcache gates SIO2
-    // devices (MMCE, MX4SIO) on real idleness because their reads contend with pad polling. Making
-    // every device wait for the worst device's constraint is not a trade worth a default.
-    gArtDelay = 0;
+    // Two inactive frames is the established fork default: long enough to avoid queuing artwork
+    // for every row during continuous navigation, short enough that covers appear promptly after
+    // the user stops. SIO2 devices retain their separate bus-idle floor in texcache.
+    gArtDelay = 2;
     gEnableFolderNav = 0;
     gDefaultPlasBlendColor[0] = 0x00;
     gDefaultPlasBlendColor[1] = 0x00;

--- a/src/system.c
+++ b/src/system.c
@@ -165,7 +165,15 @@ void sysInitDev9(void)
     if (!dev9Initialized) {
         LOG("[DEV9]:\n");
         ret = sysLoadModuleBuffer(&ps2dev9_irx, size_ps2dev9_irx, 0, NULL);
-        dev9Loaded = (ret == 0); // DEV9.IRX must have successfully loaded and returned RESIDENT END.
+        if (ret < 0) {
+            // A failed first load must remain retryable. Recent boot recovery paths can touch DEV9
+            // before Ethernet; latching this as initialized made every later network bring-up skip
+            // the only load attempt and report a missing NIC even when the transient cause had gone.
+            dev9Loaded = 0;
+            LOG("[DEV9] load failed (%d); leaving initialization retryable\n", ret);
+            return;
+        }
+        dev9Loaded = 1; // DEV9.IRX must have successfully loaded and returned RESIDENT END.
         dev9Initialized = 1;
     }
 

--- a/src/system.c
+++ b/src/system.c
@@ -158,7 +158,7 @@ exit:
 static SifCmdHandlerData_t OplSifCmdbuffer[OPL_SIF_CMD_BUFF_SIZE];
 static unsigned char dev9Initialized = 0, dev9Loaded = 0, dev9InitCount = 0;
 
-void sysInitDev9(void)
+int sysInitDev9(void)
 {
     int ret;
 
@@ -171,13 +171,14 @@ void sysInitDev9(void)
             // the only load attempt and report a missing NIC even when the transient cause had gone.
             dev9Loaded = 0;
             LOG("[DEV9] load failed (%d); leaving initialization retryable\n", ret);
-            return;
+            return ret;
         }
         dev9Loaded = 1; // DEV9.IRX must have successfully loaded and returned RESIDENT END.
         dev9Initialized = 1;
     }
 
     dev9InitCount++;
+    return 0;
 }
 
 void sysShutdownDev9(void)

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -33,6 +33,7 @@ static time_t udpfsModifiedDVDPrev;
 static int udpfsGameCount = 0;
 static base_game_info_t *udpfsGames = NULL;
 static int udpfsIomanModLoaded = 0;
+static int udpfsLoadQueued = 0;
 
 // forward declaration
 static item_list_t udpfsGameList;
@@ -50,6 +51,7 @@ static void udpfsLoadModules(void)
     char ipArg[24];
 
     LOG("UDPFSSUPPORT LoadModules\n");
+    udpfsLoadQueued = 0;
 
     if (udpfsIomanModLoaded)
         return;
@@ -110,7 +112,8 @@ void udpfsInit(item_list_t *itemList)
     udpfsGameCount = 0;
     udpfsGames = NULL;
     udpfsGameList.delay = gArtDelay;
-    ioPutRequest(IO_CUSTOM_SIMPLEACTION, &udpfsLoadModules);
+    if (ioPutRequest(IO_CUSTOM_SIMPLEACTION, &udpfsLoadModules) == IO_OK)
+        udpfsLoadQueued = 1;
     udpfsGameList.enabled = 1;
 }
 
@@ -125,6 +128,12 @@ static int udpfsNeedsUpdate(item_list_t *itemList)
 {
     int result = 0;
 
+    // A DEV9 race can make the one-shot init request fail before the UDPFS chain is resident.
+    // Keep the normal deferred-update cadence alive and let the update worker enqueue one retry;
+    // otherwise UDPFS remains dead until a full reboot even though the server is reachable.
+    if (!udpfsIomanModLoaded)
+        result = 1;
+
     // VCD view: force a rescan once on toggle, then refresh on toggle only (skip disc heuristics).
     if (vcdConsumeDirty(itemList->mode))
         return 1;
@@ -132,7 +141,7 @@ static int udpfsNeedsUpdate(item_list_t *itemList)
     if (folderConsumeDirty(itemList->mode))
         return 1;
     if (vcdListViewActive(itemList))
-        return 0;
+        return result;
 
     if (udpfsULSizePrev == -2)
         result = 1;
@@ -170,8 +179,11 @@ static int udpfsFoldersCreated = 0;
 
 static int udpfsUpdateGameList(item_list_t *itemList)
 {
-    if (udpfsIomanModLoaded == 0)
+    if (udpfsIomanModLoaded == 0) {
+        if (!udpfsLoadQueued && ioPutRequest(IO_CUSTOM_SIMPLEACTION, &udpfsLoadModules) == IO_OK)
+            udpfsLoadQueued = 1;
         return 0;
+    }
 
     if (!udpfsFoldersCreated) {
         sbCreateFolders(udpfsPrefix, 1);

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -68,7 +68,10 @@ static void udpfsLoadModules(void)
 
     // dev9 is refcounted (shared with ATA-HDD). The ministack has no DHCP client, so it needs the PS2's
     // static IP as an "ip=A.B.C.D" arg -- built exactly as bdmsupport does for the udpfs_bd chain.
-    sysInitDev9();
+    if (sysInitDev9() < 0) {
+        LOG("UDPFSSUPPORT: DEV9 initialization failed; module chain remains retryable\n");
+        return;
+    }
     snprintf(ipArg, sizeof(ipArg), "ip=%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
 
     LOG("[UDPFS_SMAP]:\n");

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -34,6 +34,9 @@ static int udpfsGameCount = 0;
 static base_game_info_t *udpfsGames = NULL;
 static int udpfsIomanModLoaded = 0;
 static int udpfsLoadQueued = 0;
+// UDPFS can leave its SMAP/ministack layers resident when the ioman module fails. Retain one DEV9
+// reference across retries and advertise the partial claim so ETH/UDPBD cannot double-drive SMAP.
+static unsigned char udpfsDev9RefHeld = 0;
 
 // forward declaration
 static item_list_t udpfsGameList;
@@ -70,9 +73,12 @@ static void udpfsLoadModules(void)
 
     // dev9 is refcounted (shared with ATA-HDD). The ministack has no DHCP client, so it needs the PS2's
     // static IP as an "ip=A.B.C.D" arg -- built exactly as bdmsupport does for the udpfs_bd chain.
-    if (sysInitDev9() < 0) {
-        LOG("UDPFSSUPPORT: DEV9 initialization failed; module chain remains retryable\n");
-        return;
+    if (!udpfsDev9RefHeld) {
+        if (sysInitDev9() < 0) {
+            LOG("UDPFSSUPPORT: DEV9 initialization failed; module chain remains retryable\n");
+            return;
+        }
+        udpfsDev9RefHeld = 1;
     }
     snprintf(ipArg, sizeof(ipArg), "ip=%d.%d.%d.%d", ps2_ip[0], ps2_ip[1], ps2_ip[2], ps2_ip[3]);
 
@@ -89,15 +95,15 @@ static void udpfsLoadModules(void)
         }
     }
 
-    // Release the dev9 reference taken above if any load failed -- otherwise a failing/retrying UDPFS
-    // inflates the refcounted dev9InitCount and a later HDD/ETH teardown can never power dev9 down.
+    // Keep the single DEV9 reference for a retry. The partially resident SMAP/ministack must retain
+    // ownership of the adapter until the IOP is reset; releasing it here would leave the next retry
+    // with a powered-off card but a resident-module latch.
     LOG("UDPFSSUPPORT: module chain failed to load\n");
-    sysShutdownDev9();
 }
 
 int udpfsGetModulesLoaded(void)
 {
-    return udpfsIomanModLoaded;
+    return udpfsIomanModLoaded || udpfsDev9RefHeld;
 }
 
 void udpfsInit(item_list_t *itemList)

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -594,8 +594,13 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
 
     int count = 0;
     struct dirent *de;
-    errno = 0; // distinguish a clean end-of-directory from a failed readdir() RPC
-    while (count < VCD_MAX_ITEMS && (de = readdir(dir)) != NULL) {
+    while (count < VCD_MAX_ITEMS) {
+        // Only readdir's errno describes this iteration; optional metadata allocation below may
+        // fail without invalidating the directory entries we already collected.
+        errno = 0;
+        de = readdir(dir);
+        if (de == NULL)
+            break;
         int len = (int)strlen(de->d_name);
         if (len < 5 || strcasecmp(de->d_name + len - 4, ".VCD") != 0)
             continue;          // keep only "*.VCD" (case-insensitive)
@@ -624,14 +629,14 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
         count++;
     }
 
-    // A directory can open successfully and still fail during enumeration. On MMCE this is a
-    // realistic transient: each readdir() is another SIO2/filesystem transaction, and a bus
-    // collision can terminate the walk after the first few entries. Treating that as a clean empty
-    // directory makes vcdFillGameList free the last-good list and the GUI clears the page. Return
-    // the same transient-failure result as an opendir() error so callers preserve their list and
-    // their existing retry policy. When count reached VCD_MAX_ITEMS, the loop stopped by design;
-    // errno is irrelevant in that case.
-    if (count < VCD_MAX_ITEMS && de == NULL && errno != 0) {
+    // MMCE does not provide a reliable POSIX EOF/error distinction: SD2PSX firmware sends status 1
+    // when its directory iterator is exhausted, and our pinned mmceman returns -1 for that status.
+    // libcglue consequently sets errno at NORMAL EOF too. Keep master's enumeration semantics on
+    // mmce0:/mmce1:; rejecting that result discards every successfully scanned VCD. This necessarily
+    // retains master's limitation that a mid-walk MMCE failure can publish a partial list.
+    // Other devices retain the error guard. Reaching the entry cap is an intentional stop, not EOF.
+    int mmceDir = !strncmp(dirPath, "mmce0:", 6) || !strncmp(dirPath, "mmce1:", 6);
+    if (!mmceDir && count < VCD_MAX_ITEMS && de == NULL && errno != 0) {
         LOG("[VCD] readdir failed for '%s' (errno %d)\n", dirPath, errno);
         free(list);
         closedir(dir);

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -594,6 +594,7 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
 
     int count = 0;
     struct dirent *de;
+    errno = 0; // distinguish a clean end-of-directory from a failed readdir() RPC
     while (count < VCD_MAX_ITEMS && (de = readdir(dir)) != NULL) {
         int len = (int)strlen(de->d_name);
         if (len < 5 || strcasecmp(de->d_name + len - 4, ".VCD") != 0)
@@ -622,6 +623,21 @@ static int vcdScanOpenDir(const char *dirPath, vcd_entry_t **outList)
         vcdNoteScanDir(list[count].name, dirPath); // string only -- NO device IO on the scan path
         count++;
     }
+
+    // A directory can open successfully and still fail during enumeration. On MMCE this is a
+    // realistic transient: each readdir() is another SIO2/filesystem transaction, and a bus
+    // collision can terminate the walk after the first few entries. Treating that as a clean empty
+    // directory makes vcdFillGameList free the last-good list and the GUI clears the page. Return
+    // the same transient-failure result as an opendir() error so callers preserve their list and
+    // their existing retry policy. When count reached VCD_MAX_ITEMS, the loop stopped by design;
+    // errno is irrelevant in that case.
+    if (count < VCD_MAX_ITEMS && de == NULL && errno != 0) {
+        LOG("[VCD] readdir failed for '%s' (errno %d)\n", dirPath, errno);
+        free(list);
+        closedir(dir);
+        return -1;
+    }
+
     closedir(dir);
     LOG("[VCD] scanned '%s': found %d entries\n", dirPath, count);
 

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -780,7 +780,7 @@ int vcdRenameFile(const char *devPrefix, const char *oldName, const char *newNam
 // exactly like the .VCD (suffixless "<name>.png"), sitting NEXT TO the game in the same POPS/ folder the
 // VCD scan reads -- so a cover whose name matches the VCD minus the extension still shows (FifthFox, HW
 // 2026-07-16; the tier removed by 86da2023's #120 single-lookup simplification). `scanPrefix` MUST be the
-// SAME prefix the device passes to vcdFillGameList (the device root for BDM, mmcePrefix for MMCE, etc.),
+// SAME prefix the device passes to vcdFillGameList (the device root for BDM and MMCE, etc.),
 // so the cover is looked up beside the .VCD. COVER/ICON ONLY -- background/logo/screenshot must never
 // fall back to the single suffixless file or each would render the cover instead. Returns
 // texDiscoverLoad's result (>= 0 hit, negative miss). No miss-memo: kept deliberately simple -- callers


### PR DESCRIPTION
## Summary

- Scan MMCE VCDs from the device-root POPS directory instead of the configured PS2 game prefix.
- Keep MMCE VCD rename, launch, config, and artwork paths on that same root.
- Leave DEV9 initialization retryable when its first module load fails, preventing recent BDM/HDD startup ordering from suppressing Ethernet bring-up.

## Validation

- Changed object targets compile successfully in the PS2DEV container.
- git diff --check passes.
- Full ELF build reached C compilation but the container stopped at the pre-existing missing iopfixup tool.
- Hardware validation is still required for MMCE VCD enumeration and network hardware detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry and failure handling for storage, network, and module initialization.
  - Prevented dependent services from starting when required hardware support is unavailable.
  - Improved cleanup after unsuccessful network initialization.
  - Corrected VCD operations to use the memory card root directory.
  - Preserved existing VCD scan results after temporary directory errors.
  - Reset VCD scan state correctly during lifecycle transitions.
  - HTTP startup now fails cleanly instead of waiting indefinitely.
  - Improved network reinitialization after module failures.
  - Improved UDPFS loading and retry behavior.

- **Improvements**
  - Invalid artwork delays now use a safer default value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->