### PR TITLE
fix(mmce): resolve the PS1 libraries at the card root

### DIFF
--- a/include/cuesupport.h
+++ b/include/cuesupport.h
@@ -160,15 +160,10 @@ int cueRenameGame(const char *devPrefix, const char *oldName, const char *newNam
 // caller then keeps its last-good list rather than blanking a page over a transient wedge.
 // This is the ONE place the two libraries are unioned.
 //
-// TWO prefixes, and the split is deliberate rather than an oversight:
-//   vcdPrefix   -- passed to the POPSTARTER scan EXACTLY as that device has always passed it. On
-//                  MMCE that includes the user's configurable games prefix (gMMCEPrefix), so a card
-//                  laid out as mmce0:/<prefix>/POPS keeps working. Changing it would relocate an
-//                  existing library out from under its owner.
-//   emberPrefix -- the device ROOT, always. EMBER/ is a new library folder and follows the standing
-//                  rule that library folders live at the root of each activated device.
-// On every BDM device the two are the same value, so nothing there is affected either way.
-int ps1FillGameList(const char *vcdPrefix, const char *emberPrefix, base_game_info_t **outGames);
+// devPrefix is the device ROOT for BOTH libraries -- POPS/ and EMBER/ are peers there, on every
+// device class. See the note at the top of this header for why the root, and not a configurable
+// games prefix, is the right home for them.
+int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames);
 
 // PS1 (Ember) cover FALLBACK inside the game's own folder: "<games>/<name>/cover.png", then
 // "<games>/<name>/<name>.png". Cover/icon suffixes only; a device getImage calls this ONLY after

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1495,8 +1495,8 @@ static int bdmUpdateGameList(item_list_t *itemList)
         // ONE list, BOTH cores: ps1FillGameList unions POPS/*.VCD with EMBER/games/* and sorts them
         // together. It reports failure only when a scan could not READ the device -- an absent POPS
         // or EMBER folder is 0 -- so a device using just one core never preserves a stale list.
-        int r = ps1FillGameList(ps1Prefix, ps1Prefix, &pDeviceData->bdmPs1Games); // same root for both halves on BDM
-        if (r >= 0)                                                               // r < 0: transient scan failure -> keep THIS view's last-good (empty if never scanned)
+        int r = ps1FillGameList(ps1Prefix, &pDeviceData->bdmPs1Games);
+        if (r >= 0) // r < 0: transient scan failure -> keep THIS view's last-good (empty if never scanned)
             pDeviceData->bdmPs1GameCount = r;
         return pDeviceData->bdmPs1GameCount;
     }

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -375,7 +375,7 @@ static int cueFillGameList(const char *devPrefix, base_game_info_t **outGames)
     return n;
 }
 
-int ps1FillGameList(const char *vcdPrefix, const char *emberPrefix, base_game_info_t **outGames)
+int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames)
 {
     base_game_info_t *vcdGames = NULL, *cueGames = NULL, *merged = NULL;
     int vcdCount, cueCount, total;
@@ -383,8 +383,8 @@ int ps1FillGameList(const char *vcdPrefix, const char *emberPrefix, base_game_in
     if (outGames == NULL)
         return 0;
 
-    vcdCount = vcdFillGameList(vcdPrefix, &vcdGames);
-    cueCount = cueFillGameList(emberPrefix, &cueGames);
+    vcdCount = vcdFillGameList(devPrefix, &vcdGames);
+    cueCount = cueFillGameList(devPrefix, &cueGames);
 
     // EITHER half failing means the device could not be READ, not that it holds no games -- an
     // absent POPS or EMBER folder reports 0. Publishing a half list would look exactly like the

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -96,9 +96,11 @@ static unsigned char mmceEverResolved = 0;
 // forward declaration
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
-// The card ROOT ("mmceN:/"), where library folders live. mmcePrefix is NOT it: that carries the
-// user's configurable games prefix (gMMCEPrefix), which POPS has always been resolved under and
-// must keep being resolved under. EMBER/ is new and follows the device-root rule instead.
+// The card ROOT ("mmceN:/"), where the PS1 library folders live -- POPS/ and EMBER/ alike, exactly
+// as on every other device. mmcePrefix is NOT the root: it carries the user's configurable games
+// prefix (gMMCEPrefix), which is right for OPL's own data (CD/ DVD/ ART/ CFG/ VMC/) and wrong for a
+// library folder. POPS used to be resolved under it, which put an MMCE card with a configured
+// prefix out of step with its own documentation and with every other device.
 static const char *mmcePs1Root(void);
 static int mmceModLoaded = 0;          // latched by mmceLoadModules; read by mmceSendGameID's arm check
 static char mmceGameIdTarget[8] = {0}; // last device a GameID 0x8 switch was SENT to (mmceGameIdSettle polls it)
@@ -645,9 +647,8 @@ static int mmceUpdateGameList(item_list_t *itemList)
     // Each view scans into its OWN array (#120): a failed rescan preserves only that view's last-good and
     // can never resurrect the other view's list (see the mmcePs1Games comment at the declarations).
     if (libViewActive(itemList->mode) == LIB_VIEW_PS1) {
-        // ONE list, BOTH cores -- POPS/*.VCD unioned with EMBER/games/*. mmcePrefix is the card
-        // root, which is where both folders live, so the same prefix serves both halves.
-        int r = ps1FillGameList(mmcePrefix, mmcePs1Root(), &mmcePs1Games);
+        // ONE list, BOTH cores -- POPS/*.VCD unioned with EMBER/games/*, both at the card root.
+        int r = ps1FillGameList(mmcePs1Root(), &mmcePs1Games);
         if (r >= 0) { // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
             mmcePs1Scanned = 1;
             mmcePs1GameCount = r;
@@ -728,7 +729,7 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
         // Ember title, so the rename would quietly do nothing; and where a .VCD of the same name
         // exists (a game held for BOTH cores, the case the merged list makes ordinary) it would
         // rename the POPSTARTER file instead. Renaming the wrong file is the worse half of that.
-        int renamed = cueIsCueEntry(game) ? cueRenameGame(mmcePs1Root(), game->name, newName) : vcdRenameFile(mmcePrefix, game->name, newName);
+        int renamed = cueIsCueEntry(game) ? cueRenameGame(mmcePs1Root(), game->name, newName) : vcdRenameFile(mmcePs1Root(), game->name, newName);
         if (renamed == 0) {
             // MMCE normally latches a successful VCD scan under NOUPDATE. Re-arm its normal scan
             // path so the deferred menu update publishes the new filename immediately.
@@ -746,7 +747,7 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
     mmceULSizePrev = -2;
 }
 
-// Launch an Ember (.cue) PS1 title BY NAME -- peer of mmceLaunchVcd below. mmcePrefix is the card
+// Launch an Ember (.cue) PS1 title BY NAME -- peer of mmceLaunchVcd below. mmcePs1Root() is the card
 // root, where EMBER/ sits next to POPS/. None of the POPSTARTER memory-card preparation applies:
 // Ember performs no IOP reset and inherits our live driver stack, so it needs no MC-side driver.
 static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set_t *configSet)
@@ -811,20 +812,20 @@ static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set
         return;
     }
 
-    if (!vcdResolvePopstarter(mmcePrefix, vcdElf, sizeof(vcdElf))) {
+    if (!vcdResolvePopstarter(mmcePs1Root(), vcdElf, sizeof(vcdElf))) {
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
         return;
     }
-    vcdBuildSelector(mmcePrefix, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
+    vcdBuildSelector(mmcePs1Root(), VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
 
     // Source MC-side externals from this MMCE card's direct POPS/ folder; never overwrite card files.
-    (void)vcdInstallPopstarterMc(mmcePrefix);
+    (void)vcdInstallPopstarterMc(mmcePs1Root());
 
     // Best-effort card prep: BDMA prep is card preparation, never a POPSTARTER launch gate.
     vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MMCE, VCD_BDMA_MMCE);
 
     char vcdFullPath[256];
-    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS/%s.VCD", mmcePrefix, vcdName);
+    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS/%s.VCD", mmcePs1Root(), vcdName);
     vcdPrepareRetroGemBarcode(vcdFullPath);
     deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the MMCE device mounted across the IOP reset
     sysLaunchPopstarter(vcdElf, vcdSelector);
@@ -1205,7 +1206,7 @@ static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, cha
         if (cueRowIsCueByName(mmcePs1Games, mmcePs1GameCount, value) == 1)
             r = cueLoadFolderCover(mmcePs1Root(), value, suffix, resultTex);
         else
-            r = vcdLoadPopsCover(mmceArtPrimary, value, suffix, resultTex);
+            r = vcdLoadPopsCover(mmcePs1Root(), value, suffix, resultTex);
     }
     return r;
 }

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -96,12 +96,15 @@ static unsigned char mmceEverResolved = 0;
 // forward declaration
 static item_list_t mmceGameList;
 static void mmceGetDeviceRoot(char *root, size_t size);
-// The card ROOT ("mmceN:/"), where the PS1 library folders live -- POPS/ and EMBER/ alike, exactly
+// The card ROOT ("mmceN:/") is where the PS1 library folders live -- POPS/ and EMBER/ alike, exactly
 // as on every other device. mmcePrefix is NOT the root: it carries the user's configurable games
 // prefix (gMMCEPrefix), which is right for OPL's own data (CD/ DVD/ ART/ CFG/ VMC/) and wrong for a
 // library folder. POPS used to be resolved under it, which put an MMCE card with a configured
 // prefix out of step with its own documentation and with every other device.
-static const char *mmcePs1Root(void);
+//
+// Read it with mmceGetDeviceRoot() into a LOCAL buffer, never a shared one: these paths are built
+// on the IO worker (the list scan), the art thread (the cover fallback) and the GUI thread (launch
+// and rename), and the device re-detect can blank mmcePrefix underneath any of them.
 static int mmceModLoaded = 0;          // latched by mmceLoadModules; read by mmceSendGameID's arm check
 static char mmceGameIdTarget[8] = {0}; // last device a GameID 0x8 switch was SENT to (mmceGameIdSettle polls it)
 
@@ -234,13 +237,6 @@ int mmceGameIdSettle(int timeoutMs)
     }
     LOG("MMCE GameID settle NOT confirmed after %d ms\n", timeoutMs);
     return -1;
-}
-
-static const char *mmcePs1Root(void)
-{
-    static char root[sizeof(mmcePrefix)];
-    mmceGetDeviceRoot(root, sizeof(root));
-    return root;
 }
 
 static void mmceGetDeviceRoot(char *root, size_t size)
@@ -648,7 +644,9 @@ static int mmceUpdateGameList(item_list_t *itemList)
     // can never resurrect the other view's list (see the mmcePs1Games comment at the declarations).
     if (libViewActive(itemList->mode) == LIB_VIEW_PS1) {
         // ONE list, BOTH cores -- POPS/*.VCD unioned with EMBER/games/*, both at the card root.
-        int r = ps1FillGameList(mmcePs1Root(), &mmcePs1Games);
+        char ps1Root[sizeof(mmcePrefix)];
+        mmceGetDeviceRoot(ps1Root, sizeof(ps1Root));
+        int r = ps1FillGameList(ps1Root, &mmcePs1Games);
         if (r >= 0) { // r < 0: transient scan failure (contended bus) -> keep the last-good VCD list
             mmcePs1Scanned = 1;
             mmcePs1GameCount = r;
@@ -729,7 +727,9 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
         // Ember title, so the rename would quietly do nothing; and where a .VCD of the same name
         // exists (a game held for BOTH cores, the case the merged list makes ordinary) it would
         // rename the POPSTARTER file instead. Renaming the wrong file is the worse half of that.
-        int renamed = cueIsCueEntry(game) ? cueRenameGame(mmcePs1Root(), game->name, newName) : vcdRenameFile(mmcePs1Root(), game->name, newName);
+        char ps1Root[sizeof(mmcePrefix)];
+        mmceGetDeviceRoot(ps1Root, sizeof(ps1Root));
+        int renamed = cueIsCueEntry(game) ? cueRenameGame(ps1Root, game->name, newName) : vcdRenameFile(ps1Root, game->name, newName);
         if (renamed == 0) {
             // MMCE normally latches a successful VCD scan under NOUPDATE. Re-arm its normal scan
             // path so the deferred menu update publishes the new filename immediately.
@@ -747,12 +747,13 @@ static void mmceRenameGame(item_list_t *itemList, int id, char *newName)
     mmceULSizePrev = -2;
 }
 
-// Launch an Ember (.cue) PS1 title BY NAME -- peer of mmceLaunchVcd below. mmcePs1Root() is the card
+// Launch an Ember (.cue) PS1 title BY NAME -- peer of mmceLaunchVcd below. The card
 // root, where EMBER/ sits next to POPS/. None of the POPSTARTER memory-card preparation applies:
 // Ember performs no IOP reset and inherits our live driver stack, so it needs no MC-side driver.
 static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set_t *configSet)
 {
     char emberElf[256], biosPath[288];
+    char ps1Root[sizeof(mmcePrefix)];
 
     (void)configSet; // an Ember title carries no per-game loader settings
 
@@ -772,18 +773,20 @@ static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set
         return;
     }
 
-    if (!cueResolveEmber(mmcePs1Root(), emberElf, sizeof(emberElf))) {
+    mmceGetDeviceRoot(ps1Root, sizeof(ps1Root));
+
+    if (!cueResolveEmber(ps1Root, emberElf, sizeof(emberElf))) {
         guiMsgBox(_l(_STR_EMBER_NOT_FOUND), 0, NULL);
         return;
     }
-    if (!cueResolveEmberBios(mmcePs1Root(), biosPath, sizeof(biosPath))) {
+    if (!cueResolveEmberBios(ps1Root, biosPath, sizeof(biosPath))) {
         guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
         return;
     }
     // The scan lists folders without reading inside them -- that would be a directory read per row
     // on every refresh. Pay for it once, HERE, while a dialog can still be drawn: an empty or
     // mis-filled folder otherwise drops the user into the PS1 BIOS shell with no explanation.
-    if (!cueGameHasImage(mmcePs1Root(), cueName)) {
+    if (!cueGameHasImage(ps1Root, cueName)) {
         guiMsgBox(_l(_STR_EMBER_NO_DISC), 0, NULL);
         return;
     }
@@ -799,6 +802,7 @@ static void mmceLaunchCue(item_list_t *itemList, const char *cueName, config_set
 static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_t *configSet)
 {
     char vcdElf[256], vcdSelector[320];
+    char ps1Root[sizeof(mmcePrefix)];
 
     if (vcdName == NULL || vcdName[0] == '\0' || !strcasecmp(vcdName, "POPSTARTER")) // reserved-name belt: the scanner no longer lists it (#154); strcasecmp -- FAT is case-insensitive
         return;
@@ -812,20 +816,22 @@ static void mmceLaunchVcd(item_list_t *itemList, const char *vcdName, config_set
         return;
     }
 
-    if (!vcdResolvePopstarter(mmcePs1Root(), vcdElf, sizeof(vcdElf))) {
+    mmceGetDeviceRoot(ps1Root, sizeof(ps1Root));
+
+    if (!vcdResolvePopstarter(ps1Root, vcdElf, sizeof(vcdElf))) {
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
         return;
     }
-    vcdBuildSelector(mmcePs1Root(), VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
+    vcdBuildSelector(ps1Root, VCD_PREFIX_MASS, vcdName, vcdSelector, sizeof(vcdSelector));
 
     // Source MC-side externals from this MMCE card's direct POPS/ folder; never overwrite card files.
-    (void)vcdInstallPopstarterMc(mmcePs1Root());
+    (void)vcdInstallPopstarterMc(ps1Root);
 
     // Best-effort card prep: BDMA prep is card preparation, never a POPSTARTER launch gate.
     vcdEnsureBdmaForLaunch(VCD_BDMA_SRC_MMCE, VCD_BDMA_MMCE);
 
     char vcdFullPath[256];
-    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS/%s.VCD", mmcePs1Root(), vcdName);
+    snprintf(vcdFullPath, sizeof(vcdFullPath), "%sPOPS/%s.VCD", ps1Root, vcdName);
     vcdPrepareRetroGemBarcode(vcdFullPath);
     deinit(UNMOUNT_EXCEPTION, itemList->mode); // keep the MMCE device mounted across the IOP reset
     sysLaunchPopstarter(vcdElf, vcdSelector);
@@ -1201,12 +1207,16 @@ static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, cha
 {
     int r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
     if (r == ERR_BAD_FILE && isRelative && (libViewActive(itemList->mode) == LIB_VIEW_PS1)) {
+        // This runs on the ART thread while the list scan runs on the IO worker, so the root goes in
+        // a LOCAL -- a shared buffer would be rewritten underneath one of them by the other.
+        char ps1Root[sizeof(mmcePrefix)];
+        mmceGetDeviceRoot(ps1Root, sizeof(ps1Root));
         // The cache hands us a NAME, so resolve which core owns the row against the published list
         // (memory scan, no card IO on the art path). Unknown falls back to the POPSTARTER layout.
         if (cueRowIsCueByName(mmcePs1Games, mmcePs1GameCount, value) == 1)
-            r = cueLoadFolderCover(mmcePs1Root(), value, suffix, resultTex);
+            r = cueLoadFolderCover(ps1Root, value, suffix, resultTex);
         else
-            r = vcdLoadPopsCover(mmcePs1Root(), value, suffix, resultTex);
+            r = vcdLoadPopsCover(ps1Root, value, suffix, resultTex);
     }
     return r;
 }


### PR DESCRIPTION
MMCE resolved `POPS/` under `mmcePrefix`, which carries the user's configurable
games prefix (`gMMCEPrefix`). A card with a prefix set therefore looked for
`mmceN:/<prefix>/POPS` while the docs, the standing library-folder rule and every
other device class say `mmceN:/POPS`.

Nathan confirmed the intended layout: **`mmce0:/POPS/`**, same as everywhere else.

## What moves, and what deliberately doesn't

The prefix is *right* for OPL's own data (`CD/ DVD/ ART/ CFG/ VMC/`) and *wrong* for
a library folder, so only the PS1 paths move — but **all six together**, because a
partial move is worse than either layout: the list would show titles the launcher
then can't find.

| Moves to the card root | Stays on the games prefix |
| --- | --- |
| the scan (`ps1FillGameList`) | `ART/` lookup (`mmceArtPrimary`) |
| rename | `CFG/`, `VMC/`, `CD/`, `DVD/` |
| `POPSTARTER.ELF` resolution | |
| MC-externals install (reads the device's own `POPS/`) | |
| RetroGEM barcode `.VCD` path | |
| in-library POPS cover fallback (sits beside the `.VCD`) | |

`vcdBuildSelector` gets the root too. It documents that it **ignores** that argument
— it emits the bare `mass:` label POPSTARTER re-derives after its own reset — but a
lone `mmcePrefix` there would read as if it still mattered.

## It also deletes code

`ps1FillGameList` goes back to **one** prefix. The two-prefix split existed only to
keep POPS under `gMMCEPrefix` while EMBER used the root; with both at the root it has
nothing left to express. **Net −4 lines.**

## Blast radius

**No-op for anyone on the default empty MMCE prefix** — there `mmcePrefix` already
*is* the card root. It only relocates the library for cards with a configured prefix,
which is exactly the case that was inconsistent with the documentation.

Verified: clean OPLDIAG and release builds both exit 0; clang-format 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PS1 game detection across device types by consistently scanning the device root.
  * Corrected PS1 game launching, renaming, artwork lookup, and related resource paths.
  * Preserved existing ISO, configuration, and virtual memory card path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->