### PR TITLE
fix: let a failed mmceman or DEV9 module load be retried

### DIFF
--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -403,15 +403,28 @@ void mmceSetPrefix(void)
 
 void mmceLoadModules(void)
 {
-    // mmceman is a singleton -- loading the IRX buffer twice creates a 2nd instance. Guard so this is
-    // idempotent: mmceInit calls it, and the BDMA equip now also calls it (to wake an MMCE source when
-    // MMCE games are off / Manual-not-started). Set the flag first so a partial load can't double-load.
+    // mmceman is a singleton, and this is called from several places -- mmceInit, the BDMA equip
+    // (to wake an MMCE source when MMCE games are off or Manual-not-started), and the boot-dir
+    // resolver -- so it has to be idempotent.
+    //
+    // It used to set the flag BEFORE the load, to stop a partial load creating a second instance.
+    // That protection already exists one layer down: sysLoadModuleBuffer keeps a table of buffers
+    // it has loaded, returns 0 for one it already holds, never records a failure, and consults that
+    // table under sysLoadModuleLock. Guarding it a second time here bought nothing and cost the
+    // retry -- a single failed load left mmceman marked resident for the whole session, so MMCE
+    // games and the GameID transport stayed silently dead until a reboot.
+    //
+    // Latch on SUCCESS instead. A retry after a failure genuinely re-attempts; a retry after a
+    // success is a cheap no-op; and a racing second caller is serialised by that same lock, so no
+    // in-progress flag is needed either.
     if (mmceModLoaded)
         return;
-    mmceModLoaded = 1;
     LOG("MMCESUPPORT LoadModules\n");
     LOG("[MMCEMAN]:\n");
-    sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
+    if (sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL) == 0)
+        mmceModLoaded = 1;
+    else
+        LOG("MMCESUPPORT mmceman load FAILED -- retry stays armed\n");
 }
 
 // Δ4 (NHDDL parity): arm the GameID transport OUTSIDE the launch path. NHDDL loads mmceman once at

--- a/src/system.c
+++ b/src/system.c
@@ -160,15 +160,25 @@ static unsigned char dev9Initialized = 0, dev9Loaded = 0, dev9InitCount = 0;
 
 void sysInitDev9(void)
 {
-    int ret;
-
     if (!dev9Initialized) {
         LOG("[DEV9]:\n");
-        ret = sysLoadModuleBuffer(&ps2dev9_irx, size_ps2dev9_irx, 0, NULL);
-        dev9Loaded = (ret == 0); // DEV9.IRX must have successfully loaded and returned RESIDENT END.
-        dev9Initialized = 1;
+        // DEV9.IRX must have loaded AND returned RESIDENT END for the adapter to be usable.
+        dev9Loaded = (sysLoadModuleBuffer(&ps2dev9_irx, size_ps2dev9_irx, 0, NULL) == 0);
+
+        // LATCH ONLY ON SUCCESS. This used to set dev9Initialized unconditionally, so a single
+        // failed load disabled DEV9 -- and with it the NIC and the internal HDD -- for the whole
+        // session: every later call saw the flag, skipped the load and just bumped the refcount.
+        //
+        // Retrying is safe rather than a double-load risk, because the guard lives one layer down:
+        // sysLoadModuleBuffer keeps a table of buffers it has loaded, returns 0 for one it already
+        // holds, and never records a failure. So a retry after a failure genuinely re-attempts, and
+        // a retry after a success is a cheap no-op. That is also why no extra in-progress flag is
+        // needed here -- that table is consulted under sysLoadModuleLock.
+        dev9Initialized = dev9Loaded;
     }
 
+    // Refcount every caller regardless, so each sysInitDev9 still pairs with its sysShutdownDev9.
+    // On a failed load dev9Loaded stays 0, so the power-off at count 0 is correctly skipped.
     dev9InitCount++;
 }
 
@@ -225,10 +235,17 @@ void sysReset(int modload_mask)
 #endif
 #endif
 
-    // The IOP was just rebooted: its DEV9 modules and refcount are gone, so reset both
-    // bookkeeping vars together. Leaving dev9InitCount stale inflates the refcount across
-    // resets, so sysShutdownDev9() would never power DEV9 off again.
+    // The IOP was just rebooted: its DEV9 modules and refcount are gone, so reset the bookkeeping
+    // vars together. Leaving dev9InitCount stale inflates the refcount across resets, so
+    // sysShutdownDev9() would never power DEV9 off again.
+    //
+    // dev9Loaded is cleared for the same reason the other two are -- the module it describes no
+    // longer exists. It was previously left behind, which was harmless only because the old
+    // unconditional assignment in sysInitDev9 always overwrote it before use. Now that the load can
+    // fail without latching, a stale 1 could outlive the reset and let sysShutdownDev9 try to power
+    // off a DEV9 that was never brought back up.
     dev9Initialized = 0;
+    dev9Loaded = 0;
     dev9InitCount = 0;
     while (!SifIopSync())
         ;


### PR DESCRIPTION
Two instances of one bug. Found by auditing the area three closed PRs pointed at,
rather than by trusting what they claimed about it.

Both functions latched a "loaded" flag **before** attempting the load and never looked
at the result, so a single failure was permanent for the session:

| | What it costs |
| --- | --- |
| `mmceLoadModules` sets `mmceModLoaded = 1` *then* loads, result discarded | MMCE games **and** the GameID transport silently dead until reboot |
| `sysInitDev9` sets `dev9Initialized = 1` unconditionally | the NIC **and** the internal HDD gone for the session |

Every later call sees the flag, skips the load, and carries on as if it had worked.

## Why retrying is safe, not a double-load risk

The guard both were duplicating already exists one layer down. `sysLoadModuleBuffer`:

- keeps a table of buffers it has loaded,
- returns `0` for one it already holds,
- **never records a failure**,
- and consults that table under `sysLoadModuleLock`.

So a retry after a failure genuinely re-attempts, a retry after a success is a cheap
no-op, and a racing second caller is serialised there.

That's also why **neither fix adds an in-progress flag**. One of the closed PRs added a
second `mmceModLoading` guard for this — unnecessary, and the comment that motivated the
early latch (*"so a partial load can't double-load"*) was describing protection the code
already had. Checking the layer below is what made these smaller than proposed.

## One DEV9 detail worth calling out

`dev9Loaded` is still assigned from the result on **every** attempt, not only on success,
and `sysReset` now clears it alongside `dev9Initialized` and `dev9InitCount`.

Leaving it behind was harmless while the old unconditional assignment always overwrote it
before use. But once a load can fail *without* latching, a stale `1` could outlive an IOP
reset and let `sysShutdownDev9` try to power off a DEV9 that was never brought back up.

The refcount is deliberately untouched: `dev9InitCount++` stays unconditional so every
`sysInitDev9` still pairs with its `sysShutdownDev9` (verified across eth / hdd / udpfs /
bdm call sites), and a failed load leaves `dev9Loaded` at 0 so the power-off at count 0 is
correctly skipped.

## Not claimed

One closed PR asserted the DEV9 latch is what suppresses Ethernet after BDM/HDD startup
ordering changes. That causal link is **unverified** — the latch is worth fixing because a
load that can never be retried is wrong on its own terms, not because it explains a
specific report.

Verified: clean OPLDIAG and release builds both exit 0; clang-format 12 clean. The single
`system.c` warning is pre-existing and in an unrelated function (`gCheatList`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)