### PR TITLE
Ember display: Default clears the key instead of just abstaining

### DIFF
--- a/.github/rolling-release-notes-block.md
+++ b/.github/rolling-release-notes-block.md
@@ -77,11 +77,12 @@ writable media.
 Available on USB, MX4SIO, iLink, exFAT-ATA and MMCE. SMB and the APA internal HDD are
 POPSTARTER-only for now.
 
-**Ember display mode.** Ember can run at 240p or 480p. There is a setting for it on the
-**PS1 settings** page — leave it on *Default* and RiptOPL does not touch Ember's own
-configuration at all. Pick 240p or 480p and it writes that choice to
-`<device>:/EMBER/settings.txt` when you launch a game, on that device only. Any other lines
-already in that file are left alone.
+**Ember display mode.** Ember can run at 240p or 480p, and there is a setting for it on the
+**PS Emulation Settings** page. Ember's `settings.txt` is optional and stays that way: pick
+240p or 480p and RiptOPL writes that choice to `<device>:/EMBER/settings.txt` when you launch
+a game — creating the file if needed, on that device only. Go back to *Default* and the
+setting is removed again, along with the file if that was all it contained. Any other lines
+in that file are left alone, and *Default* never creates one.
 
 ### Ember credit and licence
 

--- a/README.md
+++ b/README.md
@@ -232,11 +232,14 @@ This build layers several features on top of upstream OPL:
   supply your own, from hardware and media you lawfully own. Please report Ember problems to *us*
   first rather than to Gageformer: the launching is ours.
 
-  **Ember display mode.** The **PS1 settings** page carries an *Ember Display Mode* setting
-  (**Default** / **240p** / **480p**). On *Default* RiptOPL does not touch Ember's own configuration
-  at all. Choose 240p or 480p and it writes that key into `<device>:/EMBER/settings.txt` when you
-  launch an Ember title, on the launching device only, preserving any other lines already in that
-  file.
+  **Ember display mode.** The **PS Emulation Settings** page carries an *Ember Display Mode* setting
+  (**Default** / **240p** / **480p**). Ember's `settings.txt` is an optional file, and this keeps it
+  that way. Choose **240p** or **480p** and RiptOPL writes that key into
+  `<device>:/EMBER/settings.txt` when you launch an Ember title — creating the file if it is not
+  there, updating it in place if it is, and on the launching device only. Choose **Default** and it
+  goes back to having no setting: the key is removed, and so is the file if that key was all it
+  held. Any other lines you or a future Ember put in there are preserved throughout, and *Default*
+  never creates a file that was not already there.
 
 - **Alternate POPSTARTER builds:** the release package ships
   `POPS/POPSTARTER VERSIONS/` containing five builds of POPSTARTER — **MAIN**, **DEBUG**,

--- a/include/cuesupport.h
+++ b/include/cuesupport.h
@@ -135,9 +135,14 @@ int cueScanDir(const char *devPrefix, cue_entry_t **outList);
 // equip leaves its marker beside POPSTARTER. Called on the LAUNCH path only, so the file lands on
 // the device actually being launched and nowhere else.
 //
-// EMBER_DISPLAY_LEAVE writes nothing at all, which is the default: a display preference must not
-// create a file on a user's device unless they asked for one, and it is the only setting that
-// leaves a hand-written settings.txt alone.
+// settings.txt is OPTIONAL, and this function keeps it that way:
+//
+//   EMBER_DISPLAY_LEAVE ("Default") never CREATES the file. If one exists it clears our display key
+//   out of it, and removes the file entirely when that key was the only thing in it. Default has to
+//   clear rather than merely abstain, or picking 240p once and changing back would strand
+//   display:240 on the device forever while the menu claimed Default.
+//
+//   EMBER_DISPLAY_240 / _480 create the file if absent, or update the key in place if present.
 //
 // Lines other than "display:" are PRESERVED. Ember ignores keys it does not know (it logs and moves
 // on), so a key it gains later, or one a user added, must survive us rewriting this file.

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1167,4 +1167,4 @@ gui_strings:
 - label: EMBER_DISPLAY
   string: Ember Display Mode
 - label: HINT_EMBER_DISPLAY
-  string: Output mode Ember uses for PS1 games. Written to settings.txt in the device's EMBER folder when a game launches. Default leaves that file untouched.
+  string: Output mode Ember uses for PS1 games. 240p or 480p is written to settings.txt in the launched device's EMBER folder. Default removes that setting again, and the file too if it held nothing else.

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -244,15 +244,18 @@ void cueApplyDisplaySetting(const char *devPrefix)
     const char *want;
     int fd, len = 0, out = 0, i, lineStart;
 
-    if (gEmberDisplay == EMBER_DISPLAY_LEAVE || devPrefix == NULL)
+    if (devPrefix == NULL)
         return;
     want = (gEmberDisplay == EMBER_DISPLAY_480) ? "display:480" : "display:240";
 
     snprintf(path, sizeof(path), "%s%s%c%s", devPrefix, cueEmberFolder(), cueSep(devPrefix),
              EMBER_SETTINGS_NAME);
 
-    // Read whatever is there. An absent file is the normal first-run case, not an error.
+    // Read whatever is there. An absent file is the normal first-run case, not an error: on 240/480
+    // we create it below, and on Default there is nothing to clear and nothing to create.
     fd = open(path, O_RDONLY);
+    if (fd < 0 && gEmberDisplay == EMBER_DISPLAY_LEAVE)
+        return;
     if (fd >= 0) {
         len = read(fd, before, sizeof(before) - 1);
         close(fd);
@@ -296,13 +299,35 @@ void cueApplyDisplaySetting(const char *devPrefix)
     // this is a path that writes to the user's memory card or USB stick. If our own line does not
     // fit, leave the file completely alone: a settings.txt we mangled is worse than one we never
     // touched, and Ember runs fine without the key.
-    {
+    //
+    // On Default we append NOTHING, so `out` now holds the file with our key stripped out. That is
+    // what makes Default mean default: setting 240p and then changing back would otherwise leave
+    // display:240 on the device forever, with the menu claiming Default while Ember still ran 240p.
+    if (gEmberDisplay != EMBER_DISPLAY_LEAVE) {
         int n = snprintf(&after[out], sizeof(after) - out, "%s\n", want);
         if (n < 0 || n >= (int)sizeof(after) - out) {
             LOG("[CUE] no room for the display line in %s -- left untouched\n", path);
             return;
         }
         out += n;
+    }
+
+    // Nothing left to write. The file existed only to carry the key we just cleared, so remove it
+    // rather than leave an empty one behind -- settings.txt is optional, and Default means there
+    // should not be one. Only ever reached on Default: every other value appended a line above.
+    //
+    // This deletes a file, so it is deliberately narrow. It cannot fire while ANY other line
+    // survived the copy (a comment, a key we do not know, a key a future Ember adds) -- those all
+    // count toward `out` and are rewritten instead. len > 0 keeps us from unlinking a file that was
+    // already empty when we found it, which would be deleting something we never wrote to.
+    if (out == 0) {
+        if (len > 0) {
+            if (unlink(path) == 0)
+                LOG("[CUE] nothing left to keep in %s -- removed for Default\n", path);
+            else
+                LOG("[CUE] cannot remove %s -- Ember keeps its previous display mode\n", path);
+        }
+        return;
     }
 
     // Only touch the device when the content actually changes. This runs on every Ember launch, and

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -340,8 +340,30 @@ void cueApplyDisplaySetting(const char *devPrefix)
         LOG("[CUE] cannot write %s -- launching without applying the display mode\n", path);
         return;
     }
-    if (write(fd, after, out) != out)
-        LOG("[CUE] short write on %s\n", path);
+    if (write(fd, after, out) != out) {
+        close(fd);
+        // O_TRUNC already emptied the file, so a failed or short write leaves it truncated with the
+        // user's other keys and comments gone -- the one outcome this whole function exists to
+        // avoid. We still hold the original bytes in `before` (the copy loop only ever read from
+        // it), so put them back.
+        //
+        // This is best-effort, not atomic: the restore can fail too. It is worth doing anyway
+        // because the realistic cause is a full card, and the truncate above just freed at least as
+        // many bytes as we are writing back. A temp-file-and-rename would be atomic but relies on
+        // rename() behaving across mass:/mmce:, which it does not do dependably here.
+        if (len > 0) {
+            fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+            if (fd >= 0) {
+                int back = write(fd, before, len);
+                close(fd);
+                LOG("[CUE] write failed on %s -- original %s\n", path,
+                    (back == len) ? "restored" : "COULD NOT be restored");
+                return;
+            }
+        }
+        LOG("[CUE] write failed on %s\n", path);
+        return;
+    }
     close(fd);
 }
 


### PR DESCRIPTION
`settings.txt` is an optional file. This makes Default actually keep it that way.

## The gap

Default used to return immediately and touch nothing. Correct for a device that never had the file
— wrong the moment one did:

1. Pick **240p**, launch an Ember game → `EMBER/settings.txt` is created with `display:240`.
2. Switch back to **Default**.
3. `display:240` stays on the device forever. The menu says Default; Ember keeps running 240p.

The setting was lying about the state of the device.

## Now

| Setting | Behaviour |
| --- | --- |
| **Default** | Never *creates* the file. If one exists, our `display:` key is stripped out; the file itself is removed when that key was all it held. |
| **240p / 480p** | Creates the file if absent, updates the key in place if present. |

## The removal is deliberately narrow

It deletes something on a user's device, so it is fenced in:

- It cannot fire while **any** other line survived the copy — a comment, a key we don't recognise, a
  key a future Ember adds. Those are rewritten instead, and the file stays.
- It requires the file to have had content when we found it, so an empty `settings.txt` we never
  wrote to is left alone.
- A failed `unlink` is reported and says plainly that Ember keeps its previous mode.

## Verification

Modelled the algorithm line-for-line against the C and checked **14 cases, all passing**:

- `absent + Default` → creates nothing
- `absent + 240 / 480` → creates
- `key only + Default` → unlinks
- `key + comment + Default` → keeps the comment, file survives
- `key + unknown key + Default` → keeps the unknown key
- `display: 480` (spaced, per Ember's README) → still matched
- CRLF file → tolerated
- `#display:240` → **not** treated as ours; file left entirely unwritten
- `240 → 480` → updates in place
- `480 → 480` → still a no-op, no device write
- oversized file → still refused untouched

That last one was a genuine finding from the model: a commented-out key is preserved, which makes
the rewritten content byte-identical, so the existing no-op guard fires and we don't write at all.
Better than the behaviour I'd assumed.

Both flavours build clean; clang-format clean.

Docs corrected in the same pass — the header contract, the on-screen hint, README and the release
notes all said Default "leaves the file untouched", which is no longer what it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Ember display mode handling for **Default**, 240p, and 480p selections.
  - 240p and 480p settings are saved to the device’s Ember settings file when launching, creating or updating it as needed.
  - **Default** now removes the display setting, preserves unrelated entries, and deletes the file when no other settings remain. It does not create a new file.

- **Documentation**
  - Updated the README, release notes, and setting hints to explain the revised display mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->