### PR TITLE
Ember as a second PS1 core (one PS1 list, both cores)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ endif
 
 FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o elfldr_noreset.o elfldr.o lang.o lang_internal.o config.o hdd.o dialogs.o favsupport.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o udpfssupport.o hddsupport.o zso.o lz4.o \
-		appsupport.o mmcesupport.o artindex.o vcdsupport.o cuesupport.o retrogem.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
+		appsupport.o mmcesupport.o artindex.o vcdsupport.o cuesupport.o libview.o retrogem.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
 
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
 		bdm.o bdmfs_fatfs.o usbmass_bd.o iLinkman.o IEEE1394_bd.o mx4sio_bd.o \

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ endif
 
 FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o elfldr_noreset.o elfldr.o lang.o lang_internal.o config.o hdd.o dialogs.o favsupport.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o udpfssupport.o hddsupport.o zso.o lz4.o \
-		appsupport.o mmcesupport.o artindex.o vcdsupport.o retrogem.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
+		appsupport.o mmcesupport.o artindex.o vcdsupport.o cuesupport.o retrogem.o folderbrowse.o gui.o guigame.o vmc_groups.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o tar.o
 
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
 		bdm.o bdmfs_fatfs.o usbmass_bd.o iLinkman.o IEEE1394_bd.o mx4sio_bd.o \

--- a/docs/EMBER-INTEGRATION-PLAN.md
+++ b/docs/EMBER-INTEGRATION-PLAN.md
@@ -1,10 +1,51 @@
 # Ember as a second PS1 core — integration plan
 
-**Status:** design only, nothing implemented. Written for an implementing agent.
+**Status:** phases 0 and 1 landed (see Implementation status below); phases 2-5 pending hardware.
 **Base commit:** `291716d3` on `rebuild/main` (2026-08-27).
 **Permission:** Gage (author of Ember) has approved and encouraged this integration.
 
 ---
+
+## Implementation status
+
+Branch `feat/ember-ps1-core`. Update this table as phases land; it is the first thing the next
+agent should read.
+
+| Phase | State | Notes |
+| --- | --- | --- |
+| 0 — prove the handoff | **code landed, HARDWARE PENDING** | `sysLaunchEmber()` + `cuesupport.c` + an OPLDIAG-only interception in `appLaunchItem`. **Blocks phases 2-5.** See "How to run the Phase 0 test" below. |
+| 1 — view engine | **landed** | `libview.c`/`libview.h` own the ring; the binary `vcdView` API is deleted, not shadowed. Both audit gates pass (zero old-API references; per-file call-site counts identical). Rings still ISO -> VCD only, so behaviour is unchanged. |
+| 2 — CUE list on BDM | not started | gated on Phase 0 |
+| 3 — MMCE + ETH, settings, docs | not started | gated on Phase 0 |
+| 4 — Favourites v3, merged list, APA | not started | gated on Phase 0 |
+| 5 — bonus surface | not started | gated on Phase 0 |
+
+### How to run the Phase 0 test
+
+Build with `OPLDIAG=1` (a release build deliberately does NOT include the probe). On the test
+device, lay out:
+
+```
+mass0:/EMBER/ember.elf      <- from Ember.Beta.Release.zip
+mass0:/EMBER/bios.bin       <- your own PS1 BIOS, exactly 512 KB
+mass0:/EMBER/games/Crash Bandicoot (USA)/game.cue  (+ game.bin)
+```
+
+Add an APPS entry pointing at it — `boot` = `mass0:/EMBER/ember.elf`, `argv1` =
+`Crash Bandicoot (USA)` — and launch it from the APPS page.
+
+**What to report back**
+
+1. Does the game boot at all?
+2. **Do the controllers work?** This is risk R1 and it decides whether the rest of the design
+   stands as written or needs the clean-IOP fallback.
+3. Does it work from MX4SIO / MMCE / internal exFAT ATA, not just USB? (Use `mass1:` etc.)
+4. Does `bios.bin` load, and do `MC1.vmc` / `MC2.vmc` appear in the game folder afterwards?
+5. Anything that looks like IOP memory exhaustion (late, unexplained failure).
+
+The control case: the identical APPS entry on a **release** build is expected to fail, because
+`LoadELFFromFileWithPartition` resets the IOP out from under Ember. That contrast is the
+measurement — if the release build also works, the no-reset premise needs re-examining.
 
 ## Part 0 — What Ember actually is (measured, not guessed)
 

--- a/docs/EMBER-INTEGRATION-PLAN.md
+++ b/docs/EMBER-INTEGRATION-PLAN.md
@@ -162,58 +162,83 @@ RESOLVE: snprintf(path, 192, "games/%s", arg);       // 0x158b10, rodata 0x16d38
 
 ## Part 1 — Folder structure
 
-Ember cannot be given a path, so the layout is forced: **the games live under the same directory as
-the `ember.elf` we launch.** Per-device, mirroring the existing `POPS/` doctrine
-(*library folders at the ROOT of each activated device — never mc, never cwd*):
+`<device>:/EMBER/` is the peer of `<device>:/POPS/` — one folder at each activated device's root,
+sought the same way on every device class. **That is where the resemblance ends.** POPS holds loose
+`*.VCD` FILES; EMBER holds a program plus a `games/` folder of per-game DIRECTORIES. The scan is a
+directory scan, not a file scan, and the identity is the directory name with no extension to strip.
 
 ```
 <device-root>/
-  EMBER/                      <- folder name configurable (gEmberFolder, default "EMBER")
-    ember.elf                 <- required; its presence is what enables the CUE view
-    bios.bin                  <- required by Ember at launch (512 KB, user-supplied)
-    settings.txt              <- optional, Ember's own
+  POPS/                             <- unchanged
+    POPSTARTER.ELF
+    Spyro 2 (Ripto's Rage).VCD
+  EMBER/
+    ember.elf                       <- required; its presence is what enables Ember rows
+    bios.bin                        <- required at launch (512 KB, user-supplied, never shipped)
+    settings.txt                    <- optional, Ember's own (key:value; only `display:240|480`)
     games/
-      Crash Bandicoot (USA)/  <- one folder == one CUE library entry; the folder NAME is the identity
+      Spyro 2 (Ripto's Rage)/       <- one directory per title; the NAME is the launch argument
         game.cue
         game.bin
-        MC1.vmc  MC2.vmc      <- created by Ember on first launch
-      Spyro the Dragon (USA)/
-        Spyro.cue
-        Spyro.bin
+        MC1.vmc  MC2.vmc            <- Ember creates these HERE on first launch
 ```
 
-`<device-root>` per device class, matching where `POPS/` already lives:
+### Which layouts Ember accepts, and why we list exactly one
+
+Ember's resolver is looser than its README. It tries `games/<arg>` and then `<arg>`, and
+`io_find_disc` takes **either** a directory containing a `*.cue` / `*.bin` / `*.exe` **or** such a
+file directly. All four of these boot:
+
+| # | Layout | Boots | Saves |
+| --- | --- | --- | --- |
+| 1 | `games/<Name>/` holding the image | yes | **yes** |
+| 2 | `games/<Name>.cue` (loose file) | yes | no |
+| 3 | `<Name>/` beside `ember.elf` | yes | wrong place |
+| 4 | `<Name>.cue` beside `ember.elf` | yes | wrong place |
+
+**Only layout 1 saves**, and that is why it is the only one we list. `main()` calls `memcard_init`
+exactly once — verified, one call site — and always with the *composed* path `games/<arg>`, never
+with wherever the disc was actually found. The cards are therefore always
+`games/<arg>/MC1.vmc` / `MC2.vmc`. So layout 2 asks for a card *inside a file*
+(`games/Spyro.cue/MC1.vmc`), which cannot exist; layouts 3 and 4 put the cards in
+`games/<Name>/`, a directory unrelated to the disc mounted from `EMBER/<Name>/`.
+
+Those titles play and silently cannot save. That is a worse experience than not being offered — and
+the user blames the launcher, not the layout. Listing only layout 1 means every row shown is a row
+that fully works. Widen the scan only if Ember's card resolution changes to follow the resolved disc.
+
+Two further limits, both measured:
+
+- `io_find_disc` does **not** recurse. An image at `games/<Name>/disc1/game.cue` is not found.
+- `.cue` is preferred over `.exe` over `.bin` when a folder holds more than one. `.exe` (PSX-EXE) is
+  accepted and is undocumented in the README.
+
+### Verifying a folder actually holds a disc
+
+The scan lists directories without reading inside them: that would be one directory read per row on
+every refresh, which MMCE and SMB cannot afford. Instead `cueGameHasImage()` runs once on the
+**launch** path, before `deinit`, while a dialog can still be drawn. An empty or mis-filled folder
+otherwise drops the user into the PS1 BIOS shell with no explanation. A probe that itself fails to
+read reports success — never block a launch on a failed probe.
+
+### Where `<device-root>` is, per device class
 
 | Device | Root used |
 | --- | --- |
-| USB / MX4SIO / iLink / exFAT-ATA (all BDM) | `massN:/` — the **device root**, not `gBDMPrefix`. Reuse `bdmBuildVcdPrefix()`. |
-| MMCE | `mmceN:/` (`mmcePrefix`) |
-| SMB / ETH | the mounted share root (`ethGetSMBPrefix()`) — **validation-gated, see Risk R4** |
-| APA / PFS HDD | `pfs0:/EMBER/…` on the selected OPL partition (`+OPL`, else `__common`) — **Phase 4** |
-| UDPBD / UDPFS | the live `massN:` / udpfs mount — **bonus, see Risk R5** |
-
-**Invariant to enforce in code:** the scanned `games/` directory and the launched `ember.elf` are
-always the *same* `EMBER/` directory on the *same* device. There is deliberately **no**
-POPSTARTER-style "Ember Device" picker: POPSTARTER can be loaded from anywhere because it takes a
-`mass:/POPS/XX.<name>.ELF` selector string, but Ember takes a bare folder name and can only look
-inside its own directory. A picker would be a lying control. The only knob is the folder *name*
-(`gEmberFolder`), which lets a user keep e.g. `PS1/` instead of `EMBER/`.
+| USB / MX4SIO / iLink / exFAT-ATA (BDM) | `massN:/` — the device **root**, not `gBDMPrefix` |
+| MMCE | `mmceN:/` |
+| SMB / ETH | the share root — **POPSTARTER-only for now**, see R4 |
+| APA / PFS HDD | needs its own decision: APA has no filesystem root, and `POPS` lives on `__common` |
+| UDPBD / UDPFS | not enabled |
 
 ### Art and per-game config
 
-Identity = **the game folder name**, exactly parallel to a VCD's basename-without-`.VCD`. So the
-existing device art/CFG rules apply unchanged:
+Identity is the game folder name, so the device's normal rules apply unchanged:
+`<devroot>ART/<Name>_COV.png` and `<devroot>CFG/<Name>.cfg`. The Ember-specific fallback, peer of
+`vcdLoadPopsCover`, looks inside the game folder: `cover.png`, then `<Name>.png`.
 
-* `<devroot>ART/<Folder Name>_COV.png`, `<devroot>CFG/<Folder Name>.cfg`
-* Fallback, mirroring `vcdLoadPopsCover()`: `<devroot>EMBER/games/<Folder Name>/cover.png`, then
-  `<devroot>EMBER/games/<Folder Name>/<Folder Name>.png`. Cover/icon suffixes only, CUE view only.
-
-Badges: reuse `sbSetDiscAttributes(config, /*isPS1*/1, /*isCD*/1)` → `#System=PS1`, `#Media=CD`,
-`#DiscType=PS1CD`. Every shipped theme already draws these, so CUE entries look right on day one.
-Optionally also stamp `CONFIG_ITEM_FORMAT = "CUE"` so a theme can add a `CUE_#Format.png` glyph —
-purely additive, no existing theme changes.
-
----
+Badges reuse `sbSetDiscAttributes(config, isPS1=1, isCD=1)` → `#System=PS1`, `#Media=CD`,
+`#DiscType=PS1CD`, so an Ember row looks right in every shipped theme on day one.
 
 ## Part 2 — The view engine (L3)
 

--- a/docs/EMBER-INTEGRATION-PLAN.md
+++ b/docs/EMBER-INTEGRATION-PLAN.md
@@ -1,6 +1,6 @@
 # Ember as a second PS1 core — integration plan
 
-**Status:** phases 0 and 1 landed (see Implementation status below); phases 2-5 pending hardware.
+**Status:** the PS1 list ships both cores on BDM and MMCE; the Ember launch itself is hardware-unproven.
 **Base commit:** `291716d3` on `rebuild/main` (2026-08-27).
 **Permission:** Gage (author of Ember) has approved and encouraged this integration.
 
@@ -11,41 +11,51 @@
 Branch `feat/ember-ps1-core`. Update this table as phases land; it is the first thing the next
 agent should read.
 
-| Phase | State | Notes |
+| Item | State | Notes |
 | --- | --- | --- |
-| 0 — prove the handoff | **code landed, HARDWARE PENDING** | `sysLaunchEmber()` + `cuesupport.c` + an OPLDIAG-only interception in `appLaunchItem`. **Blocks phases 2-5.** See "How to run the Phase 0 test" below. |
-| 1 — view engine | **landed** | `libview.c`/`libview.h` own the ring; the binary `vcdView` API is deleted, not shadowed. Both audit gates pass (zero old-API references; per-file call-site counts identical). Rings still ISO -> VCD only, so behaviour is unchanged. |
-| 2 — CUE list on BDM | not started | gated on Phase 0 |
-| 3 — MMCE + ETH, settings, docs | not started | gated on Phase 0 |
-| 4 — Favourites v3, merged list, APA | not started | gated on Phase 0 |
-| 5 — bonus surface | not started | gated on Phase 0 |
+| Phase 0 — prove the handoff | **code landed, HARDWARE PENDING** | `sysLaunchEmber()` + `cuesupport.c` + an OPLDIAG-only interception in `appLaunchItem`. See "How to run the Phase 0 test" below. |
+| Phase 1 — view engine | **landed** | `libview.c/.h` own the ring; the binary `vcdView` API is deleted, not shadowed. Both audit gates pass. |
+| One PS1 list, both cores | **landed** | `ps1FillGameList()`; row-kind dispatch for launch and art. Wired for **BDM and MMCE**. |
+| SMB / ETH | **deliberately POPSTARTER-only** | Risk R4 (RiptOPL uses `\`, Ember uses `/`) is untested. One line to flip once proven; the reason is in the code. |
+| APA-HDD, UDPFS | not started | HDD needs its own layout decision (APA has no filesystem root — `POPS` lives on `__common`). |
+| Favourites (OFAV v3 `kind`) | not started | A CUE favourite currently has no way to record which core it belongs to. |
+| Ember settings page / `ember_folder` | not started | Nothing is required for basic operation — the list is driven by what is on disk, exactly like `POPS`. |
 
-### How to run the Phase 0 test
+### How to test Ember on hardware
 
-Build with `OPLDIAG=1` (a release build deliberately does NOT include the probe). On the test
-device, lay out:
+There are now two ways in, and both matter.
+
+**1. The real path (works in a normal release build).** Lay out the device exactly as you would a
+POPSTARTER library, with `EMBER/` beside `POPS/`:
 
 ```
-mass0:/EMBER/ember.elf      <- from Ember.Beta.Release.zip
-mass0:/EMBER/bios.bin       <- your own PS1 BIOS, exactly 512 KB
-mass0:/EMBER/games/Crash Bandicoot (USA)/game.cue  (+ game.bin)
+mass0:/POPS/  ...                                   <- your existing PS1 library, untouched
+mass0:/EMBER/ember.elf                              <- from Ember.Beta.Release.zip
+mass0:/EMBER/bios.bin                               <- your own PS1 BIOS, exactly 512 KB
+mass0:/EMBER/games/Spyro 2 (Ripto's Rage)/game.cue  (+ game.bin)
 ```
 
-Add an APPS entry pointing at it — `boot` = `mass0:/EMBER/ember.elf`, `argv1` =
-`Crash Bandicoot (USA)` — and launch it from the APPS page.
+Press **L3** on that device page to reach the PS1 list. Ember titles appear interleaved with your
+`.VCD` ones, sorted together. Launch one.
+
+**2. The OPLDIAG probe (the control experiment).** An APPS entry with `boot` =
+`mass0:/EMBER/ember.elf` and `argv1` = the folder name is handed over with the keep-IOP loader in an
+`OPLDIAG=1` build. The same entry on a **release** build is expected to *fail*, because the stock
+APPS loader resets the IOP out from under Ember. That contrast is what proves the no-reset premise —
+if the release build also works, the premise needs re-examining.
 
 **What to report back**
 
-1. Does the game boot at all?
-2. **Do the controllers work?** This is risk R1 and it decides whether the rest of the design
-   stands as written or needs the clean-IOP fallback.
-3. Does it work from MX4SIO / MMCE / internal exFAT ATA, not just USB? (Use `mass1:` etc.)
-4. Does `bios.bin` load, and do `MC1.vmc` / `MC2.vmc` appear in the game folder afterwards?
-5. Anything that looks like IOP memory exhaustion (late, unexplained failure).
+1. Do the Ember rows appear in the PS1 list, correctly interleaved with the `.VCD` ones?
+2. Does a title boot?
+3. **Do the controllers work?** This is risk R1 and it decides whether the design stands as written
+   or needs the clean-IOP fallback.
+4. Does it work from MX4SIO / MMCE / internal exFAT ATA, not just USB?
+5. Do `MC1.vmc` / `MC2.vmc` appear in the game folder afterwards? (Confirms it can write there.)
+6. Anything that looks like IOP memory exhaustion — a late, unexplained failure.
 
-The control case: the identical APPS entry on a **release** build is expected to fail, because
-`LoadELFFromFileWithPartition` resets the IOP out from under Ember. That contrast is the
-measurement — if the release build also works, the no-reset premise needs re-examining.
+Covers: an Ember row uses the device's normal `ART/<name>_COV.png` first, then falls back to
+`EMBER/games/<name>/cover.png`.
 
 ## Part 0 — What Ember actually is (measured, not guessed)
 
@@ -209,115 +219,85 @@ purely additive, no existing theme changes.
 
 ### 2.1 What exists today
 
-`src/vcdsupport.c` owns a **binary** per-mode view: `vcdView[mode]` (0=ISO, 1=VCD), a dirty flag
-consumed in each support's `itemNeedsUpdate`, and a global lock `gDefaultGameView`
-(`GAME_VIEW_BOTH` / `_ISO` / `_VCD`). `item_list_t.viewOverride` lets Favourites proxy a source
-device in a forced view without disturbing that page's own L3 state
-(`ITEM_VIEW_NATIVE` / `_FORCE_ISO` / `_FORCE_VCD`).
+`src/vcdsupport.c` owned a **binary** per-mode view: `vcdView[mode]` (0 = ISO, 1 = VCD), a dirty
+flag consumed in each support's `itemNeedsUpdate`, and a global lock `gDefaultGameView`.
+`item_list_t.viewOverride` lets Favourites proxy a source device in a forced view without
+disturbing that page's own L3 state.
 
 ### 2.2 What it becomes
 
-Generalise the binary flag into an **N-way ring**. Keep the state in `vcdsupport.c` (it already owns
-the dirty-flag protocol every support consumes) or move it to a new `src/libview.c` +
-`include/libview.h` — either is fine; what matters is that the old binary API is **deleted, not
-shadowed** (see the audit gate in §8, Phase 1).
+The state moves to `libview.c`/`libview.h` and the second stop is renamed for what the user sees:
 
 ```c
 enum LIB_VIEW {
-    LIB_VIEW_ISO = 0,   // disc games (PS2 ISO/ZSO/UL/HDL) — today's vcdView == 0
-    LIB_VIEW_VCD,       // PS1 via POPSTARTER               — today's vcdView == 1
-    LIB_VIEW_CUE,       // PS1 via Ember                    — new
-    LIB_VIEW_ELF,       // homebrew ELFs                    — Favourites only
+    LIB_VIEW_ISO = 0, // PS2 disc games: ISO / ZSO / UL / HDL
+    LIB_VIEW_PS1,     // PS1 titles -- BOTH cores in one list (Part 4)
     LIB_VIEW_COUNT
 };
 ```
 
-**Rings (the order Nathan specified):**
+**Still exactly two stops.** The rename is the point: the old name was one of the two cores, so
+every caller had to ask "is it VCD?" to mean "is it PS1?". That reads as a bug the moment a .cue row
+appears in the same list.
 
 | Page | Ring |
 | --- | --- |
-| Device pages (BDM, MMCE, ETH, HDD) | `ISO → VCD → CUE →` wrap |
-| Favourites (`FAV_MODE`) | `ISO → VCD → CUE → ELF →` wrap |
-| Apps (`APP_MODE`) | none — ELF only, L3 inert, no hint |
+| Device pages (BDM, MMCE, ETH, HDD) | `PS2 → PS1 →` wrap |
+| Favourites | `PS2 → PS1 →` wrap |
+| Apps | none — one list, L3 inert, no hint |
 
-**Combined PS1 list setting** (`gEmberSharePs1List`, default OFF). When ON:
+Favourites keeps its own independent slot, and app favourites stay where they have always been, in
+its PS2 list. (An earlier draft proposed a 4-stop ring with a separate ELF stop; that is superseded
+along with the CUE stop. If an ELF stop is ever wanted it is a UI decision on its own merits, not a
+consequence of supporting a second PS1 core.)
 
-| Page | Ring |
-| --- | --- |
-| Device pages | `ISO → PS1 →` wrap, where PS1 = VCD entries **and** CUE entries merged |
-| Favourites | `ISO → PS1 → ELF →` wrap |
+The ring machinery is deliberately kept general — supported-stop set, wrap-around advance — so
+adding a stop later needs no second rewrite.
 
-This is the "removing the need for a 3rd toggle if the user wants PS1 all together" requirement.
-
-**Stop suppression.** A ring stop is only offered when it can actually produce something, so nobody
-gets a dead L3 press:
-
-* `LIB_VIEW_VCD` — offered when `vcdModeSupported(mode)` (unchanged).
-* `LIB_VIEW_CUE` — governed by `gEmberView`: `Off` / `Auto` (default) / `Always`.
-  In `Auto`, the stop appears only when `<devroot><gEmberFolder>/ember.elf` exists. That probe is
-  one `open()`+`close()`, folded into the support's existing `itemNeedsUpdate` device tick and
-  memoised per `gCacheGeneration` — **never** on the render path.
-* `LIB_VIEW_ELF` — Favourites only, and only when `gFAVStartMode` is on.
-
-**API to add** (replacing the binary calls one-for-one):
+**API**
 
 ```c
-int  libViewSupported(int mode, int view);      // is this stop in this mode's ring?
-int  libViewActive(int mode);                   // current LIB_VIEW_* for the page
-int  libListViewActive(const item_list_t *il);  // honours viewOverride, else libViewActive(il->mode)
-void libViewAdvance(int mode);                  // L3: next supported stop, wrapping; marks dirty
-int  libViewConsumeDirty(int mode);             // unchanged semantics from vcdConsumeDirty
+int  libViewSupported(int mode, int view);      // the single definition of a page's ring
+int  libViewRingSize(int mode);                 // what the hint and the toggle guard ask
+int  libViewActive(int mode);
+int  libListViewActive(const item_list_t *il);  // honours viewOverride
+void libViewAdvance(int mode);                  // next stop, wrapping; marks dirty
+int  libViewConsumeDirty(int mode);
 void libViewMarkDirty(int mode);
 void libViewMarkAllDirty(void);
 ```
 
-`gDefaultGameView` gains `GAME_VIEW_CUE` **appended after `GAME_VIEW_VCD`** so persisted ints do not
-shift. `GAME_VIEW_BOTH` continues to mean "L3 rings"; the lock values pin the page and make L3
-inert, exactly as today.
+`gDefaultGameView` is unchanged (`BOTH` / `ISO` / `VCD`); a lock pins every page that has the pinned
+stop and makes L3 inert. No new enum value is needed, because no new stop was added.
 
-`item_list_t.viewOverride` gains `ITEM_VIEW_FORCE_CUE = 3` and `ITEM_VIEW_FORCE_ELF = 4`.
+### 2.3 The conversion rule
 
-### 2.3 Call-site conversion table
+Every old call asked a yes/no question and must become an explicit `LIB_VIEW_*` comparison. Do not
+leave a boolean wrapper behind: one that answers "is it VCD?" answers wrongly for a `.cue` row.
 
-Every one of these currently asks a **yes/no** question and must be re-expressed as an explicit
-`LIB_VIEW_*` comparison. Do not leave a `vcdViewActive()` wrapper behind — a wrapper that answers
-"is it VCD?" will silently answer "no" for a CUE page and route CUE rows down the ISO path, which is
-precisely the failure shape the pre-v1.0 audit catalogued (data half ported, code half not).
+Two sites changed *meaning* rather than spelling, and both were already asking the wrong question:
+the L3 hint and `itemExecToggleView` tested "does this device have a VCD view" to decide whether to
+offer the toggle. What they mean is "does this page have more than one list" — `libViewRingSize`.
 
-| File | Sites | Becomes |
-| --- | --- | --- |
-| `src/opl.c` | `itemExecToggleView`, hint block (~L331), `itemExecSquare` `#Size` skip, `itemExecFav` `isVcd` capture, `itemExecTriangle` VCD routing, `oplQueueVcdDeviceUpdates` | ring advance; hint text per view; skip `#Size` for VCD **and** CUE; capture a `kind`; route both PS1 kinds away from the PS2 per-game settings |
-| `src/bdmsupport.c` | `bdmNeedsUpdate`, `bdmUpdateGameList`, `bdmGetGameCount`, `bdmActiveGame`, delete/rename guards, `bdmGetImage` fallback, `bdmLaunchGame` dispatch, cleanup frees | third array `bdmCueGames`/`bdmCueGameCount` alongside `bdmGames`/`bdmVcdGames`, same last-good-on-failure discipline |
-| `src/mmcesupport.c` | mirror of the above | same |
-| `src/ethsupport.c` | mirror | same |
-| `src/hddsupport.c` | mirror (+ APA specifics) | Phase 4 |
-| `src/udpfssupport.c` | currently VCD-unsupported | leave unsupported unless R5 passes |
-| `src/favsupport.c` | `favUpdateItemList` filter, `favResolve`, `favOwnerView`, `favGetConfig`, `favLaunchItem`, `favGetImage`, `favResolveStoredId` | `kind` instead of `isVcd` throughout |
-| `src/guigame.c` | VCD per-game routing | treat CUE like VCD (no Loader Core, no compat flags) |
-| `src/texcache.c` | `cacheGetEffectiveMode` via `favGetArtMode` | unchanged shape, `kind`-aware |
+**Audit gates (both required before merging this refactor):**
 
-**Note the `bdmsupport.c` gotcha:** the file contains NUL bytes, so `grep` treats it as binary.
-Use `grep -a` / `tr -d '\000'` when reading it.
+```bash
+# Must be ZERO -- the binary API is deleted, not shadowed.
+grep -rn "vcdViewActive\|vcdListViewActive\|vcdToggleView\|vcdConsumeDirty" src/ include/
+
+# Per-file call-site counts, COMMENTS EXCLUDED, before vs after must match.
+# A raw line count will mislead: comments mentioning the old names inflate the "before".
+```
 
 ### 2.4 UI strings
 
-Existing `_STR_VCD` (L3 hint), `_STR_VCD_ON`, `_STR_VCD_OFF` are binary. Replace the hint with a
-per-view label and add toast strings. **All new labels go at the END of `lng_tmpl/_base.yml`**
-(currently after `GENERAL_SYSTEM`) — `.lng` files are consumed by line position and this rule has
-been broken three times already. Suggested new labels:
+The L3 hint became `PS1` and its toast `Showing PS1 games`. `VCD` is a bare token in all 31
+`lng_fork` translations, so that swap is safe in every language; `VCD_OFF` ("disc games" and its
+translations) is untouched because the PS2 list really is discs.
 
-```
-VIEW_TOGGLE, VIEW_ISO, VIEW_VCD, VIEW_CUE, VIEW_ELF, VIEW_PS1,
-EMBER, EMBER_VIEW, HINT_EMBER_VIEW, EMBER_FOLDER, HINT_EMBER_FOLDER,
-EMBER_SHARE_PS1, HINT_EMBER_SHARE_PS1, EMBER_CLEAN_IOP, HINT_EMBER_CLEAN_IOP,
-EMBER_NOT_FOUND, EMBER_BIOS_MISSING, EMBER_NAME_TOO_LONG, EMBER_NAME_BAD_CHARS,
-EMBER_NO_GAMES
-```
+New labels go at the **END** of `lng_tmpl/_base.yml` — `.lng` files are consumed by line position.
+`lang_autogen.h` and `lang_internal.c` are gitignored build artifacts; regenerate, never hand-edit.
 
-`lang_autogen.h` and `lang_internal.c` are **gitignored build artifacts** — regenerate, do not
-hand-edit.
-
----
 
 ## Part 3 — Scanning: `src/cuesupport.c` + `include/cuesupport.h`
 
@@ -379,38 +359,51 @@ everywhere rather than open-coding the compare.
 
 ---
 
-## Part 4 — Merged PS1 list (`gEmberSharePs1List`)
+## Part 4 — One PS1 list, two cores
 
-When ON, `LIB_VIEW_VCD` and `LIB_VIEW_CUE` collapse into one stop labelled **PS1**.
+**Decided 2026-08-28 (Nathan): there are exactly two toggles, PS2 and PS1.** The PS1 list holds
+both cores' titles together. This is not a setting and there is no third stop — merged *is* the
+list. An earlier draft of this plan proposed a separate CUE stop plus an opt-in merge; that is
+superseded, and the simpler shape is also the better one.
 
-Implementation: keep the two arrays scanned separately (they have different failure modes and
-different last-good semantics), then build a **third, merged view array** at publish time:
+A PS1 list can therefore contain:
 
 ```
-ps1Games = memalign(64, (vcdCount + cueCount) * sizeof(base_game_info_t));
-memcpy VCD rows, then CUE rows, then sort by name with the existing submenu sort.
+Spyro 2 (Ripto's Rage)      <- POPS/Spyro 2 (Ripto's Rage).VCD      -> POPSTARTER
+Spyro 2 (Ripto's Rage)      <- EMBER/games/Spyro 2 (Ripto's Rage)/  -> Ember
 ```
 
-Every downstream decision then keys off the **row**, not the page:
+Two rows, same title, different cores, sorted together. From the front end they behave identically.
 
-| Decision | Today | With merged list |
-| --- | --- | --- |
-| launch dispatch | `if (vcdViewActive(mode))` | `if (cueIsCueEntry(g))` → Ember; else → POPSTARTER |
-| art fallback | `vcdLoadPopsCover` | `cueIsCueEntry(g) ? cueLoadFolderCover : vcdLoadPopsCover` |
-| `#Size` skip | view-based | both PS1 kinds skip |
-| favourite `kind` | `isVcd` | `cueIsCueEntry(g) ? CUE : VCD` |
+**The rule that makes this work: the ROW picks the core, never the page.** Every decision that used
+to key off "is this page in the VCD view" must key off the row instead:
 
-**Trap (already bitten once, see the VCD-sort note):** `submenuSort` runs *last*, on raw display
-text, and it must stay aware of `vcdDisplayName()` (the game-ID-hiding cosmetic transform). A merged
-list runs both name shapes through the same sort, so verify `gVcdHideGameId` still only affects VCD
-rows and never mangles a CUE folder name.
+| Decision | Ask |
+| --- | --- |
+| launch dispatch | `cueIsCueEntry(game)` → Ember, else POPSTARTER |
+| art fallback | same test; `cueLoadFolderCover` vs `vcdLoadPopsCover` |
+| favourite kind | same test, stored in the record |
+| `#Size` skip | neither PS1 kind has a meaningful size — skip for the whole PS1 view |
 
-**Trap:** the CUE array is a third store to free in every `itemCleanUp` and to bounds-guard in every
-`*ActiveGame()` helper. The `bdmActiveGame` toggle-window guard exists precisely because the L3 flip
-is synchronous while the rebuild is deferred; with three (or four) arrays the guard is mandatory,
-not optional. Extend it, do not copy-paste it.
+The row-kind discriminator is `base_game_info_t.extension`: `".VCD"` or `".CUE"`.
+`ISO_GAME_EXTENSION_MAX` is 4, so it fits exactly, and no struct change is needed.
 
----
+`ps1FillGameList()` in `cuesupport.c` is the ONE place the union is formed. Its failure contract is
+load-bearing: it returns −1 only when a scan could not **read** the device. An absent `POPS` or
+`EMBER` folder is `0`, not failure — treating "this device only uses one core" as a failure would
+freeze the PS1 page of most setups. When either half genuinely fails, the whole last-good list is
+kept, because publishing half a list looks exactly like the user's titles disappearing.
+
+**Sort.** The merged comparator reuses the VCD scan's existing visible-name key, exported as
+`vcdSortKey()` so there is one definition rather than two that can drift. Enabling Ember therefore
+cannot reorder an existing PS1 list. The extension tie-break is not cosmetic: the same game held for
+both cores is the *expected* case, and without a deterministic tie-break `qsort` may swap those two
+rows on every rescan, making them appear to jump around.
+
+**Trap.** The PS1 array is a second store to free in every `itemCleanUp` and to bounds-guard in
+every `*ActiveGame()` helper. The toggle-window guard exists because the L3 flip is synchronous
+while the rebuild is deferred; extend it, do not copy-paste it.
+
 
 ## Part 5 — Launch
 
@@ -561,14 +554,12 @@ We deliberately do **not** pre-verify a `.cue`/`.bin`/`.exe` inside the folder (
 ```c
 extern int  gEmberView;          // EMBER_VIEW_OFF / _AUTO (default) / _ALWAYS
 extern char gEmberFolder[32];    // per-device folder name, default "EMBER"
-extern int  gEmberSharePs1List;  // merge the VCD and CUE lists into one PS1 stop (default 0)
 extern int  gEmberCleanIop;      // fallback handoff, see R1 (default 0)
 ```
 
 ```c
 #define CONFIG_OPL_EMBER_VIEW      "ember_view"      // 0=Off 1=Auto 2=Always
 #define CONFIG_OPL_EMBER_FOLDER    "ember_folder"    // per-device folder holding ember.elf + games/
-#define CONFIG_OPL_EMBER_SHARE_PS1 "ember_share_ps1" // one merged PS1 list instead of VCD + CUE stops
 #define CONFIG_OPL_EMBER_CLEAN_IOP "ember_clean_iop" // reset+reload the IOP before handing off (fallback)
 ```
 
@@ -585,13 +576,12 @@ from the same parent. Rows:
 | --- | --- |
 | Ember Library | enum: Off / Auto / Always (`gEmberView`) |
 | Ember Folder | string, default shown when empty (`gEmberFolder`) — reuse `diaSetShowDefaultWhenEmpty` |
-| Combine VCD + CUE into one PS1 list | on/off (`gEmberSharePs1List`) |
 | Clean IOP handoff | on/off (`gEmberCleanIop`), hidden unless advanced/diag is set |
 
 **Trap:** `diaSetEnum` stores the array *pointer*, it does not copy. Any `const char *[]` handed to
 it must outlive every render of that dialog — make them `static`, as `guiSetBdmaSettings` does.
 
-Changing `gEmberView`, `gEmberFolder` or `gEmberSharePs1List` must call `libViewMarkAllDirty()` and
+Changing `gEmberView` or `gEmberFolder` must call `libViewMarkAllDirty()` and
 then `oplQueueVcdDeviceUpdates()` (rename it `oplQueueLibraryDeviceUpdates`) — marking dirty alone
 is not enough for HDD, whose `updateDelay == -1` means a dirty view otherwise renders stale forever.
 
@@ -600,7 +590,7 @@ is not enough for HDD, whose `updateDelay == -1` means a dirty view otherwise re
 `FAV_VERSION` 2 → **3**. The per-record `isVcd` byte becomes a `kind` byte:
 
 ```
-0 = ISO   1 = VCD   2 = CUE   3 = ELF
+0 = ISO   1 = VCD   2 = CUE
 ```
 
 Read compatibility:
@@ -608,13 +598,12 @@ Read compatibility:
 | File version | Mapping |
 | --- | --- |
 | v1 (no byte) | `kind = ISO` for every record (today's behaviour) |
-| v2 (`isVcd` byte) | `isVcd == 1` → VCD; `isVcd == 0 && mode == APP_MODE` → **ELF**; else ISO |
+| v2 (`isVcd` byte) | `isVcd == 1` → VCD; else ISO — unchanged, no records move |
 | v3 | `kind` verbatim |
 
-The v2 → ELF remap is the one behaviour change existing users will see: app favourites currently sit
-in the FAV tab's ISO list and will move to the new ELF stop. That is exactly the requested
-`ISO → VCD → CUE → ELF` ring, but it must be called out in the release notes, because a user with
-app favourites will otherwise think they vanished.
+No records move between stops. App favourites stay in the Favourites PS2 list exactly where they
+are today, so unlike the earlier 4-stop draft this migration has no user-visible effect at all — the
+`kind` byte only gains the ability to say "this PS1 favourite is an Ember title".
 
 Record size line (`favsupport.c` ~L310) stays `17 + tlen` — one byte either way.
 

--- a/docs/EMBER-INTEGRATION-PLAN.md
+++ b/docs/EMBER-INTEGRATION-PLAN.md
@@ -769,22 +769,25 @@ git diff --stat origin/rebuild/main -- src/ include/
 under `gEmberView`. No favourites, no merged list, no settings page yet (hardcode `gEmberView =
 AUTO`, `gEmberFolder = "EMBER"`).
 
-Validate: list populates; L3 rings ISO → VCD → CUE; art resolves from `<devroot>ART/`; launch works;
-a device with no `EMBER/` folder shows exactly today's two-stop ring.
+Validate: the list populates; L3 rings PS2 → PS1 with Ember rows interleaved among the `.VCD` ones;
+art resolves from `<devroot>ART/`; launch works; a device with no `EMBER/` folder looks exactly as it
+did before.
 
 ### Phase 3 — MMCE + ETH, settings page, docs
 
 Mirror into `mmcesupport.c` and (gated on R4) `ethsupport.c`. Add the Ember settings page, the
 config keys, the language labels appended to `_base.yml`, `docs/EMBER.md`.
 
-### Phase 4 — Favourites v3 + merged PS1 list + APA HDD
+### Phase 4 — Favourites v3 + APA HDD
 
-OFAV v3 with the `kind` byte and the v2 migration; the `ISO → VCD → CUE → ELF` FAV ring; the
-`gEmberSharePs1List` merged list; `hddsupport.c` (`pfs0:/EMBER/`).
+OFAV v3 with the `kind` byte and the v2 migration, and the Favourites ring PS2 → PS1 → APPS (Part 2);
+`hddsupport.c` (`pfs0:/EMBER/`). There is no merged-list setting — merging is the behaviour, see
+Part 4.
 
-Validate the migration explicitly: take a v2 `favourites.bin` with ISO, VCD **and** app favourites,
-confirm all three land on the right stop after the upgrade and that a v3 file still loads on the
-next boot.
+Validate the migration explicitly: take a v2 `favourites.bin` holding ISO, VCD **and** app
+favourites, confirm all three land on the right shelf after the upgrade, **and that a v3 file still
+loads on the next boot** — the reader's accepted-version range and the writer's `FAV_VERSION` have
+to move together, and getting that wrong presents an empty tab that then overwrites the real list.
 
 ### Phase 5 — Bonus surface
 

--- a/docs/EMBER-INTEGRATION-PLAN.md
+++ b/docs/EMBER-INTEGRATION-PLAN.md
@@ -1,0 +1,768 @@
+# Ember as a second PS1 core — integration plan
+
+**Status:** design only, nothing implemented. Written for an implementing agent.
+**Base commit:** `291716d3` on `rebuild/main` (2026-08-27).
+**Permission:** Gage (author of Ember) has approved and encouraged this integration.
+
+---
+
+## Part 0 — What Ember actually is (measured, not guessed)
+
+There is no Ember source. Everything below was derived from `Ember.Beta.Release.zip`
+(tag `Beta`, published 2026-08-28, 1 557 425 bytes) by disassembling the shipped ELFs with the
+`ghcr.io/ps2dev/ps2dev:latest` toolchain. Both ELFs are **unstripped with DWARF**, so this is
+solid ground, not inference. Re-derive with:
+
+```bash
+gh release download Beta --repo Gageformer/Ember
+```
+
+The zip contains exactly two files: `ember.elf` (3 759 476 B) and `launcher.elf` (1 666 416 B).
+
+### 0.1 `launcher.elf` — the thing we are replacing
+
+Gage's launcher is a plain ps2sdk bootstrapper. Its symbol table shows the whole recipe:
+
+| Symbol / string | Meaning |
+| --- | --- |
+| `SifIopReset` | resets the IOP |
+| `sbv_patch_disable_prefix_check`, `sbv_patch_enable_lmb` | standard SBV patches |
+| `size_iomanX_irx`, `size_fileXio_irx` | loads iomanX + fileXio |
+| `size_usbd_irx`, `size_usbmass_bd_irx` | loads the USB host stack + USB mass driver |
+| `size_bdm_irx`, `size_bdmfs_fatfs_irx` | loads BDM + the FAT/exFAT filesystem layer |
+| `ExecPS2` | jumps into `ember.elf` |
+
+So the environment Ember is *designed* to receive is: **iomanX + fileXio + BDM + bdmfs_fatfs, with
+the game device already mounted as `massN:`.** That is a strict subset of what RiptOPL already has
+live at launch time. `launcher.elf` is USB-only; RiptOPL's stack is not.
+
+### 0.2 `ember.elf` — it never resets the IOP
+
+`nm ember.elf` contains `sceSifInitRpc`, `sceSifExitRpc`, `SifLoadModule`, `SifLoadFileInit`,
+`SifInitIopHeap` — and **no `SifIopReset`, no `SifIopRebootBuffer`, no `sceSifRebootIop`.**
+The only `rom0:` strings in the whole binary are `rom0:ROMVER`, `rom0:SIO2MAN`, `rom0:PADMAN`.
+
+This is the single most important fact in this document. Ember **cannot** rebuild its own device
+stack; it inherits whatever the launcher leaves running. That is why it must be handed off with
+`sysLoadELFKeepIOP()` (`src/elfldr_noreset.c`) — the same vendored no-reset child loader Neutrino
+already uses — and **not** with `LoadELFFromFileWithPartition()`.
+
+It is also why Nathan's instinct is right: *because Ember inherits the environment it is handed, it
+can play from any device RiptOPL can mount.* MX4SIO, iLink, internal ATA (exFAT), MMCE, APA/PFS,
+SMB and even UDPBD are all reachable in principle, because we hand over a live mount rather than
+asking Ember to find one. POPSTARTER can never do this (it resets and re-discovers from the memory
+card, which is exactly why `bdmLaunchVcd` has to refuse UDPBD).
+
+### 0.3 Argument contract — measured from `main` at `0x158a88`–`0x15bb44`
+
+This is the constraint that dictates the entire folder layout, so it is spelled out in full.
+
+```
+argv_join(buf /*sp+1080*/, 192, &argv[1], argc-1);   // 0x15b630 — spaces are re-joined
+if (buf[0] == '\0')             goto DEFAULT;        // 0x15b63c
+if (buf[0]=='.' && buf[1]=='.') goto REFUSE;         // 0x15bb28
+for (c in buf)                                       // 0x15b660 char scan
+    if (c=='/' || c==':' || c=='\\') goto REFUSE;    // mask (1<<45)|(1<<11)|(1<<0) over (c-47)
+ACCEPT:  s2 = buf;  arg = buf;   goto RESOLVE;       // 0x15bb3c
+DEFAULT: s2 = NULL; arg = "default";                 // 0x158af0 (rodata 0x16d710 == "default")
+REFUSE:  print "REFUSED game arg '%s' -- name a folder directly under games/";
+         s2 = NULL; arg = "default";                 // then falls into RESOLVE, no retry
+
+RESOLVE: snprintf(path, 192, "games/%s", arg);       // 0x158b10, rodata 0x16d388 == "games/%s"
+         print "Ember 2: game location: %s", path;
+         if (io_find_disc(path, &disc)) goto BOOT;
+         print "Ember 2: find=%d errno=%d disc='%s'";
+         if (s2) {                                   // 0x158b90
+             print "Ember 2: retrying arg as path: %s", s2;
+             if (io_find_disc(s2, &disc)) goto BOOT; // relative to cwd, still no separators
+         }
+         print "Ember 2: no disc (BIOS shell run)";
+```
+
+**Therefore:**
+
+1. The game argument is a **bare directory name**. `/`, `:` and `\` are hard-refused anywhere in
+   it, and `..` is refused as a prefix. **An absolute path can never be passed.**
+2. Multiple argv entries are re-joined with spaces, so a name with spaces can be sent either as one
+   argv entry or several. Send it as **one**.
+3. Resolution order is `games/<name>` then `<name>`, **both relative to Ember's working directory**.
+4. The effective name cap is ~185 bytes (`snprintf` into a 192-byte buffer after `games/`).
+
+### 0.4 Working directory, BIOS, disc discovery, memory cards
+
+* `ember.elf` links ps2sdk's `src/cwd.c` and exports `__init_cwd` / `__cwd` / `__path_absolute`.
+  ps2sdk derives the initial cwd from **`argv[0]`**. So `argv[0]` must be the *real full path of
+  `ember.elf`*, e.g. `mass0:/EMBER/ember.elf` — that is what makes `games/…` resolve.
+  `sysLoadELFKeepIOP()` already forwards a caller-controlled `argv[0]` verbatim (the POPSTARTER
+  selector rides the same mechanism), so this costs nothing.
+* `bios.bin` is opened relative to cwd and must be **exactly 512 KB**
+  (`"Ember 2: bios.bin FAILED ('%s' -> %ld, want %lu)"` / `"bios.bin loaded (512 KB)"`).
+  User-supplied; we never ship it.
+* `settings.txt` is `key:value` lines, one key implemented: `display:240` or `display:480`.
+  Unknown keys are ignored with a log line. We do not need to write it.
+* `io_find_disc()` (`0x10eed8`) accepts **either** a file whose extension is `.cue`, `.bin` or
+  `.exe` (case-insensitive `strcasecmp`), **or** a directory containing one — it `opendir()`s and
+  scans. `.cue` wins over `.bin`. Note `.exe` (PSX-EXE) is supported and undocumented in the README.
+* Memory cards are `<gamedir>/MC1.vmc`, `<gamedir>/MC2.vmc`, with optional
+  `<gamedir>/SharedMC.txt`. **Ember creates these, so the game folder must be writable.**
+* Ember loads only `rom0:SIO2MAN` and `rom0:PADMAN` itself, and logs `"pad init %s (rc=%d)"`.
+
+---
+
+## Part 1 — Folder structure
+
+Ember cannot be given a path, so the layout is forced: **the games live under the same directory as
+the `ember.elf` we launch.** Per-device, mirroring the existing `POPS/` doctrine
+(*library folders at the ROOT of each activated device — never mc, never cwd*):
+
+```
+<device-root>/
+  EMBER/                      <- folder name configurable (gEmberFolder, default "EMBER")
+    ember.elf                 <- required; its presence is what enables the CUE view
+    bios.bin                  <- required by Ember at launch (512 KB, user-supplied)
+    settings.txt              <- optional, Ember's own
+    games/
+      Crash Bandicoot (USA)/  <- one folder == one CUE library entry; the folder NAME is the identity
+        game.cue
+        game.bin
+        MC1.vmc  MC2.vmc      <- created by Ember on first launch
+      Spyro the Dragon (USA)/
+        Spyro.cue
+        Spyro.bin
+```
+
+`<device-root>` per device class, matching where `POPS/` already lives:
+
+| Device | Root used |
+| --- | --- |
+| USB / MX4SIO / iLink / exFAT-ATA (all BDM) | `massN:/` — the **device root**, not `gBDMPrefix`. Reuse `bdmBuildVcdPrefix()`. |
+| MMCE | `mmceN:/` (`mmcePrefix`) |
+| SMB / ETH | the mounted share root (`ethGetSMBPrefix()`) — **validation-gated, see Risk R4** |
+| APA / PFS HDD | `pfs0:/EMBER/…` on the selected OPL partition (`+OPL`, else `__common`) — **Phase 4** |
+| UDPBD / UDPFS | the live `massN:` / udpfs mount — **bonus, see Risk R5** |
+
+**Invariant to enforce in code:** the scanned `games/` directory and the launched `ember.elf` are
+always the *same* `EMBER/` directory on the *same* device. There is deliberately **no**
+POPSTARTER-style "Ember Device" picker: POPSTARTER can be loaded from anywhere because it takes a
+`mass:/POPS/XX.<name>.ELF` selector string, but Ember takes a bare folder name and can only look
+inside its own directory. A picker would be a lying control. The only knob is the folder *name*
+(`gEmberFolder`), which lets a user keep e.g. `PS1/` instead of `EMBER/`.
+
+### Art and per-game config
+
+Identity = **the game folder name**, exactly parallel to a VCD's basename-without-`.VCD`. So the
+existing device art/CFG rules apply unchanged:
+
+* `<devroot>ART/<Folder Name>_COV.png`, `<devroot>CFG/<Folder Name>.cfg`
+* Fallback, mirroring `vcdLoadPopsCover()`: `<devroot>EMBER/games/<Folder Name>/cover.png`, then
+  `<devroot>EMBER/games/<Folder Name>/<Folder Name>.png`. Cover/icon suffixes only, CUE view only.
+
+Badges: reuse `sbSetDiscAttributes(config, /*isPS1*/1, /*isCD*/1)` → `#System=PS1`, `#Media=CD`,
+`#DiscType=PS1CD`. Every shipped theme already draws these, so CUE entries look right on day one.
+Optionally also stamp `CONFIG_ITEM_FORMAT = "CUE"` so a theme can add a `CUE_#Format.png` glyph —
+purely additive, no existing theme changes.
+
+---
+
+## Part 2 — The view engine (L3)
+
+### 2.1 What exists today
+
+`src/vcdsupport.c` owns a **binary** per-mode view: `vcdView[mode]` (0=ISO, 1=VCD), a dirty flag
+consumed in each support's `itemNeedsUpdate`, and a global lock `gDefaultGameView`
+(`GAME_VIEW_BOTH` / `_ISO` / `_VCD`). `item_list_t.viewOverride` lets Favourites proxy a source
+device in a forced view without disturbing that page's own L3 state
+(`ITEM_VIEW_NATIVE` / `_FORCE_ISO` / `_FORCE_VCD`).
+
+### 2.2 What it becomes
+
+Generalise the binary flag into an **N-way ring**. Keep the state in `vcdsupport.c` (it already owns
+the dirty-flag protocol every support consumes) or move it to a new `src/libview.c` +
+`include/libview.h` — either is fine; what matters is that the old binary API is **deleted, not
+shadowed** (see the audit gate in §8, Phase 1).
+
+```c
+enum LIB_VIEW {
+    LIB_VIEW_ISO = 0,   // disc games (PS2 ISO/ZSO/UL/HDL) — today's vcdView == 0
+    LIB_VIEW_VCD,       // PS1 via POPSTARTER               — today's vcdView == 1
+    LIB_VIEW_CUE,       // PS1 via Ember                    — new
+    LIB_VIEW_ELF,       // homebrew ELFs                    — Favourites only
+    LIB_VIEW_COUNT
+};
+```
+
+**Rings (the order Nathan specified):**
+
+| Page | Ring |
+| --- | --- |
+| Device pages (BDM, MMCE, ETH, HDD) | `ISO → VCD → CUE →` wrap |
+| Favourites (`FAV_MODE`) | `ISO → VCD → CUE → ELF →` wrap |
+| Apps (`APP_MODE`) | none — ELF only, L3 inert, no hint |
+
+**Combined PS1 list setting** (`gEmberSharePs1List`, default OFF). When ON:
+
+| Page | Ring |
+| --- | --- |
+| Device pages | `ISO → PS1 →` wrap, where PS1 = VCD entries **and** CUE entries merged |
+| Favourites | `ISO → PS1 → ELF →` wrap |
+
+This is the "removing the need for a 3rd toggle if the user wants PS1 all together" requirement.
+
+**Stop suppression.** A ring stop is only offered when it can actually produce something, so nobody
+gets a dead L3 press:
+
+* `LIB_VIEW_VCD` — offered when `vcdModeSupported(mode)` (unchanged).
+* `LIB_VIEW_CUE` — governed by `gEmberView`: `Off` / `Auto` (default) / `Always`.
+  In `Auto`, the stop appears only when `<devroot><gEmberFolder>/ember.elf` exists. That probe is
+  one `open()`+`close()`, folded into the support's existing `itemNeedsUpdate` device tick and
+  memoised per `gCacheGeneration` — **never** on the render path.
+* `LIB_VIEW_ELF` — Favourites only, and only when `gFAVStartMode` is on.
+
+**API to add** (replacing the binary calls one-for-one):
+
+```c
+int  libViewSupported(int mode, int view);      // is this stop in this mode's ring?
+int  libViewActive(int mode);                   // current LIB_VIEW_* for the page
+int  libListViewActive(const item_list_t *il);  // honours viewOverride, else libViewActive(il->mode)
+void libViewAdvance(int mode);                  // L3: next supported stop, wrapping; marks dirty
+int  libViewConsumeDirty(int mode);             // unchanged semantics from vcdConsumeDirty
+void libViewMarkDirty(int mode);
+void libViewMarkAllDirty(void);
+```
+
+`gDefaultGameView` gains `GAME_VIEW_CUE` **appended after `GAME_VIEW_VCD`** so persisted ints do not
+shift. `GAME_VIEW_BOTH` continues to mean "L3 rings"; the lock values pin the page and make L3
+inert, exactly as today.
+
+`item_list_t.viewOverride` gains `ITEM_VIEW_FORCE_CUE = 3` and `ITEM_VIEW_FORCE_ELF = 4`.
+
+### 2.3 Call-site conversion table
+
+Every one of these currently asks a **yes/no** question and must be re-expressed as an explicit
+`LIB_VIEW_*` comparison. Do not leave a `vcdViewActive()` wrapper behind — a wrapper that answers
+"is it VCD?" will silently answer "no" for a CUE page and route CUE rows down the ISO path, which is
+precisely the failure shape the pre-v1.0 audit catalogued (data half ported, code half not).
+
+| File | Sites | Becomes |
+| --- | --- | --- |
+| `src/opl.c` | `itemExecToggleView`, hint block (~L331), `itemExecSquare` `#Size` skip, `itemExecFav` `isVcd` capture, `itemExecTriangle` VCD routing, `oplQueueVcdDeviceUpdates` | ring advance; hint text per view; skip `#Size` for VCD **and** CUE; capture a `kind`; route both PS1 kinds away from the PS2 per-game settings |
+| `src/bdmsupport.c` | `bdmNeedsUpdate`, `bdmUpdateGameList`, `bdmGetGameCount`, `bdmActiveGame`, delete/rename guards, `bdmGetImage` fallback, `bdmLaunchGame` dispatch, cleanup frees | third array `bdmCueGames`/`bdmCueGameCount` alongside `bdmGames`/`bdmVcdGames`, same last-good-on-failure discipline |
+| `src/mmcesupport.c` | mirror of the above | same |
+| `src/ethsupport.c` | mirror | same |
+| `src/hddsupport.c` | mirror (+ APA specifics) | Phase 4 |
+| `src/udpfssupport.c` | currently VCD-unsupported | leave unsupported unless R5 passes |
+| `src/favsupport.c` | `favUpdateItemList` filter, `favResolve`, `favOwnerView`, `favGetConfig`, `favLaunchItem`, `favGetImage`, `favResolveStoredId` | `kind` instead of `isVcd` throughout |
+| `src/guigame.c` | VCD per-game routing | treat CUE like VCD (no Loader Core, no compat flags) |
+| `src/texcache.c` | `cacheGetEffectiveMode` via `favGetArtMode` | unchanged shape, `kind`-aware |
+
+**Note the `bdmsupport.c` gotcha:** the file contains NUL bytes, so `grep` treats it as binary.
+Use `grep -a` / `tr -d '\000'` when reading it.
+
+### 2.4 UI strings
+
+Existing `_STR_VCD` (L3 hint), `_STR_VCD_ON`, `_STR_VCD_OFF` are binary. Replace the hint with a
+per-view label and add toast strings. **All new labels go at the END of `lng_tmpl/_base.yml`**
+(currently after `GENERAL_SYSTEM`) — `.lng` files are consumed by line position and this rule has
+been broken three times already. Suggested new labels:
+
+```
+VIEW_TOGGLE, VIEW_ISO, VIEW_VCD, VIEW_CUE, VIEW_ELF, VIEW_PS1,
+EMBER, EMBER_VIEW, HINT_EMBER_VIEW, EMBER_FOLDER, HINT_EMBER_FOLDER,
+EMBER_SHARE_PS1, HINT_EMBER_SHARE_PS1, EMBER_CLEAN_IOP, HINT_EMBER_CLEAN_IOP,
+EMBER_NOT_FOUND, EMBER_BIOS_MISSING, EMBER_NAME_TOO_LONG, EMBER_NAME_BAD_CHARS,
+EMBER_NO_GAMES
+```
+
+`lang_autogen.h` and `lang_internal.c` are **gitignored build artifacts** — regenerate, do not
+hand-edit.
+
+---
+
+## Part 3 — Scanning: `src/cuesupport.c` + `include/cuesupport.h`
+
+Model it directly on `vcdsupport.c`'s scan half. POSIX dir IO only (`opendir`/`readdir`/`closedir`)
+— the newlib-port rule; **never** `fileXio*` from the GUI thread.
+
+```c
+#define CUE_NAME_MAX        192  // Ember's argv_join buffer; we cap harder below
+#define CUE_NAME_LAUNCH_MAX 180  // leaves room for "games/" + NUL inside Ember's 192-byte buffer
+#define CUE_MAX_ITEMS       2048
+
+// Build "<devPrefix><gEmberFolder>/ember.elf" into out; 1 if it exists.
+int cueResolveEmber(const char *devPrefix, char *out, int outSize);
+
+// Build "<devPrefix><gEmberFolder>/games/" into out.
+void cueBuildGamesDir(const char *devPrefix, char *out, int outSize);
+
+// Scan <devPrefix><gEmberFolder>/games/ for SUBDIRECTORIES. Returns count, or -1 on a device
+// read failure (caller keeps its last-good list — same contract as vcdFillGameList).
+int cueFillGameList(const char *devPrefix, base_game_info_t **outGames);
+
+// 1 when a name is legal as an Ember argument (no '/', ':', '\\'; not "..";
+// length <= CUE_NAME_LAUNCH_MAX). Pure string work, no device access.
+int cueNameLaunchable(const char *name);
+
+// Cover fallback inside the game folder (cover.png, then <name>.png). Only called after the
+// device's own ART/ lookup misses, and only in the CUE view.
+int cueLoadFolderCover(const char *devPrefix, const char *value, const char *suffix, GSTEXTURE *tex);
+```
+
+`cueFillGameList` fills `base_game_info_t` per entry:
+
+```c
+snprintf(g->name,      sizeof(g->name),      "%s", dirName);  // identity: art, CFG, favourites
+snprintf(g->startup,   sizeof(g->startup),   "%s", dirName);
+snprintf(g->extension, sizeof(g->extension), ".CUE");         // the kind discriminator
+g->parts  = 1;
+g->format = GAME_FORMAT_ISO;                                  // harmless; the view gates the launch
+```
+
+**`.CUE` in `extension` is the row-level kind discriminator** and is what makes the merged PS1 list
+work (§4). `ISO_GAME_EXTENSION_MAX` is 4, so `".CUE"` fits exactly. Provide
+`int cueIsCueEntry(const base_game_info_t *g)` = `!strcasecmp(g->extension, ".CUE")` and use it
+everywhere rather than open-coding the compare.
+
+**Scanner rules**
+
+* Only subdirectories. `d_type` is untrustworthy on MMCE clones (see the MMCE theme-discovery
+  finding) — probe with `opendir()` on the candidate and treat success as "is a directory".
+* Skip `.` and `..`.
+* Skip any name failing `cueNameLaunchable()`, and `LOG()` it. Such a name cannot occur on
+  FAT/exFAT anyway; an over-long one is a user mistake, and listing an unlaunchable row would be a
+  lying control.
+* Do **not** verify that a `.cue`/`.bin`/`.exe` is present inside — that would be an `opendir` per
+  row on the scan path and MMCE/SMB cannot afford it. Ember reports the miss itself
+  (`"no disc (BIOS shell run)"`).
+* Never touch the device from a display path. There is no CUE equivalent of
+  `vcdResolveDisplayId()` and none should be added.
+
+---
+
+## Part 4 — Merged PS1 list (`gEmberSharePs1List`)
+
+When ON, `LIB_VIEW_VCD` and `LIB_VIEW_CUE` collapse into one stop labelled **PS1**.
+
+Implementation: keep the two arrays scanned separately (they have different failure modes and
+different last-good semantics), then build a **third, merged view array** at publish time:
+
+```
+ps1Games = memalign(64, (vcdCount + cueCount) * sizeof(base_game_info_t));
+memcpy VCD rows, then CUE rows, then sort by name with the existing submenu sort.
+```
+
+Every downstream decision then keys off the **row**, not the page:
+
+| Decision | Today | With merged list |
+| --- | --- | --- |
+| launch dispatch | `if (vcdViewActive(mode))` | `if (cueIsCueEntry(g))` → Ember; else → POPSTARTER |
+| art fallback | `vcdLoadPopsCover` | `cueIsCueEntry(g) ? cueLoadFolderCover : vcdLoadPopsCover` |
+| `#Size` skip | view-based | both PS1 kinds skip |
+| favourite `kind` | `isVcd` | `cueIsCueEntry(g) ? CUE : VCD` |
+
+**Trap (already bitten once, see the VCD-sort note):** `submenuSort` runs *last*, on raw display
+text, and it must stay aware of `vcdDisplayName()` (the game-ID-hiding cosmetic transform). A merged
+list runs both name shapes through the same sort, so verify `gVcdHideGameId` still only affects VCD
+rows and never mangles a CUE folder name.
+
+**Trap:** the CUE array is a third store to free in every `itemCleanUp` and to bounds-guard in every
+`*ActiveGame()` helper. The `bdmActiveGame` toggle-window guard exists precisely because the L3 flip
+is synchronous while the rebuild is deferred; with three (or four) arrays the guard is mandatory,
+not optional. Extend it, do not copy-paste it.
+
+---
+
+## Part 5 — Launch
+
+### 5.1 The primary handoff (keep-IOP) — `sysLaunchEmber()`
+
+Add to `include/system.h` / `src/system.c`, directly beneath `sysLaunchPopstarter`:
+
+```c
+// Launch Ember for one game folder. emberElf = the full path of ember.elf (also becomes the
+// target's argv[0], which is what sets Ember's cwd via ps2sdk __init_cwd — everything Ember opens,
+// including bios.bin and games/, is relative to that directory). gameFolder = the BARE folder name
+// under <emberdir>/games/; Ember hard-refuses '/', ':' and '\\' anywhere in it.
+// Caller deinit()s with UNMOUNT_EXCEPTION first: Ember performs NO IOP reset, so the game device
+// must still be mounted when it starts.
+void sysLaunchEmber(const char *emberElf, const char *gameFolder);
+```
+
+```c
+void sysLaunchEmber(const char *emberElf, const char *gameFolder)
+{
+    if (emberElf == NULL || gameFolder == NULL || gameFolder[0] == '\0') {
+        LOG("[EMBER] null arg, abort\n");
+        return;
+    }
+    char *argv[2];
+    argv[0] = (char *)emberElf;    // ps2sdk __init_cwd derives Ember's cwd from this
+    argv[1] = (char *)gameFolder;  // bare folder name; Ember joins argv[1..] with spaces
+    LOG("[EMBER] elf=%s game=%s\n", emberElf, gameFolder);
+
+    if (sysLoadELFKeepIOP(emberElf, "", 2, argv) < 0)
+        LOG("[EMBER] keep-IOP handoff failed for %s\n", emberElf);
+}
+```
+
+Budget check that `sysLoadELFKeepIOP` already enforces: `argc + 1 = 3` against the kernel's
+15-string `SetArg` limit, and `strlen(emberElf)*2 + strlen(gameFolder) + 3` against the 256-byte
+pool. With a 180-byte name cap and a ~48-byte device path this fits, but **pre-validate in the
+caller** so the user sees `EMBER_NAME_TOO_LONG` instead of a silent return.
+
+`SifExitRpc()` before `ExecPS2()` stays where it is inside `elfldr_noreset.c`. It has been removed
+twice on a false premise; it is EE-side only, resets no IOP, and leaving it out yields a stale SIF0
+handler DMAing into dead memory. **Do not touch it.**
+
+### 5.2 Per-device `*LaunchCue()`
+
+One per support, modelled line-for-line on `bdmLaunchVcd` / `mmceLaunchVcd`. Order matters and is
+copied deliberately:
+
+```c
+static void bdmLaunchCue(item_list_t *itemList, const char *cueName, config_set_t *configSet)
+{
+    bdm_device_data_t *d = itemList->priv;
+    char emberPrefix[64], emberElf[256], biosPath[256];
+
+    if (d == NULL || cueName == NULL || cueName[0] == '\0')
+        return;
+    if (!cueNameLaunchable(cueName)) {                      // Ember refuses these outright
+        guiMsgBox(_l(_STR_EMBER_NAME_BAD_CHARS), 0, NULL);
+        return;
+    }
+
+    bdmBuildVcdPrefix(emberPrefix, sizeof(emberPrefix), itemList->mode);  // device ROOT
+    if (!cueResolveEmber(emberPrefix, emberElf, sizeof(emberElf))) {
+        guiMsgBox(_l(_STR_EMBER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    snprintf(biosPath, sizeof(biosPath), "%s%s/bios.bin", emberPrefix, gEmberFolder);
+    if (!sbFileExists(biosPath)) {                           // Ember drops to the BIOS shell otherwise
+        guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
+        return;
+    }
+
+    if (d->bdmDeviceType == BDM_TYPE_SDC) {                  // MX4SIO and MMCE share SIO2
+        if (!cacheAbortMmceImageLoadsTimed(500)) {
+            guiWarning(_l(_STR_ERR_FILE_INVALID), 8);
+            return;
+        }
+    }
+
+    deinit(UNMOUNT_EXCEPTION, itemList->mode);               // KEEP this device mounted — Ember never resets
+    sysLaunchEmber(emberElf, cueName);
+}
+```
+
+Notice what is **absent** compared to the VCD path, and why:
+
+* **No memory-card preparation at all.** No `vcdInstallPopstarterMc`, no BDMA equip, no
+  `IPCONFIG.DAT`/`SMBCONFIG.DAT`, no fat32/exFAT prompt. All of that exists because POPSTARTER
+  resets the IOP and reloads drivers from `mc?:/POPSTARTER/`. Ember inherits our live drivers, so
+  none of it applies. **Do not port it.** This is the single biggest simplification and the main
+  reason Ember is worth supporting.
+* **No UDPBD refusal.** `bdmLaunchVcd` must refuse UDPBD because POPSTARTER cannot bring a network
+  block device back up after its reset. Ember has no reset, so this refusal is not needed — see R5.
+* **RetroGEM barcode** (`vcdPrepareRetroGemBarcode`) is optional parity. It would need the disc ID
+  read from inside the image. **Defer to Phase 5**; it is not on the critical path.
+
+Wire it into each support's `item_list_t` and into `itemLaunch`:
+
+```c
+if (gAutoLaunchBDMGame == NULL && game != NULL && libListViewActive(itemList) == LIB_VIEW_CUE) {
+    bdmLaunchCue(itemList, game->name, configSet);
+    return;
+}
+```
+…plus, when the merged PS1 list is on, the row-level `cueIsCueEntry(game)` dispatch from §4.
+
+### 5.3 `item_list_t` extension — APPEND ONLY
+
+Every support initialises `item_list_t` **positionally**. New members must go at the **very end**,
+after `itemGetArtArchivePath`, or every existing initialiser silently mis-assigns:
+
+```c
+    /// Launch a CUE (PS1/Ember) item by its stored folder name, regardless of the device's current
+    /// view. NULL for devices without a CUE view. Used by Favourites to launch a CUE favourite
+    /// while its source device page may be in another view.
+    void (*itemLaunchCue)(item_list_t *itemList, const char *cueName, config_set_t *configSet);
+```
+
+A unified `itemLaunchNamed(itemList, kind, name, configSet)` replacing `itemLaunchVcd` would be
+cleaner, and the rebuild deviation rule permits the restructure — but it rewrites six support tables
+in one go. **Recommendation: add `itemLaunchCue` alongside `itemLaunchVcd` now, and unify later if
+a third named-launch kind ever appears.** Lower blast radius, identical behaviour.
+
+**After ANY change to `item_list_t` or `base_game_info_t`: `rm obj/*.o` before rebuilding.** A
+mid-struct field change with stale objects produces garbage that looks like a logic bug.
+
+### 5.4 Failure surface
+
+Ember's own failure mode is a quiet drop to the PS1 BIOS shell. Everything we can check cheaply, we
+check *before* `deinit()` so we can still draw a dialog:
+
+| Condition | Message |
+| --- | --- |
+| `ember.elf` missing at the resolved path | `EMBER_NOT_FOUND` |
+| `bios.bin` missing | `EMBER_BIOS_MISSING` |
+| Name contains `/`, `:`, `\` or is `..` | `EMBER_NAME_BAD_CHARS` |
+| Name longer than `CUE_NAME_LAUNCH_MAX` | `EMBER_NAME_TOO_LONG` |
+| `games/` empty or unreadable | `EMBER_NO_GAMES` (list-level, not a dialog) |
+
+We deliberately do **not** pre-verify a `.cue`/`.bin`/`.exe` inside the folder (§3, scanner rules).
+
+---
+
+## Part 6 — Settings, config keys, favourites format, docs
+
+### 6.1 New globals (`include/opl.h`) and keys (`include/config.h`)
+
+```c
+extern int  gEmberView;          // EMBER_VIEW_OFF / _AUTO (default) / _ALWAYS
+extern char gEmberFolder[32];    // per-device folder name, default "EMBER"
+extern int  gEmberSharePs1List;  // merge the VCD and CUE lists into one PS1 stop (default 0)
+extern int  gEmberCleanIop;      // fallback handoff, see R1 (default 0)
+```
+
+```c
+#define CONFIG_OPL_EMBER_VIEW      "ember_view"      // 0=Off 1=Auto 2=Always
+#define CONFIG_OPL_EMBER_FOLDER    "ember_folder"    // per-device folder holding ember.elf + games/
+#define CONFIG_OPL_EMBER_SHARE_PS1 "ember_share_ps1" // one merged PS1 list instead of VCD + CUE stops
+#define CONFIG_OPL_EMBER_CLEAN_IOP "ember_clean_iop" // reset+reload the IOP before handing off (fallback)
+```
+
+Load in `opl.c` alongside the POPSTARTER keys (~L2674), save (~L3187), default (~L4324).
+Missing keys must fall back to the defaults above so existing `settings_riptopl.cfg` files load
+unchanged.
+
+### 6.2 Settings UI
+
+Add an **Ember** page as a peer of the existing **POPStarter** page (`guiShowVcdConfig`), reached
+from the same parent. Rows:
+
+| Row | Control |
+| --- | --- |
+| Ember Library | enum: Off / Auto / Always (`gEmberView`) |
+| Ember Folder | string, default shown when empty (`gEmberFolder`) — reuse `diaSetShowDefaultWhenEmpty` |
+| Combine VCD + CUE into one PS1 list | on/off (`gEmberSharePs1List`) |
+| Clean IOP handoff | on/off (`gEmberCleanIop`), hidden unless advanced/diag is set |
+
+**Trap:** `diaSetEnum` stores the array *pointer*, it does not copy. Any `const char *[]` handed to
+it must outlive every render of that dialog — make them `static`, as `guiSetBdmaSettings` does.
+
+Changing `gEmberView`, `gEmberFolder` or `gEmberSharePs1List` must call `libViewMarkAllDirty()` and
+then `oplQueueVcdDeviceUpdates()` (rename it `oplQueueLibraryDeviceUpdates`) — marking dirty alone
+is not enough for HDD, whose `updateDelay == -1` means a dirty view otherwise renders stale forever.
+
+### 6.3 Favourites file format — OFAV v3
+
+`FAV_VERSION` 2 → **3**. The per-record `isVcd` byte becomes a `kind` byte:
+
+```
+0 = ISO   1 = VCD   2 = CUE   3 = ELF
+```
+
+Read compatibility:
+
+| File version | Mapping |
+| --- | --- |
+| v1 (no byte) | `kind = ISO` for every record (today's behaviour) |
+| v2 (`isVcd` byte) | `isVcd == 1` → VCD; `isVcd == 0 && mode == APP_MODE` → **ELF**; else ISO |
+| v3 | `kind` verbatim |
+
+The v2 → ELF remap is the one behaviour change existing users will see: app favourites currently sit
+in the FAV tab's ISO list and will move to the new ELF stop. That is exactly the requested
+`ISO → VCD → CUE → ELF` ring, but it must be called out in the release notes, because a user with
+app favourites will otherwise think they vanished.
+
+Record size line (`favsupport.c` ~L310) stays `17 + tlen` — one byte either way.
+
+`addFavouriteItem` / `removeFavouriteByIdAndText` take `int kind` instead of `int isVcd`; kind is
+part of the identity so an ISO, a VCD and a CUE of the same name never collide.
+`favResolve()`'s VCD branch generalises: a CUE favourite binds to a source providing
+`itemLaunchCue`; an ELF favourite binds to `APP_MODE`.
+
+### 6.4 Docs
+
+Per the standing rule (docs updated in the same effort the feature lands):
+
+* New `docs/EMBER.md` — user-facing, mirroring `docs/VCD.md`'s structure: what the CUE view is, the
+  folder layout, where to put `bios.bin`, the L3 ring, the combined-PS1 setting, and an explicit
+  "Ember vs POPSTARTER — which should I use?" section.
+* `docs/VCD.md` — update §1 and §2 (the view is no longer binary) and the Favourites paragraph.
+* `README.md` — one line in the feature list.
+* Rolling release notes.
+
+---
+
+## Part 7 — Risks, in priority order
+
+### R1 — Pad modules (HIGHEST; this is the one that decides the architecture)
+
+RiptOPL loads **`freesio2.irx` as `sio2man` and `freepad.irx` as `padman`** (`Makefile` L850/L853),
+not the ROM versions. Ember calls `SifLoadModule("rom0:SIO2MAN")` then `SifLoadModule("rom0:PADMAN")`
+against our still-live IOP and logs `"pad init %s (rc=%d)"`.
+
+Two possible outcomes, and only hardware can tell them apart:
+
+* **Benign:** the ROM loads fail as already-registered, Ember's `padInit()` binds to freepad's RPC
+  (freepad is a drop-in libpad server), and controllers work. → ship as designed.
+* **Broken:** a second SIO2MAN/PADMAN loads and fights freesio2/freepad → no input, or a hang.
+
+`unloadPads()` (already called inside `deinit()`) calls `padEnd()`, which ends the RPC binding but
+**does not unload the IRX** — the modules stay resident. There is no cheap way to unload them.
+
+**Fallback if R1 comes back broken — `gEmberCleanIop`, "be the launcher ourselves":**
+Replicate `launcher.elf` exactly, using IRX RiptOPL already embeds:
+
+1. Read `ember.elf` into EE RAM **before** anything is torn down (3.7 MB; EE has 32 MB).
+2. `deinit(UNMOUNT_EXCEPTION, mode)` as usual.
+3. `SifIopReset("", 0)`; wait for sync; `SifInitRpc(0)`.
+4. `sbv_patch_disable_prefix_check()`, `sbv_patch_enable_lmb()`.
+5. Load `iomanx_irx`, `filexio_irx`, then the **device-matching** driver set (`usbd_irx` +
+   `usbmass_bd_irx` for USB; `mx4sio_bd_irx`; `ata_bd_irx`; iLink; `mmceman_irx`; the SMB set),
+   then `bdm_irx`, `bdmfs_fatfs_irx`.
+6. Wait for the mount to appear, then `ExecPS2()` the in-RAM ELF with `argv[0]` = the ELF's original
+   path string (so `__init_cwd` still resolves) and `argv[1]` = the folder name.
+
+This is strictly more code and loses the "any device for free" property (each device needs its
+driver set enumerated), which is why it is the fallback and not the default. **Phase 0 exists
+specifically to answer R1 before any UI work is written.**
+
+### R2 — Writable game folders
+
+Ember creates `MC1.vmc` / `MC2.vmc` inside the game folder on first launch. A read-only source
+(a locked SMB share, a read-only mount) will fail *inside* Ember, after we have already torn down.
+Mitigation: document it, and consider a launch-time write probe
+(`open(<gamedir>/.oplw, O_WRONLY|O_CREAT)` then `remove`) behind `__OPLDIAG` only — it costs a write
+per launch and should not ship enabled.
+
+### R3 — IOP RAM headroom
+
+Ember calls `SifInitIopHeap` and loads modules into a **used** IOP. RiptOPL's IOP at menu time
+carries iomanX, fileXio, sio2man, padman, mcman/mcserv, poweroff, usbd, the BDM stack, plus
+whichever of mmceman / smbman+ps2ip+ps2smap+ps2dev9 / udpbd are live, plus audio. If Ember runs out
+of IOP heap it will fail late and opaquely. Mitigation: `deinit(UNMOUNT_EXCEPTION, mode)` already
+tears down every *other* device support before the handoff, which is most of the recovery. Watch for
+it in Phase 0 and record it in the test log.
+
+### R4 — SMB path separators
+
+RiptOPL composes SMB paths with `\\` (see `sbCreateFoldersFromList`), while Ember composes with `/`
+(`io_path` format string `"%s/%s%s"`). Whether smbman accepts `/` from Ember decides whether the CUE
+view can exist on ETH at all. **Gate ETH support on a test**; if it fails, `libViewSupported()`
+simply omits `LIB_VIEW_CUE` for `ETH_MODE` and nothing else changes.
+
+### R5 — UDPBD / UDPFS (upside, not downside)
+
+`bdmLaunchVcd` refuses UDPBD because POPSTARTER cannot rebuild a network block device after its
+reset. Ember has no reset, so a UDPBD-hosted CUE game *should* just work — PS1 over the network,
+which POPSTARTER can never do. Treat this as a bonus to validate in Phase 5, not a requirement.
+Do **not** copy the `BDM_TYPE_UDPBD` refusal into `bdmLaunchCue`.
+
+### R6 — `gDefaultGameView` semantics
+
+Adding `GAME_VIEW_CUE` to a persisted enum is safe only if appended after `GAME_VIEW_VCD`.
+Clamp on load (`opl.c` ~L2664 already clamps to `GAME_VIEW_BOTH`) and extend the clamp bound.
+
+---
+
+## Part 8 — Phasing and validation gates
+
+Each phase is a separate PR. CI must be read line by line before merging — `check-format` is not a
+required check, so a red format run still merges. Build and run **clang-format 12** locally first.
+
+### Phase 0 — Prove the handoff (no UI)
+
+Smallest possible change: a hardcoded `sysLaunchEmber()` reachable from a debug path. Note that the
+existing APPS entry mechanism (`boot` + `argv1`) is *not* a shortcut here — `appLaunchItem` uses
+`LoadELFFromFileWithPartition`, which resets the IOP, so it will fail. That failure is itself a
+useful control experiment: it demonstrates §0.2 on hardware.
+
+Ship an `__OPLDIAG` build (never `__DEBUG` — CI builds `make release`, so `__DEBUG` never reaches a
+tester). Hand testers a run-pinned `nightly.link` artifact, per standing policy.
+
+**Answers required before Phase 1 starts:**
+
+1. Does the game boot at all through `sysLoadELFKeepIOP`? (validates §0.2)
+2. **Do controllers work?** (R1 — decides architecture)
+3. Does it work from MX4SIO / MMCE / internal exFAT ATA, not just USB? (validates "any device")
+4. Does `bios.bin` load, and are `MC*.vmc` created? (R2)
+5. Any sign of IOP heap exhaustion? (R3)
+
+### Phase 1 — View engine only
+
+`libView*` API in, all existing `vcdView*` call sites converted, `viewOverride` extended.
+**No CUE stop is offered yet.** The ring for every page is still `ISO → VCD`.
+Success criterion: **zero observable behaviour change.** This is the highest-risk refactor in the
+plan and must land on its own so a regression is unambiguous.
+
+**Audit gate before merge** — this is the query that catches the fork's recurring defect shape
+(*data half ported, comment half ported, code half not*), and it is not optional:
+
+```bash
+# Must be ZERO — the binary API is deleted, not shadowed.
+grep -rn "vcdViewActive\|vcdListViewActive\|vcdToggleView\|vcdConsumeDirty" src/ include/
+
+# Call-site COUNT per file before and after must match; an N -> N-1 drop is the bug.
+git diff --stat origin/rebuild/main -- src/ include/
+```
+
+### Phase 2 — CUE list on BDM only
+
+`cuesupport.c`, the third array in `bdmsupport.c`, `bdmLaunchCue`, `LIB_VIEW_CUE` in the BDM ring
+under `gEmberView`. No favourites, no merged list, no settings page yet (hardcode `gEmberView =
+AUTO`, `gEmberFolder = "EMBER"`).
+
+Validate: list populates; L3 rings ISO → VCD → CUE; art resolves from `<devroot>ART/`; launch works;
+a device with no `EMBER/` folder shows exactly today's two-stop ring.
+
+### Phase 3 — MMCE + ETH, settings page, docs
+
+Mirror into `mmcesupport.c` and (gated on R4) `ethsupport.c`. Add the Ember settings page, the
+config keys, the language labels appended to `_base.yml`, `docs/EMBER.md`.
+
+### Phase 4 — Favourites v3 + merged PS1 list + APA HDD
+
+OFAV v3 with the `kind` byte and the v2 migration; the `ISO → VCD → CUE → ELF` FAV ring; the
+`gEmberSharePs1List` merged list; `hddsupport.c` (`pfs0:/EMBER/`).
+
+Validate the migration explicitly: take a v2 `favourites.bin` with ISO, VCD **and** app favourites,
+confirm all three land on the right stop after the upgrade and that a v3 file still loads on the
+next boot.
+
+### Phase 5 — Bonus surface
+
+UDPBD/UDPFS (R5), RetroGEM game-ID parity, `settings.txt` display passthrough as a per-game option.
+
+---
+
+## Part 9 — Quick reference for the implementing agent
+
+| Thing | Where |
+| --- | --- |
+| No-reset ELF handoff | `src/elfldr_noreset.c` → `sysLoadELFKeepIOP()` |
+| POPSTARTER launch (the template) | `src/system.c:1556` `sysLaunchPopstarter()` |
+| Neutrino launch (keep-IOP + args, the other template) | `src/system.c:1308` `sysLaunchNeutrino()` |
+| VCD view state | `src/vcdsupport.c:966-1035` |
+| L3 handler | `src/opl.c:432` `itemExecToggleView()` |
+| L3 hint | `src/opl.c:331` |
+| Fav R3 capture | `src/opl.c:~525` `itemExecFav()` |
+| BDM two-array pattern | `src/bdmsupport.c:1443-1600` (**contains NUL bytes — use `grep -a`**) |
+| Fav record + versioning | `src/favsupport.c:38-120`, `240-340` |
+| Fav resolve/launch/art | `src/favsupport.c:448-560`, `713-760` |
+| Device badges | `src/supportbase.c:1218` `sbSetDiscAttributes()` |
+| POPSTARTER settings page (UI template) | `src/gui.c:1356` `guiShowVcdConfig()` |
+| Language template (append at END) | `lng_tmpl/_base.yml`, after `GENERAL_SYSTEM` |
+
+**Standing rules that apply to this work**
+
+* `lng_tmpl/_base.yml` is **append-only**; `.lng` files are read by line position.
+  `lang_autogen.h` and `lang_internal.c` are gitignored build artifacts.
+* Any `item_list_t` / `base_game_info_t` change → **`rm obj/*.o`** before rebuilding.
+* `diaSetEnum` keeps a raw pointer — its string array must outlive every dialog render.
+* Never take an ioman semaphore from the GUI thread.
+* Tester diagnostics go behind `__OPLDIAG`, never `__DEBUG` (CI builds `make release`).
+* Library folders live at the **root of each activated device** — never on `mc`, never in cwd.
+  Settings live in cwd.
+* `SifExitRpc()` before `ExecPS2()` in `elfldr` must stay.

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -50,8 +50,8 @@ typedef struct
     // absent dir from a contended one (opendir just fails) and returns -1 = preserve-last-good. Separate
     // arrays make a failed scan of one view preserve only THAT view's last-good (empty if never scanned),
     // so it can never resurrect the other view's contents. Mirrors mmceGames/mmceVcdGames.
-    int bdmVcdGameCount;
-    base_game_info_t *bdmVcdGames;
+    int bdmPs1GameCount;
+    base_game_info_t *bdmPs1Games;
     char bdmDriver[32];
     int bdmDeviceType;      // Type of BDM device, see BDM_TYPE_* above
     int bdmDeviceTick;      // Used alongside BdmGeneration to tell if device data needs to be refreshed
@@ -157,8 +157,8 @@ typedef struct
     unsigned int foldersCreated;
     const void *games; // %p only
     int gameCount;
-    const void *vcdGames; // %p only
-    int vcdGameCount;
+    const void *ps1Games; // %p only
+    int ps1GameCount;
 } bdm_config_diag_snapshot_t;
 
 // Call UNDER the menu lock. Pure value copies, no I/O.

--- a/include/cuesupport.h
+++ b/include/cuesupport.h
@@ -8,9 +8,39 @@
   author's blessing.
 
   Ember's library sits at <device>:/EMBER/, the exact peer of POPSTARTER's <device>:/POPS/ -- one
-  folder at each activated device's root, sought the same way on every device class. The contents
-  differ (POPS holds loose *.VCD files; EMBER holds ember.elf, bios.bin and a games/ folder of
-  per-game directories) but nothing above the scan needs to care.
+  folder at each activated device's root, sought the same way on every device class. That is where
+  the resemblance ENDS, and the difference is not cosmetic:
+
+      POPS/   holds loose *.VCD FILES        -> scan for files, identity = basename minus ".VCD"
+      EMBER/  holds ember.elf, bios.bin and
+              a games/ folder of per-game
+              DIRECTORIES                    -> scan a subfolder for DIRECTORIES, identity = the
+                                                directory name (there is no extension to strip)
+
+  WHICH LAYOUTS EMBER ACCEPTS, AND WHY WE LIST ONLY ONE. Ember's resolver is looser than its README:
+  it tries "games/<arg>" and then "<arg>", and io_find_disc takes EITHER a directory containing a
+  *.cue / *.bin / *.exe OR such a file directly. So all four of these boot:
+
+      1. games/<Name>/            a directory holding the image   <- the README layout
+      2. games/<Name>.cue         a loose image file
+      3. <Name>/                  a directory beside ember.elf     <- via the "retry arg as path" leg
+      4. <Name>.cue               a loose file beside ember.elf    <- same leg
+
+  We deliberately list ONLY layout 1, because only layout 1 saves. main() calls memcard_init exactly
+  once, and always with the COMPOSED path "games/<arg>" -- never with wherever the disc was actually
+  found. The per-game cards are then "games/<arg>/MC1.vmc" and "MC2.vmc". So:
+
+      - layout 2 puts the cards under a FILE ("games/Spyro.cue/MC1.vmc"), which cannot exist;
+      - layouts 3 and 4 put the cards in "games/<Name>/", a directory unrelated to the disc that
+        was actually mounted from EMBER/<Name>/.
+
+  Those titles play and silently cannot save, which is a worse experience than not being offered --
+  and the user would blame RiptOPL, not the layout. Listing only layout 1 means every row we show is
+  a row that fully works. Do NOT "fix" this by widening the scan; widen it only if Ember's memory
+  card resolution changes to follow the resolved disc.
+
+  Note also that io_find_disc does not recurse: an image at games/<Name>/disc1/game.cue is NOT found.
+  One level only.
 
   ONE PS1 LIST, TWO CORES. A device page has two stops -- PS2 discs and PS1 -- and the PS1 stop
   lists both cores' titles together, sorted as one library:
@@ -99,6 +129,15 @@ int cueNameLaunchable(const char *name);
 // (contended bus): an absent EMBER folder is 0, "readable, nothing here", exactly as the VCD scan
 // treats an absent POPS folder -- so a device with only one of the two never looks like a failure.
 int cueScanDir(const char *devPrefix, cue_entry_t **outList);
+
+// Does this game folder actually hold something Ember can mount -- a *.cue, *.bin or *.exe at its
+// top level? Costs ONE directory read, so callers use it on the LAUNCH path only (before deinit,
+// while a dialog can still be drawn) and never on the scan path, where it would be one directory
+// read per row on every refresh -- unaffordable on MMCE and SMB. An empty or mis-filled folder is a
+// user mistake rather than a normal state, so paying for it once per launch is the right trade.
+// Returns 1 when an image is present, 0 when the folder is readable and holds none, and 1 when the
+// folder cannot be read at all (never block a launch on a probe that itself failed).
+int cueGameHasImage(const char *devPrefix, const char *name);
 
 // 1 when a published row is an Ember title rather than a POPSTARTER one. THE row-kind test; use it
 // for launch dispatch and art fallback instead of asking which view the page is on.

--- a/include/cuesupport.h
+++ b/include/cuesupport.h
@@ -148,12 +148,27 @@ int cueIsCueEntry(const base_game_info_t *game);
 // handed a name rather than the row.
 int cueRowIsCueByName(const base_game_info_t *games, int count, const char *name);
 
+// Rename an Ember game by renaming its FOLDER under EMBER/games/. The folder name IS the identity
+// -- launch argument, art key, config key -- so this is the exact peer of vcdRenameFile, which
+// renames the .VCD file. Returns 0 on success, -1 otherwise (bad name, folder absent, or the
+// filesystem refusing a directory rename). Nothing is moved on failure.
+int cueRenameGame(const char *devPrefix, const char *oldName, const char *newName);
+
 // Fill a base_game_info_t list with the device's COMPLETE PS1 library: POPSTARTER *.VCD entries and
 // Ember game folders, merged and sorted together as one list (frees *outGames first, memalign'd
 // like sbReadList). Returns the count, or -1 when EITHER half could not read the device -- the
 // caller then keeps its last-good list rather than blanking a page over a transient wedge.
 // This is the ONE place the two libraries are unioned.
-int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames);
+//
+// TWO prefixes, and the split is deliberate rather than an oversight:
+//   vcdPrefix   -- passed to the POPSTARTER scan EXACTLY as that device has always passed it. On
+//                  MMCE that includes the user's configurable games prefix (gMMCEPrefix), so a card
+//                  laid out as mmce0:/<prefix>/POPS keeps working. Changing it would relocate an
+//                  existing library out from under its owner.
+//   emberPrefix -- the device ROOT, always. EMBER/ is a new library folder and follows the standing
+//                  rule that library folders live at the root of each activated device.
+// On every BDM device the two are the same value, so nothing there is affected either way.
+int ps1FillGameList(const char *vcdPrefix, const char *emberPrefix, base_game_info_t **outGames);
 
 // PS1 (Ember) cover FALLBACK inside the game's own folder: "<games>/<name>/cover.png", then
 // "<games>/<name>/<name>.png". Cover/icon suffixes only; a device getImage calls this ONLY after

--- a/include/cuesupport.h
+++ b/include/cuesupport.h
@@ -7,23 +7,37 @@
   PS2. RiptOPL drives ember.elf directly and replaces Ember's own bundled launcher.elf, with the
   author's blessing.
 
-  Every constant and rule here was MEASURED by disassembling the shipped Beta ember.elf (it ships
-  unstripped, with DWARF), not read off the README -- the README is thinner and, on the accepted
-  file extensions, wrong. The full derivation lives in docs/EMBER-INTEGRATION-PLAN.md Part 0.
+  Ember's library sits at <device>:/EMBER/, the exact peer of POPSTARTER's <device>:/POPS/ -- one
+  folder at each activated device's root, sought the same way on every device class. The contents
+  differ (POPS holds loose *.VCD files; EMBER holds ember.elf, bios.bin and a games/ folder of
+  per-game directories) but nothing above the scan needs to care.
 
-  Two facts shape this whole file:
+  ONE PS1 LIST, TWO CORES. A device page has two stops -- PS2 discs and PS1 -- and the PS1 stop
+  lists both cores' titles together, sorted as one library:
+
+      Spyro 2 (Ripto's Rage)        <- POPS/Spyro 2 (Ripto's Rage).VCD   -> POPSTARTER
+      Spyro 2 (Ripto's Rage)        <- EMBER/games/Spyro 2 (Ripto's Rage)/ -> Ember
+
+  Both rows behave identically to the user; which core runs one is a property of the ROW, resolved
+  at launch, and never of the page. Ask cueIsCueEntry(row) -- never the view.
+
+  Every Ember constant and rule below was MEASURED by disassembling the shipped Beta ember.elf (it
+  ships unstripped, with DWARF), not read off the README -- the README is thinner and, on the
+  accepted file extensions, wrong. The derivation is in docs/EMBER-INTEGRATION-PLAN.md Part 0.
+
+  Two facts shape this file:
 
   1. ember.elf performs NO IOP reset. It has sceSifInitRpc/SifLoadModule/SifInitIopHeap and no
      SifIopReset, so it inherits the launcher's live driver stack. The handoff therefore uses
-     sysLoadELFKeepIOP() (see sysLaunchEmber in system.c) and the caller must deinit with
+     sysLoadELFKeepIOP() (sysLaunchEmber in system.c) and the caller must deinit with
      UNMOUNT_EXCEPTION. It is also why Ember can reach any device OPL can mount, unlike POPSTARTER,
      which resets and re-discovers from the memory card.
 
   2. Ember's game argument is a BARE FOLDER NAME. Its argv scan hard-refuses '/', ':' and '\\'
      anywhere in the argument and refuses a leading "..", then resolves "games/<name>" followed by
      "<name>", both relative to a working directory ps2sdk derives from argv[0]. A path can never
-     be passed. That is why the games must live under the ember.elf directory and why there is
-     deliberately no POPSTARTER-style device picker for Ember -- such a control could not work.
+     be passed. That is why the games live under the ember.elf's own directory, and why there is
+     deliberately no POPSTARTER-style "Ember device" picker -- such a control could not work.
 
   POSIX directory IO only (opendir/readdir/closedir), like vcdsupport.c: the newlib port rejects
   direct fileXio use from these paths.
@@ -33,20 +47,32 @@
 #define __CUESUPPORT_H
 
 #include "include/iosupport.h"
+#include "include/supportbase.h" // base_game_info_t
 
 // Ember joins argv[1..] with spaces into a 192-byte buffer, then snprintf()s "games/%s" into a
-// second 192-byte buffer. A longer name cannot round-trip, so refuse it here with a message rather
-// than hand the target something it will silently truncate.
+// second 192-byte buffer. A longer name cannot round-trip, so refuse it with a message rather than
+// hand the target something it will silently truncate.
 #define CUE_NAME_MAX        192
 #define CUE_NAME_LAUNCH_MAX 180 // 192 less "games/" and the NUL, with headroom
+#define CUE_MAX_ITEMS       2048
 
-// Per-device folder holding ember.elf + bios.bin + games/. The NAME is the only knob Ember's
-// argument contract leaves us (the folder must be the ember.elf's own directory), and it becomes a
-// setting in a later phase -- read it through cueEmberFolder(), never the macro.
+// Per-device folder holding ember.elf + bios.bin + games/, the peer of POPS_FOLDER. The NAME is the
+// only knob Ember's argument contract leaves us (the library must be the ember.elf's own
+// directory) -- read it through cueEmberFolder(), never the macro.
 #define EMBER_FOLDER_DEFAULT "EMBER"
 #define EMBER_ELF_NAME       "ember.elf"
 #define EMBER_BIOS_NAME      "bios.bin"
 #define EMBER_GAMES_FOLDER   "games"
+
+// The extension stamped into base_game_info_t for an Ember row. This is the ROW-KIND discriminator
+// that makes one merged PS1 list possible: a .VCD row launches through POPSTARTER, a .CUE row
+// through Ember, and nothing else about them differs. ISO_GAME_EXTENSION_MAX is 4, so it fits.
+#define CUE_ROW_EXTENSION ".CUE"
+
+typedef struct
+{
+    char name[CUE_NAME_MAX]; // game FOLDER name under EMBER/games/ -- the launch argument and identity
+} cue_entry_t;
 
 // The active per-device Ember folder name. Never NULL.
 const char *cueEmberFolder(void);
@@ -65,8 +91,35 @@ void cueBuildGamesDir(const char *devPrefix, char *out, int outSize);
 
 // 1 when `name` is legal as Ember's game argument. Mirrors Ember's own checks exactly rather than a
 // tidied version of them: any '/', ':' or '\\' refuses (its char scan at main+0x3d48), and so does
-// a name STARTING with ".." (main+0x4210 -- not only the exact string ".."). Pure string work, no
-// device access.
+// a name STARTING with ".." (main+0x4210 -- not only the exact string ".."). Pure string work.
 int cueNameLaunchable(const char *name);
+
+// Scan "<devPrefix><EmberFolder>/games/" for game SUBDIRECTORIES. Returns the count; *outList is a
+// calloc'd cue_entry_t array the caller frees. Returns -1 only when the directory could not be READ
+// (contended bus): an absent EMBER folder is 0, "readable, nothing here", exactly as the VCD scan
+// treats an absent POPS folder -- so a device with only one of the two never looks like a failure.
+int cueScanDir(const char *devPrefix, cue_entry_t **outList);
+
+// 1 when a published row is an Ember title rather than a POPSTARTER one. THE row-kind test; use it
+// for launch dispatch and art fallback instead of asking which view the page is on.
+int cueIsCueEntry(const base_game_info_t *game);
+
+// Which core owns the PS1 row called `name` in an already-published list: 1 = Ember, 0 = POPSTARTER,
+// -1 = not found. Pure memory scan, no device access -- for callers like a device getImage that are
+// handed a name rather than the row.
+int cueRowIsCueByName(const base_game_info_t *games, int count, const char *name);
+
+// Fill a base_game_info_t list with the device's COMPLETE PS1 library: POPSTARTER *.VCD entries and
+// Ember game folders, merged and sorted together as one list (frees *outGames first, memalign'd
+// like sbReadList). Returns the count, or -1 when EITHER half could not read the device -- the
+// caller then keeps its last-good list rather than blanking a page over a transient wedge.
+// This is the ONE place the two libraries are unioned.
+int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames);
+
+// PS1 (Ember) cover FALLBACK inside the game's own folder: "<games>/<name>/cover.png", then
+// "<games>/<name>/<name>.png". Cover/icon suffixes only; a device getImage calls this ONLY after
+// its own <dev>ART/<name>_<suffix>.png misses, and only for a CUE row. The POPSTARTER peer is
+// vcdLoadPopsCover. Returns texDiscoverLoad's result (>= 0 hit, negative miss).
+int cueLoadFolderCover(const char *devPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex);
 
 #endif

--- a/include/cuesupport.h
+++ b/include/cuesupport.h
@@ -1,0 +1,72 @@
+/*
+  Copyright 2026, Open-PS2-Loader contributors
+  Licenced under Academic Free License version 3.0
+  Review OpenUsbLd README & LICENSE files for further details.
+
+  CUE (PS1-via-Ember) support. Ember (github.com/Gageformer/Ember) is a native PS1 emulator for the
+  PS2. RiptOPL drives ember.elf directly and replaces Ember's own bundled launcher.elf, with the
+  author's blessing.
+
+  Every constant and rule here was MEASURED by disassembling the shipped Beta ember.elf (it ships
+  unstripped, with DWARF), not read off the README -- the README is thinner and, on the accepted
+  file extensions, wrong. The full derivation lives in docs/EMBER-INTEGRATION-PLAN.md Part 0.
+
+  Two facts shape this whole file:
+
+  1. ember.elf performs NO IOP reset. It has sceSifInitRpc/SifLoadModule/SifInitIopHeap and no
+     SifIopReset, so it inherits the launcher's live driver stack. The handoff therefore uses
+     sysLoadELFKeepIOP() (see sysLaunchEmber in system.c) and the caller must deinit with
+     UNMOUNT_EXCEPTION. It is also why Ember can reach any device OPL can mount, unlike POPSTARTER,
+     which resets and re-discovers from the memory card.
+
+  2. Ember's game argument is a BARE FOLDER NAME. Its argv scan hard-refuses '/', ':' and '\\'
+     anywhere in the argument and refuses a leading "..", then resolves "games/<name>" followed by
+     "<name>", both relative to a working directory ps2sdk derives from argv[0]. A path can never
+     be passed. That is why the games must live under the ember.elf directory and why there is
+     deliberately no POPSTARTER-style device picker for Ember -- such a control could not work.
+
+  POSIX directory IO only (opendir/readdir/closedir), like vcdsupport.c: the newlib port rejects
+  direct fileXio use from these paths.
+*/
+
+#ifndef __CUESUPPORT_H
+#define __CUESUPPORT_H
+
+#include "include/iosupport.h"
+
+// Ember joins argv[1..] with spaces into a 192-byte buffer, then snprintf()s "games/%s" into a
+// second 192-byte buffer. A longer name cannot round-trip, so refuse it here with a message rather
+// than hand the target something it will silently truncate.
+#define CUE_NAME_MAX        192
+#define CUE_NAME_LAUNCH_MAX 180 // 192 less "games/" and the NUL, with headroom
+
+// Per-device folder holding ember.elf + bios.bin + games/. The NAME is the only knob Ember's
+// argument contract leaves us (the folder must be the ember.elf's own directory), and it becomes a
+// setting in a later phase -- read it through cueEmberFolder(), never the macro.
+#define EMBER_FOLDER_DEFAULT "EMBER"
+#define EMBER_ELF_NAME       "ember.elf"
+#define EMBER_BIOS_NAME      "bios.bin"
+#define EMBER_GAMES_FOLDER   "games"
+
+// The active per-device Ember folder name. Never NULL.
+const char *cueEmberFolder(void);
+
+// Build "<devPrefix><EmberFolder><sep>ember.elf" into out; returns 1 when that file exists, else 0.
+// devPrefix is a device ROOT ending in its separator ("mass0:/", "mmce0:/", an SMB prefix ending
+// "\\"), NOT gBDMPrefix -- Ember reads its own directory and nothing else.
+int cueResolveEmber(const char *devPrefix, char *out, int outSize);
+
+// As cueResolveEmber, for the user-supplied bios.bin Ember needs at launch. A missing BIOS drops
+// Ember to the PS1 shell with no explanation, so callers check this BEFORE deinit and say so.
+int cueResolveEmberBios(const char *devPrefix, char *out, int outSize);
+
+// Build "<devPrefix><EmberFolder><sep>games" into out (no trailing separator, ready for opendir).
+void cueBuildGamesDir(const char *devPrefix, char *out, int outSize);
+
+// 1 when `name` is legal as Ember's game argument. Mirrors Ember's own checks exactly rather than a
+// tidied version of them: any '/', ':' or '\\' refuses (its char scan at main+0x3d48), and so does
+// a name STARTING with ".." (main+0x4210 -- not only the exact string ".."). Pure string work, no
+// device access.
+int cueNameLaunchable(const char *name);
+
+#endif

--- a/include/favsupport.h
+++ b/include/favsupport.h
@@ -7,10 +7,28 @@
 #define FAV_TEXT_MAX          256        // cap on a stored favourite's text length (incl. NUL)
 #define FAV_MAX_ITEMS         512        // cap on records read from favourites.bin
 #define FAV_MAGIC             0x4641464F // 'OFAV' (little-endian on the EE)
-#define FAV_VERSION           2          // v2 adds a per-record isVcd byte; v1 is still read (isVcd=0)
+#define FAV_VERSION           3          // v3 widens v2's isVcd byte to a KIND (see FAV_KIND_*)
 
 // Defined in favsupport.c; consumed by opl.c/gui.c (config load/save/default).
 extern int gFAVStartMode;
+
+// Which shelf a favourite belongs on, and which core launches it. Stored in the byte OFAV v2 used
+// for isVcd, so the on-disk record layout is unchanged and only its meaning widens.
+//   ISO -- a PS2 disc game, launched by id through the source's itemLaunch
+//   VCD -- a PS1 title launched by NAME through POPSTARTER (itemLaunchVcd)
+//   CUE -- a PS1 title launched by NAME through Ember     (itemLaunchCue)
+//   ELF -- a homebrew app, launched by id from the APPS tab
+// VCD and CUE share the Favourites PS1 shelf; the kind picks the core, exactly as a row's extension
+// does on a device page.
+enum FAV_KIND {
+    FAV_KIND_ISO = 0,
+    FAV_KIND_VCD,
+    FAV_KIND_CUE,
+    FAV_KIND_ELF
+};
+
+// The LIB_VIEW_* shelf a kind is displayed on.
+int favKindView(int kind);
 
 item_list_t *favGetObject(int initOnly);
 
@@ -34,8 +52,8 @@ int favGetArtMode(const char *value);
 // item is already present. removeFavouriteByIdAndText matches mode (BDM-lenient) + id + text + isVcd.
 // isVcd = 1 when the favourited item was a PS1/.VCD entry (device was in its L3 VCD view); such
 // favourites resolve + launch as POPSTARTER rather than as a disc image. See favsupport.c.
-int addFavouriteItem(int mode, int id, int icon_id, int text_id, const char *text, int isVcd);
-int removeFavouriteByIdAndText(int mode, int id, const char *text, int isVcd);
+int addFavouriteItem(int mode, int id, int icon_id, int text_id, const char *text, int kind);
+int removeFavouriteByIdAndText(int mode, int id, const char *text, int kind);
 
 // Remove the favourite at FAV-list index favIndex (R3 pressed on the Favourites tab).
 void favRemoveByIndex(int favIndex);

--- a/include/folderbrowse.h
+++ b/include/folderbrowse.h
@@ -40,7 +40,7 @@ int folderAscend(int mode);
 void folderReset(int mode);
 
 // One-shot: returns 1 once after a descend/ascend/reset, so NeedsUpdate can force the rescan even
-// when the device's own change-detection would otherwise short-circuit (mirrors vcdConsumeDirty).
+// when the device's own change-detection would otherwise short-circuit (mirrors libViewConsumeDirty).
 int folderConsumeDirty(int mode);
 
 #endif

--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -172,10 +172,17 @@ typedef struct _item_list_t
     // sweep is appropriate, -1 when no home (no tar should be probed).
     // Placed after viewOverride so existing positional initializers remain valid.
     int (*itemGetArtArchivePath)(item_list_t *itemList, char *out, int outSize);
+
+    /// Launch an Ember (.cue) PS1 title by its stored game-folder name, regardless of the device's
+    /// current view -- the peer of itemLaunchVcd. NULL on a device with no Ember support. Used by
+    /// Favourites, whose PS1 shelf holds both cores' titles and must send each row to the right one.
+    /// APPENDED at the end: every support initialises item_list_t POSITIONALLY, so a member added
+    /// anywhere else silently shifts every one of them.
+    void (*itemLaunchCue)(item_list_t *itemList, const char *cueName, config_set_t *configSet);
 } item_list_t;
 
 #define ITEM_VIEW_NATIVE    0
 #define ITEM_VIEW_FORCE_ISO 1
-#define ITEM_VIEW_FORCE_VCD 2
+#define ITEM_VIEW_FORCE_PS1 2 // the PS1 list -- holds POPSTARTER *.VCD and Ember rows alike
 
 #endif

--- a/include/libview.h
+++ b/include/libview.h
@@ -6,7 +6,9 @@
   Library view state: which of a page's several lists is on screen, and the L3 ring that moves
   between them.
 
-  There are exactly two stops: PS2 discs, and PS1. The PS1 stop is deliberately ONE list holding
+  A device page has two stops: PS2 discs, and PS1. Favourites has three -- PS2, PS1, APPS -- so its
+  saved ELF entries get a shelf of their own instead of sharing the PS2 list. Rings are per-mode for
+  exactly this reason; nothing else needs to know. The PS1 stop is deliberately ONE list holding
   BOTH PS1 cores' titles -- POPSTARTER *.VCD entries and Ember game folders, interleaved and sorted
   together. A user thinks "PS1", not "which emulator", so the front end does too; which core launches
   a given row is a property of the ROW, resolved at launch time, and never of the page.
@@ -34,6 +36,7 @@
 enum LIB_VIEW {
     LIB_VIEW_ISO = 0, // PS2 disc games: ISO / ZSO / UL / HDL
     LIB_VIEW_PS1,     // PS1 titles, BOTH cores together (see the note above)
+    LIB_VIEW_ELF,     // homebrew ELFs -- a stop on the FAVOURITES ring only
     LIB_VIEW_COUNT
 };
 
@@ -55,6 +58,11 @@ int libViewActive(int mode);
 // shallow proxy may force a view through item_list_t.viewOverride without disturbing the real
 // source page's own L3 state.
 int libListViewActive(const item_list_t *itemList);
+
+// Can L3 do anything on this page -- more than one stop AND not pinned by the global setting?
+// The on-screen hint and the L3 handler must both ask THIS, or one will offer a toggle the other
+// refuses (or hide one that works). Favourites is never pinned; see libViewPinned in libview.c.
+int libViewRingUsable(int mode);
 
 // L3: advance to the next supported stop, wrapping, and mark the mode dirty. No-op when the global
 // default-view setting pins the page, or when the ring has fewer than two stops.

--- a/include/libview.h
+++ b/include/libview.h
@@ -1,0 +1,74 @@
+/*
+  Copyright 2026, Open-PS2-Loader contributors
+  Licenced under Academic Free License version 3.0
+  Review OpenUsbLd README & LICENSE files for further details.
+
+  Library view state: which of a page's several lists is on screen, and the L3 ring that moves
+  between them.
+
+  This replaces the binary per-mode VCD flag that used to live in vcdsupport.c. That flag answered
+  one yes/no question -- "is this page showing its VCD list?" -- which stopped being expressible the
+  moment a page could show a THIRD list (CUE, PS1 via Ember). A retained boolean helper would have
+  answered "no" for a CUE page and routed CUE rows down the ISO path, silently. The whole point of
+  this file is that every caller now names the view it means.
+
+  A page's ring is the ordered set of views it supports. L3 advances one stop and wraps. The global
+  gDefaultGameView setting can PIN every page that has a given stop to it, which makes L3 inert --
+  that behaviour is unchanged, only generalised.
+
+  The dirty protocol is unchanged too, because every device support already consumes it: advancing
+  the view marks the mode dirty, the support's itemNeedsUpdate consumes the flag and forces one
+  rescan, and the deferred IO update rebuilds the submenu.
+*/
+
+#ifndef __LIBVIEW_H
+#define __LIBVIEW_H
+
+#include "include/iosupport.h"
+
+enum LIB_VIEW {
+    LIB_VIEW_ISO = 0, // disc games: PS2 ISO / ZSO / UL / HDL
+    LIB_VIEW_VCD,     // PS1 via POPSTARTER (*.VCD)
+    LIB_VIEW_CUE,     // PS1 via Ember (a game folder holding *.cue / *.bin / *.exe)
+    LIB_VIEW_ELF,     // homebrew ELFs
+    LIB_VIEW_COUNT
+};
+
+// Is `view` a stop in this mode's ring? This is the ONE place a page's ring is defined; nothing
+// else should hard-code which devices have which lists.
+int libViewSupported(int mode, int view);
+
+// How many stops this mode's ring has. 1 means there is nothing to toggle: L3 is inert and the
+// on-screen hint is suppressed. Callers that used to ask "does this device have a VCD view" to
+// decide whether to offer the toggle want THIS, not libViewSupported(mode, LIB_VIEW_VCD) -- the two
+// stopped meaning the same thing once a page could have more than two lists.
+int libViewRingSize(int mode);
+
+// The view a page is currently showing. Always a stop in that page's ring; LIB_VIEW_ISO for a mode
+// with no ring of its own.
+int libViewActive(int mode);
+
+// The view an item list is showing. A normal source delegates to libViewActive(mode); a Favourites
+// shallow proxy may force a view through item_list_t.viewOverride without disturbing the real
+// source page's own L3 state.
+int libListViewActive(const item_list_t *itemList);
+
+// L3: advance to the next supported stop, wrapping, and mark the mode dirty. No-op when the global
+// default-view setting pins the page, or when the ring has fewer than two stops.
+void libViewAdvance(int mode);
+
+// Returns 1 exactly once after an advance (and clears the flag). Call from the support's
+// itemNeedsUpdate so the forced rescan cannot be swallowed by per-generation device caching.
+int libViewConsumeDirty(int mode);
+
+// Mark one ringed mode dirty after its storage changes. Runtime callers still enqueue that
+// support's normal deferred update; this only makes the existing NeedsUpdate path rescan it.
+void libViewMarkDirty(int mode);
+
+// Mark every ringed mode dirty (one rescan each) -- used when a global setting changes what the
+// lists contain or how they sort. Deliberately side-effect-free: it also runs during early config
+// loading, before the IO worker and device modules exist, so runtime callers must additionally
+// enqueue the deferred updates themselves (oplQueueLibraryDeviceUpdates).
+void libViewMarkAllDirty(void);
+
+#endif

--- a/include/libview.h
+++ b/include/libview.h
@@ -6,11 +6,16 @@
   Library view state: which of a page's several lists is on screen, and the L3 ring that moves
   between them.
 
-  This replaces the binary per-mode VCD flag that used to live in vcdsupport.c. That flag answered
-  one yes/no question -- "is this page showing its VCD list?" -- which stopped being expressible the
-  moment a page could show a THIRD list (CUE, PS1 via Ember). A retained boolean helper would have
-  answered "no" for a CUE page and routed CUE rows down the ISO path, silently. The whole point of
-  this file is that every caller now names the view it means.
+  There are exactly two stops: PS2 discs, and PS1. The PS1 stop is deliberately ONE list holding
+  BOTH PS1 cores' titles -- POPSTARTER *.VCD entries and Ember game folders, interleaved and sorted
+  together. A user thinks "PS1", not "which emulator", so the front end does too; which core launches
+  a given row is a property of the ROW, resolved at launch time, and never of the page.
+
+  This replaces the binary per-mode VCD flag that used to live in vcdsupport.c. That flag was named
+  for one of the two cores, and every caller had to ask "is it VCD?" to mean "is it PS1?". The ring
+  machinery below is kept general (supported-stop set, wrap-around advance) so a genuinely separate
+  third list can be added later without another rewrite -- but adding one is a UI decision, not a
+  consequence of supporting another core.
 
   A page's ring is the ordered set of views it supports. L3 advances one stop and wraps. The global
   gDefaultGameView setting can PIN every page that has a given stop to it, which makes L3 inert --
@@ -27,10 +32,8 @@
 #include "include/iosupport.h"
 
 enum LIB_VIEW {
-    LIB_VIEW_ISO = 0, // disc games: PS2 ISO / ZSO / UL / HDL
-    LIB_VIEW_VCD,     // PS1 via POPSTARTER (*.VCD)
-    LIB_VIEW_CUE,     // PS1 via Ember (a game folder holding *.cue / *.bin / *.exe)
-    LIB_VIEW_ELF,     // homebrew ELFs
+    LIB_VIEW_ISO = 0, // PS2 disc games: ISO / ZSO / UL / HDL
+    LIB_VIEW_PS1,     // PS1 titles, BOTH cores together (see the note above)
     LIB_VIEW_COUNT
 };
 
@@ -40,7 +43,7 @@ int libViewSupported(int mode, int view);
 
 // How many stops this mode's ring has. 1 means there is nothing to toggle: L3 is inert and the
 // on-screen hint is suppressed. Callers that used to ask "does this device have a VCD view" to
-// decide whether to offer the toggle want THIS, not libViewSupported(mode, LIB_VIEW_VCD) -- the two
+// decide whether to offer the toggle want THIS, not libViewSupported(mode, LIB_VIEW_PS1) -- the two
 // stopped meaning the same thing once a page could have more than two lists.
 int libViewRingSize(int mode);
 

--- a/include/opl.h
+++ b/include/opl.h
@@ -96,9 +96,9 @@ extern int gDeinitTerminal; // 1 while deinit() runs for exit/poweroff, 0 for a 
 extern int gArtAbandoned;   // 1 when cacheEnd() could NOT join the art worker: a thread is still inside a
                             // device read while teardown proceeds. hddCleanUp skips its unmount and
                             // PDIOC_CLOSEALL when set -- see the comment there.
-// Enqueue a deferred list rebuild for every enabled VCD-capable page (vcdMarkAllDirty is
+// Enqueue a deferred list rebuild for every enabled page that has a list ring (libViewMarkAllDirty is
 // side-effect-free by design; runtime view changes must explicitly queue the rebuilds).
-void oplQueueVcdDeviceUpdates(void);
+void oplQueueLibraryDeviceUpdates(void);
 
 // Shutdown minimal services initiated for auto loading.
 void miniDeinit(config_set_t *configSet);

--- a/include/system.h
+++ b/include/system.h
@@ -47,6 +47,18 @@ int sysNeutrinoPreflight(const char *driver, const char *neutrinoPath);
 // "<POPS>/<prefix><name>.ELF" token. Caller deinit()s with UNMOUNT_EXCEPTION first.
 void sysLaunchPopstarter(const char *popstarterElf, const char *selector);
 
+// Launch an external ember.elf for a PS1 CUE title (the second PS1 core; see include/cuesupport.h).
+//   emberElf   full path of ember.elf. It is ALSO the target's argv[0], and that is load-bearing:
+//              ps2sdk's __init_cwd derives Ember's working directory from argv[0], so everything
+//              Ember opens -- bios.bin, settings.txt, games/ -- resolves relative to it.
+//   gameFolder the BARE game-folder name under <emberdir>/games/. Ember refuses '/', ':' and '\\'
+//              anywhere in it, so validate with cueNameLaunchable() first. NULL or "" passes no
+//              game argument at all, which is Ember's own default: it then looks for games/default
+//              and otherwise runs the PS1 BIOS shell.
+// Caller deinit()s with UNMOUNT_EXCEPTION first and MUST leave the game's device mounted -- Ember
+// performs no IOP reset of its own and cannot bring a device back up.
+void sysLaunchEmber(const char *emberElf, const char *gameFolder);
+
 // ELF handoff that KEEPS the IOP (drivers + mounts) alive -- NHDDL parity: the vendored elfldr/
 // child loader SifLoadElf()s the target through OPL's live mounts and never SifIopReset()s (the
 // target resets the IOP itself). argv is the target's FULL argv, argv[0] INCLUDED and

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -80,10 +80,16 @@ void vcdBuildSelector(const char *devPrefix, const char *prefix, const char *nam
 // Returns texDiscoverLoad's result (>= 0 hit, negative miss).
 int vcdLoadPopsCover(const char *scanPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex);
 
-// ---- per-device VCD view -----------------------------------------------------------
-// The view state itself now lives in libview.h: which list a page shows became an N-way ring
-// (ISO / VCD / CUE / ELF) the moment a second PS1 core arrived, and a boolean "is it VCD?" helper
-// could only answer that question wrongly for the new stops. Ask libViewActive(mode) == LIB_VIEW_VCD.
+// ---- PS1 list display --------------------------------------------------------------
+// The view state itself lives in libview.h; ask libViewActive(mode) == LIB_VIEW_PS1. Note that one
+// PS1 list holds BOTH cores' titles, so "is this page showing PS1" and "is this row a .VCD" are
+// different questions -- the second is a property of the ROW (cueIsCueEntry, cuesupport.h).
+//
+// Sort/display key for a PS1 row's name: skips the leading game-ID prefix while gVcdHideGameId is
+// on, so the visible order matches the visible text. Returns a pointer INTO `name`. Exported so the
+// merged PS1 list sorts by exactly the rule the VCD-only scan always used -- one definition of it,
+// not two that can drift apart.
+const char *vcdSortKey(const char *name);
 //
 // Display-only: strip a leading PS1 game-ID prefix from a VCD list name when the gVcdHideGameId
 // setting is on and `mode` is showing its VCD list; returns `text` unchanged otherwise. COSMETIC --

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -80,27 +80,15 @@ void vcdBuildSelector(const char *devPrefix, const char *prefix, const char *nam
 // Returns texDiscoverLoad's result (>= 0 hit, negative miss).
 int vcdLoadPopsCover(const char *scanPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex);
 
-// ---- per-device VCD view (L3 toggle) ----------------------------------------------
-// Does this device class get a VCD view? (BDM range, MMCE, ETH, and the APA/PFS HDD.)
-int vcdModeSupported(int mode);
-// Is the given device mode currently showing its VCD list (vs its disc list)?
-int vcdViewActive(int mode);
-// Same query for an item-list instance. A normal source delegates to vcdViewActive(mode); a
-// Favourites shallow proxy may force ISO or VCD without changing the source page's own L3 state.
-int vcdListViewActive(const item_list_t *itemList);
+// ---- per-device VCD view -----------------------------------------------------------
+// The view state itself now lives in libview.h: which list a page shows became an N-way ring
+// (ISO / VCD / CUE / ELF) the moment a second PS1 core arrived, and a boolean "is it VCD?" helper
+// could only answer that question wrongly for the new stops. Ask libViewActive(mode) == LIB_VIEW_VCD.
+//
 // Display-only: strip a leading PS1 game-ID prefix from a VCD list name when the gVcdHideGameId
-// setting is on and `mode` is a VCD view; returns `text` unchanged otherwise. COSMETIC -- the
-// result is for on-screen text only, never for launch/art/favourites/config lookups.
+// setting is on and `mode` is showing its VCD list; returns `text` unchanged otherwise. COSMETIC --
+// the result is for on-screen text only, never for launch/art/favourites/config lookups.
 const char *vcdDisplayName(int mode, const char *text);
-// Flip the VCD view for a mode + mark it dirty so the owning support's NeedsUpdate forces a rescan.
-void vcdToggleView(int mode);
-// Returns 1 exactly once after a toggle (and clears the flag) -- call from the support's NeedsUpdate.
-int vcdConsumeDirty(int mode);
-// Mark one VCD-capable mode dirty after its VCD storage changes. Runtime callers still enqueue that
-// support's normal deferred update; this only makes the existing NeedsUpdate path rescan it.
-void vcdMarkDirty(int mode);
-// Mark all VCD-capable modes dirty (one rescan each) -- used when the global default-view setting changes.
-void vcdMarkAllDirty(void);
 
 // Fill a base_game_info_t list (memalign'd like sbReadList; frees *outGames first) from
 // <devPrefix>POPS/*.VCD. Returns the count. name/startup = VCD basename without the extension.

--- a/lng_fork/Albanian.yml
+++ b/lng_fork/Albanian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Shkruaj Konfigurimin e Rrjetit POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Ruaj gjithashtu këto vlera IP + SMB në IPCONFIG.DAT / SMBCONFIG.DAT të POPSTARTER në kartën e memories (për VCD mbi SMB).
   POPSTARTER_NET_ERR: Nuk u shkrua konfigurimi i rrjetit POPSTARTER në kartën e memories.
-  VCD: VCD
-  VCD_ON: Po shfaq lojërat VCD
+  VCD: PS1
+  VCD_ON: Po shfaq lojërat PS1
   VCD_OFF: Po shfaq lojërat e diskut
   NEUTRINO_ARGS: Argumente të Nisjes Neutrino
   HINT_NEUTRINO_ARGS: Flamurë shtesë Neutrino, të ndarë me hapësira (p.sh. -mt=dvd). Globale zbatohet për të gjitha lojërat; për-lojë shtohet sipër. Parashtro një flamur me $ për ta çaktivizuar pa fshirë.

--- a/lng_fork/Arabic.yml
+++ b/lng_fork/Arabic.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: كتابة إعدادات شبكة POPSTARTER
   HINT_WRITE_POPSTARTER_NET: احفظ قيم IP + SMB أيضاً في IPCONFIG.DAT / SMBCONFIG.DAT الخاصة بـ POPSTARTER على بطاقة الذاكرة (لـ VCD عبر SMB).
   POPSTARTER_NET_ERR: تعذّرت كتابة إعدادات شبكة POPSTARTER على بطاقة الذاكرة.
-  VCD: VCD
-  VCD_ON: عرض ألعاب VCD
+  VCD: PS1
+  VCD_ON: عرض ألعاب PS1
   VCD_OFF: عرض ألعاب الأقراص
   NEUTRINO_ARGS: وسيطات تشغيل Neutrino
   HINT_NEUTRINO_ARGS: أعلام Neutrino إضافية مفصولة بمسافة (مثال -mt=dvd). العامة تُطبَّق على جميع الألعاب؛ الخاصة بالعبة تُضاف فوقها. ضع $ قبل العلم لتعطيله دون حذفه.

--- a/lng_fork/Bulgarian.yml
+++ b/lng_fork/Bulgarian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Запис на мрежова конфигурация на POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Записва стойностите на IP + SMB споделяне в собствените IPCONFIG.DAT / SMBCONFIG.DAT на POPSTARTER на картата с памет (за VCD по SMB).
   POPSTARTER_NET_ERR: Неуспешен запис на мрежовата конфигурация на POPSTARTER в картата с памет.
-  VCD: VCD
-  VCD_ON: Показване на VCD игри
+  VCD: PS1
+  VCD_ON: Показване на PS1 игри
   VCD_OFF: Показване на дискови игри
   NEUTRINO_ARGS: Аргументи за стартиране на Neutrino
   HINT_NEUTRINO_ARGS: Допълнителни флагове на Neutrino, разделени с интервал (напр. -mt=dvd). Глобалните се прилагат за всички игри; за отделна игра се добавят отгоре. Поставете $ пред флаг, за да го деактивирате без изтриване.

--- a/lng_fork/Cebuano.yml
+++ b/lng_fork/Cebuano.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: I-sulat ang POPSTARTER Network Config
   HINT_WRITE_POPSTARTER_NET: I-save usab kining IP + SMB share nga mga kantidad sa kaugalingon nga IPCONFIG.DAT / SMBCONFIG.DAT sa POPSTARTER sa memory card (para sa VCD-over-SMB).
   POPSTARTER_NET_ERR: Dili ma-sulat ang POPSTARTER network config sa memory card.
-  VCD: VCD
-  VCD_ON: Gipakita ang VCD games
+  VCD: PS1
+  VCD_ON: Gipakita ang PS1 games
   VCD_OFF: Gipakita ang disc games
   NEUTRINO_ARGS: Neutrino Launch Args
   HINT_NEUTRINO_ARGS: Dugang Neutrino flags, gibulag og espasyo (hal. -mt=dvd). Global alang sa tanan nga laro; per-game dugang pa. Ibutang ang $ sa unahan sa flag aron ma-disable nga dili pa ma-delete.

--- a/lng_fork/Croatian.yml
+++ b/lng_fork/Croatian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Spremi POPSTARTER mrežnu konfiguraciju
   HINT_WRITE_POPSTARTER_NET: Spremi ove IP + SMB vrijednosti i u POPSTARTER-ove IPCONFIG.DAT / SMBCONFIG.DAT na memorijskoj kartici (za VCD-over-SMB).
   POPSTARTER_NET_ERR: Nije moguće zapisati POPSTARTER mrežnu konfiguraciju na memorijsku karticu.
-  VCD: VCD
-  VCD_ON: Prikazuju se VCD igre
+  VCD: PS1
+  VCD_ON: Prikazuju se PS1 igre
   VCD_OFF: Prikazuju se disk igre
   NEUTRINO_ARGS: Neutrino Argumenti pokretanja
   HINT_NEUTRINO_ARGS: Dodatne Neutrino zastavice, odvojene razmacima (npr. -mt=dvd). Globalno vrijedi za sve igre; po igri dodaje na vrh. Prefiks zastavice s $ onemogućuje je bez brisanja.

--- a/lng_fork/Czech.yml
+++ b/lng_fork/Czech.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Zapsat síťovou konfiguraci POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Uložit také tyto hodnoty IP + SMB sdílení do vlastních souborů POPSTARTER IPCONFIG.DAT / SMBCONFIG.DAT na paměťové kartě (pro VCD přes SMB).
   POPSTARTER_NET_ERR: Nepodařilo se zapsat síťovou konfiguraci POPSTARTER na paměťovou kartu.
-  VCD: VCD
-  VCD_ON: Zobrazuji VCD hry
+  VCD: PS1
+  VCD_ON: Zobrazuji PS1 hry
   VCD_OFF: Zobrazuji diskové hry
   NEUTRINO_ARGS: Neutrino Spouštěcí Args
   HINT_NEUTRINO_ARGS: 'Extra příznaky Neutrino, oddělené mezerami (např. -mt=dvd). Globální platí pro všechny hry; na hru se přidá navíc. Prefix příznaku $ ho zakáže bez smazání.'

--- a/lng_fork/Danish.yml
+++ b/lng_fork/Danish.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Skriv POPSTARTER-netværkskonfig
   HINT_WRITE_POPSTARTER_NET: Gem også disse IP + SMB-delingsværdier til POPSTARTERs egne IPCONFIG.DAT / SMBCONFIG.DAT på hukommelseskortet (til VCD over SMB).
   POPSTARTER_NET_ERR: Kunne ikke skrive POPSTARTER-netværkskonfig til hukommelseskortet.
-  VCD: VCD
-  VCD_ON: Viser VCD-spil
+  VCD: PS1
+  VCD_ON: Viser PS1-spil
   VCD_OFF: Viser diskspil
   NEUTRINO_ARGS: Neutrino-startargumenter
   HINT_NEUTRINO_ARGS: 'Ekstra Neutrino-flag, mellemrumsadskilt (f.eks. -mt=dvd). Global gælder alle spil; per spil tilføjes ovenpå. Præfiks et flag med $ for at deaktivere det uden at slette det.'

--- a/lng_fork/Dutch.yml
+++ b/lng_fork/Dutch.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: POPSTARTER-netwerkconfiguratie schrijven
   HINT_WRITE_POPSTARTER_NET: Sla ook deze IP- en SMB-sharewaarden op in POPSTARTER's eigen IPCONFIG.DAT / SMBCONFIG.DAT op de geheugenkaart (voor VCD via SMB).
   POPSTARTER_NET_ERR: Kan POPSTARTER-netwerkconfiguratie niet naar de geheugenkaart schrijven.
-  VCD: VCD
-  VCD_ON: VCD-spellen worden getoond
+  VCD: PS1
+  VCD_ON: PS1-spellen worden getoond
   VCD_OFF: Schijfspellen worden getoond
   NEUTRINO_ARGS: Neutrino opstartargumenten
   HINT_NEUTRINO_ARGS: Extra Neutrino-vlaggen, spatie-gescheiden (bijv. -mt=dvd). Globaal geldt voor alle spellen; per spel wordt bovenop toegevoegd. Prefix een vlag met $ om hem te deactiveren zonder te verwijderen.

--- a/lng_fork/Filipino.yml
+++ b/lng_fork/Filipino.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: I-save ang POPSTARTER Network Config
   HINT_WRITE_POPSTARTER_NET: I-save din ang mga IP + SMB share na ito sa sariling IPCONFIG.DAT / SMBCONFIG.DAT ng POPSTARTER sa memory card (para sa VCD-over-SMB).
   POPSTARTER_NET_ERR: Hindi nasulat ang POPSTARTER network config sa memory card.
-  VCD: VCD
-  VCD_ON: Ipinapakita ang mga VCD game
+  VCD: PS1
+  VCD_ON: Ipinapakita ang mga PS1 game
   VCD_OFF: Ipinapakita ang mga disc game
   NEUTRINO_ARGS: Neutrino Launch Args
   HINT_NEUTRINO_ARGS: Karagdagang Neutrino flags, pinaghiwalay ng espasyo (hal. -mt=dvd). Ang Global ay naaangkop sa lahat ng laro; ang per-game ay nadaragdag pa. Lagyan ng $ prefix ang isang flag para i-disable nang hindi binubura.

--- a/lng_fork/French.yml
+++ b/lng_fork/French.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Écrire la config réseau POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Enregistre également les valeurs IP + partage SMB dans IPCONFIG.DAT / SMBCONFIG.DAT de POPSTARTER sur la carte mémoire (pour VCD via SMB).
   POPSTARTER_NET_ERR: Impossible d'écrire la config réseau POPSTARTER sur la carte mémoire.
-  VCD: VCD
-  VCD_ON: Affichage des jeux VCD
+  VCD: PS1
+  VCD_ON: Affichage des jeux PS1
   VCD_OFF: Affichage des jeux disque
   NEUTRINO_ARGS: Arguments de lancement Neutrino
   HINT_NEUTRINO_ARGS: Options Neutrino supplémentaires, séparées par des espaces (ex. -mt=dvd). Global s'applique à tous les jeux ; par jeu s'ajoute en plus. Préfixez un paramètre avec $ pour le désactiver sans le supprimer.

--- a/lng_fork/German.yml
+++ b/lng_fork/German.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: POPSTARTER Netzwerkkonfiguration schreiben
   HINT_WRITE_POPSTARTER_NET: Diese IP- und SMB-Freigabewerte auch in POPSTARTER's eigene IPCONFIG.DAT / SMBCONFIG.DAT auf der Speicherkarte schreiben (für VCD über SMB).
   POPSTARTER_NET_ERR: POPSTARTER-Netzwerkkonfiguration konnte nicht auf die Speicherkarte geschrieben werden.
-  VCD: VCD
-  VCD_ON: VCD-Spiele werden angezeigt
+  VCD: PS1
+  VCD_ON: PS1-Spiele werden angezeigt
   VCD_OFF: Disc-Spiele werden angezeigt
   NEUTRINO_ARGS: Neutrino Startargumente
   HINT_NEUTRINO_ARGS: 'Zusätzliche Neutrino-Flags, durch Leerzeichen getrennt (z.B. -mt=dvd). Global gilt für alle Spiele; pro Spiel wird obendrauf addiert. Flag mit $ präfixieren, um es ohne Löschen zu deaktivieren.'

--- a/lng_fork/Greek.yml
+++ b/lng_fork/Greek.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Εγγραφή Ρύθμισης Δικτύου POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Αποθήκευση τιμών IP + SMB και στα IPCONFIG.DAT / SMBCONFIG.DAT του POPSTARTER στην κάρτα μνήμης (για VCD μέσω SMB).
   POPSTARTER_NET_ERR: Αποτυχία εγγραφής ρύθμισης δικτύου POPSTARTER στην κάρτα μνήμης.
-  VCD: VCD
-  VCD_ON: Εμφάνιση VCD παιχνιδιών
+  VCD: PS1
+  VCD_ON: Εμφάνιση PS1 παιχνιδιών
   VCD_OFF: Εμφάνιση παιχνιδιών δίσκου
   NEUTRINO_ARGS: Ορίσματα Εκκίνησης Neutrino
   HINT_NEUTRINO_ARGS: 'Επιπλέον σημαίες Neutrino, διαχωρισμένες με κενό (π.χ. -mt=dvd). Το καθολικό ισχύει για όλα τα παιχνίδια· ανά παιχνίδι προστίθεται επιπλέον. Προσθέστε $ πριν μια σημαία για απενεργοποίηση χωρίς διαγραφή.'

--- a/lng_fork/Hungarian.yml
+++ b/lng_fork/Hungarian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: POPSTARTER hálózati konfiguráció írása
   HINT_WRITE_POPSTARTER_NET: Az IP + SMB megosztási értékek mentése a POPSTARTER saját IPCONFIG.DAT / SMBCONFIG.DAT fájljaiba a memóriakártyán (SMB-n keresztüli VCD-hez).
   POPSTARTER_NET_ERR: Nem sikerült a POPSTARTER hálózati konfigurációt a memóriakártyára írni.
-  VCD: VCD
-  VCD_ON: VCD játékok megjelenítése
+  VCD: PS1
+  VCD_ON: PS1 játékok megjelenítése
   VCD_OFF: Lemezes játékok megjelenítése
   NEUTRINO_ARGS: Neutrino indítási argumentumok
   HINT_NEUTRINO_ARGS: 'Extra Neutrino jelzők, szóközzel elválasztva (pl. -mt=dvd). A globális minden játékra vonatkozik; a játékonkénti hozzáadódik. Egy jelző elé írj $ jelet a letiltásához törlés nélkül.'

--- a/lng_fork/Indonesian.yml
+++ b/lng_fork/Indonesian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Tulis Konfigurasi Jaringan POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Simpan juga nilai IP + SMB share ini ke IPCONFIG.DAT / SMBCONFIG.DAT milik POPSTARTER di kartu memori (untuk VCD lewat SMB).
   POPSTARTER_NET_ERR: Gagal menulis konfigurasi jaringan POPSTARTER ke kartu memori.
-  VCD: VCD
-  VCD_ON: Menampilkan game VCD
+  VCD: PS1
+  VCD_ON: Menampilkan game PS1
   VCD_OFF: Menampilkan game disc
   NEUTRINO_ARGS: Argumen Launch Neutrino
   HINT_NEUTRINO_ARGS: 'Flag Neutrino tambahan, dipisah spasi (misal -mt=dvd). Global berlaku untuk semua game; per-game ditambahkan di atasnya. Awali flag dengan $ untuk menonaktifkan tanpa menghapus.'

--- a/lng_fork/Italian.yml
+++ b/lng_fork/Italian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Scrivi Config di Rete POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Salva anche i valori IP + condivisione SMB nei file IPCONFIG.DAT / SMBCONFIG.DAT di POPSTARTER sulla memory card (per VCD via SMB).
   POPSTARTER_NET_ERR: Impossibile scrivere la config di rete POPSTARTER sulla memory card.
-  VCD: VCD
-  VCD_ON: Mostra giochi VCD
+  VCD: PS1
+  VCD_ON: Mostra giochi PS1
   VCD_OFF: Mostra giochi da disco
   NEUTRINO_ARGS: Argomenti Avvio Neutrino
   HINT_NEUTRINO_ARGS: Flag extra Neutrino, separati da spazio (es. -mt=dvd). Globale si applica a tutti i giochi; per-gioco si aggiunge. Anteponi $ a un flag per disabilitarlo senza eliminarlo.

--- a/lng_fork/Japanese.yml
+++ b/lng_fork/Japanese.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: POPSTARTER ネットワーク設定を書き込む
   HINT_WRITE_POPSTARTER_NET: IP と SMB 共有の値をメモリーカード上の POPSTARTER 専用 IPCONFIG.DAT / SMBCONFIG.DAT にも保存します（SMB 経由の VCD 用）。
   POPSTARTER_NET_ERR: メモリーカードへの POPSTARTER ネットワーク設定の書き込みに失敗しました。
-  VCD: VCD
-  VCD_ON: VCD ゲームを表示中
+  VCD: PS1
+  VCD_ON: PS1 ゲームを表示中
   VCD_OFF: ディスクゲームを表示中
   NEUTRINO_ARGS: Neutrino 起動引数
   HINT_NEUTRINO_ARGS: 追加の Neutrino フラグをスペース区切りで指定（例 -mt=dvd）。グローバルは全ゲームに適用、ゲーム個別はその上に追加。フラグの先頭に $ を付けると削除せずに無効化できます。

--- a/lng_fork/Korean.yml
+++ b/lng_fork/Korean.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: POPSTARTER 네트워크 설정 저장
   HINT_WRITE_POPSTARTER_NET: IP + SMB 공유 값을 메모리 카드의 POPSTARTER용 IPCONFIG.DAT / SMBCONFIG.DAT에도 저장합니다 (SMB 경유 VCD용).
   POPSTARTER_NET_ERR: 메모리 카드에 POPSTARTER 네트워크 설정을 쓸 수 없습니다.
-  VCD: VCD
-  VCD_ON: VCD 게임 표시 중
+  VCD: PS1
+  VCD_ON: PS1 게임 표시 중
   VCD_OFF: 디스크 게임 표시 중
   NEUTRINO_ARGS: Neutrino 실행 인수
   HINT_NEUTRINO_ARGS: '추가 Neutrino 플래그, 공백으로 구분 (예: -mt=dvd). 전역은 모든 게임에 적용; 게임별은 추가됩니다. 플래그 앞에 $를 붙이면 삭제 없이 비활성화됩니다.'

--- a/lng_fork/Laotian.yml
+++ b/lng_fork/Laotian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: ບັນທຶກ POPSTARTER Network Config
   HINT_WRITE_POPSTARTER_NET: ບັນທຶກຄ່າ IP + SMB share ນີ້ໄປຍັງ IPCONFIG.DAT / SMBCONFIG.DAT ຂອງ POPSTARTER ໃນ memory card (ສຳລັບ VCD ຜ່ານ SMB).
   POPSTARTER_NET_ERR: ບໍ່ສາມາດບັນທຶກ network config ຂອງ POPSTARTER ລົງ memory card.
-  VCD: VCD
-  VCD_ON: ກຳລັງສະແດງເກມ VCD
+  VCD: PS1
+  VCD_ON: ກຳລັງສະແດງເກມ PS1
   VCD_OFF: ກຳລັງສະແດງເກມ disc
   NEUTRINO_ARGS: Neutrino Launch Args
   HINT_NEUTRINO_ARGS: "flags Neutrino ເພີ່ມເຕີມ, ຄັ່ນດ້ວຍຍະຫວ່າງ (ເຊັ່ນ -mt=dvd). Global ໃຊ້ກັບທຸກເກມ; ຕໍ່ເກມເພີ່ມໄລຍ. ໃສ່ $ ໜ້າ flag ເພື່ອປິດໂດຍບໍ່ລຶບ."

--- a/lng_fork/Persian.yml
+++ b/lng_fork/Persian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: نوشتن تنظیمات شبکه POPSTARTER
   HINT_WRITE_POPSTARTER_NET: 'مقادیر IP + SMB را در IPCONFIG.DAT / SMBCONFIG.DAT مربوط به POPSTARTER روی کارت حافظه ذخیره کنید (برای VCD از طریق SMB).'
   POPSTARTER_NET_ERR: نوشتن تنظیمات شبکه POPSTARTER روی کارت حافظه ناموفق بود.
-  VCD: VCD
-  VCD_ON: نمایش بازی‌های VCD
+  VCD: PS1
+  VCD_ON: نمایش بازی‌های PS1
   VCD_OFF: نمایش بازی‌های دیسک
   NEUTRINO_ARGS: آرگومان‌های اجرای Neutrino
   HINT_NEUTRINO_ARGS: فلگ‌های اضافی Neutrino، جداشده با فاصله (مثلاً -mt=dvd). کلی روی همه بازی‌ها اعمال می‌شود؛ هر بازی می‌تواند فلگ اضافه کند. پیشوند $ فلگ را بدون حذف غیرفعال می‌کند.

--- a/lng_fork/Polish.yml
+++ b/lng_fork/Polish.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Zapisz konfigurację sieciową POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Zapisz również wartości IP + udziału SMB do własnych plików IPCONFIG.DAT / SMBCONFIG.DAT POPSTARTERa na karcie pamięci (dla VCD przez SMB).
   POPSTARTER_NET_ERR: Nie można zapisać konfiguracji sieciowej POPSTARTER na kartę pamięci.
-  VCD: VCD
-  VCD_ON: Wyświetlanie gier VCD
+  VCD: PS1
+  VCD_ON: Wyświetlanie gier PS1
   VCD_OFF: Wyświetlanie gier z dysku
   NEUTRINO_ARGS: Argumenty uruchamiania Neutrino
   HINT_NEUTRINO_ARGS: Dodatkowe flagi Neutrino, oddzielone spacjami (np. -mt=dvd). Globalne dotyczą wszystkich gier; dla gry dodawane na wierzch. Poprzedź flagę $ aby ją wyłączyć bez usuwania.

--- a/lng_fork/Portuguese.yml
+++ b/lng_fork/Portuguese.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Gravar Config de Rede do POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Guarda também estes valores de IP + partilha SMB nos ficheiros IPCONFIG.DAT / SMBCONFIG.DAT do POPSTARTER no cartão de memória (para VCD via SMB).
   POPSTARTER_NET_ERR: Não foi possível gravar a configuração de rede do POPSTARTER no cartão de memória.
-  VCD: VCD
-  VCD_ON: A mostrar jogos VCD
+  VCD: PS1
+  VCD_ON: A mostrar jogos PS1
   VCD_OFF: A mostrar jogos de disco
   NEUTRINO_ARGS: Args de Lançamento Neutrino
   HINT_NEUTRINO_ARGS: Flags extra do Neutrino, separadas por espaço (ex. -mt=dvd). Global aplica-se a todos os jogos; por jogo acrescenta. Prefixe uma flag com $ para desativá-la sem apagar.

--- a/lng_fork/Portuguese_BR.yml
+++ b/lng_fork/Portuguese_BR.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Gravar Config de Rede do POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Salva também os valores de IP + compartilhamento SMB nos arquivos IPCONFIG.DAT / SMBCONFIG.DAT do POPSTARTER no cartão de memória (para VCD via SMB).
   POPSTARTER_NET_ERR: Não foi possível gravar a configuração de rede do POPSTARTER no cartão de memória.
-  VCD: VCD
-  VCD_ON: Exibindo jogos VCD
+  VCD: PS1
+  VCD_ON: Exibindo jogos PS1
   VCD_OFF: Exibindo jogos em disco
   NEUTRINO_ARGS: Args de Inicialização do Neutrino
   HINT_NEUTRINO_ARGS: Flags extras do Neutrino, separadas por espaço (ex. -mt=dvd). Global aplica a todos os jogos; por jogo adiciona ao topo. Prefixe uma flag com $ para desativá-la sem excluir.

--- a/lng_fork/Romana.yml
+++ b/lng_fork/Romana.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Scrie Config Rețea POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Salvează și valorile IP + SMB în IPCONFIG.DAT / SMBCONFIG.DAT proprii ale POPSTARTER pe cardul de memorie (pentru VCD prin SMB).
   POPSTARTER_NET_ERR: Nu s-a putut scrie configurația de rețea POPSTARTER pe cardul de memorie.
-  VCD: VCD
-  VCD_ON: Se afișează jocuri VCD
+  VCD: PS1
+  VCD_ON: Se afișează jocuri PS1
   VCD_OFF: Se afișează jocuri disc
   NEUTRINO_ARGS: Argumente Lansare Neutrino
   HINT_NEUTRINO_ARGS: Indicatori Neutrino suplimentari, separați prin spațiu (ex. -mt=dvd). Global se aplică tuturor jocurilor; per-joc se adaugă în plus. Prefixați un indicator cu $ pentru a-l dezactiva fără a-l șterge.

--- a/lng_fork/Russian.yml
+++ b/lng_fork/Russian.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Записать сетевую конфигурацию POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Также сохранить значения IP + SMB в IPCONFIG.DAT / SMBCONFIG.DAT POPSTARTER на карте памяти (для VCD через SMB).
   POPSTARTER_NET_ERR: Не удалось записать сетевую конфигурацию POPSTARTER на карту памяти.
-  VCD: VCD
-  VCD_ON: Показаны VCD-игры
+  VCD: PS1
+  VCD_ON: Показаны PS1-игры
   VCD_OFF: Показаны дисковые игры
   NEUTRINO_ARGS: Аргументы запуска Neutrino
   HINT_NEUTRINO_ARGS: Дополнительные флаги Neutrino через пробел (напр. -mt=dvd). Глобальные применяются ко всем играм; игровые добавляются поверх. Префикс $ отключает флаг без удаления.

--- a/lng_fork/Ryukyuan.yml
+++ b/lng_fork/Ryukyuan.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: POPSTARTER ネットワーク設定を書き込む
   HINT_WRITE_POPSTARTER_NET: IP と SMB 共有の値をメモリーカード上の POPSTARTER 用 IPCONFIG.DAT / SMBCONFIG.DAT にも保存すん（VCD-over-SMB 向け）。
   POPSTARTER_NET_ERR: POPSTARTER ネットワーク設定をメモリーカードに書き込めんかた。
-  VCD: VCD
-  VCD_ON: VCD ゲームを表示中
+  VCD: PS1
+  VCD_ON: PS1 ゲームを表示中
   VCD_OFF: ディスクゲームを表示中
   NEUTRINO_ARGS: Neutrino 起動引数
   HINT_NEUTRINO_ARGS: 'Neutrino 追加フラグをスペース区切りで入力（例: -mt=dvd）。グローバルは全ゲームに適用、ゲーム別は追加分。フラグの前に $ を付けると削除せずに無効化できゅん。'

--- a/lng_fork/SChinese.yml
+++ b/lng_fork/SChinese.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: 写入 POPSTARTER 网络配置
   HINT_WRITE_POPSTARTER_NET: 同时将 IP 和 SMB 共享值保存到存储卡上 POPSTARTER 的 IPCONFIG.DAT / SMBCONFIG.DAT（用于 VCD over SMB）。
   POPSTARTER_NET_ERR: 无法将 POPSTARTER 网络配置写入存储卡。
-  VCD: VCD
-  VCD_ON: 正在显示 VCD 游戏
+  VCD: PS1
+  VCD_ON: 正在显示 PS1 游戏
   VCD_OFF: 正在显示光盘游戏
   NEUTRINO_ARGS: Neutrino 启动参数
   HINT_NEUTRINO_ARGS: 额外的 Neutrino 标志，以空格分隔（如 -mt=dvd）。全局参数适用于所有游戏；单游戏参数在此基础上追加。在标志前加 $ 可禁用而不删除。

--- a/lng_fork/Spanish.yml
+++ b/lng_fork/Spanish.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Escribir configuración de red de POPSTARTER
   HINT_WRITE_POPSTARTER_NET: También guarda estos valores de IP + recurso SMB en el propio IPCONFIG.DAT / SMBCONFIG.DAT de POPSTARTER en la tarjeta de memoria (para VCD por SMB).
   POPSTARTER_NET_ERR: No se pudo escribir la configuración de red de POPSTARTER en la tarjeta de memoria.
-  VCD: VCD
-  VCD_ON: Mostrando juegos VCD
+  VCD: PS1
+  VCD_ON: Mostrando juegos PS1
   VCD_OFF: Mostrando juegos de disco
   NEUTRINO_ARGS: Argumentos de lanzamiento de Neutrino
   HINT_NEUTRINO_ARGS: Flags adicionales de Neutrino separados por espacios (ej. -mt=dvd). Global se aplica a todos los juegos; por juego se añade encima. Prefija un flag con $ para desactivarlo sin borrarlo.

--- a/lng_fork/Swedish.yml
+++ b/lng_fork/Swedish.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Skriv POPSTARTER Nätverkskonfiguration
   HINT_WRITE_POPSTARTER_NET: Spara även dessa IP + SMB-delningsvärden till POPSTARTER's egna IPCONFIG.DAT / SMBCONFIG.DAT på minneskortet (för VCD via SMB).
   POPSTARTER_NET_ERR: Kunde inte skriva POPSTARTER-nätverkskonfiguration till minneskortet.
-  VCD: VCD
-  VCD_ON: Visar VCD-spel
+  VCD: PS1
+  VCD_ON: Visar PS1-spel
   VCD_OFF: Visar skivspel
   NEUTRINO_ARGS: Neutrino Startargument
   HINT_NEUTRINO_ARGS: Extra Neutrino-flaggor, blankstegsavskilda (t.ex. -mt=dvd). Global gäller alla spel; per-spel läggs till ovanpå. Prefix en flagga med $ för att inaktivera den utan att ta bort den.

--- a/lng_fork/TChinese.yml
+++ b/lng_fork/TChinese.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: 寫入 POPSTARTER 網路設定
   HINT_WRITE_POPSTARTER_NET: 同時將 IP 及 SMB 共享值儲存至記憶卡上 POPSTARTER 自身的 IPCONFIG.DAT / SMBCONFIG.DAT（用於 VCD over SMB）。
   POPSTARTER_NET_ERR: 無法將 POPSTARTER 網路設定寫入記憶卡。
-  VCD: VCD
-  VCD_ON: 顯示 VCD 遊戲
+  VCD: PS1
+  VCD_ON: 顯示 PS1 遊戲
   VCD_OFF: 顯示光碟遊戲
   NEUTRINO_ARGS: Neutrino 啟動參數
   HINT_NEUTRINO_ARGS: 額外的 Neutrino 旗標，以空格分隔（例如 -mt=dvd）。全域設定套用至所有遊戲；個別遊戲設定疊加於其上。在旗標前加 $ 可停用而不刪除。

--- a/lng_fork/Turkish.yml
+++ b/lng_fork/Turkish.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: POPSTARTER Ağ Yapılandırmasını Yaz
   HINT_WRITE_POPSTARTER_NET: Bu IP + SMB paylaşım değerlerini hafıza kartındaki POPSTARTER'ın IPCONFIG.DAT / SMBCONFIG.DAT dosyalarına da kaydet (SMB üzerinden VCD için).
   POPSTARTER_NET_ERR: POPSTARTER ağ yapılandırması hafıza kartına yazılamadı.
-  VCD: VCD
-  VCD_ON: VCD oyunları gösteriliyor
+  VCD: PS1
+  VCD_ON: PS1 oyunları gösteriliyor
   VCD_OFF: Disk oyunları gösteriliyor
   NEUTRINO_ARGS: Neutrino Başlatma Parametreleri
   HINT_NEUTRINO_ARGS: 'Ekstra Neutrino bayrakları, boşlukla ayrılmış (ör. -mt=dvd). Global tüm oyunlara uygulanır; oyun başına üstüne eklenir. Bir bayrağı silmeden devre dışı bırakmak için $ öneki ekleyin.'

--- a/lng_fork/Vietnamese.yml
+++ b/lng_fork/Vietnamese.yml
@@ -41,8 +41,8 @@ translations:
   WRITE_POPSTARTER_NET: Ghi cấu hình mạng POPSTARTER
   HINT_WRITE_POPSTARTER_NET: Cũng lưu các giá trị IP + SMB vào IPCONFIG.DAT / SMBCONFIG.DAT của POPSTARTER trên thẻ nhớ (dành cho VCD qua SMB).
   POPSTARTER_NET_ERR: Không thể ghi cấu hình mạng POPSTARTER vào thẻ nhớ.
-  VCD: VCD
-  VCD_ON: Đang hiển thị game VCD
+  VCD: PS1
+  VCD_ON: Đang hiển thị game PS1
   VCD_OFF: Đang hiển thị game đĩa
   NEUTRINO_ARGS: Tham số khởi động Neutrino
   HINT_NEUTRINO_ARGS: Cờ Neutrino bổ sung, cách nhau bằng dấu cách (vd. -mt=dvd). Toàn cục áp dụng cho tất cả game; riêng game cộng thêm. Thêm $ trước cờ để tắt mà không xóa.

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1160,3 +1160,5 @@ gui_strings:
   string: Missing bios.bin beside ember.elf
 - label: EMBER_BAD_NAME
   string: Ember cannot use this folder name (no slash, colon or backslash, and no leading dots).
+- label: EMBER_NO_DISC
+  string: No PS1 disc image in this Ember game folder.

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1003,9 +1003,9 @@ gui_strings:
 - label: NEUTRINO_VMC_HDD_UNSUPPORTED
   string: Neutrino cannot use a VMC on APA HDD (no pfs support) -- launching without it.
 - label: VCD
-  string: VCD
+  string: PS1
 - label: VCD_ON
-  string: Showing VCD games
+  string: Showing PS1 games
 - label: VCD_OFF
   string: Showing disc games
 - label: BOOT_SCANNING_BDM
@@ -1154,3 +1154,9 @@ gui_strings:
   string: HDD is busy. Try again once loading finishes.
 - label: GENERAL_SYSTEM
   string: General & System
+- label: EMBER_NOT_FOUND
+  string: Missing ember.elf
+- label: EMBER_BIOS_MISSING
+  string: Missing bios.bin beside ember.elf
+- label: EMBER_BAD_NAME
+  string: Ember cannot use this folder name (no slash, colon or backslash, and no leading dots).

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1162,3 +1162,5 @@ gui_strings:
   string: Ember cannot use this folder name (no slash, colon or backslash, and no leading dots).
 - label: EMBER_NO_DISC
   string: No PS1 disc image in this Ember game folder.
+- label: VIEW_APPS
+  string: Showing apps

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -10,6 +10,7 @@
 #include "include/bdmsupport.h"
 #include "include/ethsupport.h"
 #include "include/vcdsupport.h"
+#include "include/cuesupport.h"
 #include "include/hddsupport.h"
 #include "include/texcache.h"
 #include "include/textures.h"
@@ -140,6 +141,36 @@ static int appIsPopstarterSmb(const char *startup)
         return 0;
     return 1;
 }
+
+#ifdef __OPLDIAG
+// Ember probe (docs/EMBER-INTEGRATION-PLAN.md Phase 0): does this APPS boot path name an ember.elf?
+// Basename match only, case-insensitively -- FAT is case-insensitive and Ember's install folder is
+// the user's to name. Separator handling mirrors appIsPopstarterSmb above so smb0:\EMBER\ember.elf
+// is recognised too, without changing appGetELFName()'s semantics for other callers.
+static int appIsEmberElf(const char *startup)
+{
+    const char *base;
+    const char *p1;
+    const char *p2;
+    const char *p3;
+    const char *last;
+
+    if (startup == NULL || startup[0] == '\0')
+        return 0;
+
+    p1 = strrchr(startup, '/');
+    p2 = strrchr(startup, '\\');
+    p3 = strrchr(startup, ':');
+    last = p1;
+    if (p2 != NULL && (last == NULL || p2 > last))
+        last = p2;
+    if (p3 != NULL && (last == NULL || p3 > last))
+        last = p3;
+    base = (last != NULL) ? last + 1 : startup;
+
+    return strcasecmp(base, EMBER_ELF_NAME) == 0;
+}
+#endif
 
 static unsigned int appHashStartup(const char *value)
 {
@@ -838,6 +869,37 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
             argv[0] = altStartup;
             argc = 1;
         }
+
+#ifdef __OPLDIAG
+        // ---- Ember Phase 0 probe (docs/EMBER-INTEGRATION-PLAN.md Part 8) --------------------
+        // An APPS entry whose boot path names an ember.elf is handed over with the KEEP-IOP loader
+        // instead of the resetting SDK one below, passing argv1 through as the bare game-folder
+        // name. Ember performs no IOP reset of its own, so it needs the launcher's live driver
+        // stack; LoadELFFromFileWithPartition() a few lines down resets the IOP and is therefore
+        // the CONTROL CASE -- the identical entry on a release build is expected to fail, and that
+        // contrast is the measurement this probe exists to make.
+        //
+        // Diagnostic builds only, deliberately: an APPS row that silently launches through a
+        // different loader than every other APPS row would be a lying control in a shipping build.
+        // The real, user-visible launch path arrives with the CUE view and is not this.
+        if (appIsEmberElf(filename)) {
+            // Validate BEFORE deinit, while the GUI can still draw a dialog. An untranslated
+            // English string is correct here: this is OPLDIAG-only text, matching the existing
+            // convention for diagnostic detail (see setErrorMessageWithCodeAndDetail in opl.c).
+            const char *emberGame = (argc > 0) ? argv[0] : NULL;
+
+            if (emberGame != NULL && !cueNameLaunchable(emberGame)) {
+                guiMsgBox("Ember probe: argv1 must be a bare folder name under games/\n"
+                          "No '/', ':' or '\\', not starting with '..', max 180 chars.",
+                          0, NULL);
+                return;
+            }
+
+            deinit(UNMOUNT_EXCEPTION, mode); // keep THIS device mounted: Ember cannot remount it
+            sysLaunchEmber(filename, emberGame);
+            return; // reached only when the handoff itself failed; OPL is already torn down
+        }
+#endif
 
         deinit(UNMOUNT_EXCEPTION, mode); // CAREFUL: deinit will call appCleanUp, which frees appsList, appArtLookupTable, and configApps
         LoadELFFromFileWithPartition(filename, partition, argc, argv);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -4,7 +4,8 @@
 #include "include/supportbase.h"
 #include "include/bdmsupport.h"
 #include "include/vcdsupport.h"
-#include "include/libview.h" // libViewActive / libListViewActive -- which list this page shows
+#include "include/cuesupport.h" // PS1 rows can belong to either core; the ROW decides
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 #include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/themes.h"
@@ -200,7 +201,7 @@ static void bdmBuildGamePrefix(char *target, int targetLength, const char *devic
 // library folder: POPSTARTER's own BDMA driver always reads <root>/POPS/<name>.VCD, so a prefixed scan
 // ("mass0:<prefix>/POPS") would list VCDs that POPSTARTER can never boot -- they'd all drop to OSDSYS.
 // gBDMPrefix stays a PS2-game-library concept only.
-static void bdmBuildVcdPrefix(char *target, int targetLength, int massSlot)
+static void bdmBuildPs1Prefix(char *target, int targetLength, int massSlot)
 {
     snprintf(target, targetLength, "mass%d:/", massSlot);
 }
@@ -428,10 +429,10 @@ static void bdmLogIdentityDiagnostic(const char *event, const bdm_config_diag_sn
     LOG("[BDM DIAG] event=%s generation=%u itemList=%p mode=%d visible=%d config=%p uid=%u modified=%d format=%d filename=\"%s\"\n",
         event, snap->generation, snap->itemListAddr, snap->mode, snap->visible, snap->configAddr, snap->configUid,
         snap->configModified, snap->configFormat, snap->configFilename);
-    LOG("[BDM DIAG] event=%s cached slot=%d root=\"%s\" prefix=\"%s\" driver=\"%s\" devnr=%d type=%s(%d) folders=%u games=%p/%d vcdGames=%p/%d\n",
+    LOG("[BDM DIAG] event=%s cached slot=%d root=\"%s\" prefix=\"%s\" driver=\"%s\" devnr=%d type=%s(%d) folders=%u games=%p/%d ps1Games=%p/%d\n",
         event, slot, snap->deviceRoot, snap->devicePrefix, snap->driver, snap->massDeviceIndex,
         bdmDeviceTypeName(snap->bdmDeviceType), snap->bdmDeviceType, snap->foldersCreated,
-        snap->games, snap->gameCount, snap->vcdGames, snap->vcdGameCount);
+        snap->games, snap->gameCount, snap->ps1Games, snap->ps1GameCount);
     LOG("[BDM DIAG] event=%s legacy=\"%s\" readable=%d open=%d identity=%d driver=\"%s\" devnr=%d driverMatch=%d devnrMatch=%d revalidated=%d\n",
         event, legacyRoot, legacyIdentity.openResult >= 0, legacyIdentity.openResult, legacyIdentity.identityResult,
         legacyIdentity.driver, legacyIdentity.deviceIndex, legacyDriverMatch, legacyDeviceMatch, legacyRevalidated);
@@ -849,8 +850,8 @@ void bdmCaptureConfigWriteDiag(item_list_t *itemList, const config_set_t *config
     out->foldersCreated = device->FoldersCreated;
     out->games = device->bdmGames;
     out->gameCount = device->bdmGameCount;
-    out->vcdGames = device->bdmVcdGames;
-    out->vcdGameCount = device->bdmVcdGameCount;
+    out->ps1Games = device->bdmPs1Games;
+    out->ps1GameCount = device->bdmPs1GameCount;
 #else
     (void)itemList;
     (void)configSet;
@@ -1238,8 +1239,8 @@ static void bdmInit(item_list_t *itemList)
     pDeviceData->bdmModifiedDVDPrev = 0;
     pDeviceData->bdmGameCount = 0;
     pDeviceData->bdmGames = NULL;
-    pDeviceData->bdmVcdGameCount = 0; // #120: separate VCD store (see bdm_device_data_t)
-    pDeviceData->bdmVcdGames = NULL;
+    pDeviceData->bdmPs1GameCount = 0; // #120: separate VCD store (see bdm_device_data_t)
+    pDeviceData->bdmPs1Games = NULL;
     pDeviceData->FoldersCreated = 0;
     pDeviceData->bdmDeviceType = BDM_TYPE_UNKNOWN;
     pDeviceData->bdmHddIsLBA48 = -1;
@@ -1441,7 +1442,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     // VCD view: while this device shows its VCD list, skip the disc-folder heuristics (it refreshes on
     // L3 toggle / manual refresh only). The toggle's forced rescan is consumed ABOVE the device-tick
     // gate (see libViewConsumeDirty near the top) so the per-generation cache can't swallow it.
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         return 0;
 
     snprintf(path, sizeof(path), "%sCD", pDeviceData->bdmPrefix);
@@ -1488,13 +1489,16 @@ static int bdmUpdateGameList(item_list_t *itemList)
     // bdmGames, so a VCD scan reporting failure (r < 0) left the ISO list published under the VCD
     // view -- the L3 toggle then "never changed the list" (Nathan, HW, ATA/HDD_BD), and a device with
     // no POPS folder hit that on every single toggle.
-    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
-        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
-        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode); // device root, NOT gBDMPrefix
-        int r = vcdFillGameList(vcdPrefix, &pDeviceData->bdmVcdGames);
+    if (libListViewActive(itemList) == LIB_VIEW_PS1) {
+        char ps1Prefix[BDM_DEVICE_ROOT_MAX + 2];
+        bdmBuildPs1Prefix(ps1Prefix, sizeof(ps1Prefix), itemList->mode); // device root, NOT gBDMPrefix
+        // ONE list, BOTH cores: ps1FillGameList unions POPS/*.VCD with EMBER/games/* and sorts them
+        // together. It reports failure only when a scan could not READ the device -- an absent POPS
+        // or EMBER folder is 0 -- so a device using just one core never preserves a stale list.
+        int r = ps1FillGameList(ps1Prefix, &pDeviceData->bdmPs1Games);
         if (r >= 0) // r < 0: transient scan failure -> keep THIS view's last-good (empty if never scanned)
-            pDeviceData->bdmVcdGameCount = r;
-        return pDeviceData->bdmVcdGameCount;
+            pDeviceData->bdmPs1GameCount = r;
+        return pDeviceData->bdmPs1GameCount;
     }
     sbReadList(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, folderGetSub(itemList->mode), &pDeviceData->bdmULSizePrev, &pDeviceData->bdmGameCount);
     return pDeviceData->bdmGameCount;
@@ -1504,7 +1508,7 @@ static int bdmGetGameCount(item_list_t *itemList)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? pDeviceData->bdmVcdGameCount : pDeviceData->bdmGameCount;
+    return (libListViewActive(itemList) == LIB_VIEW_PS1) ? pDeviceData->bdmPs1GameCount : pDeviceData->bdmGameCount;
 }
 
 // Toggle-window guard (mirrors mmceActiveGame). The L3 toggle changes the active view SYNCHRONOUSLY
@@ -1519,9 +1523,9 @@ static base_game_info_t bdmEmptyGame = {0};
 static base_game_info_t *bdmActiveGame(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
-    int vcd = (libListViewActive(itemList) == LIB_VIEW_VCD);
-    base_game_info_t *arr = vcd ? pDeviceData->bdmVcdGames : pDeviceData->bdmGames;
-    int count = vcd ? pDeviceData->bdmVcdGameCount : pDeviceData->bdmGameCount;
+    int vcd = (libListViewActive(itemList) == LIB_VIEW_PS1);
+    base_game_info_t *arr = vcd ? pDeviceData->bdmPs1Games : pDeviceData->bdmGames;
+    int count = vcd ? pDeviceData->bdmPs1GameCount : pDeviceData->bdmGameCount;
 
     if (arr == NULL || id < 0 || id >= count)
         return &bdmEmptyGame;
@@ -1551,7 +1555,7 @@ static char *bdmGetGameStartup(item_list_t *itemList, int id)
 
     // VCD view: identity is the filename, not a disc ID -> per-game data (CFG/art) keys off the
     // VCD name (matches sbPopulateConfig).
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         return g->name;
     return g->startup;
 }
@@ -1560,7 +1564,7 @@ static void bdmDeleteGame(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         return; // #120: a VCD is not an ISO game -- no delete in VCD view (mirrors mmceDeleteGame)
     if (bdmActiveGame(itemList, id) == &bdmEmptyGame)
         return;                                   // stale id in the toggle window: sbDelete does NOT bounds-check -> avoid an OOB/wrong unlink
@@ -1574,13 +1578,13 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
+    if (libListViewActive(itemList) == LIB_VIEW_PS1) {
         base_game_info_t *game = bdmActiveGame(itemList, id);
         char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
 
         if (game == &bdmEmptyGame)
             return; // stale id in the toggle window
-        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
+        bdmBuildPs1Prefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
         if (vcdRenameFile(vcdPrefix, game->name, newName) == 0)
             pDeviceData->ForceRefresh = 1; // the queued menu update re-scans POPS/
         return;
@@ -1591,6 +1595,60 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
     sbRename(&pDeviceData->bdmGames, pDeviceData->bdmPrefix, "/", pDeviceData->bdmGameCount, id, newName);
     pDeviceData->bdmULSizePrev = -2;
     pDeviceData->ForceRefresh = 1;
+}
+
+// Launch an Ember (.cue) PS1 title BY NAME -- the view-independent entry point, peer of
+// bdmLaunchVcd below. `cueName` is the game FOLDER under EMBER/games/, which is also Ember's launch
+// argument and the row's identity for art and per-game config.
+//
+// Notice how much SHORTER this is than the POPSTARTER path below, and why: every one of that
+// function's memory-card steps -- installing MC externals, equipping a BDMAssault exFAT driver
+// pair, the fat32/exFAT prompt -- exists because POPSTARTER resets the IOP and then reloads its
+// block driver from mc?:/POPSTARTER/. Ember performs no reset and inherits our live driver stack,
+// so none of that applies to it. Do not port any of it here.
+static void bdmLaunchCue(item_list_t *itemList, const char *cueName, config_set_t *configSet)
+{
+    bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    char ps1Prefix[64], emberElf[256], biosPath[288];
+
+    (void)configSet; // an Ember title carries no per-game loader settings (see guigame.c)
+
+    if (pDeviceData == NULL || cueName == NULL || cueName[0] == ' ')
+        return;
+
+    // Refuse what Ember itself would refuse, while a dialog can still be drawn. The scanner already
+    // filters these out, so reaching this is either a favourite stored before a rename or a
+    // hand-edited entry -- both worth a message rather than a drop to the PS1 BIOS shell.
+    if (!cueNameLaunchable(cueName)) {
+        guiMsgBox(_l(_STR_EMBER_BAD_NAME), 0, NULL);
+        return;
+    }
+
+    bdmBuildPs1Prefix(ps1Prefix, sizeof(ps1Prefix), itemList->mode); // device ROOT: EMBER/ lives there
+
+    if (!cueResolveEmber(ps1Prefix, emberElf, sizeof(emberElf))) {
+        guiMsgBox(_l(_STR_EMBER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    // Ember needs a user-supplied bios.bin beside it and says nothing useful when it is missing --
+    // it just runs the PS1 BIOS shell. Check while we can still explain.
+    if (!cueResolveEmberBios(ps1Prefix, biosPath, sizeof(biosPath))) {
+        guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
+        return;
+    }
+
+    // MX4SIO shares the SIO2 bus with MMCE artwork; quiesce it before the handoff reads the device.
+    if (pDeviceData->bdmDeviceType == BDM_TYPE_SDC) {
+        if (!cacheAbortMmceImageLoadsTimed(500)) {
+            guiWarning(_l(_STR_ERR_FILE_INVALID), 8);
+            return;
+        }
+    }
+
+    // UNMOUNT_EXCEPTION is load-bearing here, not defensive: Ember never resets the IOP, so the
+    // device it reads its game from must still be mounted when it starts.
+    deinit(UNMOUNT_EXCEPTION, itemList->mode);
+    sysLaunchEmber(emberElf, cueName);
 }
 
 // Launch a PS1/.VCD entry BY NAME via POPSTARTER (the view-independent entry point used by both the
@@ -1610,7 +1668,7 @@ static void bdmLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
         guiMsgBox(_l(_STR_VCD_NOT_ON_NET), 0, NULL);
         return;
     }
-    bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode); // device root, NOT gBDMPrefix -- POPSTARTER reads <root>/POPS only
+    bdmBuildPs1Prefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode); // device root, NOT gBDMPrefix -- POPSTARTER reads <root>/POPS only
     if (!vcdResolvePopstarter(vcdPrefix, vcdElf, sizeof(vcdElf))) {
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
         return;
@@ -1907,8 +1965,15 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // disc / Neutrino path below (which is entirely disc-specific). The BDM_TYPE_ATA internal exFAT HDD
     // still launches off the live massN: prefix, NOT ata0:/ (OPL never mounts an ata0: filesystem -- a
     // re-point there made LoadELFFromFile fail into an already-deinit'd OPL = black-screen freeze).
-    if (gAutoLaunchBDMGame == NULL && game != NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
-        bdmLaunchVcd(itemList, game->name, configSet);
+    if (gAutoLaunchBDMGame == NULL && game != NULL && (libListViewActive(itemList) == LIB_VIEW_PS1)) {
+        // ONE PS1 list, TWO cores. Which one runs this title is a property of the ROW -- a .VCD row
+        // goes to POPSTARTER, an Ember game folder to ember.elf -- and NEVER of the page, because
+        // both kinds sit side by side in the same list. Asking the view here instead of the row is
+        // exactly the mistake that would send every Ember title to POPSTARTER.
+        if (cueIsCueEntry(game))
+            bdmLaunchCue(itemList, game->name, configSet);
+        else
+            bdmLaunchVcd(itemList, game->name, configSet);
         return;
     }
 
@@ -2259,10 +2324,16 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
-        char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
-        bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
-        r = vcdLoadPopsCover(vcdPrefix, value, suffix, resultTex);
+    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_PS1)) {
+        char ps1Prefix[BDM_DEVICE_ROOT_MAX + 2];
+        bdmBuildPs1Prefix(ps1Prefix, sizeof(ps1Prefix), itemList->mode);
+        // The cache hands us a NAME, not the row, so resolve the kind against the published list
+        // (pure memory scan, no device IO on the art path). An unknown name falls back to the
+        // POPSTARTER layout, which is what every pre-Ember library is.
+        if (cueRowIsCueByName(pDeviceData->bdmPs1Games, pDeviceData->bdmPs1GameCount, value) == 1)
+            r = cueLoadFolderCover(ps1Prefix, value, suffix, resultTex);
+        else
+            r = vcdLoadPopsCover(ps1Prefix, value, suffix, resultTex);
     }
     return r;
 }
@@ -2315,7 +2386,7 @@ static void bdmCleanUp(item_list_t *itemList, int exception)
 
         bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
         free(pDeviceData->bdmGames);
-        free(pDeviceData->bdmVcdGames); // #120: free the separate VCD store too
+        free(pDeviceData->bdmPs1Games); // #120: free the separate VCD store too
         free(pDeviceData);
         itemList->priv = NULL;
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1495,8 +1495,8 @@ static int bdmUpdateGameList(item_list_t *itemList)
         // ONE list, BOTH cores: ps1FillGameList unions POPS/*.VCD with EMBER/games/* and sorts them
         // together. It reports failure only when a scan could not READ the device -- an absent POPS
         // or EMBER folder is 0 -- so a device using just one core never preserves a stale list.
-        int r = ps1FillGameList(ps1Prefix, &pDeviceData->bdmPs1Games);
-        if (r >= 0) // r < 0: transient scan failure -> keep THIS view's last-good (empty if never scanned)
+        int r = ps1FillGameList(ps1Prefix, ps1Prefix, &pDeviceData->bdmPs1Games); // same root for both halves on BDM
+        if (r >= 0)                                                               // r < 0: transient scan failure -> keep THIS view's last-good (empty if never scanned)
             pDeviceData->bdmPs1GameCount = r;
         return pDeviceData->bdmPs1GameCount;
     }
@@ -1585,8 +1585,13 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
         if (game == &bdmEmptyGame)
             return; // stale id in the toggle window
         bdmBuildPs1Prefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
-        if (vcdRenameFile(vcdPrefix, game->name, newName) == 0)
-            pDeviceData->ForceRefresh = 1; // the queued menu update re-scans POPS/
+        // The ROW picks the target, as the launch does. Dispatching on the view would hand an Ember
+        // row to vcdRenameFile, which looks in POPS/ for "<name>.VCD" -- absent for an Ember title,
+        // so the rename would quietly do nothing; and where a .VCD of the same name exists (a game
+        // held for BOTH cores, which the merged list makes an ordinary case) it would rename the
+        // POPSTARTER file instead. Renaming the wrong file is the worse half of that.
+        if ((cueIsCueEntry(game) ? cueRenameGame(vcdPrefix, game->name, newName) : vcdRenameFile(vcdPrefix, game->name, newName)) == 0)
+            pDeviceData->ForceRefresh = 1; // the queued menu update re-scans both libraries
         return;
     }
     if (bdmActiveGame(itemList, id) == &bdmEmptyGame)
@@ -2421,6 +2426,7 @@ static void bdmShutdown(item_list_t *itemList)
 
         // Free device data.
         free(pDeviceData->bdmGames);
+        free(pDeviceData->bdmPs1Games); // both stores, same as bdmCleanUp -- the asymmetry leaked
         free(pDeviceData);
         itemList->priv = NULL;
     }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1613,7 +1613,7 @@ static void bdmLaunchCue(item_list_t *itemList, const char *cueName, config_set_
 
     (void)configSet; // an Ember title carries no per-game loader settings (see guigame.c)
 
-    if (pDeviceData == NULL || cueName == NULL || cueName[0] == ' ')
+    if (pDeviceData == NULL || cueName == NULL || cueName[0] == '\0')
         return;
 
     // Refuse what Ember itself would refuse, while a dialog can still be drawn. The scanner already
@@ -1634,6 +1634,13 @@ static void bdmLaunchCue(item_list_t *itemList, const char *cueName, config_set_
     // it just runs the PS1 BIOS shell. Check while we can still explain.
     if (!cueResolveEmberBios(ps1Prefix, biosPath, sizeof(biosPath))) {
         guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
+        return;
+    }
+    // The scan lists folders without reading inside them -- that would be a directory read per row
+    // on every refresh. Pay for it once, HERE, while a dialog can still be drawn: an empty or
+    // mis-filled folder otherwise drops the user into the PS1 BIOS shell with no explanation.
+    if (!cueGameHasImage(ps1Prefix, cueName)) {
+        guiMsgBox(_l(_STR_EMBER_NO_DISC), 0, NULL);
         return;
     }
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -4,6 +4,7 @@
 #include "include/supportbase.h"
 #include "include/bdmsupport.h"
 #include "include/vcdsupport.h"
+#include "include/libview.h" // libViewActive / libListViewActive -- which list this page shows
 #include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/themes.h"
@@ -1320,11 +1321,11 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     // mmceNeedsUpdate checks it first). Otherwise a device already scanned this BdmGeneration -- which
     // every USB stick is, the moment its ISO list loads -- short-circuits at the gate and never
     // rescans, leaving the VCD (PS1/POPSTARTER) list permanently empty on USB/BDM while MMCE worked.
-    if (vcdConsumeDirty(itemList->mode))
+    if (libViewConsumeDirty(itemList->mode))
         return 1;
 
     // Folder browsing: a descend/ascend marks the mode dirty but bumps nothing the tick gate below
-    // watches, so consume it here (same discipline as vcdConsumeDirty) or the deeper/shallower list
+    // watches, so consume it here (same discipline as libViewConsumeDirty) or the deeper/shallower list
     // never rebuilds on a device already scanned this BdmGeneration.
     if (folderConsumeDirty(itemList->mode))
         return 1;
@@ -1439,8 +1440,8 @@ static int bdmNeedsUpdate(item_list_t *itemList)
 
     // VCD view: while this device shows its VCD list, skip the disc-folder heuristics (it refreshes on
     // L3 toggle / manual refresh only). The toggle's forced rescan is consumed ABOVE the device-tick
-    // gate (see vcdConsumeDirty near the top) so the per-generation cache can't swallow it.
-    if (vcdListViewActive(itemList))
+    // gate (see libViewConsumeDirty near the top) so the per-generation cache can't swallow it.
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         return 0;
 
     snprintf(path, sizeof(path), "%sCD", pDeviceData->bdmPrefix);
@@ -1487,7 +1488,7 @@ static int bdmUpdateGameList(item_list_t *itemList)
     // bdmGames, so a VCD scan reporting failure (r < 0) left the ISO list published under the VCD
     // view -- the L3 toggle then "never changed the list" (Nathan, HW, ATA/HDD_BD), and a device with
     // no POPS folder hit that on every single toggle.
-    if (vcdListViewActive(itemList)) {
+    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
         char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
         bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode); // device root, NOT gBDMPrefix
         int r = vcdFillGameList(vcdPrefix, &pDeviceData->bdmVcdGames);
@@ -1503,12 +1504,12 @@ static int bdmGetGameCount(item_list_t *itemList)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    return vcdListViewActive(itemList) ? pDeviceData->bdmVcdGameCount : pDeviceData->bdmGameCount;
+    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? pDeviceData->bdmVcdGameCount : pDeviceData->bdmGameCount;
 }
 
-// Toggle-window guard (mirrors mmceActiveGame). The L3 toggle flips vcdViewActive() SYNCHRONOUSLY
-// (vcdToggleView) but rebuilds the submenu on the DEFERRED IO thread, so for a window the OLD submenu's
-// ids are still live while vcdViewActive() already reports the NEW view -- and an id from the old view
+// Toggle-window guard (mirrors mmceActiveGame). The L3 toggle changes the active view SYNCHRONOUSLY
+// (libViewAdvance) but rebuilds the submenu on the DEFERRED IO thread, so for a window the OLD submenu's
+// ids are still live while libViewActive() already reports the NEW view -- and an id from the old view
 // can index the freshly-switched other-view array, which may be NULL (never scanned), shorter, or
 // mid-scan. Resolve EVERY id through here: an out-of-range id yields a STATIC EMPTY entry, so a stale-id
 // READ is safe empty data instead of an OOB deref, and launch/delete/rename treat &bdmEmptyGame as
@@ -1518,7 +1519,7 @@ static base_game_info_t bdmEmptyGame = {0};
 static base_game_info_t *bdmActiveGame(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
-    int vcd = vcdListViewActive(itemList);
+    int vcd = (libListViewActive(itemList) == LIB_VIEW_VCD);
     base_game_info_t *arr = vcd ? pDeviceData->bdmVcdGames : pDeviceData->bdmGames;
     int count = vcd ? pDeviceData->bdmVcdGameCount : pDeviceData->bdmGameCount;
 
@@ -1550,7 +1551,7 @@ static char *bdmGetGameStartup(item_list_t *itemList, int id)
 
     // VCD view: identity is the filename, not a disc ID -> per-game data (CFG/art) keys off the
     // VCD name (matches sbPopulateConfig).
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         return g->name;
     return g->startup;
 }
@@ -1559,7 +1560,7 @@ static void bdmDeleteGame(item_list_t *itemList, int id)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         return; // #120: a VCD is not an ISO game -- no delete in VCD view (mirrors mmceDeleteGame)
     if (bdmActiveGame(itemList, id) == &bdmEmptyGame)
         return;                                   // stale id in the toggle window: sbDelete does NOT bounds-check -> avoid an OOB/wrong unlink
@@ -1573,7 +1574,7 @@ static void bdmRenameGame(item_list_t *itemList, int id, char *newName)
 {
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (vcdListViewActive(itemList)) {
+    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
         base_game_info_t *game = bdmActiveGame(itemList, id);
         char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
 
@@ -1906,7 +1907,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // disc / Neutrino path below (which is entirely disc-specific). The BDM_TYPE_ATA internal exFAT HDD
     // still launches off the live massN: prefix, NOT ata0:/ (OPL never mounts an ata0: filesystem -- a
     // re-point there made LoadELFFromFile fail into an already-deinit'd OPL = black-screen freeze).
-    if (gAutoLaunchBDMGame == NULL && game != NULL && vcdListViewActive(itemList)) {
+    if (gAutoLaunchBDMGame == NULL && game != NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
         bdmLaunchVcd(itemList, game->name, configSet);
         return;
     }
@@ -2258,7 +2259,7 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList)) {
+    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
         char vcdPrefix[BDM_DEVICE_ROOT_MAX + 2];
         bdmBuildVcdPrefix(vcdPrefix, sizeof(vcdPrefix), itemList->mode);
         r = vcdLoadPopsCover(vcdPrefix, value, suffix, resultTex);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -2441,7 +2441,8 @@ static char *bdmGetPrefix(item_list_t *itemList)
 static item_list_t bdmGameList = {
     BDM_MODE, 2, 0, 0, MENU_MIN_INACTIVE_FRAMES, BDM_MODE_UPDATE_DELAY, NULL, NULL, &bdmGetTextId, &bdmGetPrefix, &bdmInit, &bdmNeedsUpdate,
     &bdmUpdateGameList, &bdmGetGameCount, &bdmGetGame, &bdmGetGameName, &bdmGetGameNameLength, &bdmGetGameStartup, &bdmDeleteGame, &bdmRenameGame,
-    &bdmLaunchGame, &bdmGetConfig, &bdmGetImage, &bdmCleanUp, &bdmShutdown, &bdmCheckVMC, &bdmGetIconId, &bdmLaunchVcd};
+    &bdmLaunchGame, &bdmGetConfig, &bdmGetImage, &bdmCleanUp, &bdmShutdown, &bdmCheckVMC, &bdmGetIconId, &bdmLaunchVcd,
+    /* viewOverride */ 0, /* itemGetArtArchivePath */ NULL, &bdmLaunchCue};
 
 void bdmInitSemaphore()
 {

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -3,18 +3,25 @@
   Licenced under Academic Free License version 3.0
   Review OpenUsbLd README & LICENSE files for further details.
 
-  CUE (PS1-via-Ember) path resolution and argument validation. See include/cuesupport.h for the
-  measured Ember contract this implements, and docs/EMBER-INTEGRATION-PLAN.md for its derivation.
+  CUE (PS1-via-Ember) scan, path resolution and argument validation, plus the union that makes one
+  PS1 list out of both cores' libraries. See include/cuesupport.h for the measured Ember contract
+  this implements, and docs/EMBER-INTEGRATION-PLAN.md for its derivation.
 
   POSIX IO only -- the newlib port rejects direct fileXio use here, same rule as vcdsupport.c.
 */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>  // errno/ENOENT in the absent-vs-contended split, mirroring vcdScanOpenDir
+#include <malloc.h> // memalign -- the published list matches sbReadList's alignment
 
-#include "include/opl.h"
+#include "include/opl.h"        // pulls <dirent.h> (opendir/readdir/DIR) + strcasecmp, like vcdsupport.c
+#include "include/ioman.h"      // LOG
+#include "include/textures.h"   // texDiscoverLoad + ERR_BAD_FILE (folder cover fallback)
+#include "include/vcdsupport.h" // vcdFillGameList + vcdSortKey -- the POPSTARTER half of the union
 #include "include/cuesupport.h"
 
 // Path separator for a device prefix: '\\' for SMB (its prefix ends in a backslash), else '/'.
@@ -29,9 +36,9 @@ static char cueSep(const char *devPrefix)
 
 const char *cueEmberFolder(void)
 {
-    // A configurable folder name arrives with the Ember settings page. Resolving it through this
-    // accessor from the start keeps that change to one line and keeps every caller honest about
-    // the fact that the folder is not a fixed part of the contract -- the ember.elf's DIRECTORY is.
+    // A configurable folder name can arrive later as a setting. Resolving it through this accessor
+    // from the start keeps that change to one line and keeps every caller honest about the fact
+    // that the folder NAME is not part of Ember's contract -- the ember.elf's DIRECTORY is.
     return EMBER_FOLDER_DEFAULT;
 }
 
@@ -71,8 +78,7 @@ void cueBuildGamesDir(const char *devPrefix, char *out, int outSize)
         return;
     }
 
-    char sep = cueSep(devPrefix);
-    snprintf(out, outSize, "%s%s%c%s", devPrefix, cueEmberFolder(), sep, EMBER_GAMES_FOLDER);
+    snprintf(out, outSize, "%s%s%c%s", devPrefix, cueEmberFolder(), cueSep(devPrefix), EMBER_GAMES_FOLDER);
 }
 
 int cueNameLaunchable(const char *name)
@@ -85,7 +91,7 @@ int cueNameLaunchable(const char *name)
     if (name[0] == '.' && name[1] == '.')
         return 0;
 
-    // Scanner artefacts: the current/parent directory entries are never games.
+    // Scanner artefact: the current-directory entry is never a game.
     if (!strcmp(name, "."))
         return 0;
 
@@ -100,4 +106,269 @@ int cueNameLaunchable(const char *name)
         return 0;
 
     return 1;
+}
+
+// Is this directory entry a game folder? d_type is trusted only when it says DT_DIR: it is a
+// documented liar on MMCE clones (the same finding that forced the theme discovery to opendir-probe),
+// so anything else is probed rather than believed. On a well-formed FAT/exFAT games/ folder that
+// costs nothing -- every entry answers DT_DIR on the first test -- and the probe is paid only for
+// stray files, or on a device whose d_type cannot be trusted at all.
+static int cueEntryIsDir(const char *gamesDir, const struct dirent *de)
+{
+    char probe[320];
+    DIR *d;
+
+#ifdef DT_DIR
+    if (de->d_type == DT_DIR)
+        return 1;
+#endif
+
+    snprintf(probe, sizeof(probe), "%s/%s", gamesDir, de->d_name);
+    d = opendir(probe);
+    if (d == NULL)
+        return 0;
+    closedir(d);
+    return 1;
+}
+
+int cueScanDir(const char *devPrefix, cue_entry_t **outList)
+{
+    char gamesDir[288];
+    cue_entry_t *list;
+    struct dirent *de;
+    DIR *dir;
+    int count = 0;
+
+    if (outList == NULL)
+        return 0;
+    *outList = NULL;
+    if (devPrefix == NULL)
+        return 0;
+
+    cueBuildGamesDir(devPrefix, gamesDir, sizeof(gamesDir));
+    if (gamesDir[0] == '\0')
+        return 0;
+
+    errno = 0; // clear BEFORE opendir so the NULL branch reads THIS call's errno, not a stale one
+    dir = opendir(gamesDir);
+    if (dir == NULL) {
+        // Absent-vs-contended split, identical in spirit to vcdScanOpenDir. A device with a POPS
+        // folder and no EMBER folder is the ordinary case and MUST report 0 ("readable, nothing
+        // here"), not a failure -- ps1FillGameList treats a failure from either half as a reason to
+        // keep the whole last-good list, so getting this wrong would freeze the PS1 page of every
+        // device that only uses one core.
+        if (errno == ENOENT)
+            return 0;
+        // Anything else: the directory could not be READ (bus contended, device mid-detach). Signal
+        // failure so the caller preserves its last-good list rather than blanking the page.
+        // MMCE caveat, same as the VCD scan: mmceman's dopen collapses every failure into a bare -1
+        // (EE sees EPERM, not ENOENT) unless the paired mmceman patch is in the build, so on mmceN:
+        // an absent EMBER folder lands here. That costs a preserved list, never a wrong one.
+        LOG("[CUE] cannot read '%s' (errno %d)\n", gamesDir, errno);
+        return -1;
+    }
+
+    list = (cue_entry_t *)calloc(CUE_MAX_ITEMS, sizeof(cue_entry_t));
+    if (list == NULL) {
+        closedir(dir);
+        return -1; // OOM: preserve the caller's current list rather than blank it
+    }
+
+    while (count < CUE_MAX_ITEMS && (de = readdir(dir)) != NULL) {
+        if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
+            continue;
+
+        // Refuse here what Ember would refuse at launch, so the list never offers a row whose X
+        // button cannot work. A name with a separator cannot occur on FAT/exFAT; an over-long one
+        // is a user mistake worth a log line rather than a silent dead row.
+        if (!cueNameLaunchable(de->d_name)) {
+            LOG("[CUE] skip (unlaunchable name): %s\n", de->d_name);
+            continue;
+        }
+        // The row store caps names at ISO_GAME_NAME_MAX; a longer one would be truncated and then
+        // resolve to a folder that does not exist.
+        if ((int)strlen(de->d_name) > ISO_GAME_NAME_MAX) {
+            LOG("[CUE] skip (name > %d chars): %s\n", ISO_GAME_NAME_MAX, de->d_name);
+            continue;
+        }
+        if (!cueEntryIsDir(gamesDir, de))
+            continue; // loose files in games/ (a stray readme, a leftover archive) are not games
+
+        snprintf(list[count].name, sizeof(list[count].name), "%s", de->d_name);
+        count++;
+    }
+    closedir(dir);
+    LOG("[CUE] scanned '%s': found %d entries\n", gamesDir, count);
+
+    if (count == 0) {
+        free(list);
+        return 0;
+    }
+
+    *outList = list;
+    return count;
+}
+
+int cueIsCueEntry(const base_game_info_t *game)
+{
+    return (game != NULL && strcasecmp(game->extension, CUE_ROW_EXTENSION) == 0);
+}
+
+int cueRowIsCueByName(const base_game_info_t *games, int count, const char *name)
+{
+    int i;
+
+    if (games == NULL || name == NULL)
+        return -1;
+
+    for (i = 0; i < count; i++) {
+        if (strcmp(games[i].name, name) == 0)
+            return cueIsCueEntry(&games[i]) ? 1 : 0;
+    }
+    return -1;
+}
+
+// Merged-list comparator. Sorts by the same visible key the VCD-only scan always used, so turning
+// on Ember cannot reorder anyone's existing PS1 list. The extension tie-break is not cosmetic: two
+// rows CAN share a display name (the same game held for both cores is the expected case), and
+// without a deterministic tie-break qsort would be free to swap them between rescans, making rows
+// appear to jump around on every refresh.
+static int ps1RowCmp(const void *a, const void *b)
+{
+    const base_game_info_t *ga = (const base_game_info_t *)a;
+    const base_game_info_t *gb = (const base_game_info_t *)b;
+    int r = strcasecmp(vcdSortKey(ga->name), vcdSortKey(gb->name));
+
+    if (r != 0)
+        return r;
+    return strcasecmp(ga->extension, gb->extension);
+}
+
+// Fill a list from EMBER/games/ alone. Static: every caller wants the merged PS1 list, and exposing
+// a "just the Ember half" entry point would invite a second place where the union is formed.
+static int cueFillGameList(const char *devPrefix, base_game_info_t **outGames)
+{
+    cue_entry_t *entries = NULL;
+    base_game_info_t *games;
+    int n, i;
+
+    if (outGames == NULL)
+        return 0;
+
+    n = cueScanDir(devPrefix, &entries);
+    if (n < 0)
+        return -1; // could not read the device -> caller preserves its list
+    if (n == 0) {
+        free(entries);
+        *outGames = NULL;
+        return 0;
+    }
+
+    games = (base_game_info_t *)memalign(64, n * sizeof(base_game_info_t));
+    if (games == NULL) {
+        free(entries);
+        return -1;
+    }
+    memset(games, 0, n * sizeof(base_game_info_t));
+
+    for (i = 0; i < n; i++) {
+        // IDENTITY is the folder name, and it stays the folder name: it is Ember's launch argument,
+        // and art / per-game CFG / favourites all key off it. Exactly the discipline the VCD rows
+        // use with their filename.
+        snprintf(games[i].name, sizeof(games[i].name), "%s", entries[i].name);
+        snprintf(games[i].startup, sizeof(games[i].startup), "%s", entries[i].name);
+        snprintf(games[i].extension, sizeof(games[i].extension), "%s", CUE_ROW_EXTENSION);
+        games[i].parts = 1;
+        games[i].format = GAME_FORMAT_ISO; // harmless; the row's extension gates the launch path
+    }
+
+    free(entries);
+    *outGames = games;
+    return n;
+}
+
+int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames)
+{
+    base_game_info_t *vcdGames = NULL, *cueGames = NULL, *merged = NULL;
+    int vcdCount, cueCount, total;
+
+    if (outGames == NULL)
+        return 0;
+
+    vcdCount = vcdFillGameList(devPrefix, &vcdGames);
+    cueCount = cueFillGameList(devPrefix, &cueGames);
+
+    // EITHER half failing means the device could not be READ, not that it holds no games -- an
+    // absent POPS or EMBER folder reports 0. Publishing a half list would look exactly like the
+    // user's titles disappearing, so keep the caller's last-good list instead.
+    if (vcdCount < 0 || cueCount < 0) {
+        free(vcdGames);
+        free(cueGames);
+        LOG("[PS1] scan failed (vcd=%d cue=%d) -- keeping last-good list\n", vcdCount, cueCount);
+        return -1;
+    }
+
+    total = vcdCount + cueCount;
+
+    // Both scans reached the device: only NOW is it safe to replace the old list.
+    free(*outGames);
+    *outGames = NULL;
+
+    if (total == 0) {
+        free(vcdGames);
+        free(cueGames);
+        return 0;
+    }
+
+    merged = (base_game_info_t *)memalign(64, total * sizeof(base_game_info_t));
+    if (merged == NULL) {
+        free(vcdGames);
+        free(cueGames);
+        return 0; // list already released above; an empty page beats a dangling one
+    }
+
+    if (vcdCount > 0)
+        memcpy(merged, vcdGames, vcdCount * sizeof(base_game_info_t));
+    if (cueCount > 0)
+        memcpy(merged + vcdCount, cueGames, cueCount * sizeof(base_game_info_t));
+
+    free(vcdGames);
+    free(cueGames);
+
+    // Gated on the same Automatic Sorting switch every other list honours. With it off the halves
+    // stay concatenated in scan order, which is the "raw directory order" the setting promises.
+    if (gAutosort && total > 1)
+        qsort(merged, total, sizeof(base_game_info_t), &ps1RowCmp);
+
+    *outGames = merged;
+    return total;
+}
+
+int cueLoadFolderCover(const char *devPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex)
+{
+    char path[320];
+    char gamesDir[288];
+    int r;
+
+    // Cover/icon only, matching vcdLoadPopsCover: the other art suffixes have no in-folder
+    // convention and probing for them would be pure IO on the miss path.
+    if (devPrefix == NULL || value == NULL || suffix == NULL)
+        return ERR_BAD_FILE;
+    if (strcmp(suffix, "COV") != 0 && strcmp(suffix, "ICO") != 0)
+        return ERR_BAD_FILE;
+
+    cueBuildGamesDir(devPrefix, gamesDir, sizeof(gamesDir));
+    if (gamesDir[0] == '\0')
+        return ERR_BAD_FILE;
+
+    // "<games>/<name>/cover" first: one obvious filename a user can drop in without knowing the
+    // title's exact spelling. texDiscoverLoad appends the extension it supports.
+    snprintf(path, sizeof(path), "%s/%s/cover", gamesDir, value);
+    r = texDiscoverLoad(resultTex, path, -1);
+    if (r >= 0)
+        return r;
+
+    // Then "<games>/<name>/<name>", the POPSLoader-style suffixless peer of vcdLoadPopsCover.
+    snprintf(path, sizeof(path), "%s/%s/%s", gamesDir, value, value);
+    return texDiscoverLoad(resultTex, path, -1);
 }

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -1,0 +1,103 @@
+/*
+  Copyright 2026, Open-PS2-Loader contributors
+  Licenced under Academic Free License version 3.0
+  Review OpenUsbLd README & LICENSE files for further details.
+
+  CUE (PS1-via-Ember) path resolution and argument validation. See include/cuesupport.h for the
+  measured Ember contract this implements, and docs/EMBER-INTEGRATION-PLAN.md for its derivation.
+
+  POSIX IO only -- the newlib port rejects direct fileXio use here, same rule as vcdsupport.c.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "include/opl.h"
+#include "include/cuesupport.h"
+
+// Path separator for a device prefix: '\\' for SMB (its prefix ends in a backslash), else '/'.
+// Auto-detected from the trailing character so one code path serves mass/mmce/pfs and SMB alike.
+// Same rule as vcdsupport.c's vcdSep(); kept local rather than shared so neither file's separator
+// behaviour can be changed from under the other.
+static char cueSep(const char *devPrefix)
+{
+    int n = (devPrefix != NULL) ? (int)strlen(devPrefix) : 0;
+    return (n > 0 && devPrefix[n - 1] == '\\') ? '\\' : '/';
+}
+
+const char *cueEmberFolder(void)
+{
+    // A configurable folder name arrives with the Ember settings page. Resolving it through this
+    // accessor from the start keeps that change to one line and keeps every caller honest about
+    // the fact that the folder is not a fixed part of the contract -- the ember.elf's DIRECTORY is.
+    return EMBER_FOLDER_DEFAULT;
+}
+
+// Shared body for the two file probes: compose "<devPrefix><folder><sep><file>" and open() it.
+static int cueResolveEmberFile(const char *devPrefix, const char *fileName, char *out, int outSize)
+{
+    int fd;
+
+    if (out == NULL || outSize <= 0 || devPrefix == NULL || fileName == NULL)
+        return 0;
+
+    snprintf(out, outSize, "%s%s%c%s", devPrefix, cueEmberFolder(), cueSep(devPrefix), fileName);
+
+    fd = open(out, O_RDONLY);
+    if (fd < 0)
+        return 0;
+    close(fd);
+    return 1;
+}
+
+int cueResolveEmber(const char *devPrefix, char *out, int outSize)
+{
+    return cueResolveEmberFile(devPrefix, EMBER_ELF_NAME, out, outSize);
+}
+
+int cueResolveEmberBios(const char *devPrefix, char *out, int outSize)
+{
+    return cueResolveEmberFile(devPrefix, EMBER_BIOS_NAME, out, outSize);
+}
+
+void cueBuildGamesDir(const char *devPrefix, char *out, int outSize)
+{
+    if (out == NULL || outSize <= 0)
+        return;
+    if (devPrefix == NULL) {
+        out[0] = '\0';
+        return;
+    }
+
+    char sep = cueSep(devPrefix);
+    snprintf(out, outSize, "%s%s%c%s", devPrefix, cueEmberFolder(), sep, EMBER_GAMES_FOLDER);
+}
+
+int cueNameLaunchable(const char *name)
+{
+    if (name == NULL || name[0] == '\0')
+        return 0;
+
+    // Ember refuses any argument STARTING with ".." -- it compares buf[0] and buf[1] and never looks
+    // further, so "..", "../x" and "..foo" are all refused. Match that, not the tidier "== ..".
+    if (name[0] == '.' && name[1] == '.')
+        return 0;
+
+    // Scanner artefacts: the current/parent directory entries are never games.
+    if (!strcmp(name, "."))
+        return 0;
+
+    // Ember's char scan refuses '/', ':' and '\\' ANYWHERE in the argument. On FAT/exFAT these
+    // cannot appear in a directory entry, so in practice this fires only on a hand-typed argument
+    // -- but it is the difference between a clear message and Ember dropping to the PS1 BIOS shell.
+    if (strpbrk(name, "/:\\") != NULL)
+        return 0;
+
+    // Longer than Ember's own buffers can carry (see CUE_NAME_LAUNCH_MAX).
+    if ((int)strlen(name) > CUE_NAME_LAUNCH_MAX)
+        return 0;
+
+    return 1;
+}

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -209,6 +209,54 @@ int cueScanDir(const char *devPrefix, cue_entry_t **outList)
     return count;
 }
 
+// The extensions Ember's io_find_disc accepts, in ITS priority order (.cue beats .exe beats .bin).
+// We only test presence, so the order is documentation rather than logic -- but it is the reason a
+// folder holding just a .bin is still a valid game.
+static const char *const cueDiscExts[] = {".cue", ".exe", ".bin"};
+
+int cueGameHasImage(const char *devPrefix, const char *name)
+{
+    char gamesDir[288];
+    char gameDir[320];
+    struct dirent *de;
+    DIR *dir;
+    int found = 0;
+    unsigned int i;
+
+    if (devPrefix == NULL || name == NULL || name[0] == '\0')
+        return 0;
+
+    cueBuildGamesDir(devPrefix, gamesDir, sizeof(gamesDir));
+    if (gamesDir[0] == '\0')
+        return 0;
+    snprintf(gameDir, sizeof(gameDir), "%s/%s", gamesDir, name);
+
+    dir = opendir(gameDir);
+    if (dir == NULL) {
+        // The probe itself failed -- the folder may be there and merely unreadable this instant.
+        // Never let a failed PROBE block a launch: report "has an image" and let Ember be the judge.
+        LOG("[CUE] cannot probe '%s' -- launching anyway\n", gameDir);
+        return 1;
+    }
+
+    while (!found && (de = readdir(dir)) != NULL) {
+        int len = (int)strlen(de->d_name);
+        if (len < 5)
+            continue; // shortest possible match is "x.cue"
+        for (i = 0; i < sizeof(cueDiscExts) / sizeof(cueDiscExts[0]); i++) {
+            if (strcasecmp(de->d_name + len - 4, cueDiscExts[i]) == 0) {
+                found = 1;
+                break;
+            }
+        }
+    }
+    closedir(dir);
+
+    if (!found)
+        LOG("[CUE] '%s' holds no .cue/.bin/.exe\n", gameDir);
+    return found;
+}
+
 int cueIsCueEntry(const base_game_info_t *game)
 {
     return (game != NULL && strcasecmp(game->extension, CUE_ROW_EXTENSION) == 0);

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -257,6 +257,46 @@ int cueGameHasImage(const char *devPrefix, const char *name)
     return found;
 }
 
+int cueRenameGame(const char *devPrefix, const char *oldName, const char *newName)
+{
+    char gamesDir[288];
+    char oldPath[320];
+    char newPath[320];
+    DIR *probe;
+
+    // The NEW name has to satisfy Ember's argument rules, or the rename would succeed on disk and
+    // leave behind a row that can never be launched.
+    if (devPrefix == NULL || oldName == NULL || newName == NULL)
+        return -1;
+    if (!cueNameLaunchable(oldName) || !cueNameLaunchable(newName))
+        return -1;
+    if (!strcmp(oldName, newName))
+        return 0;
+
+    cueBuildGamesDir(devPrefix, gamesDir, sizeof(gamesDir));
+    if (gamesDir[0] == '\0')
+        return -1;
+    if (snprintf(oldPath, sizeof(oldPath), "%s/%s", gamesDir, oldName) >= (int)sizeof(oldPath))
+        return -1;
+    if (snprintf(newPath, sizeof(newPath), "%s/%s", gamesDir, newName) >= (int)sizeof(newPath))
+        return -1;
+
+    // Refuse to clobber an existing folder. rename() over a non-empty directory is not portable
+    // across the filesystems here, and silently merging two libraries would be worse than refusing.
+    probe = opendir(newPath);
+    if (probe != NULL) {
+        closedir(probe);
+        LOG("[CUE] rename refused, target exists: %s\n", newPath);
+        return -1;
+    }
+
+    if (rename(oldPath, newPath) != 0) {
+        LOG("[CUE] rename failed: %s -> %s (%d)\n", oldPath, newPath, errno);
+        return -1;
+    }
+    return 0;
+}
+
 int cueIsCueEntry(const base_game_info_t *game)
 {
     return (game != NULL && strcasecmp(game->extension, CUE_ROW_EXTENSION) == 0);
@@ -335,7 +375,7 @@ static int cueFillGameList(const char *devPrefix, base_game_info_t **outGames)
     return n;
 }
 
-int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames)
+int ps1FillGameList(const char *vcdPrefix, const char *emberPrefix, base_game_info_t **outGames)
 {
     base_game_info_t *vcdGames = NULL, *cueGames = NULL, *merged = NULL;
     int vcdCount, cueCount, total;
@@ -343,8 +383,8 @@ int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames)
     if (outGames == NULL)
         return 0;
 
-    vcdCount = vcdFillGameList(devPrefix, &vcdGames);
-    cueCount = cueFillGameList(devPrefix, &cueGames);
+    vcdCount = vcdFillGameList(vcdPrefix, &vcdGames);
+    cueCount = cueFillGameList(emberPrefix, &cueGames);
 
     // EITHER half failing means the device could not be READ, not that it holds no games -- an
     // absent POPS or EMBER folder reports 0. Publishing a half list would look exactly like the
@@ -358,22 +398,32 @@ int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames)
 
     total = vcdCount + cueCount;
 
-    // Both scans reached the device: only NOW is it safe to replace the old list.
-    free(*outGames);
-    *outGames = NULL;
-
     if (total == 0) {
+        // Both scans reached the device and it genuinely holds no PS1 titles: publishing empty is
+        // the correct answer, so release the old list here.
+        free(*outGames);
+        *outGames = NULL;
         free(vcdGames);
         free(cueGames);
         return 0;
     }
 
+    // ALLOCATE BEFORE RELEASING. Freeing the published list first and then failing to allocate its
+    // replacement turns a transient out-of-memory into a permanently blank PS1 page -- the caller is
+    // told 0 ("readable, nothing here") and has nothing left to fall back on. Failing to allocate is
+    // exactly the case where the last-good list is most worth keeping, so report it like any other
+    // scan failure and leave *outGames untouched.
     merged = (base_game_info_t *)memalign(64, total * sizeof(base_game_info_t));
     if (merged == NULL) {
         free(vcdGames);
         free(cueGames);
-        return 0; // list already released above; an empty page beats a dangling one
+        LOG("[PS1] merge alloc failed (%d rows) -- keeping last-good list\n", total);
+        return -1;
     }
+
+    // The replacement exists: only NOW is it safe to drop the old one.
+    free(*outGames);
+    *outGames = NULL;
 
     if (vcdCount > 0)
         memcpy(merged, vcdGames, vcdCount * sizeof(base_game_info_t));

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -550,7 +550,7 @@ static int ethNeedsUpdate(item_list_t *itemList)
     // toggle only (skip disc heuristics). With no share yet, fall through so the share list updates.
     if (libViewConsumeDirty(itemList->mode))
         return 1;
-    if (gPCShareName[0] && (libListViewActive(itemList) == LIB_VIEW_VCD))
+    if (gPCShareName[0] && (libListViewActive(itemList) == LIB_VIEW_PS1))
         return 0;
 
     if (ethULSizePrev == -2)
@@ -591,7 +591,14 @@ static int ethUpdateGameList(item_list_t *itemList)
         if (gNetworkStartup != 0)
             return 0;
 
-        if (libListViewActive(itemList) == LIB_VIEW_VCD) {
+        if (libListViewActive(itemList) == LIB_VIEW_PS1) {
+            // POPSTARTER titles ONLY on SMB, deliberately: this is the one device class where the
+            // Ember half is not yet known to work. RiptOPL composes SMB paths with '\' while Ember
+            // composes its own with '/' (its io_path format string is "%s/%s%s"), and whether
+            // smbman accepts that has not been tested on hardware. Listing Ember rows here that
+            // then fail to open would be worse than not listing them -- half a working list is
+            // worse than none. Swap this for ps1FillGameList once an Ember title is confirmed to
+            // launch from a share; nothing else on this path needs to change.
             int r = vcdFillGameList(ethPrefix, &ethGames);
             if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
                 ethGameCount = r;
@@ -653,7 +660,7 @@ int ethResolveIsoFavourite(int id, const char *name, int *outId)
     if (name == NULL || outId == NULL || id < 0 || !gPCShareName[0] || gNetworkStartup != 0)
         return 0;
 
-    if (libViewActive(ETH_MODE) != LIB_VIEW_VCD) {
+    if (libViewActive(ETH_MODE) != LIB_VIEW_PS1) {
         // The live ETH backing store already IS the ISO list. Preserve the old id+name validation.
         games = ethGames;
         count = ethGameCount;
@@ -691,7 +698,7 @@ static base_game_info_t *ethBackingForView(item_list_t *itemList, int *count)
     // to live ethGames when that snapshot was invalidated: returning an empty view is safer than using
     // the same numeric ID against the wrong backing list, and the normal favourite rebuild will resolve
     // it again after the ETH mutation/reconnect that invalidated the snapshot.
-    if (itemList != NULL && itemList->viewOverride == ITEM_VIEW_FORCE_ISO && (libViewActive(ETH_MODE) == LIB_VIEW_VCD)) {
+    if (itemList != NULL && itemList->viewOverride == ITEM_VIEW_FORCE_ISO && (libViewActive(ETH_MODE) == LIB_VIEW_PS1)) {
         if (!ethFavIsoValid || ethFavIsoGames == NULL) {
             if (count != NULL)
                 *count = 0;
@@ -748,7 +755,7 @@ static char *ethGetGameStartup(item_list_t *itemList, int id)
     if (game == NULL)
         return "";
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         return game->name;
     return game->startup;
 }
@@ -762,7 +769,7 @@ static void ethDeleteGame(item_list_t *itemList, int id)
 
 static void ethRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
+    if (libListViewActive(itemList) == LIB_VIEW_PS1) {
         base_game_info_t *game = ethGameForView(itemList, id);
 
         if (game != NULL && vcdRenameFile(ethPrefix, game->name, newName) == 0) {
@@ -835,7 +842,7 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
     unsigned short int layer1_part;
 
     // VCD view (SMB): hand off to POPSTARTER by name, only once a share is selected.
-    if (gPCShareName[0] && game != NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
+    if (gPCShareName[0] && game != NULL && (libListViewActive(itemList) == LIB_VIEW_PS1)) {
         ethLaunchVcd(itemList, game->name, configSet);
         return;
     }
@@ -1019,7 +1026,7 @@ static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_VCD))
+    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_PS1))
         r = vcdLoadPopsCover(ethPrefix, value, suffix, resultTex);
     return r;
 }

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -5,6 +5,7 @@
 #include "include/supportbase.h"
 #include "include/ethsupport.h"
 #include "include/vcdsupport.h"
+#include "include/libview.h" // libViewActive / libListViewActive -- which list this page shows
 #include "include/util.h"
 #include "include/renderman.h"
 #include "include/themes.h"
@@ -547,9 +548,9 @@ static int ethNeedsUpdate(item_list_t *itemList)
 
     // VCD view: force a rescan once on toggle; once a share is selected, the VCD list refreshes on
     // toggle only (skip disc heuristics). With no share yet, fall through so the share list updates.
-    if (vcdConsumeDirty(itemList->mode))
+    if (libViewConsumeDirty(itemList->mode))
         return 1;
-    if (gPCShareName[0] && vcdListViewActive(itemList))
+    if (gPCShareName[0] && (libListViewActive(itemList) == LIB_VIEW_VCD))
         return 0;
 
     if (ethULSizePrev == -2)
@@ -590,7 +591,7 @@ static int ethUpdateGameList(item_list_t *itemList)
         if (gNetworkStartup != 0)
             return 0;
 
-        if (vcdListViewActive(itemList)) {
+        if (libListViewActive(itemList) == LIB_VIEW_VCD) {
             int r = vcdFillGameList(ethPrefix, &ethGames);
             if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
                 ethGameCount = r;
@@ -652,7 +653,7 @@ int ethResolveIsoFavourite(int id, const char *name, int *outId)
     if (name == NULL || outId == NULL || id < 0 || !gPCShareName[0] || gNetworkStartup != 0)
         return 0;
 
-    if (!vcdViewActive(ETH_MODE)) {
+    if (libViewActive(ETH_MODE) != LIB_VIEW_VCD) {
         // The live ETH backing store already IS the ISO list. Preserve the old id+name validation.
         games = ethGames;
         count = ethGameCount;
@@ -690,7 +691,7 @@ static base_game_info_t *ethBackingForView(item_list_t *itemList, int *count)
     // to live ethGames when that snapshot was invalidated: returning an empty view is safer than using
     // the same numeric ID against the wrong backing list, and the normal favourite rebuild will resolve
     // it again after the ETH mutation/reconnect that invalidated the snapshot.
-    if (itemList != NULL && itemList->viewOverride == ITEM_VIEW_FORCE_ISO && vcdViewActive(ETH_MODE)) {
+    if (itemList != NULL && itemList->viewOverride == ITEM_VIEW_FORCE_ISO && (libViewActive(ETH_MODE) == LIB_VIEW_VCD)) {
         if (!ethFavIsoValid || ethFavIsoGames == NULL) {
             if (count != NULL)
                 *count = 0;
@@ -747,7 +748,7 @@ static char *ethGetGameStartup(item_list_t *itemList, int id)
     if (game == NULL)
         return "";
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         return game->name;
     return game->startup;
 }
@@ -761,14 +762,14 @@ static void ethDeleteGame(item_list_t *itemList, int id)
 
 static void ethRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (vcdListViewActive(itemList)) {
+    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
         base_game_info_t *game = ethGameForView(itemList, id);
 
         if (game != NULL && vcdRenameFile(ethPrefix, game->name, newName) == 0) {
             ethInvalidateFavIsoBacking();
             // ETH otherwise treats its VCD list as toggle-only; consume this on the already queued
             // deferred update so the renamed POPS/ directory is scanned again.
-            vcdMarkDirty(itemList->mode);
+            libViewMarkDirty(itemList->mode);
         }
         return;
     }
@@ -834,7 +835,7 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
     unsigned short int layer1_part;
 
     // VCD view (SMB): hand off to POPSTARTER by name, only once a share is selected.
-    if (gPCShareName[0] && game != NULL && vcdListViewActive(itemList)) {
+    if (gPCShareName[0] && game != NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
         ethLaunchVcd(itemList, game->name, configSet);
         return;
     }
@@ -1018,7 +1019,7 @@ static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList))
+    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_VCD))
         r = vcdLoadPopsCover(ethPrefix, value, suffix, resultTex);
     return r;
 }

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -24,9 +24,10 @@
 #include "include/textures.h"
 #include "include/config.h"
 #include "include/supportbase.h" // sbPopulateConfig + base_game_info_t (VCD favourite config)
-#include "include/vcdsupport.h"  // VCD favourites: name-addressed POPSTARTER launch helpers
-#include "include/libview.h"     // libViewActive / libListViewActive -- which list this page shows
-#include "include/ethsupport.h"  // ETH ISO favourite resolution while the live source is in VCD view
+#include "include/vcdsupport.h"
+#include "include/cuesupport.h" // CUE_ROW_EXTENSION -- a PS1 favourite names its core  // VCD favourites: name-addressed POPSTARTER launch helpers
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
+#include "include/ethsupport.h" // ETH ISO favourite resolution while the live source is in VCD view
 #include "include/favsupport.h"
 
 int gFAVStartMode;
@@ -43,7 +44,7 @@ typedef struct
     int id;             // source item id (validated present in owner's submenu; unused for VCD)
     int icon_id;
     int text_id;
-    int isVcd;  // 1 = a PS1/.VCD favourite -> resolve/render/launch by NAME (text), not by submenu id
+    int kind;   // FAV_KIND_*: which shelf it sits on and which core launches it
     char *text; // heap copy; owned here (for a VCD favourite this is the .VCD basename / launch name)
 } fav_rec_t;
 
@@ -111,7 +112,7 @@ typedef struct
     int id;
     int icon_id;
     int text_id;
-    int isVcd; // 1 = PS1/.VCD favourite (OFAV v2+); v1 files / foreign imports default to 0
+    int kind; // FAV_KIND_*; v1 files and foreign imports default to FAV_KIND_ISO
     char text[FAV_TEXT_MAX];
 } fav_raw_t;
 
@@ -238,11 +239,11 @@ static fav_raw_t *favReadFile(int *outCount)
     for (int i = 0; i < (int)cnt; i++) {
         u16 mode = 0, tlen = 0;
         u32 id = 0, icon = 0, tid = 0;
-        u8 isVcd = 0;
+        u8 kindByte = 0;
         if (!rdU16(fd, &mode) || !rdU32(fd, &id) || !rdU32(fd, &icon) || !rdU32(fd, &tid))
             break; // short read -> stop, keep what we have
-        if (ver >= 2 && !rdBytes(fd, &isVcd, 1))
-            break; // v2 records carry a per-record isVcd byte between text_id and text_len
+        if (ver >= 2 && !rdBytes(fd, &kindByte, 1))
+            break; // v2/v3 records carry a per-record byte between text_id and text_len
         if (!rdU16(fd, &tlen))
             break;
         if (tlen == 0 || tlen > FAV_TEXT_MAX) {
@@ -256,7 +257,17 @@ static fav_raw_t *favReadFile(int *outCount)
         recs[got].id = (int)id;
         recs[got].icon_id = (int)icon;
         recs[got].text_id = (int)tid;
-        recs[got].isVcd = (int)isVcd; // v1 files leave this 0 (all ISO favourites)
+        // v1: no byte at all -> ISO. v2: the byte was a BOOLEAN isVcd, so 1 means VCD and 0
+        // means "not VCD" -- which lumped app favourites in with disc games on one shelf. Now that
+        // APPS has a shelf of its own, a v2 record whose source is the APPS tab is an ELF
+        // favourite; that is the only record whose shelf changes on upgrade. v3 stores the kind
+        // directly. Values we do not recognise fall back to ISO rather than being dropped.
+        if (ver >= 3)
+            recs[got].kind = (kindByte <= FAV_KIND_ELF) ? (int)kindByte : FAV_KIND_ISO;
+        else if (kindByte)
+            recs[got].kind = FAV_KIND_VCD;
+        else
+            recs[got].kind = ((int)mode == APP_MODE) ? FAV_KIND_ELF : FAV_KIND_ISO;
         got++;
     }
     close(fd);
@@ -308,7 +319,7 @@ static int favWriteFile(fav_raw_t *recs, int count)
         int tlen = (int)strlen(recs[i].text) + 1;
         if (tlen > FAV_TEXT_MAX)
             tlen = FAV_TEXT_MAX;
-        size += 17 + tlen; // mode(2) id(4) icon(4) text_id(4) isVcd(1) text_len(2) + text
+        size += 17 + tlen; // mode(2) id(4) icon(4) text_id(4) kind(1) text_len(2) + text
     }
 
     img = (u8 *)malloc(size);
@@ -328,7 +339,7 @@ static int favWriteFile(fav_raw_t *recs, int count)
         bufU32(img, &off, (u32)recs[i].id);
         bufU32(img, &off, (u32)recs[i].icon_id);
         bufU32(img, &off, (u32)recs[i].text_id);
-        img[off++] = recs[i].isVcd ? 1 : 0; // one byte between text_id and text_len (OFAV v2 layout)
+        img[off++] = (u8)recs[i].kind; // same slot v2 used for isVcd, now a FAV_KIND_* (OFAV v3)
         bufU16(img, &off, (u16)tlen);
         memcpy(img + off, recs[i].text, tlen - 1);
         img[off + tlen - 1] = 0; // tlen counts the NUL, and a name capped at FAV_TEXT_MAX has none
@@ -410,7 +421,27 @@ static submenu_list_t *favFindItemByText(submenu_list_t *sub, const char *text)
     return NULL;
 }
 
-static int favResolveStoredId(item_list_t *source, int id, const char *text, int isVcd, int *outId)
+int favKindView(int kind)
+{
+    switch (kind) {
+        case FAV_KIND_VCD:
+        case FAV_KIND_CUE:
+            return LIB_VIEW_PS1; // both PS1 cores share one shelf, as they do on a device page
+        case FAV_KIND_ELF:
+            return LIB_VIEW_ELF;
+        default:
+            return LIB_VIEW_ISO;
+    }
+}
+
+// A PS1 favourite is name-addressed (art, config and launch all key off the stored text) and so is
+// view-independent; an ISO or ELF one is id-addressed against its source's list.
+static int favKindIsNameAddressed(int kind)
+{
+    return kind == FAV_KIND_VCD || kind == FAV_KIND_CUE;
+}
+
+static int favResolveStoredId(item_list_t *source, int id, const char *text, int kind, int *outId)
 {
     if (source == NULL || text == NULL || outId == NULL || source->itemGetCount == NULL || source->itemGetName == NULL)
         return 0;
@@ -418,11 +449,11 @@ static int favResolveStoredId(item_list_t *source, int id, const char *text, int
     // ETH has one live backing array whose contents follow the source page's L3 state, so a shallow
     // viewOverride cannot turn VCD-backed ethGames into the ISO list. Resolve that one mode through
     // ETH's private read-only ISO backing probe. Every other device keeps the existing proxy path.
-    if (source->mode == ETH_MODE && !isVcd)
+    if (source->mode == ETH_MODE && kind == FAV_KIND_ISO)
         return ethResolveIsoFavourite(id, text, outId);
 
     item_list_t view = *source;
-    view.viewOverride = isVcd ? ITEM_VIEW_FORCE_VCD : ITEM_VIEW_FORCE_ISO;
+    view.viewOverride = favKindIsNameAddressed(kind) ? ITEM_VIEW_FORCE_PS1 : ITEM_VIEW_FORCE_ISO;
     int count = view.itemGetCount(&view);
 
     // APP ids are aggregate-list positions and can move; their stable identity is the title.
@@ -446,24 +477,35 @@ static int favResolveStoredId(item_list_t *source, int id, const char *text, int
     return 1;
 }
 
-static item_list_t *favResolve(int mode, int id, const char *text, int isVcd, int *outMode, int *outId)
+// Can this support launch a PS1 favourite of the wanted core by NAME?
+static int favSupportLaunches(const item_list_t *support, int needCue)
+{
+    if (support == NULL)
+        return 0;
+    return needCue ? (support->itemLaunchCue != NULL) : (support->itemLaunchVcd != NULL);
+}
+
+static item_list_t *favResolve(int mode, int id, const char *text, int kind, int *outMode, int *outId)
 {
     *outMode = mode;
     *outId = id;
 
-    // VCD favourites are name-addressed and already view-independent: art/config/launch all key off
-    // the stored .VCD basename. Bind them to a loaded VCD-capable source without disturbing that
-    // source page's current ISO/VCD view.
-    if (isVcd) {
+    // PS1 favourites are name-addressed and already view-independent: art/config/launch all key off
+    // the stored name. Bind one to a loaded source that can launch ITS core -- a POPSTARTER
+    // favourite needs itemLaunchVcd, an Ember one needs itemLaunchCue -- without disturbing that
+    // source page's current view. Binding a CUE favourite to a device with no Ember support would
+    // produce a row whose X button cannot work.
+    if (favKindIsNameAddressed(kind)) {
+        const int needCue = (kind == FAV_KIND_CUE);
         if (mode >= BDM_MODE && mode <= BDM_MODE_LAST) {
             opl_io_module_t *mod = oplGetModule(mode);
-            if (mod != NULL && mod->support != NULL && mod->support->itemLaunchVcd != NULL) {
+            if (mod != NULL && mod->support != NULL && favSupportLaunches(mod->support, needCue)) {
                 favVcdMarkStar(mod, id, text);
                 return mod->support;
             }
             for (int m = BDM_MODE; m <= BDM_MODE_LAST; m++) {
                 opl_io_module_t *bm = oplGetModule(m);
-                if (bm != NULL && bm->support != NULL && bm->support->itemLaunchVcd != NULL) {
+                if (bm != NULL && bm->support != NULL && favSupportLaunches(bm->support, needCue)) {
                     *outMode = m;
                     favVcdMarkStar(bm, id, text);
                     return bm->support;
@@ -474,7 +516,7 @@ static item_list_t *favResolve(int mode, int id, const char *text, int isVcd, in
         if (mode < 0 || mode >= MODE_COUNT)
             return NULL;
         opl_io_module_t *mod = oplGetModule(mode);
-        if (mod == NULL || mod->support == NULL || mod->support->itemLaunchVcd == NULL)
+        if (mod == NULL || mod->support == NULL || !favSupportLaunches(mod->support, needCue))
             return NULL;
         favVcdMarkStar(mod, id, text);
         return mod->support;
@@ -574,15 +616,15 @@ static int favUpdateItemList(item_list_t *itemList)
     // also restores the star on the source submenu. Filtering first meant a saved VCD record was never
     // resolved while FAV itself was in ISO view, so rebuilding the HDD list on an L3 toggle erased the
     // visible star and loadFavourites() could not put it back (#495).
-    int favVcdView = (libViewActive(FAV_MODE) == LIB_VIEW_PS1);
+    int favShelf = libViewActive(FAV_MODE);
     for (int i = 0; i < rawCount; i++) {
         int resolvedMode = recs[i].mode;
         int resolvedId = recs[i].id;
-        item_list_t *owner = favResolve(recs[i].mode, recs[i].id, recs[i].text, recs[i].isVcd, &resolvedMode, &resolvedId);
+        item_list_t *owner = favResolve(recs[i].mode, recs[i].id, recs[i].text, recs[i].kind, &resolvedMode, &resolvedId);
 
-        // The FAV page still deliberately has its own L3 split: resolution above is global star/state
-        // reconciliation; only display population is filtered to the page's current view.
-        if ((recs[i].isVcd ? 1 : 0) != favVcdView)
+        // The FAV page keeps its own L3 ring (PS2 / PS1 / APPS): resolution above is global
+        // star/state reconciliation; only display population is filtered to the current shelf.
+        if (favKindView(recs[i].kind) != favShelf)
             continue;
 
         if (owner == NULL) {
@@ -615,7 +657,7 @@ static int favUpdateItemList(item_list_t *itemList)
         favArray[favCount].id = resolvedId;
         favArray[favCount].icon_id = recs[i].icon_id;
         favArray[favCount].text_id = recs[i].text_id;
-        favArray[favCount].isVcd = recs[i].isVcd;
+        favArray[favCount].kind = recs[i].kind;
         favArray[favCount].text = txt;
         favCount++;
     }
@@ -638,7 +680,10 @@ static item_list_t *favOwnerView(int id, item_list_t *view)
         return NULL;
 
     *view = *favArray[id].owner;
-    view->viewOverride = favArray[id].isVcd ? ITEM_VIEW_FORCE_VCD : ITEM_VIEW_FORCE_ISO;
+    // A PS1 favourite reads its source's retained PS1 array (which holds both cores' rows) even
+    // while that source page shows PS2; anything else reads the source's own base list. An ELF
+    // favourite's source is the APPS tab, which has one list and ignores the override entirely.
+    view->viewOverride = favKindIsNameAddressed(favArray[id].kind) ? ITEM_VIEW_FORCE_PS1 : ITEM_VIEW_FORCE_ISO;
     return view;
 }
 
@@ -672,8 +717,8 @@ static char *favGetItemStartup(item_list_t *itemList, int id)
 {
     if (!favValidIndex(id))
         return "";
-    if (favArray[id].isVcd)
-        return favArray[id].text; // VCD favourites key art/launch off the .VCD name, not a submenu id
+    if (favKindIsNameAddressed(favArray[id].kind))
+        return favArray[id].text; // PS1 favourites key art/launch off the stored name, not a submenu id
     item_list_t ownerView;
     item_list_t *o = favOwnerView(id, &ownerView);
     if (o == NULL || o->itemGetStartup == NULL || !favOwnerHasId(o, favArray[id].id))
@@ -692,7 +737,7 @@ static config_set_t *favGetConfig(item_list_t *itemList, int id)
     // VCD favourite: the owner's id-based config is the disc list (wrong list / wrong id while the
     // device is in ISO view). Build the PS1 config straight from the .VCD name + the device prefix,
     // exactly as sbPopulateConfig keys VCD per-game data by filename -> gives Title + #DiscType badge.
-    if (favArray[id].isVcd) {
+    if (favKindIsNameAddressed(favArray[id].kind)) {
         char *prefix = (o->itemGetPrefix != NULL) ? o->itemGetPrefix(o) : NULL;
         if (prefix == NULL)
             return NULL;
@@ -701,9 +746,13 @@ static config_set_t *favGetConfig(item_list_t *itemList, int id)
         base_game_info_t game;
         memset(&game, 0, sizeof(game));
         snprintf(game.name, sizeof(game.name), "%s", favArray[id].text);
-        snprintf(game.extension, sizeof(game.extension), ".VCD");
+        // The extension is the ROW-KIND discriminator, exactly as on a device page: stamp the
+        // core this favourite actually belongs to, or an Ember favourite would describe itself as a
+        // POPSTARTER one to every consumer that inspects the row.
+        snprintf(game.extension, sizeof(game.extension), "%s",
+                 (favArray[id].kind == FAV_KIND_CUE) ? CUE_ROW_EXTENSION : ".VCD");
         game.parts = 1;
-        game.format = GAME_FORMAT_ISO; // matches vcdFillGameList; the .VCD extension drives the PS1 badge
+        game.format = GAME_FORMAT_ISO; // matches the device scans; the extension drives the PS1 badge
         return sbPopulateConfig(&game, prefix, sep);
     }
     if (o->itemGetConfig == NULL || !favOwnerHasId(o, favArray[id].id))
@@ -719,13 +768,19 @@ static void favLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
     item_list_t *o = favOwnerView(id, &ownerView);
     if (o == NULL)
         return;
-    // VCD favourite: hand the .VCD name to the owner's POPSTARTER launcher. This is view-independent
-    // (works while the device page is in ISO view), unlike the id-based itemLaunch whose VCD branch is
-    // gated on the device being live in VCD view. favResolve only binds a VCD fav to a device that
-    // provides itemLaunchVcd, so the NULL check below should never fire for a resolved VCD fav.
-    if (favArray[id].isVcd) {
-        if (o->itemLaunchVcd != NULL)
-            o->itemLaunchVcd(o, favArray[id].text, configSet);
+    // PS1 favourite: hand the stored name to the owner's launcher for THIS row's core. Being
+    // name-addressed, it works while the source page shows PS2 -- unlike the id-based itemLaunch,
+    // whose PS1 branch is gated on the device being live in its PS1 view. favResolve only binds a
+    // PS1 favourite to a device that provides the matching hook, so neither NULL check below should
+    // fire for a resolved favourite.
+    if (favKindIsNameAddressed(favArray[id].kind)) {
+        if (favArray[id].kind == FAV_KIND_CUE) {
+            if (o->itemLaunchCue != NULL)
+                o->itemLaunchCue(o, favArray[id].text, configSet);
+        } else {
+            if (o->itemLaunchVcd != NULL)
+                o->itemLaunchVcd(o, favArray[id].text, configSet);
+        }
         return;
     }
     if (o->itemLaunch == NULL || !favOwnerHasId(o, favArray[id].id))
@@ -744,9 +799,10 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
         item_list_t *o = favOwnerView(i, &ownerView);
         if (o == NULL)
             continue;
-        // VCD favourite: route both the primary filename and the cache's strict-ID fallback through
-        // the OWNER device's normal ART path. No separate directory or VCD art loader is used (#120).
-        if (favArray[i].isVcd) {
+        // PS1 favourite: route both the primary name and the cache's strict-ID fallback through the
+        // OWNER device's normal ART path, which already resolves the per-core in-library fallback by
+        // row kind. The disc-ID fallback simply never matches an Ember folder name, which is correct.
+        if (favKindIsNameAddressed(favArray[i].kind)) {
             if (strcmp(favArray[i].text, value) != 0) {
                 char fallbackKey[VCD_ID_MAX];
                 if (!vcdExtractGameId(favArray[i].text, fallbackKey, sizeof(fallbackKey)) ||
@@ -791,7 +847,7 @@ static int favGetImage(item_list_t *itemList, char *folder, int isRelative, char
             item_list_t ownerView;
             item_list_t *o = favOwnerView(i, &ownerView);
             if (o == NULL || o->itemGetImage == NULL ||
-                (!favArray[i].isVcd && !favOwnerHasId(o, favArray[i].id)))
+                (!favKindIsNameAddressed(favArray[i].kind) && !favOwnerHasId(o, favArray[i].id)))
                 continue;
             int r = o->itemGetImage(o, folder, isRelative, value, suffix, resultTex, psm);
             if (r != -1)
@@ -826,7 +882,7 @@ int favGetArtMode(const char *value)
         item_list_t *o = favOwnerView(i, &ownerView);
         if (o == NULL)
             continue;
-        if (favArray[i].isVcd) {
+        if (favKindIsNameAddressed(favArray[i].kind)) {
             if (strcmp(favArray[i].text, value) != 0) {
                 char fallbackKey[VCD_ID_MAX];
                 if (!vcdExtractGameId(favArray[i].text, fallbackKey, sizeof(fallbackKey)) ||
@@ -914,7 +970,7 @@ static int favModesMatch(int a, int b)
 
 // ---- public toggle / refresh API ----------------------------------------------
 
-int addFavouriteItem(int mode, int id, int icon_id, int text_id, const char *text, int isVcd)
+int addFavouriteItem(int mode, int id, int icon_id, int text_id, const char *text, int kind)
 {
     if (text == NULL || text[0] == '\0')
         return 0;
@@ -922,14 +978,14 @@ int addFavouriteItem(int mode, int id, int icon_id, int text_id, const char *tex
     int count = 0;
     fav_raw_t *recs = favReadFile(&count); // may be NULL (empty / new file)
 
-    // Already present (same mode + id + text + isVcd) -> treat as success (the star stays set).
+    // Already present (same mode + id + text + kind) -> treat as success (the star stays set).
     // Use favModesMatch so a BDM favourite that moved slots (e.g. BDM_MODE -> BDM_MODE1) is
     // recognised as already-present, matching the BDM-lenient logic in removeFavouriteByIdAndText.
-    // isVcd is part of the identity so a disc favourite and a PS1 favourite never collide.
+    // kind is part of the identity so a disc favourite and a PS1 favourite never collide.
     for (int i = 0; i < count; i++) {
         // favIdsMatchForMode: apps identify by title (their stored id shifts with the device set) --
         // without it, a shifted app would collect a DUPLICATE record on every re-favourite.
-        if (favModesMatch(recs[i].mode, mode) && favIdsMatchForMode(mode, recs[i].id, id) && (recs[i].isVcd ? 1 : 0) == (isVcd ? 1 : 0) && strcmp(recs[i].text, text) == 0) {
+        if (favModesMatch(recs[i].mode, mode) && favIdsMatchForMode(mode, recs[i].id, id) && recs[i].kind == kind && strcmp(recs[i].text, text) == 0) {
             free(recs);
             return 1;
         }
@@ -951,7 +1007,7 @@ int addFavouriteItem(int mode, int id, int icon_id, int text_id, const char *tex
     out[count].id = id;
     out[count].icon_id = icon_id;
     out[count].text_id = text_id;
-    out[count].isVcd = isVcd ? 1 : 0;
+    out[count].kind = kind;
     snprintf(out[count].text, FAV_TEXT_MAX, "%s", text);
 
     int ok = favWriteFile(out, newCount);
@@ -960,7 +1016,7 @@ int addFavouriteItem(int mode, int id, int icon_id, int text_id, const char *tex
     return ok;
 }
 
-int removeFavouriteByIdAndText(int mode, int id, const char *text, int isVcd)
+int removeFavouriteByIdAndText(int mode, int id, const char *text, int kind)
 {
     int count = 0;
     fav_raw_t *recs = favReadFile(&count);
@@ -969,11 +1025,11 @@ int removeFavouriteByIdAndText(int mode, int id, const char *text, int isVcd)
 
     int survivors = 0;
     for (int i = 0; i < count; i++) {
-        // Match on id + text + mode (BDM-lenient) + isVcd so a same-titled favourite in a different
+        // Match on id + text + mode (BDM-lenient) + kind so a same-titled favourite in a different
         // device mode -- or a disc vs PS1 favourite of the same title -- is NOT collaterally deleted.
         // Apps match by title alone (favIdsMatchForMode): their stored id shifts with the device set,
         // and without the leniency R3 on an already-starred app could not un-favourite it.
-        if (!(favIdsMatchForMode(mode, recs[i].id, id) && text != NULL && strcmp(recs[i].text, text) == 0 && favModesMatch(recs[i].mode, mode) && (recs[i].isVcd ? 1 : 0) == (isVcd ? 1 : 0)))
+        if (!(favIdsMatchForMode(mode, recs[i].id, id) && text != NULL && strcmp(recs[i].text, text) == 0 && favModesMatch(recs[i].mode, mode) && recs[i].kind == kind))
             recs[survivors++] = recs[i]; // compact in place (single buffer)
     }
     int ok = favWriteFile(recs, survivors); // survivors may be 0 -> writes a header-only (empty) file
@@ -987,7 +1043,7 @@ void favRemoveByIndex(int favIndex)
         return;
     int srcMode = favArray[favIndex].mode;
     int srcId = favArray[favIndex].id;
-    int srcIsVcd = favArray[favIndex].isVcd;
+    int srcKind = favArray[favIndex].kind;
     char *txt = favArray[favIndex].text;
 
     // Clear the star on the source-list copy, then drop the record from the store. (For a VCD fav the
@@ -999,7 +1055,7 @@ void favRemoveByIndex(int favIndex)
         if (src != NULL)
             src->item.favourited = 0;
     }
-    removeFavouriteByIdAndText(srcMode, srcId, txt, srcIsVcd);
+    removeFavouriteByIdAndText(srcMode, srcId, txt, srcKind);
 }
 
 void loadFavourites(void)

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -24,7 +24,8 @@
 #include "include/textures.h"
 #include "include/config.h"
 #include "include/supportbase.h" // sbPopulateConfig + base_game_info_t (VCD favourite config)
-#include "include/vcdsupport.h"  // vcdViewActive / vcdConsumeDirty (VCD favourites)
+#include "include/vcdsupport.h"  // VCD favourites: name-addressed POPSTARTER launch helpers
+#include "include/libview.h"     // libViewActive / libListViewActive -- which list this page shows
 #include "include/ethsupport.h"  // ETH ISO favourite resolution while the live source is in VCD view
 #include "include/favsupport.h"
 
@@ -376,7 +377,7 @@ static void favFreeArray(void)
 // shifted -- purely cosmetic on the source page; the FAV record + launch are unaffected either way.
 static void favVcdMarkStar(opl_io_module_t *mod, int id, const char *text)
 {
-    if (mod == NULL || mod->support == NULL || !vcdViewActive(mod->support->mode))
+    if (mod == NULL || mod->support == NULL || libViewActive(mod->support->mode) != LIB_VIEW_VCD)
         return;
     submenu_list_t *src = submenuFindItemByIdAndText(mod->subMenu, id, text);
     if (src != NULL)
@@ -489,7 +490,7 @@ static item_list_t *favResolve(int mode, int id, const char *text, int isVcd, in
                 continue;
             int liveId = id;
             if (favResolveStoredId(mod->support, id, text, 0, &liveId)) {
-                if (!vcdViewActive(mod->support->mode)) {
+                if (libViewActive(mod->support->mode) != LIB_VIEW_VCD) {
                     submenu_list_t *src = submenuFindItemByIdAndText(mod->subMenu, liveId, text);
                     if (src != NULL)
                         src->item.favourited = 1;
@@ -512,7 +513,7 @@ static item_list_t *favResolve(int mode, int id, const char *text, int isVcd, in
     if (!favResolveStoredId(mod->support, id, text, 0, &liveId))
         return NULL;
 
-    if (!vcdViewActive(mod->support->mode)) {
+    if (libViewActive(mod->support->mode) != LIB_VIEW_VCD) {
         submenu_list_t *src = submenuFindItemByIdAndText(mod->subMenu, liveId, text);
         if (src != NULL)
             src->item.favourited = 1;
@@ -538,7 +539,7 @@ static int favNeedsUpdate(item_list_t *itemList)
     // Consume the FAV L3 ISO<->VCD dirty flag UNCONDITIONALLY (and first) so a concurrent
     // favForceUpdate rebuild also clears it -- otherwise a default-view change that raises both would
     // trigger one redundant byte-identical re-read on the following pass.
-    int viewToggled = vcdConsumeDirty(FAV_MODE);
+    int viewToggled = libViewConsumeDirty(FAV_MODE);
     if (favForceUpdate) {
         favForceUpdate = 0;
         return 1;
@@ -573,7 +574,7 @@ static int favUpdateItemList(item_list_t *itemList)
     // also restores the star on the source submenu. Filtering first meant a saved VCD record was never
     // resolved while FAV itself was in ISO view, so rebuilding the HDD list on an L3 toggle erased the
     // visible star and loadFavourites() could not put it back (#495).
-    int favVcdView = vcdViewActive(FAV_MODE);
+    int favVcdView = (libViewActive(FAV_MODE) == LIB_VIEW_VCD);
     for (int i = 0; i < rawCount; i++) {
         int resolvedMode = recs[i].mode;
         int resolvedId = recs[i].id;

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -377,7 +377,7 @@ static void favFreeArray(void)
 // shifted -- purely cosmetic on the source page; the FAV record + launch are unaffected either way.
 static void favVcdMarkStar(opl_io_module_t *mod, int id, const char *text)
 {
-    if (mod == NULL || mod->support == NULL || libViewActive(mod->support->mode) != LIB_VIEW_VCD)
+    if (mod == NULL || mod->support == NULL || libViewActive(mod->support->mode) != LIB_VIEW_PS1)
         return;
     submenu_list_t *src = submenuFindItemByIdAndText(mod->subMenu, id, text);
     if (src != NULL)
@@ -490,7 +490,7 @@ static item_list_t *favResolve(int mode, int id, const char *text, int isVcd, in
                 continue;
             int liveId = id;
             if (favResolveStoredId(mod->support, id, text, 0, &liveId)) {
-                if (libViewActive(mod->support->mode) != LIB_VIEW_VCD) {
+                if (libViewActive(mod->support->mode) != LIB_VIEW_PS1) {
                     submenu_list_t *src = submenuFindItemByIdAndText(mod->subMenu, liveId, text);
                     if (src != NULL)
                         src->item.favourited = 1;
@@ -513,7 +513,7 @@ static item_list_t *favResolve(int mode, int id, const char *text, int isVcd, in
     if (!favResolveStoredId(mod->support, id, text, 0, &liveId))
         return NULL;
 
-    if (libViewActive(mod->support->mode) != LIB_VIEW_VCD) {
+    if (libViewActive(mod->support->mode) != LIB_VIEW_PS1) {
         submenu_list_t *src = submenuFindItemByIdAndText(mod->subMenu, liveId, text);
         if (src != NULL)
             src->item.favourited = 1;
@@ -574,7 +574,7 @@ static int favUpdateItemList(item_list_t *itemList)
     // also restores the star on the source submenu. Filtering first meant a saved VCD record was never
     // resolved while FAV itself was in ISO view, so rebuilding the HDD list on an L3 toggle erased the
     // visible star and loadFavourites() could not put it back (#495).
-    int favVcdView = (libViewActive(FAV_MODE) == LIB_VIEW_VCD);
+    int favVcdView = (libViewActive(FAV_MODE) == LIB_VIEW_PS1);
     for (int i = 0; i < rawCount; i++) {
         int resolvedMode = recs[i].mode;
         int resolvedId = recs[i].id;

--- a/src/favsupport.c
+++ b/src/favsupport.c
@@ -217,7 +217,12 @@ static fav_raw_t *favReadFile(int *outCount)
         close(fd);
         return imported;
     }
-    if (ver != 1 && ver != 2) {
+    // Range-checked against FAV_VERSION rather than listing versions. The enumerated form let the
+    // writer's version outrun the reader's list: FAV_VERSION went to 3, favWriteFile stamped 3, and
+    // this gate still admitted only 1 and 2 -- so the first save after upgrading produced a file the
+    // NEXT boot refused, presenting an empty favourites tab that would then be written back over the
+    // user's real list. Bumping the version must never again require remembering to edit this line.
+    if (ver < 1 || ver > FAV_VERSION) {
         LOG("FAV reject: unsupported OFAV version %d\n", ver);
         close(fd);
         return NULL;

--- a/src/gui.c
+++ b/src/gui.c
@@ -26,6 +26,7 @@
 #include "include/bdmsupport.h" // bdmIsUDPBDLoaded() + bdmForceDeviceRefresh()
 #include "include/hddsupport.h" // staged normal APA OPL-home selector
 #include "include/vcdsupport.h" // POPStarter pages: BDMA equip, list options, POPS net config
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 #include "include/compatupd.h"
 #include "include/pggsm.h"
 #include "include/cheatman.h"
@@ -1033,7 +1034,7 @@ reshow_ui:
         diaGetInt(diaUIConfig, UICFG_GAMEVIEW, &gDefaultGameView);
         int gameViewChanged = gDefaultGameView != previousGameView;
         if (gameViewChanged) {
-            vcdMarkAllDirty(); // rebuild every VCD-capable page so the new default view takes effect
+            libViewMarkAllDirty(); // rebuild every VCD-capable page so the new default view takes effect
         }
         diaGetInt(diaUIConfig, UICFG_VMODE, &gVMode);
 
@@ -1045,7 +1046,7 @@ reshow_ui:
             // applyConfig(..., skipDeviceRefresh=1) deliberately avoids device scans. Queue after it
             // returns so HDD (which has no automatic refresh) cannot retain PS2 rows while rendering
             // uses the new VCD view, without racing the theme/menu bookkeeping above.
-            oplQueueVcdDeviceUpdates();
+            oplQueueLibraryDeviceUpdates();
             loadFavourites(); // queued after source pages so the FAV resolver sees their rebuilt rows
         }
         sfxInit(0);
@@ -1506,7 +1507,7 @@ void guiShowVcdListConfig(void)
         {
             // #195: hide-gameid is NO LONGER purely cosmetic -- it is now a SORT KEY. The menu sort
             // (submenuSort) orders by the DISPLAYED title, i.e. past the hidden prefix, so a change must
-            // re-sort every VCD-capable page. vcdMarkAllDirty() + rebuildVcdLists forces that menu rebuild
+            // re-sort every VCD-capable page. libViewMarkAllDirty() + rebuildVcdLists forces that menu rebuild
             // and its submenuSort re-runs against the new vcdDisplayName key -- WITHOUT re-reading any
             // device. Do NOT invalidate the HDD VCD cache here (unlike first-disc-only below): this toggle
             // changes only the DISPLAY ORDER, not the list CONTENTS, and submenuSort reorders the cached
@@ -1517,7 +1518,7 @@ void guiShowVcdListConfig(void)
             int previousHideGameId = gVcdHideGameId;
             diaGetInt(diaVcdListConfig, CFG_VCD_HIDE_GAMEID, &gVcdHideGameId);
             if (gVcdHideGameId != previousHideGameId) {
-                vcdMarkAllDirty();
+                libViewMarkAllDirty();
                 rebuildVcdLists = 1;
             }
         }
@@ -1528,7 +1529,7 @@ void guiShowVcdListConfig(void)
             int previousFirstDiscOnly = gVcdFirstDiscOnly;
             diaGetInt(diaVcdListConfig, CFG_VCD_FIRST_DISC_ONLY, &gVcdFirstDiscOnly);
             if (gVcdFirstDiscOnly != previousFirstDiscOnly) {
-                vcdMarkAllDirty();
+                libViewMarkAllDirty();
                 hddVcdInvalidateCache(); // scan-time filter changed -> the cached HDD VCD list is stale
                 rebuildVcdLists = 1;
             }
@@ -1540,7 +1541,7 @@ void guiShowVcdListConfig(void)
             int previousShowPpPops = gVcdShowPpPops;
             diaGetInt(diaVcdListConfig, CFG_VCD_SHOW_PP_POPS, &gVcdShowPpPops);
             if (gVcdShowPpPops != previousShowPpPops) {
-                vcdMarkAllDirty();
+                libViewMarkAllDirty();
                 hddVcdInvalidateCache();
                 rebuildVcdLists = 1;
             }
@@ -1550,7 +1551,7 @@ void guiShowVcdListConfig(void)
         // Queue after applyConfig/menu reinit so the IO worker cannot rebuild a submenu concurrently
         // with their support/menu bookkeeping on the GUI thread.
         if (rebuildVcdLists)
-            oplQueueVcdDeviceUpdates();
+            oplQueueLibraryDeviceUpdates();
     }
 }
 
@@ -2884,7 +2885,7 @@ reshow_interface:
             diaGetInt(ui, UICFG_GAMEVIEW, &gDefaultGameView);
             gameViewChanged = gDefaultGameView != previousGameView;
             if (gameViewChanged)
-                vcdMarkAllDirty();
+                libViewMarkAllDirty();
         }
         diaGetInt(ui, UICFG_VMODE, &gVMode);
         diaGetInt(ui, UICFG_WIDESCREEN, &gWideScreen);
@@ -2901,7 +2902,7 @@ reshow_interface:
             bgmStop();
         applyConfig(themeID, langID, 1);
         if (gameViewChanged) {
-            oplQueueVcdDeviceUpdates();
+            oplQueueLibraryDeviceUpdates();
             loadFavourites();
         }
         sfxInit(0);

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -12,7 +12,8 @@
 #include "include/ethsupport.h"
 #include "include/favsupport.h"
 #include "include/bdmsupport.h"
-#include "include/vcdsupport.h" // vcdViewActive -- VCD games are POPSTARTER-only (Loader Core is N/A)
+#include "include/vcdsupport.h" // VCD games are POPSTARTER-only (Loader Core is N/A)
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 #include "include/compatupd.h"
 #include "include/cheatman.h"
 #include "include/system.h"
@@ -1184,17 +1185,17 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
     // a VCD (PS1) view never launches through Neutrino at all. FAV proxies the real device, so it
     // stays enabled and the launch-side guard arbitrates.
     bsdfsDeviceCapable = (support == NULL) ||
-                         ((support->mode >= BDM_MODE && support->mode <= BDM_MODE6 && !vcdViewActive(support->mode)) ||
+                         ((support->mode >= BDM_MODE && support->mode <= BDM_MODE6 && libViewActive(support->mode) != LIB_VIEW_VCD) ||
                           support->mode == FAV_MODE);
     // VCD games launch through POPSTARTER only, so the Loader Core is inert for them -- keep every
     // Neutrino-only row greyed even under a Neutrino global default (guiGameSetCoreAwareState reads
     // this). SMB likewise: ethsupport has no Neutrino launch leg, the effective core is always <OPL>.
-    coreNeverNeutrino = (support != NULL && (vcdViewActive(support->mode) || support->mode == ETH_MODE));
+    coreNeverNeutrino = (support != NULL && ((libViewActive(support->mode) == LIB_VIEW_VCD) || support->mode == ETH_MODE));
 
     // UDPBD games have no OPL core backend -- they always launch via Neutrino
     // (bdmsupport.c forces it). Lock the selector to Neutrino so the screen matches;
     // re-enable it for every other device (the dialog struct is reused across games).
-    if (support != NULL && vcdViewActive(support->mode)) {
+    if (support != NULL && (libViewActive(support->mode) == LIB_VIEW_VCD)) {
         // VCD (PS1) games launch ONLY via POPSTARTER -- neither OPL's core nor Neutrino is used, so the
         // Loader Core choice is meaningless. Pin it to the inert "Default" row (index 2 -> no per-game
         // $CoreLoader key persisted, as before) and lock the row so the screen doesn't imply a VCD game

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -1185,17 +1185,17 @@ void guiGameShowCompatConfig(int id, item_list_t *support, config_set_t *configS
     // a VCD (PS1) view never launches through Neutrino at all. FAV proxies the real device, so it
     // stays enabled and the launch-side guard arbitrates.
     bsdfsDeviceCapable = (support == NULL) ||
-                         ((support->mode >= BDM_MODE && support->mode <= BDM_MODE6 && libViewActive(support->mode) != LIB_VIEW_VCD) ||
+                         ((support->mode >= BDM_MODE && support->mode <= BDM_MODE6 && libViewActive(support->mode) != LIB_VIEW_PS1) ||
                           support->mode == FAV_MODE);
     // VCD games launch through POPSTARTER only, so the Loader Core is inert for them -- keep every
     // Neutrino-only row greyed even under a Neutrino global default (guiGameSetCoreAwareState reads
     // this). SMB likewise: ethsupport has no Neutrino launch leg, the effective core is always <OPL>.
-    coreNeverNeutrino = (support != NULL && ((libViewActive(support->mode) == LIB_VIEW_VCD) || support->mode == ETH_MODE));
+    coreNeverNeutrino = (support != NULL && ((libViewActive(support->mode) == LIB_VIEW_PS1) || support->mode == ETH_MODE));
 
     // UDPBD games have no OPL core backend -- they always launch via Neutrino
     // (bdmsupport.c forces it). Lock the selector to Neutrino so the screen matches;
     // re-enable it for every other device (the dialog struct is reused across games).
-    if (support != NULL && (libViewActive(support->mode) == LIB_VIEW_VCD)) {
+    if (support != NULL && (libViewActive(support->mode) == LIB_VIEW_PS1)) {
         // VCD (PS1) games launch ONLY via POPSTARTER -- neither OPL's core nor Neutrino is used, so the
         // Loader Core choice is meaningless. Pin it to the inert "Default" row (index 2 -> no per-game
         // $CoreLoader key persisted, as before) and lock the row so the screen doesn't imply a VCD game

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1033,7 +1033,7 @@ static int hddNeedsUpdate(item_list_t *itemList)
        Hence any update request would be issued by the user, which should be taken as an explicit request to re-scan the HDD. */
     if (libViewConsumeDirty(itemList->mode))
         return 1; // L3 toggle / default-view change -> rebuild the submenu (the ARRAY may be cached)
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         // The locked-to-VCD startup path also receives the normal initial deferred update, but no
         // toggle dirtied the view first. Build once when the VCD backing list does not exist yet.
         // A manual HDD/VCD refresh invalidates this latch before posting the same deferred update.
@@ -1126,7 +1126,7 @@ static int hddUpdateGameList(item_list_t *itemList)
     if (!hddSupportModulesLoaded)
         LOG("HDDSUPPORT UpdateGameList: PFS support incomplete; attempting read-only APA enumeration anyway\n");
 
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         // Reuse the session's built list on view flips; hddBuildVcdGameList runs only when never
         // built, invalidated (first-disc-only change), or freed by teardown (hddFreeVcdGameList).
         return hddVcdListBuilt ? hddVcdGameCount : hddBuildVcdGameList();
@@ -1170,7 +1170,7 @@ static int hddUpdateGameList(item_list_t *itemList)
 
 static int hddGetGameCount(item_list_t *itemList)
 {
-    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? hddVcdGameCount : (int)hddGames.count;
+    return (libListViewActive(itemList) == LIB_VIEW_PS1) ? hddVcdGameCount : (int)hddGames.count;
 }
 
 // Toggle-window guard (Codex/Fable audit), mirroring mmceActiveGame. HDD_MODE has a VCD stop in its ring, so the L3
@@ -1197,28 +1197,28 @@ static hdl_game_info_t *hddActiveHdl(int id)
 
 static void *hddGetGame(item_list_t *itemList, int id)
 {
-    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? (void *)hddActiveVcd(id) : (void *)hddActiveHdl(id);
+    return (libListViewActive(itemList) == LIB_VIEW_PS1) ? (void *)hddActiveVcd(id) : (void *)hddActiveHdl(id);
 }
 
 static char *hddGetGameName(item_list_t *itemList, int id)
 {
-    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? hddActiveVcd(id)->name : hddActiveHdl(id)->name;
+    return (libListViewActive(itemList) == LIB_VIEW_PS1) ? hddActiveVcd(id)->name : hddActiveHdl(id)->name;
 }
 
 static int hddGetGameNameLength(item_list_t *itemList, int id)
 {
-    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? VCD_NAME_MAX : (HDL_GAME_NAME_MAX + 1);
+    return (libListViewActive(itemList) == LIB_VIEW_PS1) ? VCD_NAME_MAX : (HDL_GAME_NAME_MAX + 1);
 }
 
 static char *hddGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game CFG/art off the VCD filename (game->name), not a disc id.
-    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? hddActiveVcd(id)->name : hddActiveHdl(id)->startup;
+    return (libListViewActive(itemList) == LIB_VIEW_PS1) ? hddActiveVcd(id)->name : hddActiveHdl(id)->startup;
 }
 
 static void hddDeleteGame(item_list_t *itemList, int id)
 {
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         return; // a VCD is not an HDL partition -- no delete in VCD view
     hdl_game_info_t *game = hddActiveHdl(id);
     if (game == &hddEmptyHdl)
@@ -1519,7 +1519,7 @@ static void hddRenameVcd(int id, const char *newName)
 
 static void hddRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
+    if (libListViewActive(itemList) == LIB_VIEW_PS1) {
         hddRenameVcd(id, newName);
         return;
     }
@@ -1768,7 +1768,7 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // POPSTARTER self-mounts it after the loader's IOP reset. HW-VALIDATE: POPSTARTER's exact HDD
     // selector/partition contract is hardware-testable -- POPSLoader proved the shape with a vendored
     // loader; we use the stock ps2sdk loader, the same one the shipping USB/MMCE/SMB VCD launch uses.
-    if (gAutoLaunchGame == NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
+    if (gAutoLaunchGame == NULL && (libListViewActive(itemList) == LIB_VIEW_PS1)) {
         char vcdName[VCD_NAME_MAX];
         char vcdPart[APA_IDMAX + 1];
 
@@ -1990,7 +1990,7 @@ static config_set_t *hddGetConfig(item_list_t *itemList, int id)
     // VCD (PS1) view: `id` indexes hddVcdGames, NOT hddGames. The list itself is discoverable from
     // APA even when the persistent config/art PFS home is temporarily unavailable. In that state
     // return a runtime-only config instead of dereferencing a NULL prefix or hiding the whole list.
-    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
+    if (libListViewActive(itemList) == LIB_VIEW_PS1) {
         base_game_info_t *g = hddActiveVcd(id);
         if (gHDDPrefix != NULL)
             return sbPopulateConfig(g, gHDDPrefix, "/");

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -4,7 +4,8 @@
 #include "include/gui.h"
 #include "include/supportbase.h"
 #include "include/hddsupport.h"
-#include "include/vcdsupport.h" // HDD VCD view: vcdScanDirRoot/vcdViewActive + vcd_entry_t
+#include "include/vcdsupport.h" // HDD VCD view: vcdScanDirRoot + vcd_entry_t
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 #include "include/util.h"
 #include "include/themes.h"
 #include "include/textures.h"
@@ -1030,9 +1031,9 @@ static int hddBuildVcdGameList(void)
 static int hddNeedsUpdate(item_list_t *itemList)
 { /* Auto refresh is disabled by setting HDD_MODE_UPDATE_DELAY to MENU_UPD_DELAY_NOUPDATE, within hddsupport.h.
        Hence any update request would be issued by the user, which should be taken as an explicit request to re-scan the HDD. */
-    if (vcdConsumeDirty(itemList->mode))
+    if (libViewConsumeDirty(itemList->mode))
         return 1; // L3 toggle / default-view change -> rebuild the submenu (the ARRAY may be cached)
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         // The locked-to-VCD startup path also receives the normal initial deferred update, but no
         // toggle dirtied the view first. Build once when the VCD backing list does not exist yet.
         // A manual HDD/VCD refresh invalidates this latch before posting the same deferred update.
@@ -1125,7 +1126,7 @@ static int hddUpdateGameList(item_list_t *itemList)
     if (!hddSupportModulesLoaded)
         LOG("HDDSUPPORT UpdateGameList: PFS support incomplete; attempting read-only APA enumeration anyway\n");
 
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         // Reuse the session's built list on view flips; hddBuildVcdGameList runs only when never
         // built, invalidated (first-disc-only change), or freed by teardown (hddFreeVcdGameList).
         return hddVcdListBuilt ? hddVcdGameCount : hddBuildVcdGameList();
@@ -1169,11 +1170,11 @@ static int hddUpdateGameList(item_list_t *itemList)
 
 static int hddGetGameCount(item_list_t *itemList)
 {
-    return vcdListViewActive(itemList) ? hddVcdGameCount : (int)hddGames.count;
+    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? hddVcdGameCount : (int)hddGames.count;
 }
 
-// Toggle-window guard (Codex/Fable audit), mirroring mmceActiveGame. HDD_MODE is vcdModeSupported, so the L3
-// toggle flips vcdViewActive() SYNCHRONOUSLY ahead of the DEFERRED per-__.POPS pfs rebuild -- a WIDER window
+// Toggle-window guard (Codex/Fable audit), mirroring mmceActiveGame. HDD_MODE has a VCD stop in its ring, so the L3
+// toggle changes the active view SYNCHRONOUSLY ahead of the DEFERRED per-__.POPS pfs rebuild -- a WIDER window
 // than MMCE. During it an OLD-view id can index the freshly-switched other array (hddGames.games is {NULL,0}
 // on a PS1-only HDD; hddVcdGames NULL/shorter if that view never scanned) -> NULL/OOB deref + crash. Resolve
 // every id through these: an out-of-range id returns a static empty entry so a stale READ is safe empty data
@@ -1196,28 +1197,28 @@ static hdl_game_info_t *hddActiveHdl(int id)
 
 static void *hddGetGame(item_list_t *itemList, int id)
 {
-    return vcdListViewActive(itemList) ? (void *)hddActiveVcd(id) : (void *)hddActiveHdl(id);
+    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? (void *)hddActiveVcd(id) : (void *)hddActiveHdl(id);
 }
 
 static char *hddGetGameName(item_list_t *itemList, int id)
 {
-    return vcdListViewActive(itemList) ? hddActiveVcd(id)->name : hddActiveHdl(id)->name;
+    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? hddActiveVcd(id)->name : hddActiveHdl(id)->name;
 }
 
 static int hddGetGameNameLength(item_list_t *itemList, int id)
 {
-    return vcdListViewActive(itemList) ? VCD_NAME_MAX : (HDL_GAME_NAME_MAX + 1);
+    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? VCD_NAME_MAX : (HDL_GAME_NAME_MAX + 1);
 }
 
 static char *hddGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game CFG/art off the VCD filename (game->name), not a disc id.
-    return vcdListViewActive(itemList) ? hddActiveVcd(id)->name : hddActiveHdl(id)->startup;
+    return (libListViewActive(itemList) == LIB_VIEW_VCD) ? hddActiveVcd(id)->name : hddActiveHdl(id)->startup;
 }
 
 static void hddDeleteGame(item_list_t *itemList, int id)
 {
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         return; // a VCD is not an HDL partition -- no delete in VCD view
     hdl_game_info_t *game = hddActiveHdl(id);
     if (game == &hddEmptyHdl)
@@ -1518,7 +1519,7 @@ static void hddRenameVcd(int id, const char *newName)
 
 static void hddRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (vcdListViewActive(itemList)) {
+    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
         hddRenameVcd(id, newName);
         return;
     }
@@ -1767,7 +1768,7 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     // POPSTARTER self-mounts it after the loader's IOP reset. HW-VALIDATE: POPSTARTER's exact HDD
     // selector/partition contract is hardware-testable -- POPSLoader proved the shape with a vendored
     // loader; we use the stock ps2sdk loader, the same one the shipping USB/MMCE/SMB VCD launch uses.
-    if (gAutoLaunchGame == NULL && vcdListViewActive(itemList)) {
+    if (gAutoLaunchGame == NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
         char vcdName[VCD_NAME_MAX];
         char vcdPart[APA_IDMAX + 1];
 
@@ -1989,7 +1990,7 @@ static config_set_t *hddGetConfig(item_list_t *itemList, int id)
     // VCD (PS1) view: `id` indexes hddVcdGames, NOT hddGames. The list itself is discoverable from
     // APA even when the persistent config/art PFS home is temporarily unavailable. In that state
     // return a runtime-only config instead of dereferencing a NULL prefix or hiding the whole list.
-    if (vcdListViewActive(itemList)) {
+    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
         base_game_info_t *g = hddActiveVcd(id);
         if (gHDDPrefix != NULL)
             return sbPopulateConfig(g, gHDDPrefix, "/");

--- a/src/libview.c
+++ b/src/libview.c
@@ -6,8 +6,9 @@
   Library view state + the L3 ring. See include/libview.h for the contract.
 
   Ported from the binary vcdView[]/vcdDirty[] pair that lived in vcdsupport.c. Behaviour is
-  deliberately IDENTICAL to that flag while the ring holds only ISO and VCD; the CUE and ELF stops
-  are declared but not yet offered, so this file changes structure and nothing else.
+  deliberately IDENTICAL to that flag: the same two stops on the same pages. What changed is that
+  the second stop is now named for what it shows the user (PS1) rather than for one of the two
+  cores that can launch a row in it.
 */
 
 #include <string.h>
@@ -28,33 +29,28 @@ int libViewSupported(int mode, int view)
         case LIB_VIEW_ISO:
             // Every page's base list.
             //
-            // APPS is the standing exception in waiting: its only list is ELF, so its ring becomes
-            // a single ELF stop when that view is introduced. Until then it reports ISO here, which
-            // reproduces the old flag exactly -- appsupport never asked for the view at all, and
-            // the old boolean helper reported ISO for APP_MODE. Nothing reads it either way.
+            // APPS has one list and no ring, so it simply reports its base stop here and L3 stays
+            // inert on it -- exactly what the old flag did, and appsupport never asks for the view
+            // at all.
             return 1;
 
-        case LIB_VIEW_VCD:
-            // Unchanged from the old VCD-capability test: USB / exFAT, MMCE, MX4SIO, iLink, SMB, ATA
-            // (BDM HDD), APA / PFS HDD, and FAV_MODE.
+        case LIB_VIEW_PS1:
+            // USB / exFAT, MMCE, MX4SIO, iLink, SMB, ATA (BDM HDD), APA / PFS HDD, and FAV_MODE.
             //
             // FAV_MODE has a ring of its own: the Favourites tab swaps between disc favourites and
             // PS1 favourites, and its slot is independent of any device's, so toggling Favourites
             // never disturbs a device page's view.
             //
-            // UDPBD is excluded because POPSTARTER cannot bring a network block device back up
-            // after its own IOP reset. That reasoning is POPSTARTER-specific and does NOT carry
-            // over to the CUE stop below -- Ember never resets, so it keeps whatever mount it is
-            // handed. Do not "tidy" the two cases into one.
+            // UDPBD is excluded, and the reason is POPSTARTER-specific: it cannot bring a network
+            // block device back up after its own IOP reset. Ember has no reset and keeps whatever
+            // mount it is handed, so an Ember title on UDPBD should in principle work. The stop is
+            // still withheld here because a PS1 page on UDPBD would list POPSTARTER titles that
+            // cannot launch alongside Ember ones that can -- half a working list is worse than
+            // none. Revisit as a per-ROW rule once the Ember launch is hardware-proven, not by
+            // flipping this line.
             if (mode >= BDM_MODE && mode <= BDM_MODE_LAST)
                 return !bdmModeIsUDPBD(mode);
             return mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE;
-
-        case LIB_VIEW_CUE:
-            return 0; // introduced with the Ember library scan
-
-        case LIB_VIEW_ELF:
-            return 0; // introduced with the Favourites ELF stop
 
         default:
             return 0;
@@ -81,7 +77,7 @@ static int libViewPinned(void)
     if (gDefaultGameView == GAME_VIEW_ISO)
         return LIB_VIEW_ISO;
     if (gDefaultGameView == GAME_VIEW_VCD)
-        return LIB_VIEW_VCD;
+        return LIB_VIEW_PS1;
     return -1;
 }
 
@@ -109,7 +105,7 @@ int libListViewActive(const item_list_t *itemList)
     if (itemList->viewOverride == ITEM_VIEW_FORCE_ISO)
         return LIB_VIEW_ISO;
     if (itemList->viewOverride == ITEM_VIEW_FORCE_VCD)
-        return LIB_VIEW_VCD;
+        return LIB_VIEW_PS1;
 
     return libViewActive(itemList->mode);
 }

--- a/src/libview.c
+++ b/src/libview.c
@@ -1,0 +1,160 @@
+/*
+  Copyright 2026, Open-PS2-Loader contributors
+  Licenced under Academic Free License version 3.0
+  Review OpenUsbLd README & LICENSE files for further details.
+
+  Library view state + the L3 ring. See include/libview.h for the contract.
+
+  Ported from the binary vcdView[]/vcdDirty[] pair that lived in vcdsupport.c. Behaviour is
+  deliberately IDENTICAL to that flag while the ring holds only ISO and VCD; the CUE and ELF stops
+  are declared but not yet offered, so this file changes structure and nothing else.
+*/
+
+#include <string.h>
+
+#include "include/opl.h"        // gDefaultGameView + GAME_VIEW_*
+#include "include/bdmsupport.h" // bdmModeIsUDPBD -- the one BDM slot with no PS1 story
+#include "include/libview.h"
+
+static unsigned char libView[MODE_COUNT];  // current LIB_VIEW_* per mode (0 == LIB_VIEW_ISO)
+static unsigned char libDirty[MODE_COUNT]; // 1 = view just changed -> force one rescan
+
+int libViewSupported(int mode, int view)
+{
+    if (mode < 0 || mode >= MODE_COUNT || view < 0 || view >= LIB_VIEW_COUNT)
+        return 0;
+
+    switch (view) {
+        case LIB_VIEW_ISO:
+            // Every page's base list.
+            //
+            // APPS is the standing exception in waiting: its only list is ELF, so its ring becomes
+            // a single ELF stop when that view is introduced. Until then it reports ISO here, which
+            // reproduces the old flag exactly -- appsupport never asked for the view at all, and
+            // the old boolean helper reported ISO for APP_MODE. Nothing reads it either way.
+            return 1;
+
+        case LIB_VIEW_VCD:
+            // Unchanged from the old VCD-capability test: USB / exFAT, MMCE, MX4SIO, iLink, SMB, ATA
+            // (BDM HDD), APA / PFS HDD, and FAV_MODE.
+            //
+            // FAV_MODE has a ring of its own: the Favourites tab swaps between disc favourites and
+            // PS1 favourites, and its slot is independent of any device's, so toggling Favourites
+            // never disturbs a device page's view.
+            //
+            // UDPBD is excluded because POPSTARTER cannot bring a network block device back up
+            // after its own IOP reset. That reasoning is POPSTARTER-specific and does NOT carry
+            // over to the CUE stop below -- Ember never resets, so it keeps whatever mount it is
+            // handed. Do not "tidy" the two cases into one.
+            if (mode >= BDM_MODE && mode <= BDM_MODE_LAST)
+                return !bdmModeIsUDPBD(mode);
+            return mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE;
+
+        case LIB_VIEW_CUE:
+            return 0; // introduced with the Ember library scan
+
+        case LIB_VIEW_ELF:
+            return 0; // introduced with the Favourites ELF stop
+
+        default:
+            return 0;
+    }
+}
+
+int libViewRingSize(int mode)
+{
+    int v, n = 0;
+
+    for (v = 0; v < LIB_VIEW_COUNT; v++) {
+        if (libViewSupported(mode, v))
+            n++;
+    }
+    return n;
+}
+
+// The view every ringed page is pinned to by the global setting, or -1 when the setting leaves the
+// L3 ring free (GAME_VIEW_BOTH). A page that does not have the pinned stop is NOT pinned -- it
+// keeps showing its base list, which is what the old flag did for a non-VCD mode under the VCD
+// lock, and is what keeps APPS and UDPFS on their normal lists.
+static int libViewPinned(void)
+{
+    if (gDefaultGameView == GAME_VIEW_ISO)
+        return LIB_VIEW_ISO;
+    if (gDefaultGameView == GAME_VIEW_VCD)
+        return LIB_VIEW_VCD;
+    return -1;
+}
+
+int libViewActive(int mode)
+{
+    int pin;
+
+    if (mode < 0 || mode >= MODE_COUNT)
+        return LIB_VIEW_ISO;
+
+    pin = libViewPinned();
+    if (pin >= 0)
+        return libViewSupported(mode, pin) ? pin : LIB_VIEW_ISO;
+
+    return libView[mode];
+}
+
+int libListViewActive(const item_list_t *itemList)
+{
+    if (itemList == NULL)
+        return LIB_VIEW_ISO;
+
+    // A Favourites shallow proxy forces the view of the favourite it is resolving, so an ISO
+    // favourite reads its source's retained ISO array even while that source page shows VCD.
+    if (itemList->viewOverride == ITEM_VIEW_FORCE_ISO)
+        return LIB_VIEW_ISO;
+    if (itemList->viewOverride == ITEM_VIEW_FORCE_VCD)
+        return LIB_VIEW_VCD;
+
+    return libViewActive(itemList->mode);
+}
+
+void libViewAdvance(int mode)
+{
+    int cur, step, cand;
+
+    if (mode < 0 || mode >= MODE_COUNT)
+        return;
+    if (libViewPinned() >= 0)
+        return; // globally pinned to one list -> the L3 ring is inert
+    if (libViewRingSize(mode) < 2)
+        return; // nothing to move between
+
+    cur = libView[mode];
+    for (step = 1; step <= LIB_VIEW_COUNT; step++) {
+        cand = (cur + step) % LIB_VIEW_COUNT;
+        if (libViewSupported(mode, cand)) {
+            libView[mode] = (unsigned char)cand;
+            break;
+        }
+    }
+
+    libDirty[mode] = 1;
+}
+
+int libViewConsumeDirty(int mode)
+{
+    if (mode < 0 || mode >= MODE_COUNT || !libDirty[mode])
+        return 0;
+    libDirty[mode] = 0;
+    return 1;
+}
+
+void libViewMarkDirty(int mode)
+{
+    if (mode >= 0 && mode < MODE_COUNT && libViewRingSize(mode) > 1)
+        libDirty[mode] = 1;
+}
+
+void libViewMarkAllDirty(void)
+{
+    int m;
+
+    for (m = 0; m < MODE_COUNT; m++)
+        libViewMarkDirty(m);
+}

--- a/src/libview.c
+++ b/src/libview.c
@@ -52,6 +52,13 @@ int libViewSupported(int mode, int view)
                 return !bdmModeIsUDPBD(mode);
             return mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE;
 
+        case LIB_VIEW_ELF:
+            // FAVOURITES ONLY. A device page's ELFs live on the APPS tab, which is its own page --
+            // giving devices a third stop would duplicate that tab per device for no gain. But a
+            // saved app favourite had nowhere of its own and sat in the Favourites PS2 list, mixed
+            // in with disc games; this is the shelf it belongs on.
+            return mode == FAV_MODE;
+
         default:
             return 0;
     }
@@ -72,8 +79,18 @@ int libViewRingSize(int mode)
 // L3 ring free (GAME_VIEW_BOTH). A page that does not have the pinned stop is NOT pinned -- it
 // keeps showing its base list, which is what the old flag did for a non-VCD mode under the VCD
 // lock, and is what keeps APPS and UDPFS on their normal lists.
-static int libViewPinned(void)
+static int libViewPinned(int mode)
 {
+    // FAVOURITES IS NEVER PINNED, and this is load-bearing rather than a preference. The setting is
+    // "Default game view" -- it decides which list a GAME DEVICE page opens on. Favourites is not a
+    // device page: it is one shelf per kind of thing you saved, and its ring now has three stops.
+    // Pinning it to a single stop would make the APPS shelf permanently unreachable for anyone who
+    // locked the setting, silently hiding their app favourites with no way to get them back. When
+    // that shelf did not exist the question never arose; now it does, so Favourites keeps its own
+    // ring and L3 always works there.
+    if (mode == FAV_MODE)
+        return -1;
+
     if (gDefaultGameView == GAME_VIEW_ISO)
         return LIB_VIEW_ISO;
     if (gDefaultGameView == GAME_VIEW_VCD)
@@ -88,7 +105,7 @@ int libViewActive(int mode)
     if (mode < 0 || mode >= MODE_COUNT)
         return LIB_VIEW_ISO;
 
-    pin = libViewPinned();
+    pin = libViewPinned(mode);
     if (pin >= 0)
         return libViewSupported(mode, pin) ? pin : LIB_VIEW_ISO;
 
@@ -104,10 +121,17 @@ int libListViewActive(const item_list_t *itemList)
     // favourite reads its source's retained ISO array even while that source page shows VCD.
     if (itemList->viewOverride == ITEM_VIEW_FORCE_ISO)
         return LIB_VIEW_ISO;
-    if (itemList->viewOverride == ITEM_VIEW_FORCE_VCD)
+    if (itemList->viewOverride == ITEM_VIEW_FORCE_PS1)
         return LIB_VIEW_PS1;
 
     return libViewActive(itemList->mode);
+}
+
+int libViewRingUsable(int mode)
+{
+    if (mode < 0 || mode >= MODE_COUNT)
+        return 0;
+    return libViewRingSize(mode) > 1 && libViewPinned(mode) < 0;
 }
 
 void libViewAdvance(int mode)
@@ -116,7 +140,7 @@ void libViewAdvance(int mode)
 
     if (mode < 0 || mode >= MODE_COUNT)
         return;
-    if (libViewPinned() >= 0)
+    if (libViewPinned(mode) >= 0)
         return; // globally pinned to one list -> the L3 ring is inert
     if (libViewRingSize(mode) < 2)
         return; // nothing to move between

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1485,7 +1485,7 @@ static void menuRenderElements(theme_elems_t *elems)
     // Deep VCD ID inspection is cosmetic and must be explicit-theme-demand only. ItemText is
     // the sole render element that consumes vcdDisplayIdCached(), so a family without ItemText does
     // zero .VCD opens/seeks here. The resolver itself is opportunistic and yields to art/BGM.
-    if (elems->needsVcdDisplayId && list != NULL && (libViewActive(list->mode) == LIB_VIEW_VCD) &&
+    if (elems->needsVcdDisplayId && list != NULL && (libViewActive(list->mode) == LIB_VIEW_PS1) &&
         selected_item->item->current != NULL) {
         char *vcdName = list->itemGetStartup(list, selected_item->item->current->item.id);
         if (vcdName != NULL)
@@ -1512,7 +1512,7 @@ static void menuRenderElements(theme_elems_t *elems)
 // guard so the two paths cannot drift again.
 static theme_elems_t *menuGetInfoElems(item_list_t *list)
 {
-    if (list != NULL && (libViewActive(list->mode) == LIB_VIEW_VCD))
+    if (list != NULL && (libViewActive(list->mode) == LIB_VIEW_PS1))
         return gTheme->vcdInfoElems.first ? &gTheme->vcdInfoElems : &gTheme->infoElems;
     if (list != NULL && list->mode == FAV_MODE)
         return gTheme->favsInfoElems.first ? &gTheme->favsInfoElems : &gTheme->infoElems;
@@ -1523,7 +1523,7 @@ static theme_elems_t *menuGetInfoElems(item_list_t *list)
 
 static theme_elems_t *menuGetMainElems(item_list_t *list)
 {
-    if (list != NULL && (libViewActive(list->mode) == LIB_VIEW_VCD))
+    if (list != NULL && (libViewActive(list->mode) == LIB_VIEW_PS1))
         return gTheme->vcdMainElems.first ? &gTheme->vcdMainElems : &gTheme->mainElems;
     if (list != NULL && list->mode == FAV_MODE)
         return gTheme->favsMainElems.first ? &gTheme->favsMainElems : &gTheme->mainElems;
@@ -1536,7 +1536,7 @@ void menuRenderMain(void)
 {
     item_list_t *list = selected_item->item->userdata;
 
-    if (libViewActive(list->mode) == LIB_VIEW_VCD) {
+    if (libViewActive(list->mode) == LIB_VIEW_PS1) {
         // VCD/PS1 listings render with the vcd family (vcdMain*; each slot falls back at parse time to
         // appsMain* then main*). The VCD list uses its OWN items-list slot (vcdItemsList) so it keeps a
         // SEPARATE cover cache from the device's ISO list -- the view reuses the device's game list
@@ -1647,7 +1647,7 @@ void menuRenderInfo(void)
 {
     item_list_t *list = selected_item->item->userdata;
 
-    if (libViewActive(list->mode) == LIB_VIEW_VCD) {
+    if (libViewActive(list->mode) == LIB_VIEW_PS1) {
         menuRenderElements(menuGetInfoElems(list));
         gTheme->itemsList = thmResolveItemsList(&gTheme->vcdInfoElems, gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else if (list->mode == FAV_MODE) {
@@ -1767,7 +1767,7 @@ static int gameMenuCoreIsNeutrino(void)
     // be blocked under a Neutrino global default.
     if (selected_item != NULL && selected_item->item != NULL) {
         item_list_t *support = (item_list_t *)selected_item->item->userdata;
-        if (support != NULL && ((libViewActive(support->mode) == LIB_VIEW_VCD) || support->mode == ETH_MODE))
+        if (support != NULL && ((libViewActive(support->mode) == LIB_VIEW_PS1) || support->mode == ETH_MODE))
             return 0;
     }
     // UDPBD games are Neutrino-only even while $CoreLoader is still its OPL default.

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -21,7 +21,8 @@
 #include "include/sound.h"
 #include "include/favsupport.h"   // gFAVStartMode -- the Favourites tab counts as "something to show"
 #include "include/folderbrowse.h" // menuFolderResetLeaving -- leave a device page at its folder root
-#include "include/vcdsupport.h"   // vcdViewActive() -- VCD launches never use Neutrino
+#include "include/vcdsupport.h"   // VCD launches never use Neutrino
+#include "include/libview.h"      // libViewActive / libListViewActive -- which list this page shows
 #include "include/bdmsupport.h"   // bdmSupportIsUDPBD() -- UDPBD games are Neutrino-only
 #include <assert.h>
 #include <delaythread.h>
@@ -1484,7 +1485,7 @@ static void menuRenderElements(theme_elems_t *elems)
     // Deep VCD ID inspection is cosmetic and must be explicit-theme-demand only. ItemText is
     // the sole render element that consumes vcdDisplayIdCached(), so a family without ItemText does
     // zero .VCD opens/seeks here. The resolver itself is opportunistic and yields to art/BGM.
-    if (elems->needsVcdDisplayId && list != NULL && vcdViewActive(list->mode) &&
+    if (elems->needsVcdDisplayId && list != NULL && (libViewActive(list->mode) == LIB_VIEW_VCD) &&
         selected_item->item->current != NULL) {
         char *vcdName = list->itemGetStartup(list, selected_item->item->current->item.id);
         if (vcdName != NULL)
@@ -1511,7 +1512,7 @@ static void menuRenderElements(theme_elems_t *elems)
 // guard so the two paths cannot drift again.
 static theme_elems_t *menuGetInfoElems(item_list_t *list)
 {
-    if (list != NULL && vcdViewActive(list->mode))
+    if (list != NULL && (libViewActive(list->mode) == LIB_VIEW_VCD))
         return gTheme->vcdInfoElems.first ? &gTheme->vcdInfoElems : &gTheme->infoElems;
     if (list != NULL && list->mode == FAV_MODE)
         return gTheme->favsInfoElems.first ? &gTheme->favsInfoElems : &gTheme->infoElems;
@@ -1522,7 +1523,7 @@ static theme_elems_t *menuGetInfoElems(item_list_t *list)
 
 static theme_elems_t *menuGetMainElems(item_list_t *list)
 {
-    if (list != NULL && vcdViewActive(list->mode))
+    if (list != NULL && (libViewActive(list->mode) == LIB_VIEW_VCD))
         return gTheme->vcdMainElems.first ? &gTheme->vcdMainElems : &gTheme->mainElems;
     if (list != NULL && list->mode == FAV_MODE)
         return gTheme->favsMainElems.first ? &gTheme->favsMainElems : &gTheme->mainElems;
@@ -1535,7 +1536,7 @@ void menuRenderMain(void)
 {
     item_list_t *list = selected_item->item->userdata;
 
-    if (vcdViewActive(list->mode)) {
+    if (libViewActive(list->mode) == LIB_VIEW_VCD) {
         // VCD/PS1 listings render with the vcd family (vcdMain*; each slot falls back at parse time to
         // appsMain* then main*). The VCD list uses its OWN items-list slot (vcdItemsList) so it keeps a
         // SEPARATE cover cache from the device's ISO list -- the view reuses the device's game list
@@ -1646,7 +1647,7 @@ void menuRenderInfo(void)
 {
     item_list_t *list = selected_item->item->userdata;
 
-    if (vcdViewActive(list->mode)) {
+    if (libViewActive(list->mode) == LIB_VIEW_VCD) {
         menuRenderElements(menuGetInfoElems(list));
         gTheme->itemsList = thmResolveItemsList(&gTheme->vcdInfoElems, gTheme->vcdItemsList ? gTheme->vcdItemsList : gTheme->gamesItemsList, selected_item->item->icon_id);
     } else if (list->mode == FAV_MODE) {
@@ -1766,7 +1767,7 @@ static int gameMenuCoreIsNeutrino(void)
     // be blocked under a Neutrino global default.
     if (selected_item != NULL && selected_item->item != NULL) {
         item_list_t *support = (item_list_t *)selected_item->item->userdata;
-        if (support != NULL && (vcdViewActive(support->mode) || support->mode == ETH_MODE))
+        if (support != NULL && ((libViewActive(support->mode) == LIB_VIEW_VCD) || support->mode == ETH_MODE))
             return 0;
     }
     // UDPBD games are Neutrino-only even while $CoreLoader is still its OPL default.

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -738,7 +738,7 @@ static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set
 
     (void)configSet; // an Ember title carries no per-game loader settings
 
-    if (cueName == NULL || cueName[0] == ' ')
+    if (cueName == NULL || cueName[0] == '\0')
         return;
     if (!cueNameLaunchable(cueName)) {
         guiMsgBox(_l(_STR_EMBER_BAD_NAME), 0, NULL);
@@ -760,6 +760,13 @@ static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set
     }
     if (!cueResolveEmberBios(mmcePrefix, biosPath, sizeof(biosPath))) {
         guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
+        return;
+    }
+    // The scan lists folders without reading inside them -- that would be a directory read per row
+    // on every refresh. Pay for it once, HERE, while a dialog can still be drawn: an empty or
+    // mis-filled folder otherwise drops the user into the PS1 BIOS shell with no explanation.
+    if (!cueGameHasImage(mmcePrefix, cueName)) {
+        guiMsgBox(_l(_STR_EMBER_NO_DISC), 0, NULL);
         return;
     }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -4,6 +4,7 @@
 #include "include/supportbase.h"
 #include "include/mmcesupport.h"
 #include "include/vcdsupport.h"
+#include "include/libview.h" // libViewActive / libListViewActive -- which list this page shows
 #include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/themes.h"
@@ -504,14 +505,14 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     }
 
     // VCD view: force a rescan once on toggle, then skip the disc heuristics while showing VCDs.
-    if (vcdConsumeDirty(itemList->mode)) {
+    if (libViewConsumeDirty(itemList->mode)) {
         mmceVcdScanRetries = 0; // fresh user toggle re-arms the failed-scan retry budget
         return 1;
     }
     // Folder browsing: descend/ascend forces one rescan (consumed before the NOUPDATE latch below).
     if (folderConsumeDirty(itemList->mode))
         return 1;
-    if (vcdViewActive(itemList->mode)) {
+    if (libViewActive(itemList->mode) == LIB_VIEW_VCD) {
         if (!mmceVcdScanned) {
             mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
             return 1;
@@ -631,7 +632,7 @@ static int mmceUpdateGameList(item_list_t *itemList)
 
     // Each view scans into its OWN array (#120): a failed rescan preserves only that view's last-good and
     // can never resurrect the other view's list (see the mmceVcdGames comment at the declarations).
-    if (vcdViewActive(itemList->mode)) {
+    if (libViewActive(itemList->mode) == LIB_VIEW_VCD) {
         int r = vcdFillGameList(mmcePrefix, &mmceVcdGames);
         if (r >= 0) { // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
             mmceVcdScanned = 1;
@@ -650,13 +651,13 @@ static int mmceUpdateGameList(item_list_t *itemList)
 
 static int mmceGetGameCount(item_list_t *itemList)
 {
-    return vcdViewActive(itemList->mode) ? mmceVcdGameCount : mmceGameCount;
+    return (libViewActive(itemList->mode) == LIB_VIEW_VCD) ? mmceVcdGameCount : mmceGameCount;
 }
 
 static base_game_info_t mmceEmptyGame;
 static base_game_info_t *mmceActiveGame(item_list_t *itemList, int id)
 {
-    int vcd = vcdViewActive(itemList->mode);
+    int vcd = (libViewActive(itemList->mode) == LIB_VIEW_VCD);
     base_game_info_t *arr = vcd ? mmceVcdGames : mmceGames;
     int count = vcd ? mmceVcdGameCount : mmceGameCount;
     if (arr == NULL || id < 0 || id >= count)
@@ -684,17 +685,17 @@ static char *mmceGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
     base_game_info_t *g = mmceActiveGame(itemList, id);
-    if (vcdViewActive(itemList->mode))
+    if (libViewActive(itemList->mode) == LIB_VIEW_VCD)
         return g->name;
     return g->startup;
 }
 
 static void mmceDeleteGame(item_list_t *itemList, int id)
 {
-    if (vcdViewActive(itemList->mode))
+    if (libViewActive(itemList->mode) == LIB_VIEW_VCD)
         return; // #120: a VCD is not an ISO game -- no delete in VCD view
     if (mmceActiveGame(itemList, id) == &mmceEmptyGame)
-        return;                                   // stale id in the VCD->ISO toggle window (vcdViewActive already flipped, old VCD submenu id
+        return;                                   // stale id in the VCD->ISO toggle window (libViewActive already flipped, old VCD submenu id
                                                   // still live): sbDelete does NOT bounds-check, so this avoids an OOB/NULL deref + wrong unlink
     sbSetBrowseSub(folderGetSub(itemList->mode)); // delete inside the current subfolder, not the root
     sbDelete(&mmceGames, mmcePrefix, "/", mmceGameCount, id);
@@ -703,7 +704,7 @@ static void mmceDeleteGame(item_list_t *itemList, int id)
 
 static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (vcdViewActive(itemList->mode)) {
+    if (libViewActive(itemList->mode) == LIB_VIEW_VCD) {
         base_game_info_t *game = mmceActiveGame(itemList, id);
 
         if (game == &mmceEmptyGame)
@@ -805,7 +806,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     }
 
     // VCD view: hand off to POPSTARTER (by name) instead of the disc path below. Menu-launch only.
-    if (gAutoLaunchBDMGame == NULL && game != NULL && vcdViewActive(itemList->mode)) {
+    if (gAutoLaunchBDMGame == NULL && game != NULL && (libViewActive(itemList->mode) == LIB_VIEW_VCD)) {
         mmceLaunchVcd(itemList, game->name, configSet);
         return;
     }
@@ -1128,7 +1129,7 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     int r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
-    if (r == ERR_BAD_FILE && isRelative && vcdViewActive(itemList->mode))
+    if (r == ERR_BAD_FILE && isRelative && (libViewActive(itemList->mode) == LIB_VIEW_VCD))
         r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
     return r;
 }

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -4,7 +4,8 @@
 #include "include/supportbase.h"
 #include "include/mmcesupport.h"
 #include "include/vcdsupport.h"
-#include "include/libview.h" // libViewActive / libListViewActive -- which list this page shows
+#include "include/cuesupport.h" // PS1 rows can belong to either core; the ROW decides
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 #include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/themes.h"
@@ -33,9 +34,9 @@ static int mmceULSizePrev = -2;
 // quiescing on success/expiry. (The other half of the old "-1 for both" ambiguity is now split at
 // the source: vcdScanOpenDir returns 0 for a genuinely-ABSENT POPS folder -- #154 residual -- so
 // only contention ever arms this budget.)
-static unsigned char mmceVcdScanned = 0;
-static unsigned char mmceVcdScanFailed = 0;
-static unsigned char mmceVcdScanRetries = 0;
+static unsigned char mmcePs1Scanned = 0;
+static unsigned char mmcePs1ScanFailed = 0;
+static unsigned char mmcePs1ScanRetries = 0;
 #define MMCE_VCD_SCAN_RETRY_MAX 15
 static time_t mmceModifiedCDPrev;
 static time_t mmceModifiedDVDPrev;
@@ -47,8 +48,8 @@ static base_game_info_t *mmceGames;
 // list on screen (Andrew's #129 "can't switch to PS2 list"). Separate arrays (mirroring hddGames vs
 // hddVcdGames) make a failed scan of one view preserve only THAT view's last-good (empty if never
 // scanned), so it can never resurrect the other view's contents.
-static int mmceVcdGameCount = 0;
-static base_game_info_t *mmceVcdGames = NULL;
+static int mmcePs1GameCount = 0;
+static base_game_info_t *mmcePs1Games = NULL;
 // Auto-slot (gMMCESlot==2) resolution cache: mmceDetectSlot()'s last result (2=mmce0, 3=mmce1,
 // -1=unresolved). Avoids re-probing BOTH slots over SIO2 every menu refresh -- that steady devctl
 // drip contends with MX4SIO on the shared bus. Reset by mmceInit (tab re-enable / settings apply).
@@ -431,8 +432,8 @@ void mmceInit(item_list_t *itemList)
     mmceModifiedDVDPrev = 0;
     mmceGameCount = 0;
     mmceGames = NULL;
-    mmceVcdGameCount = 0;
-    mmceVcdGames = NULL;
+    mmcePs1GameCount = 0;
+    mmcePs1Games = NULL;
     mmceResolvedDevice = -1; // re-detect the Auto slot on a fresh init (tab re-enable / settings apply)
     mmceFoldersCreatedFor[0] = '\0';
     mmceFolderRetries = 0;
@@ -472,16 +473,16 @@ static int mmceNeedsUpdate(item_list_t *itemList)
         // Card gone with an EMPTY failed VCD list never reaches mmceUpdateGameList's resets (this
         // early return fires first), so a reinserted card would inherit an exhausted retry budget
         // and a dead VCD page (CodeRabbit review of #248, vetted). Fresh card = fresh budget.
-        mmceVcdScanned = 0;
-        mmceVcdScanFailed = 0;
-        mmceVcdScanRetries = 0;
+        mmcePs1Scanned = 0;
+        mmcePs1ScanFailed = 0;
+        mmcePs1ScanRetries = 0;
         // Card gone: re-arm THM/LNG registration so a swapped-in card's assets get discovered
         // (Gemini review of #153). The old card's already-registered entries stay in the pickers --
         // eviction infrastructure doesn't exist -- but picking a stale one fails gracefully
         // (thmLoad abandons and keeps the current theme), and thmAddElements caps at THM_MAX_FILES.
         ThemesLoaded = 0;
         LanguagesLoaded = 0;
-        return (mmceGameCount > 0 || mmceVcdGameCount > 0);
+        return (mmceGameCount > 0 || mmcePs1GameCount > 0);
     }
 
     mmceGameList.updateDelay = MENU_UPD_DELAY_NOUPDATE;
@@ -506,22 +507,22 @@ static int mmceNeedsUpdate(item_list_t *itemList)
 
     // VCD view: force a rescan once on toggle, then skip the disc heuristics while showing VCDs.
     if (libViewConsumeDirty(itemList->mode)) {
-        mmceVcdScanRetries = 0; // fresh user toggle re-arms the failed-scan retry budget
+        mmcePs1ScanRetries = 0; // fresh user toggle re-arms the failed-scan retry budget
         return 1;
     }
     // Folder browsing: descend/ascend forces one rescan (consumed before the NOUPDATE latch below).
     if (folderConsumeDirty(itemList->mode))
         return 1;
-    if (libViewActive(itemList->mode) == LIB_VIEW_VCD) {
-        if (!mmceVcdScanned) {
+    if (libViewActive(itemList->mode) == LIB_VIEW_PS1) {
+        if (!mmcePs1Scanned) {
             mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
             return 1;
         }
         // A contended scan left the VCD page empty (S6): keep the ~2s refresh alive until a scan
         // succeeds or the bounded budget runs out (no endless bus churn -- #246 doctrine). Also
         // revives the manual-refresh button in the failed state.
-        if (mmceVcdScanFailed && mmceVcdScanRetries < MMCE_VCD_SCAN_RETRY_MAX) {
-            mmceVcdScanRetries++;
+        if (mmcePs1ScanFailed && mmcePs1ScanRetries < MMCE_VCD_SCAN_RETRY_MAX) {
+            mmcePs1ScanRetries++;
             mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
             return 1;
         }
@@ -617,33 +618,35 @@ static int mmceUpdateGameList(item_list_t *itemList)
             free(mmceGames);
             mmceGames = NULL;
         }
-        if (mmceVcdGames != NULL) {
-            free(mmceVcdGames);
-            mmceVcdGames = NULL;
+        if (mmcePs1Games != NULL) {
+            free(mmcePs1Games);
+            mmcePs1Games = NULL;
         }
         mmceGameCount = 0;
-        mmceVcdGameCount = 0;
+        mmcePs1GameCount = 0;
         mmceULSizePrev = -2; // force a fresh scan when a card returns
-        mmceVcdScanned = 0;
-        mmceVcdScanFailed = 0;
-        mmceVcdScanRetries = 0;
+        mmcePs1Scanned = 0;
+        mmcePs1ScanFailed = 0;
+        mmcePs1ScanRetries = 0;
         return 0;
     }
 
     // Each view scans into its OWN array (#120): a failed rescan preserves only that view's last-good and
-    // can never resurrect the other view's list (see the mmceVcdGames comment at the declarations).
-    if (libViewActive(itemList->mode) == LIB_VIEW_VCD) {
-        int r = vcdFillGameList(mmcePrefix, &mmceVcdGames);
+    // can never resurrect the other view's list (see the mmcePs1Games comment at the declarations).
+    if (libViewActive(itemList->mode) == LIB_VIEW_PS1) {
+        // ONE list, BOTH cores -- POPS/*.VCD unioned with EMBER/games/*. mmcePrefix is the card
+        // root, which is where both folders live, so the same prefix serves both halves.
+        int r = ps1FillGameList(mmcePrefix, &mmcePs1Games);
         if (r >= 0) { // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
-            mmceVcdScanned = 1;
-            mmceVcdGameCount = r;
-            mmceVcdScanFailed = 0;
-            mmceVcdScanRetries = 0;
+            mmcePs1Scanned = 1;
+            mmcePs1GameCount = r;
+            mmcePs1ScanFailed = 0;
+            mmcePs1ScanRetries = 0;
         } else {
-            mmceVcdScanned = 0;
-            mmceVcdScanFailed = 1; // arm mmceNeedsUpdate's bounded retry (S6)
+            mmcePs1Scanned = 0;
+            mmcePs1ScanFailed = 1; // arm mmceNeedsUpdate's bounded retry (S6)
         }
-        return mmceVcdGameCount;
+        return mmcePs1GameCount;
     }
     sbReadList(&mmceGames, mmcePrefix, folderGetSub(itemList->mode), &mmceULSizePrev, &mmceGameCount);
     return mmceGameCount;
@@ -651,15 +654,15 @@ static int mmceUpdateGameList(item_list_t *itemList)
 
 static int mmceGetGameCount(item_list_t *itemList)
 {
-    return (libViewActive(itemList->mode) == LIB_VIEW_VCD) ? mmceVcdGameCount : mmceGameCount;
+    return (libViewActive(itemList->mode) == LIB_VIEW_PS1) ? mmcePs1GameCount : mmceGameCount;
 }
 
 static base_game_info_t mmceEmptyGame;
 static base_game_info_t *mmceActiveGame(item_list_t *itemList, int id)
 {
-    int vcd = (libViewActive(itemList->mode) == LIB_VIEW_VCD);
-    base_game_info_t *arr = vcd ? mmceVcdGames : mmceGames;
-    int count = vcd ? mmceVcdGameCount : mmceGameCount;
+    int vcd = (libViewActive(itemList->mode) == LIB_VIEW_PS1);
+    base_game_info_t *arr = vcd ? mmcePs1Games : mmceGames;
+    int count = vcd ? mmcePs1GameCount : mmceGameCount;
     if (arr == NULL || id < 0 || id >= count)
         return &mmceEmptyGame;
     return &arr[id];
@@ -685,14 +688,14 @@ static char *mmceGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
     base_game_info_t *g = mmceActiveGame(itemList, id);
-    if (libViewActive(itemList->mode) == LIB_VIEW_VCD)
+    if (libViewActive(itemList->mode) == LIB_VIEW_PS1)
         return g->name;
     return g->startup;
 }
 
 static void mmceDeleteGame(item_list_t *itemList, int id)
 {
-    if (libViewActive(itemList->mode) == LIB_VIEW_VCD)
+    if (libViewActive(itemList->mode) == LIB_VIEW_PS1)
         return; // #120: a VCD is not an ISO game -- no delete in VCD view
     if (mmceActiveGame(itemList, id) == &mmceEmptyGame)
         return;                                   // stale id in the VCD->ISO toggle window (libViewActive already flipped, old VCD submenu id
@@ -704,7 +707,7 @@ static void mmceDeleteGame(item_list_t *itemList, int id)
 
 static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
 {
-    if (libViewActive(itemList->mode) == LIB_VIEW_VCD) {
+    if (libViewActive(itemList->mode) == LIB_VIEW_PS1) {
         base_game_info_t *game = mmceActiveGame(itemList, id);
 
         if (game == &mmceEmptyGame)
@@ -712,9 +715,9 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
         if (vcdRenameFile(mmcePrefix, game->name, newName) == 0) {
             // MMCE normally latches a successful VCD scan under NOUPDATE. Re-arm its normal scan
             // path so the deferred menu update publishes the new filename immediately.
-            mmceVcdScanned = 0;
-            mmceVcdScanFailed = 0;
-            mmceVcdScanRetries = 0;
+            mmcePs1Scanned = 0;
+            mmcePs1ScanFailed = 0;
+            mmcePs1ScanRetries = 0;
             mmceGameList.updateDelay = MMCE_MODE_UPDATE_DELAY;
         }
         return;
@@ -724,6 +727,45 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
     sbSetBrowseSub(folderGetSub(itemList->mode)); // rename inside the current subfolder, not the root
     sbRename(&mmceGames, mmcePrefix, "/", mmceGameCount, id, newName);
     mmceULSizePrev = -2;
+}
+
+// Launch an Ember (.cue) PS1 title BY NAME -- peer of mmceLaunchVcd below. mmcePrefix is the card
+// root, where EMBER/ sits next to POPS/. None of the POPSTARTER memory-card preparation applies:
+// Ember performs no IOP reset and inherits our live driver stack, so it needs no MC-side driver.
+static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set_t *configSet)
+{
+    char emberElf[256], biosPath[288];
+
+    (void)configSet; // an Ember title carries no per-game loader settings
+
+    if (cueName == NULL || cueName[0] == ' ')
+        return;
+    if (!cueNameLaunchable(cueName)) {
+        guiMsgBox(_l(_STR_EMBER_BAD_NAME), 0, NULL);
+        return;
+    }
+
+    guiRenderTextScreen(_l(_STR_PLEASE_WAIT));
+
+    // MMCE artwork and this launch share the SIO2 bus -- quiesce before touching the card, exactly
+    // as the POPSTARTER leg does.
+    if (!cacheAbortMmceImageLoadsTimed(MMCE_ART_ABORT_WAIT_TICKS)) {
+        guiWarning(_l(_STR_ERR_FILE_INVALID), 8);
+        return;
+    }
+
+    if (!cueResolveEmber(mmcePrefix, emberElf, sizeof(emberElf))) {
+        guiMsgBox(_l(_STR_EMBER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    if (!cueResolveEmberBios(mmcePrefix, biosPath, sizeof(biosPath))) {
+        guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
+        return;
+    }
+
+    // UNMOUNT_EXCEPTION is load-bearing: Ember cannot remount the card it reads the game from.
+    deinit(UNMOUNT_EXCEPTION, itemList->mode);
+    sysLaunchEmber(emberElf, cueName);
 }
 
 // Launch a PS1/.VCD entry BY NAME via POPSTARTER (view-independent entry point: the in-view menu
@@ -806,8 +848,12 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     }
 
     // VCD view: hand off to POPSTARTER (by name) instead of the disc path below. Menu-launch only.
-    if (gAutoLaunchBDMGame == NULL && game != NULL && (libViewActive(itemList->mode) == LIB_VIEW_VCD)) {
-        mmceLaunchVcd(itemList, game->name, configSet);
+    if (gAutoLaunchBDMGame == NULL && game != NULL && (libViewActive(itemList->mode) == LIB_VIEW_PS1)) {
+        // The ROW picks the core, never the page -- both kinds share this one PS1 list.
+        if (cueIsCueEntry(game))
+            mmceLaunchCue(itemList, game->name, configSet);
+        else
+            mmceLaunchVcd(itemList, game->name, configSet);
         return;
     }
 
@@ -1129,8 +1175,14 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     int r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
-    if (r == ERR_BAD_FILE && isRelative && (libViewActive(itemList->mode) == LIB_VIEW_VCD))
-        r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
+    if (r == ERR_BAD_FILE && isRelative && (libViewActive(itemList->mode) == LIB_VIEW_PS1)) {
+        // The cache hands us a NAME, so resolve which core owns the row against the published list
+        // (memory scan, no card IO on the art path). Unknown falls back to the POPSTARTER layout.
+        if (cueRowIsCueByName(mmcePs1Games, mmcePs1GameCount, value) == 1)
+            r = cueLoadFolderCover(mmceArtPrimary, value, suffix, resultTex);
+        else
+            r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
+    }
     return r;
 }
 
@@ -1156,8 +1208,8 @@ static void mmceCleanUp(item_list_t *itemList, int exception)
 
         free(mmceGames);
         mmceGames = NULL;
-        free(mmceVcdGames); // #120: free the separate VCD array too; NULL both (CleanUp + Shutdown both run)
-        mmceVcdGames = NULL;
+        free(mmcePs1Games); // #120: free the separate VCD array too; NULL both (CleanUp + Shutdown both run)
+        mmcePs1Games = NULL;
 
         //      if ((exception & UNMOUNT_EXCEPTION) == 0)
         //          ...
@@ -1172,8 +1224,8 @@ static void mmceShutdown(item_list_t *itemList)
 
         free(mmceGames);
         mmceGames = NULL;
-        free(mmceVcdGames);
-        mmceVcdGames = NULL;
+        free(mmcePs1Games);
+        mmcePs1Games = NULL;
     }
 
     // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -96,6 +96,10 @@ static unsigned char mmceEverResolved = 0;
 // forward declaration
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
+// The card ROOT ("mmceN:/"), where library folders live. mmcePrefix is NOT it: that carries the
+// user's configurable games prefix (gMMCEPrefix), which POPS has always been resolved under and
+// must keep being resolved under. EMBER/ is new and follows the device-root rule instead.
+static const char *mmcePs1Root(void);
 static int mmceModLoaded = 0;          // latched by mmceLoadModules; read by mmceSendGameID's arm check
 static char mmceGameIdTarget[8] = {0}; // last device a GameID 0x8 switch was SENT to (mmceGameIdSettle polls it)
 
@@ -228,6 +232,13 @@ int mmceGameIdSettle(int timeoutMs)
     }
     LOG("MMCE GameID settle NOT confirmed after %d ms\n", timeoutMs);
     return -1;
+}
+
+static const char *mmcePs1Root(void)
+{
+    static char root[sizeof(mmcePrefix)];
+    mmceGetDeviceRoot(root, sizeof(root));
+    return root;
 }
 
 static void mmceGetDeviceRoot(char *root, size_t size)
@@ -636,7 +647,7 @@ static int mmceUpdateGameList(item_list_t *itemList)
     if (libViewActive(itemList->mode) == LIB_VIEW_PS1) {
         // ONE list, BOTH cores -- POPS/*.VCD unioned with EMBER/games/*. mmcePrefix is the card
         // root, which is where both folders live, so the same prefix serves both halves.
-        int r = ps1FillGameList(mmcePrefix, &mmcePs1Games);
+        int r = ps1FillGameList(mmcePrefix, mmcePs1Root(), &mmcePs1Games);
         if (r >= 0) { // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
             mmcePs1Scanned = 1;
             mmcePs1GameCount = r;
@@ -711,8 +722,14 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
         base_game_info_t *game = mmceActiveGame(itemList, id);
 
         if (game == &mmceEmptyGame)
-            return; // stale id in the VCD->ISO toggle window
-        if (vcdRenameFile(mmcePrefix, game->name, newName) == 0) {
+            return; // stale id in the PS2<->PS1 toggle window
+        // The ROW picks the target, exactly as the launch does. Dispatching on the view would send
+        // an Ember row to vcdRenameFile, which searches POPS/ for "<name>.VCD" -- absent for an
+        // Ember title, so the rename would quietly do nothing; and where a .VCD of the same name
+        // exists (a game held for BOTH cores, the case the merged list makes ordinary) it would
+        // rename the POPSTARTER file instead. Renaming the wrong file is the worse half of that.
+        int renamed = cueIsCueEntry(game) ? cueRenameGame(mmcePs1Root(), game->name, newName) : vcdRenameFile(mmcePrefix, game->name, newName);
+        if (renamed == 0) {
             // MMCE normally latches a successful VCD scan under NOUPDATE. Re-arm its normal scan
             // path so the deferred menu update publishes the new filename immediately.
             mmcePs1Scanned = 0;
@@ -754,18 +771,18 @@ static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set
         return;
     }
 
-    if (!cueResolveEmber(mmcePrefix, emberElf, sizeof(emberElf))) {
+    if (!cueResolveEmber(mmcePs1Root(), emberElf, sizeof(emberElf))) {
         guiMsgBox(_l(_STR_EMBER_NOT_FOUND), 0, NULL);
         return;
     }
-    if (!cueResolveEmberBios(mmcePrefix, biosPath, sizeof(biosPath))) {
+    if (!cueResolveEmberBios(mmcePs1Root(), biosPath, sizeof(biosPath))) {
         guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
         return;
     }
     // The scan lists folders without reading inside them -- that would be a directory read per row
     // on every refresh. Pay for it once, HERE, while a dialog can still be drawn: an empty or
     // mis-filled folder otherwise drops the user into the PS1 BIOS shell with no explanation.
-    if (!cueGameHasImage(mmcePrefix, cueName)) {
+    if (!cueGameHasImage(mmcePs1Root(), cueName)) {
         guiMsgBox(_l(_STR_EMBER_NO_DISC), 0, NULL);
         return;
     }
@@ -1186,7 +1203,7 @@ static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, cha
         // The cache hands us a NAME, so resolve which core owns the row against the published list
         // (memory scan, no card IO on the art path). Unknown falls back to the POPSTARTER layout.
         if (cueRowIsCueByName(mmcePs1Games, mmcePs1GameCount, value) == 1)
-            r = cueLoadFolderCover(mmceArtPrimary, value, suffix, resultTex);
+            r = cueLoadFolderCover(mmcePs1Root(), value, suffix, resultTex);
         else
             r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
     }

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -1252,4 +1252,5 @@ static char *mmceGetPrefix(item_list_t *itemList)
 static item_list_t mmceGameList = {
     MMCE_MODE, 2, 0, 0, MENU_MIN_INACTIVE_FRAMES, MMCE_MODE_UPDATE_DELAY, NULL, NULL, &mmceGetTextId, &mmceGetPrefix, &mmceInit, &mmceNeedsUpdate,
     &mmceUpdateGameList, &mmceGetGameCount, &mmceGetGame, &mmceGetGameName, &mmceGetGameNameLength, &mmceGetGameStartup, &mmceDeleteGame, &mmceRenameGame,
-    &mmceLaunchGame, &mmceGetConfig, &mmceGetImage, &mmceCleanUp, &mmceShutdown, &mmceCheckVMC, &mmceGetIconId, &mmceLaunchVcd};
+    &mmceLaunchGame, &mmceGetConfig, &mmceGetImage, &mmceCleanUp, &mmceShutdown, &mmceCheckVMC, &mmceGetIconId, &mmceLaunchVcd,
+    /* viewOverride */ 0, /* itemGetArtArchivePath */ NULL, &mmceLaunchCue};

--- a/src/opl.c
+++ b/src/opl.c
@@ -4116,6 +4116,18 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
 
+    // Say something BEFORE the blocking teardown below, because it can hold this thread for the
+    // whole of LAUNCH_IO_DRAIN_TICKS (~10 s) and nothing repaints while it does. Measured on
+    // hardware: roughly seven seconds of black screen between pressing X and the game's first
+    // output, with a loading spinner visible for only the first instant. A user cannot tell that
+    // from a freeze, and reasonably concludes the console has hung.
+    //
+    // This is the one place worth doing it: every launch and the exit path all funnel through here,
+    // so a per-launch-leg banner would have to be repeated in each and would still miss some. The
+    // frame flips and then persists on its own -- nothing draws again until the handoff -- so one
+    // call covers the entire wait.
+    guiRenderTextScreen(_l(_STR_PLEASE_WAIT));
+
     // Give up on the covers still QUEUED before draining. The drain waits on the ioman LIST, and the
     // worker keeps servicing it regardless of isIOBlocked, so without this the handoff pays for every
     // queued cover to be read off the game device first -- for a menu guiEnd() is about to destroy.
@@ -4173,6 +4185,18 @@ void deinitEx(int exception, int modeSelected, int modeSelected2)
 void deinit(int exception, int modeSelected)
 {
     gDeinitTerminal = (modeSelected == IO_MODE_SELECTED_ALL || modeSelected == IO_MODE_SELECTED_NONE);
+
+    // Say something BEFORE the blocking teardown below, because it can hold this thread for the
+    // whole of LAUNCH_IO_DRAIN_TICKS (~10 s) and nothing repaints while it does. Measured on
+    // hardware: roughly seven seconds of black screen between pressing X and the game's first
+    // output, with a loading spinner visible for only the first instant. A user cannot tell that
+    // from a freeze, and reasonably concludes the console has hung.
+    //
+    // This is the one place worth doing it: every launch and the exit path all funnel through here,
+    // so a per-launch-leg banner would have to be repeated in each and would still miss some. The
+    // frame flips and then persists on its own -- nothing draws again until the handoff -- so one
+    // call covers the entire wait.
+    guiRenderTextScreen(_l(_STR_PLEASE_WAIT));
 
     // Give up on the covers still QUEUED before draining. The drain waits on the ioman LIST, and the
     // worker keeps servicing it regardless of isIOBlocked, so without this the handoff pays for every

--- a/src/opl.c
+++ b/src/opl.c
@@ -36,7 +36,8 @@
 #include "include/folderbrowse.h" // folderDepth -- favourites suppression inside subfolders
 #include "include/mmcesupport.h"  // mmceLoadModules() -- MMCE boot branch of resolveBootDirToMass
 #include "include/tar.h"          // tarInvalidate -- re-arm the .tar probe on a settings apply
-#include "include/vcdsupport.h"   // vcdViewActive stub -- isVcd stays 0 until item 12 lands
+#include "include/vcdsupport.h"   // VCD display naming + POPSTARTER launch helpers
+#include "include/libview.h"      // libViewActive / libListViewActive -- which list this page shows
 
 #include "include/cheatman.h"
 #include "include/sound.h"
@@ -326,9 +327,13 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         if (gFAVStartMode)
             menuAddHint(&mod->menuItem, _STR_FAV_HINT, R3_ICON);
 
-        // L3 toggles the device's disc list <-> its VCD (PS1-via-POPSTARTER) list -- only under the
-        // "Both" default-view setting; ISO/VCD lock the page, so the toggle and its hint go away.
-        if (vcdModeSupported(mod->support->mode) && gDefaultGameView == GAME_VIEW_BOTH)
+        // L3 moves the page around its ring of lists -- only under the "Both" default-view setting;
+        // a locked setting pins the page, so the toggle and its hint go away.
+        //
+        // The question is "does this page have more than one list", NOT "does it have a VCD list".
+        // Those were the same thing while every ring was ISO<->VCD, and stop being the same as soon
+        // as a page offers a third; libViewRingSize keeps the hint honest either way.
+        if (libViewRingSize(mod->support->mode) > 1 && gDefaultGameView == GAME_VIEW_BOTH)
             menuAddHint(&mod->menuItem, _STR_VCD, L3_ICON);
     }
 
@@ -420,7 +425,7 @@ static void itemExecRefresh(struct menu_item *curMenu)
         if (support->mode == FAV_MODE) {
             loadFavourites();
         } else {
-            if (support->mode == HDD_MODE && vcdListViewActive(support))
+            if (support->mode == HDD_MODE && (libListViewActive(support) == LIB_VIEW_VCD))
                 hddVcdInvalidateCache();
             ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
         }
@@ -428,13 +433,13 @@ static void itemExecRefresh(struct menu_item *curMenu)
     }
 }
 
-// L3: toggle the device's list between its disc games and its VCD (PS1-via-POPSTARTER) list. Only
-// device classes that have a VCD view (vcdModeSupported) respond. vcdToggleView marks the mode
-// dirty; the deferred update + the support's NeedsUpdate (vcdConsumeDirty) then force the rescan.
+// L3: advance the page one stop around its ring of lists. Only pages with more than one list
+// respond. libViewAdvance marks the mode dirty; the deferred update + the support's NeedsUpdate
+// (libViewConsumeDirty) then force the rescan.
 static void itemExecToggleView(struct menu_item *curMenu)
 {
     item_list_t *support = curMenu->userdata;
-    if (!support || !vcdModeSupported(support->mode))
+    if (!support || libViewRingSize(support->mode) < 2)
         return;
     if (gDefaultGameView != GAME_VIEW_BOTH)
         return; // the global default-view setting locks the page to one type -> L3 is inert
@@ -442,7 +447,7 @@ static void itemExecToggleView(struct menu_item *curMenu)
     // Folder browsing: the VCD/POPS list has no folder tree, so drop any ISO-view subfolder position
     // back to root on a view toggle (the deferred rebuild below restores the plain device title).
     folderReset(support->mode);
-    vcdToggleView(support->mode);
+    libViewAdvance(support->mode);
 
     // Every cover already queued belongs to the view being discarded, and none of them will be
     // cancelled on their own: the loader's per-row cancellation keys on a row having scrolled away,
@@ -453,7 +458,7 @@ static void itemExecToggleView(struct menu_item *curMenu)
     cacheDropQueuedArt();
 
     sfxPlay(SFX_CONFIRM);
-    guiWarning(vcdViewActive(support->mode) ? _l(_STR_VCD_ON) : _l(_STR_VCD_OFF), 2);
+    guiWarning((libViewActive(support->mode) == LIB_VIEW_VCD) ? _l(_STR_VCD_ON) : _l(_STR_VCD_OFF), 2);
     ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
 }
 
@@ -503,7 +508,7 @@ static void itemExecSquare(struct menu_item *curMenu)
         // Direct HDD/HDL rows already carry their size in APA metadata (total_size_in_kb), so the
         // generic CFG+stat pass is redundant there. VCD rows likewise have no meaningful #Size.
         // Avoid putting either no-op read onto the shared IO worker merely for opening Info.
-        if (support == NULL || (!vcdListViewActive(support) && support->mode != HDD_MODE))
+        if (support == NULL || (libListViewActive(support) != LIB_VIEW_VCD && support->mode != HDD_MODE))
             menuRequestInfoSize();
         guiSwitchScreen(GUI_SCREEN_INFO);
     }
@@ -536,7 +541,7 @@ static void itemExecFav(struct menu_item *curMenu)
     } else {
         // A favourite captured while the device page is in its L3 VCD view is a PS1/.VCD favourite
         // (checklist item 12; the stub keeps isVcd at 0 until VCD views exist).
-        int isVcd = vcdViewActive(support->mode) ? 1 : 0;
+        int isVcd = (libViewActive(support->mode) == LIB_VIEW_VCD) ? 1 : 0;
         // Only on a device whose VCD favourites can actually be resolved/launched later: storing one
         // on a device without itemLaunchVcd would leave a permanently-hidden, unlaunchable record.
         if (isVcd && support->itemLaunchVcd == NULL)
@@ -568,8 +573,8 @@ static void itemExecTriangle(struct menu_item *curMenu)
     if (support) {
         // A VCD is a POPSTARTER title, not a PS2-loader title. Route before the generic per-game
         // settings branch: that branch loads/creates CFG state and exposes controls that can never
-        // affect a POPSTARTER handoff. vcdListViewActive also covers a forced-VCD Favourites proxy.
-        if (vcdListViewActive(support)) {
+        // affect a POPSTARTER handoff. libListViewActive also covers a forced-VCD Favourites proxy.
+        if (libListViewActive(support) == LIB_VIEW_VCD) {
             if (menuCheckParentalLock() == 0) {
                 menuInitVcdMenu();
                 guiSwitchScreen(GUI_SCREEN_APP_MENU);
@@ -771,15 +776,15 @@ static void deinitAllSupport(int exception, int modeSelected)
     }
 }
 
-void oplQueueVcdDeviceUpdates(void)
+void oplQueueLibraryDeviceUpdates(void)
 {
-    // vcdMarkAllDirty() is intentionally side-effect-free because it also runs during early config
+    // libViewMarkAllDirty() is intentionally side-effect-free because it also runs during early config
     // loading, before the IO worker and device modules are ready. Runtime callers must explicitly
     // enqueue the enabled pages. This matters most for HDD, whose updateDelay=-1 means a dirty view
     // otherwise keeps displaying the old submenu indefinitely while rendering uses the new view.
     for (int i = 0; i < MODE_COUNT; i++) {
         item_list_t *support = list_support[i].support;
-        if (support != NULL && support->enabled && support->mode != FAV_MODE && vcdModeSupported(support->mode))
+        if (support != NULL && support->enabled && support->mode != FAV_MODE && libViewRingSize(support->mode) > 1)
             ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
     }
 }
@@ -2664,13 +2669,13 @@ static void _loadConfig()
             if (gDefaultGameView < GAME_VIEW_BOTH || gDefaultGameView > GAME_VIEW_VCD)
                 gDefaultGameView = GAME_VIEW_BOTH;
             // A boot default-view locked to one type (VCD or ISO) must force the same one-shot
-            // rescan the settings dialog does on a view change (gui.c). Without it, vcdViewActive()
+            // rescan the settings dialog does on a view change (gui.c). Without it, libViewActive()
             // short-circuits bdm/hdd/eth NeedsUpdate before the initial-scan trigger and the
             // list stays blank on boot -- a manual SELECT does not recover it (NeedsUpdate still
             // returns 0), only re-toggling the view does. This runs before applyConfig()'s first
             // support scans, so each VCD-capable page consumes the dirty flag on its first refresh.
             if (gDefaultGameView != GAME_VIEW_BOTH)
-                vcdMarkAllDirty();
+                libViewMarkAllDirty();
             configGetStrCopy(configOPL, CONFIG_OPL_POPSTARTER_PATH, gPopstarterPath, sizeof(gPopstarterPath));
             // POPSTARTER device TYPE (POPS_DEV_*). Absent in legacy configs: a non-empty custom
             // popstarter_path migrates to Custom (honour the old override); otherwise Default (cwd).

--- a/src/opl.c
+++ b/src/opl.c
@@ -524,8 +524,16 @@ static void itemExecSquare(struct menu_item *curMenu)
 // are ELF favourites, a PS1 page's rows are PS1 favourites), but for PS1 the CORE comes from the
 // ROW -- both cores share that one list, so asking the page which core to record would file every
 // Ember title as a POPSTARTER one and it would then launch through the wrong core.
-static int itemFavKind(item_list_t *support, int id)
+// `text` is the row as DRAWN. L3 changes the active backing list synchronously while the submenu is
+// rebuilt on the deferred IO thread, so for a short window the drawn rows belong to the old view
+// while itemGet already indexes the new one. Comparing the looked-up row's name against the drawn
+// text is what closes that window: they agree only when the row on screen is the row we resolved.
+// Returns -1 when they disagree, and the caller declines the action rather than writing a record
+// that names one game and launches another.
+static int itemFavKind(item_list_t *support, int id, const char *text)
 {
+    const base_game_info_t *game;
+
     if (support == NULL)
         return FAV_KIND_ISO;
     if (support->mode == APP_MODE)
@@ -533,15 +541,20 @@ static int itemFavKind(item_list_t *support, int id)
     if (libViewActive(support->mode) != LIB_VIEW_PS1)
         return FAV_KIND_ISO;
 
-    // itemGet hands back the live base_game_info_t; its extension is the row-kind discriminator.
-    // A support without itemGet (or a stale id during the toggle window) falls back to POPSTARTER,
-    // which is what every pre-Ember library is.
-    if (support->itemGet != NULL) {
-        const base_game_info_t *game = (const base_game_info_t *)support->itemGet(support, id);
-        if (game != NULL && cueIsCueEntry(game))
-            return FAV_KIND_CUE;
-    }
-    return FAV_KIND_VCD;
+    // A PS1 page holds both cores, so the CORE comes from the row. Without itemGet there is nothing
+    // to read it from; POPSTARTER is the right assumption, being what every pre-Ember library is.
+    if (support->itemGet == NULL || text == NULL)
+        return FAV_KIND_VCD;
+
+    game = (const base_game_info_t *)support->itemGet(support, id);
+    if (game == NULL)
+        return -1;
+    // The toggle-window guards hand back a static EMPTY entry for an id the new list cannot honour;
+    // its name is "", which no drawn row has, so the mismatch below catches that case too.
+    if (strcmp(game->name, text) != 0)
+        return -1;
+
+    return cueIsCueEntry(game) ? FAV_KIND_CUE : FAV_KIND_VCD;
 }
 
 // R3: toggle the current row's favourite star (checklist item 33). On the Favourites tab
@@ -569,7 +582,13 @@ static void itemExecFav(struct menu_item *curMenu)
     if (support->mode == FAV_MODE) {
         favRemoveByIndex(it->id);
     } else {
-        int kind = itemFavKind(support, it->id);
+        int kind = itemFavKind(support, it->id, it->text);
+        // Mid-rebuild: the row on screen is not the row the backing list would give us. Storing it
+        // now would file the favourite under the wrong core, or under a name that is about to move.
+        // Do nothing and let the user press R3 again once the list has settled -- the star is not
+        // touched either, so nothing on screen lies about what was saved.
+        if (kind < 0)
+            return;
         // Only store a favourite this device can actually resolve and launch later. A PS1 record
         // whose source has no hook for that core would be a permanently-hidden, unlaunchable entry.
         if (kind == FAV_KIND_VCD && support->itemLaunchVcd == NULL)

--- a/src/opl.c
+++ b/src/opl.c
@@ -425,7 +425,7 @@ static void itemExecRefresh(struct menu_item *curMenu)
         if (support->mode == FAV_MODE) {
             loadFavourites();
         } else {
-            if (support->mode == HDD_MODE && (libListViewActive(support) == LIB_VIEW_VCD))
+            if (support->mode == HDD_MODE && (libListViewActive(support) == LIB_VIEW_PS1))
                 hddVcdInvalidateCache();
             ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
         }
@@ -458,7 +458,7 @@ static void itemExecToggleView(struct menu_item *curMenu)
     cacheDropQueuedArt();
 
     sfxPlay(SFX_CONFIRM);
-    guiWarning((libViewActive(support->mode) == LIB_VIEW_VCD) ? _l(_STR_VCD_ON) : _l(_STR_VCD_OFF), 2);
+    guiWarning((libViewActive(support->mode) == LIB_VIEW_PS1) ? _l(_STR_VCD_ON) : _l(_STR_VCD_OFF), 2);
     ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
 }
 
@@ -508,7 +508,7 @@ static void itemExecSquare(struct menu_item *curMenu)
         // Direct HDD/HDL rows already carry their size in APA metadata (total_size_in_kb), so the
         // generic CFG+stat pass is redundant there. VCD rows likewise have no meaningful #Size.
         // Avoid putting either no-op read onto the shared IO worker merely for opening Info.
-        if (support == NULL || (libListViewActive(support) != LIB_VIEW_VCD && support->mode != HDD_MODE))
+        if (support == NULL || (libListViewActive(support) != LIB_VIEW_PS1 && support->mode != HDD_MODE))
             menuRequestInfoSize();
         guiSwitchScreen(GUI_SCREEN_INFO);
     }
@@ -541,7 +541,7 @@ static void itemExecFav(struct menu_item *curMenu)
     } else {
         // A favourite captured while the device page is in its L3 VCD view is a PS1/.VCD favourite
         // (checklist item 12; the stub keeps isVcd at 0 until VCD views exist).
-        int isVcd = (libViewActive(support->mode) == LIB_VIEW_VCD) ? 1 : 0;
+        int isVcd = (libViewActive(support->mode) == LIB_VIEW_PS1) ? 1 : 0;
         // Only on a device whose VCD favourites can actually be resolved/launched later: storing one
         // on a device without itemLaunchVcd would leave a permanently-hidden, unlaunchable record.
         if (isVcd && support->itemLaunchVcd == NULL)
@@ -574,7 +574,7 @@ static void itemExecTriangle(struct menu_item *curMenu)
         // A VCD is a POPSTARTER title, not a PS2-loader title. Route before the generic per-game
         // settings branch: that branch loads/creates CFG state and exposes controls that can never
         // affect a POPSTARTER handoff. libListViewActive also covers a forced-VCD Favourites proxy.
-        if (libListViewActive(support) == LIB_VIEW_VCD) {
+        if (libListViewActive(support) == LIB_VIEW_PS1) {
             if (menuCheckParentalLock() == 0) {
                 menuInitVcdMenu();
                 guiSwitchScreen(GUI_SCREEN_APP_MENU);

--- a/src/opl.c
+++ b/src/opl.c
@@ -36,8 +36,9 @@
 #include "include/folderbrowse.h" // folderDepth -- favourites suppression inside subfolders
 #include "include/mmcesupport.h"  // mmceLoadModules() -- MMCE boot branch of resolveBootDirToMass
 #include "include/tar.h"          // tarInvalidate -- re-arm the .tar probe on a settings apply
-#include "include/vcdsupport.h"   // VCD display naming + POPSTARTER launch helpers
-#include "include/libview.h"      // libViewActive / libListViewActive -- which list this page shows
+#include "include/vcdsupport.h"
+#include "include/cuesupport.h" // cueIsCueEntry -- a PS1 row names its own core   // VCD display naming + POPSTARTER launch helpers
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 
 #include "include/cheatman.h"
 #include "include/sound.h"
@@ -333,7 +334,7 @@ void moduleUpdateMenuInternal(opl_io_module_t *mod, int themeChanged, int langCh
         // The question is "does this page have more than one list", NOT "does it have a VCD list".
         // Those were the same thing while every ring was ISO<->VCD, and stop being the same as soon
         // as a page offers a third; libViewRingSize keeps the hint honest either way.
-        if (libViewRingSize(mod->support->mode) > 1 && gDefaultGameView == GAME_VIEW_BOTH)
+        if (libViewRingUsable(mod->support->mode))
             menuAddHint(&mod->menuItem, _STR_VCD, L3_ICON);
     }
 
@@ -439,10 +440,8 @@ static void itemExecRefresh(struct menu_item *curMenu)
 static void itemExecToggleView(struct menu_item *curMenu)
 {
     item_list_t *support = curMenu->userdata;
-    if (!support || libViewRingSize(support->mode) < 2)
+    if (!support || !libViewRingUsable(support->mode))
         return;
-    if (gDefaultGameView != GAME_VIEW_BOTH)
-        return; // the global default-view setting locks the page to one type -> L3 is inert
 
     // Folder browsing: the VCD/POPS list has no folder tree, so drop any ISO-view subfolder position
     // back to root on a view toggle (the deferred rebuild below restores the plain device title).
@@ -458,7 +457,14 @@ static void itemExecToggleView(struct menu_item *curMenu)
     cacheDropQueuedArt();
 
     sfxPlay(SFX_CONFIRM);
-    guiWarning((libViewActive(support->mode) == LIB_VIEW_PS1) ? _l(_STR_VCD_ON) : _l(_STR_VCD_OFF), 2);
+    // Three shelves are possible now (Favourites rings PS2 -> PS1 -> APPS), so the toast names the
+    // one you landed on rather than reading as an on/off flag.
+    {
+        int view = libViewActive(support->mode);
+        int msg = (view == LIB_VIEW_PS1) ? _STR_VCD_ON : (view == LIB_VIEW_ELF) ? _STR_VIEW_APPS :
+                                                                                  _STR_VCD_OFF;
+        guiWarning(_l(msg), 2);
+    }
     ioPutRequest(IO_MENU_UPDATE_DEFFERED, &support->mode);
 }
 
@@ -514,6 +520,30 @@ static void itemExecSquare(struct menu_item *curMenu)
     }
 }
 
+// Which favourite kind is the row at `id` on this page? The SHELF comes from the page (APPS rows
+// are ELF favourites, a PS1 page's rows are PS1 favourites), but for PS1 the CORE comes from the
+// ROW -- both cores share that one list, so asking the page which core to record would file every
+// Ember title as a POPSTARTER one and it would then launch through the wrong core.
+static int itemFavKind(item_list_t *support, int id)
+{
+    if (support == NULL)
+        return FAV_KIND_ISO;
+    if (support->mode == APP_MODE)
+        return FAV_KIND_ELF;
+    if (libViewActive(support->mode) != LIB_VIEW_PS1)
+        return FAV_KIND_ISO;
+
+    // itemGet hands back the live base_game_info_t; its extension is the row-kind discriminator.
+    // A support without itemGet (or a stale id during the toggle window) falls back to POPSTARTER,
+    // which is what every pre-Ember library is.
+    if (support->itemGet != NULL) {
+        const base_game_info_t *game = (const base_game_info_t *)support->itemGet(support, id);
+        if (game != NULL && cueIsCueEntry(game))
+            return FAV_KIND_CUE;
+    }
+    return FAV_KIND_VCD;
+}
+
 // R3: toggle the current row's favourite star (checklist item 33). On the Favourites tab
 // itself R3 removes; on any source list it adds/removes by (mode, id, text).
 static void itemExecFav(struct menu_item *curMenu)
@@ -539,18 +569,18 @@ static void itemExecFav(struct menu_item *curMenu)
     if (support->mode == FAV_MODE) {
         favRemoveByIndex(it->id);
     } else {
-        // A favourite captured while the device page is in its L3 VCD view is a PS1/.VCD favourite
-        // (checklist item 12; the stub keeps isVcd at 0 until VCD views exist).
-        int isVcd = (libViewActive(support->mode) == LIB_VIEW_PS1) ? 1 : 0;
-        // Only on a device whose VCD favourites can actually be resolved/launched later: storing one
-        // on a device without itemLaunchVcd would leave a permanently-hidden, unlaunchable record.
-        if (isVcd && support->itemLaunchVcd == NULL)
+        int kind = itemFavKind(support, it->id);
+        // Only store a favourite this device can actually resolve and launch later. A PS1 record
+        // whose source has no hook for that core would be a permanently-hidden, unlaunchable entry.
+        if (kind == FAV_KIND_VCD && support->itemLaunchVcd == NULL)
+            return;
+        if (kind == FAV_KIND_CUE && support->itemLaunchCue == NULL)
             return;
         if (it->favourited) {
-            if (removeFavouriteByIdAndText(support->mode, it->id, it->text, isVcd))
+            if (removeFavouriteByIdAndText(support->mode, it->id, it->text, kind))
                 it->favourited = 0; // only clear the star once the store write succeeded
         } else {
-            if (addFavouriteItem(support->mode, it->id, it->icon_id, it->text_id, it->text, isVcd))
+            if (addFavouriteItem(support->mode, it->id, it->icon_id, it->text_id, it->text, kind))
                 it->favourited = 1; // only show the star once the store write succeeded
         }
     }

--- a/src/sound.c
+++ b/src/sound.c
@@ -739,6 +739,19 @@ void bgmQuiesce(void)
     if (!audio_initialized)
         return;
 
+    // MUTE FIRST, then ask the threads to wind down. Setting terminateFlag only stops the FEEDER;
+    // audsrv keeps playing whatever is already queued, and the decode thread stops refilling it --
+    // so the last fraction of a second loops or judders while the caller gets on with a teardown
+    // that can block for seconds (see LAUNCH_IO_DRAIN_TICKS). That judder is the "audio stutters
+    // when a game launches" report, and it is purely cosmetic damage done while we are on the way
+    // out. Dropping the volume makes the same interval silent instead.
+    //
+    // Volume, not audsrv_stop_audio(): the BGM thread may be inside audsrv_play_audio right now,
+    // and issuing a competing stop on the same RPC channel from this thread is exactly the class of
+    // teardown race that produced the old exit-hang. Muting touches no state the thread owns, and
+    // the real stop still happens in audioEnd() where it always did.
+    bgmMute();
+
     terminateFlag = 1;
     SignalSema(inSema);
     SignalSema(outSema);

--- a/src/system.c
+++ b/src/system.c
@@ -1571,6 +1571,47 @@ void sysLaunchPopstarter(const char *popstarterElf, const char *selector)
         LOG("[POPS] keep-IOP handoff failed for %s\n", popstarterElf);
 }
 
+// Hand off to an external ember.elf to boot a PS1 CUE title. Contract in include/system.h.
+//
+// The keep-IOP loader is MANDATORY here, not a preference. ember.elf carries sceSifInitRpc,
+// SifLoadModule and SifInitIopHeap but NO SifIopReset / SifIopRebootBuffer / sceSifRebootIop
+// (verified against the shipped Beta binary, which is unstripped) -- it cannot rebuild a device
+// stack and simply inherits whatever the launcher leaves running. Ember's own bundled launcher.elf
+// resets the IOP and then loads iomanX + fileXio + usbd + usbmass_bd + bdm + bdmfs_fatfs before
+// ExecPS2'ing into it; OPL's live IOP is a superset of that, which is why this handoff reaches
+// every device OPL can mount rather than USB alone. Using the resetting SDK loader instead leaves
+// Ember with no drivers and no way to make any -- a black screen, not a degraded launch.
+//
+// argv[0] must be ember.elf's real path: ps2sdk's __init_cwd derives the target's working
+// directory from it, and Ember resolves bios.bin, settings.txt and games/<name> against that.
+// sysLoadELFKeepIOP forwards argv verbatim (argv[0] included), the same property the POPSTARTER
+// selector relies on.
+void sysLaunchEmber(const char *emberElf, const char *gameFolder)
+{
+    char *argv[2];
+    int argc = 0;
+
+    if (emberElf == NULL) {
+        LOG("[EMBER] null arg, abort\n");
+        return;
+    }
+
+    argv[argc++] = (char *)emberElf;
+
+    // No game argument is a legitimate call, not a caller bug: Ember then resolves games/default
+    // and, failing that, runs the PS1 BIOS shell. Both are useful answers when probing a setup.
+    if (gameFolder != NULL && gameFolder[0] != '\0')
+        argv[argc++] = (char *)gameFolder;
+
+    LOG("[EMBER] elf=%s game=%s\n", emberElf, (argc > 1) ? argv[1] : "(none)");
+
+    // The kernel argv budget (15 strings / 256-byte pool, counting the child loader's own argv[0])
+    // is enforced inside sysLoadELFKeepIOP, which refuses rather than truncating. Callers keep the
+    // game name under CUE_NAME_LAUNCH_MAX so a refusal here means a pathological device path.
+    if (sysLoadELFKeepIOP(emberElf, "", argc, argv) < 0)
+        LOG("[EMBER] keep-IOP handoff failed for %s\n", emberElf);
+}
+
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags)
 {
     unsigned int modules, ModuleStorageSize;

--- a/src/themes.c
+++ b/src/themes.c
@@ -12,6 +12,7 @@
 #include "include/texcache.h"
 #include "include/favsupport.h"
 #include "include/vcdsupport.h" // vcdDisplayName -- display-only VCD game-ID prefix hide
+#include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 
 #include <time.h>
 #include <math.h>
@@ -1854,7 +1855,7 @@ static void drawItemText(struct menu_list *menu, struct submenu_list *item, conf
                 // ONLY (vcdDisplayIdCached): the id is resolved off the render thread
                 // (vcdRequestDisplayId, menusys.c), so a slow device never blocks here; until it
                 // lands, the filename's own id prefix is shown, then the title as before.
-                if (vcdViewActive(support->mode)) {
+                if (libViewActive(support->mode) == LIB_VIEW_VCD) {
                     char vcdId[VCD_ID_MAX];
                     if (vcdDisplayIdCached(startup, vcdId, sizeof(vcdId)) ||
                         vcdExtractGameId(startup, vcdId, sizeof(vcdId))) {

--- a/src/themes.c
+++ b/src/themes.c
@@ -1855,7 +1855,7 @@ static void drawItemText(struct menu_list *menu, struct submenu_list *item, conf
                 // ONLY (vcdDisplayIdCached): the id is resolved off the render thread
                 // (vcdRequestDisplayId, menusys.c), so a slow device never blocks here; until it
                 // lands, the filename's own id prefix is shown, then the title as before.
-                if (libViewActive(support->mode) == LIB_VIEW_VCD) {
+                if (libViewActive(support->mode) == LIB_VIEW_PS1) {
                     char vcdId[VCD_ID_MAX];
                     if (vcdDisplayIdCached(startup, vcdId, sizeof(vcdId)) ||
                         vcdExtractGameId(startup, vcdId, sizeof(vcdId))) {

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -129,7 +129,7 @@ static int udpfsNeedsUpdate(item_list_t *itemList)
     // Folder browsing: descend/ascend forces one rescan.
     if (folderConsumeDirty(itemList->mode))
         return 1;
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         return 0;
 
     if (udpfsULSizePrev == -2)
@@ -176,7 +176,7 @@ static int udpfsUpdateGameList(item_list_t *itemList)
         udpfsFoldersCreated = 1;
     }
 
-    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
+    if (libListViewActive(itemList) == LIB_VIEW_PS1) {
         int r = vcdFillGameList(udpfsPrefix, &udpfsGames);
         if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
             udpfsGameCount = r;
@@ -212,7 +212,7 @@ static int udpfsGetGameNameLength(item_list_t *itemList, int id)
 static char *udpfsGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
-    if (libListViewActive(itemList) == LIB_VIEW_VCD)
+    if (libListViewActive(itemList) == LIB_VIEW_PS1)
         return udpfsGames[id].name;
     return udpfsGames[id].startup;
 }
@@ -255,7 +255,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     sbSetBrowseSub(folderGetSub(itemList->mode));
 
     // VCD view: udpfs cannot host a POPSTARTER launch (network filesystem) -> hand off to the guard.
-    if (game != NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
+    if (game != NULL && (libListViewActive(itemList) == LIB_VIEW_PS1)) {
         udpfsLaunchVcd(itemList, game->name, configSet);
         return;
     }
@@ -368,7 +368,7 @@ static int udpfsGetImage(item_list_t *itemList, char *folder, int isRelative, ch
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_VCD))
+    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_PS1))
         r = vcdLoadPopsCover(udpfsPrefix, value, suffix, resultTex);
     return r;
 }

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -4,6 +4,7 @@
 #include "include/supportbase.h"
 #include "include/udpfssupport.h"
 #include "include/vcdsupport.h"
+#include "include/libview.h" // libViewActive / libListViewActive -- which list this page shows
 #include "include/folderbrowse.h"
 #include "include/util.h"
 #include "include/renderman.h"
@@ -123,12 +124,12 @@ static int udpfsNeedsUpdate(item_list_t *itemList)
     int result = 0;
 
     // VCD view: force a rescan once on toggle, then refresh on toggle only (skip disc heuristics).
-    if (vcdConsumeDirty(itemList->mode))
+    if (libViewConsumeDirty(itemList->mode))
         return 1;
     // Folder browsing: descend/ascend forces one rescan.
     if (folderConsumeDirty(itemList->mode))
         return 1;
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         return 0;
 
     if (udpfsULSizePrev == -2)
@@ -175,7 +176,7 @@ static int udpfsUpdateGameList(item_list_t *itemList)
         udpfsFoldersCreated = 1;
     }
 
-    if (vcdListViewActive(itemList)) {
+    if (libListViewActive(itemList) == LIB_VIEW_VCD) {
         int r = vcdFillGameList(udpfsPrefix, &udpfsGames);
         if (r >= 0) // r < 0: transient scan failure -> preserve the last-good list
             udpfsGameCount = r;
@@ -211,7 +212,7 @@ static int udpfsGetGameNameLength(item_list_t *itemList, int id)
 static char *udpfsGetGameStartup(item_list_t *itemList, int id)
 {
     // VCD view keys per-game data (CFG/art) off the VCD filename, not a disc ID (see sbPopulateConfig).
-    if (vcdListViewActive(itemList))
+    if (libListViewActive(itemList) == LIB_VIEW_VCD)
         return udpfsGames[id].name;
     return udpfsGames[id].startup;
 }
@@ -254,7 +255,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     sbSetBrowseSub(folderGetSub(itemList->mode));
 
     // VCD view: udpfs cannot host a POPSTARTER launch (network filesystem) -> hand off to the guard.
-    if (game != NULL && vcdListViewActive(itemList)) {
+    if (game != NULL && (libListViewActive(itemList) == LIB_VIEW_VCD)) {
         udpfsLaunchVcd(itemList, game->name, configSet);
         return;
     }
@@ -367,7 +368,7 @@ static int udpfsGetImage(item_list_t *itemList, char *folder, int isRelative, ch
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && vcdListViewActive(itemList))
+    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_VCD))
         r = vcdLoadPopsCover(udpfsPrefix, value, suffix, resultTex);
     return r;
 }

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -32,6 +32,7 @@
 #include "include/bdma_embed.h"  // embedded BDMAssault variant pairs (gzipped; PROVENANCE.md)
 #include <zlib.h>                // inflate for the embedded pairs (already linked via libpng)
 #include "include/vcdsupport.h"
+#include "include/libview.h" // which list a page is showing (the L3 ring)
 #include "include/retrogem.h"
 
 
@@ -174,7 +175,10 @@ static int vcdGameIdPrefixLen(const char *name)
 const char *vcdDisplayName(int mode, const char *text)
 {
     int n;
-    if (!gVcdHideGameId || text == NULL || !vcdViewActive(mode))
+    // VCD rows only, and deliberately so: the game-ID prefix this strips is a POPSTARTER/.VCD
+    // filename convention. A CUE row's name is an Ember game FOLDER, which carries no such prefix
+    // and must never be trimmed by this option.
+    if (!gVcdHideGameId || text == NULL || libViewActive(mode) != LIB_VIEW_VCD)
         return text;
     n = vcdGameIdPrefixLen(text);
     return n ? text + n : text;
@@ -958,82 +962,10 @@ void vcdBuildSelector(const char *devPrefix, const char *prefix, const char *nam
     snprintf(out, outSize, "%s/%s/%s%s.ELF", root, POPS_FOLDER, prefix ? prefix : "", name ? name : "");
 }
 
-// ---- per-device VCD view state ------------------------------------------------
-
-static unsigned char vcdView[MODE_COUNT];  // 1 = this mode is showing its VCD list
-static unsigned char vcdDirty[MODE_COUNT]; // 1 = view just toggled -> force one rescan
-
-int vcdModeSupported(int mode)
-{
-    // FAV_MODE has its own L3 ISO<->VCD view too: the Favourites tab swaps between disc favourites and
-    // PS1/.VCD favourites (favsupport filters its list by vcdViewActive(FAV_MODE)). Its vcdView slot is
-    // independent of any device's, so toggling Favourites never disturbs a device page's view.
-    //
-    // Supported L3 VCD pages:
-    // - USB / exFAT, MMCE, MX4SIO, SMB, ATA (BDM HDD), APA / PFS HDD, FAV_MODE
-    //
-    // Unsupported:
-    // - UDPBD, UDPFS, APPS
-    if (mode >= BDM_MODE && mode <= BDM_MODE_LAST)
-        return !bdmModeIsUDPBD(mode);
-
-    return mode == MMCE_MODE || mode == ETH_MODE || mode == HDD_MODE || mode == FAV_MODE;
-}
-
-int vcdViewActive(int mode)
-{
-    if (mode < 0 || mode >= MODE_COUNT || !vcdModeSupported(mode))
-        return 0;
-    // The global default-view setting overrides the per-device L3 toggle when locked to one type.
-    if (gDefaultGameView == GAME_VIEW_ISO)
-        return 0; // locked to the ISO/disc list
-    if (gDefaultGameView == GAME_VIEW_VCD)
-        return 1;         // locked to the VCD (PS1) list
-    return vcdView[mode]; // GAME_VIEW_BOTH: per-device L3 toggle (defaults to ISO)
-}
-
-int vcdListViewActive(const item_list_t *itemList)
-{
-    if (itemList == NULL)
-        return 0;
-    if (itemList->viewOverride == ITEM_VIEW_FORCE_ISO)
-        return 0;
-    if (itemList->viewOverride == ITEM_VIEW_FORCE_VCD)
-        return 1;
-    return vcdViewActive(itemList->mode);
-}
-
-void vcdToggleView(int mode)
-{
-    if (mode < 0 || mode >= MODE_COUNT)
-        return;
-    if (gDefaultGameView != GAME_VIEW_BOTH)
-        return; // globally locked to one type -> the L3 toggle is disabled
-    vcdView[mode] = vcdView[mode] ? 0 : 1;
-    vcdDirty[mode] = 1;
-}
-
-int vcdConsumeDirty(int mode)
-{
-    if (mode < 0 || mode >= MODE_COUNT || !vcdDirty[mode])
-        return 0;
-    vcdDirty[mode] = 0;
-    return 1;
-}
-
-void vcdMarkDirty(int mode)
-{
-    if (mode >= 0 && mode < MODE_COUNT && vcdModeSupported(mode))
-        vcdDirty[mode] = 1;
-}
-
-// Mark every VCD-capable mode for one rescan -- call after the global default-view setting changes so
-// each device page rebuilds its list (ISO <-> VCD) on its next refresh.
-void vcdMarkAllDirty(void)
-{
-    for (int m = 0; m < MODE_COUNT; m++)
-        vcdMarkDirty(m);
-}
+// ---- per-device VCD view ---------------------------------------------------
+// The view state moved to libview.c when the per-page list choice stopped being a boolean.
+// vcdDisplayName below is the only piece that stayed: it is display formatting for the VCD
+// list, not view state, and it asks libViewActive() which list is on screen.
 
 // #118: a multi-disc PS1 game is a set of separate .VCD files whose titles carry a disc token, e.g.
 // "Game (Disc 2).VCD". With gVcdFirstDiscOnly on, the device VCD lists hide discs 2+ (POPSLoader

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -178,7 +178,7 @@ const char *vcdDisplayName(int mode, const char *text)
     // VCD rows only, and deliberately so: the game-ID prefix this strips is a POPSTARTER/.VCD
     // filename convention. A CUE row's name is an Ember game FOLDER, which carries no such prefix
     // and must never be trimmed by this option.
-    if (!gVcdHideGameId || text == NULL || libViewActive(mode) != LIB_VIEW_VCD)
+    if (!gVcdHideGameId || text == NULL || libViewActive(mode) != LIB_VIEW_PS1)
         return text;
     n = vcdGameIdPrefixLen(text);
     return n ? text + n : text;
@@ -188,6 +188,13 @@ const char *vcdDisplayName(int mode, const char *text)
 // uses (strcasecmp on the SAME display-adjusted key -- menusys.c was updated alongside this to sort by
 // vcdDisplayName), or the two disagree and the menu-level gAutosort pass, which runs LAST, silently
 // undoes this backing array's order.
+const char *vcdSortKey(const char *name)
+{
+    if (name == NULL)
+        return name;
+    return gVcdHideGameId ? name + vcdGameIdPrefixLen(name) : name;
+}
+
 static int vcdEntryCmp(const void *a, const void *b)
 {
     const char *na = ((const vcd_entry_t *)a)->name;
@@ -198,10 +205,8 @@ static int vcdEntryCmp(const void *a, const void *b)
     // part in the alphabet"). Skip the same prefix here so the visible order matches the visible text.
     // With hide off, the prefix IS shown, so it stays part of the sort key. vcdGameIdPrefixLen returns
     // 0 for a name without a strict game-ID prefix, so untagged titles are unaffected either way.
-    if (gVcdHideGameId) {
-        na += vcdGameIdPrefixLen(na);
-        nb += vcdGameIdPrefixLen(nb);
-    }
+    na = vcdSortKey(na);
+    nb = vcdSortKey(nb);
     return strcasecmp(na, nb);
 }
 


### PR DESCRIPTION
**Draft — the Ember launch itself is not yet hardware-proven. Merging is gated on the test below.**

Adds [Ember](https://github.com/Gageformer/Ember) (Gageformer) as a second PS1 core alongside
POPSTARTER. Gage has approved and encouraged this. RiptOPL replaces Ember's bundled `launcher.elf`
and drives `ember.elf` directly with per-game arguments.

## What a user sees

Two toggles, unchanged: **PS2** and **PS1**. The PS1 list now holds *both* cores' titles, sorted
together as one library:

```
Spyro 2 (Ripto's Rage)     <- POPS/Spyro 2 (Ripto's Rage).VCD      -> POPSTARTER
Spyro 2 (Ripto's Rage)     <- EMBER/games/Spyro 2 (Ripto's Rage)/  -> Ember
```

No third stop, no setting to merge them. Which core runs a row is a property of the **row**,
resolved at launch, never of the page.

## Layout — `EMBER/` beside `POPS/`

```
<device>:/EMBER/
    ember.elf              <- required; its presence is what makes Ember rows appear
    bios.bin               <- required at launch, exactly 512 KB (user-supplied, never shipped)
    settings.txt           <- optional (display:240 | display:480)
    games/
        Spyro 2 (Ripto's Rage)/
            whatever.cue
            whatever.bin
```

The folder name is the display name, Ember's launch argument, and the key for art and per-game
config — the same role a `.VCD` filename plays. So `ART/Spyro 2 (Ripto's Rage)_COV.png` just works.

## How this was derived

There is no Ember source. Everything is **measured** by disassembling the shipped Beta `ember.elf`
(it ships unstripped with DWARF), not read off the README — which is thinner and, on the accepted
file extensions, wrong. Full derivation in `docs/EMBER-INTEGRATION-PLAN.md`.

Three load-bearing findings:

1. **`ember.elf` performs no IOP reset.** No `SifIopReset` / `SifIopRebootBuffer` /
   `sceSifRebootIop` anywhere. It inherits the launcher's live driver stack, so the handoff must use
   `sysLoadELFKeepIOP()` (the no-reset loader Neutrino already uses) and deinit with
   `UNMOUNT_EXCEPTION`. This is also why Ember can reach any device OPL can mount — POPSTARTER
   cannot, which is exactly why `bdmLaunchVcd` has to refuse UDPBD.
2. **Its game argument is a bare folder name.** `/`, `:` and `\` are hard-refused anywhere, and a
   leading `..` too. A path can never be passed, so the games must live under the `ember.elf`
   directory — and a POPSTARTER-style "Ember device" picker is impossible, not merely unimplemented.
3. **Only one game layout can save.** `main()` calls `memcard_init` exactly once, always with the
   composed path `games/<arg>`, never with wherever the disc was found. Ember also accepts a loose
   `games/<Name>.cue`, and retries the bare argument as a path beside `ember.elf` — but those play
   and *silently lose saves*, so we deliberately list only `games/<Name>/`. The header records why,
   so nobody widens the scan later without knowing.

## Commits

| Commit | What |
| --- | --- |
| `d7902a3a` | The plan, with the measured Ember contract |
| `67aaca41` | `sysLaunchEmber()` + `cuesupport.c`; OPLDIAG-only probe |
| `d2901227` | Binary VCD view flag → N-way list ring (`libview.c`), behaviour-neutral |
| `9eb87d14` | One PS1 list, both cores |
| `635a466a` | Plan follows the two-toggle decision |
| `77965515` | List only the layout Ember can save in; launch-time image probe |

The view refactor (`d2901227`) is the riskiest piece and landed alone so a regression would be
unambiguous. Both audit gates pass: zero references to the deleted binary API, and per-file
call-site counts (comments excluded) identical across all 13 consumer files.

## Testing

**Grab `PS2DEVPINNED`** from this PR's *Build flavours* run for normal testing, or
**`PS2DEVPINNED-DIAG`** for the OPLDIAG control case.

Lay out a stick as above and press **L3** on that device page. Ember titles should appear
interleaved with your `.VCD` ones.

**What we need back — in priority order:**

1. **Do the controllers work?** This is the open risk. RiptOPL loads `freesio2`/`freepad`; Ember
   loads `rom0:SIO2MAN`/`rom0:PADMAN` over our live IOP. Either they bind cleanly or they collide
   and there is no input. `unloadPads()` ends the RPC but does not unload the IRX, so there is no
   cheap fix — a collision means falling back to a clean-IOP handoff and losing "any device for
   free".
2. Do the Ember rows appear, correctly interleaved and sorted with the `.VCD` ones?
3. Does a title boot?
4. Does it work from MX4SIO / MMCE / internal exFAT ATA, not just USB?
5. Do `MC1.vmc` / `MC2.vmc` appear in the game folder afterwards? (Confirms it can write there.)
6. Anything resembling IOP memory exhaustion — a late, unexplained failure.

**Control case:** an APPS entry with `boot` = `mass0:/EMBER/ember.elf` and `argv1` = the folder name
works on `PS2DEVPINNED-DIAG` but is *expected to fail* on `PS2DEVPINNED`, because the stock APPS
loader resets the IOP out from under Ember. If it works on both, the no-reset premise needs
re-examining.

## Not done yet

- **SMB/ETH is deliberately POPSTARTER-only.** We compose SMB paths with `\`, Ember with `/`, and
  that is untested. One line to flip once proven; the reason is in the code.
- **APA-HDD and UDPFS** unchanged. APA needs its own layout decision — it has no filesystem root and
  `POPS` lives on `__common`.
- **Favourites don't know about Ember rows yet.** A PS1 favourite records only "is it VCD", so an
  Ember favourite would resolve to POPSTARTER. Needs the OFAV `kind` byte; no existing records move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for launching Ember-based PS1 titles alongside existing PS1 games.
  * Combined PS1 game sources into one browsable list, including artwork and favourites support.
  * Added an L3 library ring for switching between PS2, PS1, and apps views.
  * Added improved handling for PS1 game launching and memory-card workflows.
* **Style**
  * Updated localized interface text to use “PS1” terminology instead of “VCD.”
* **Documentation**
  * Added an Ember integration plan covering setup, behavior, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->