### PR TITLE
docs(site): two-core PS1 pages, Ember coverage, corrected settings names

### DIFF
--- a/cheats.html
+++ b/cheats.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>

--- a/coverflow.html
+++ b/coverflow.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html" class="active"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -57,8 +57,8 @@ and widescreen. It is a <b>built-in theme</b>: no files to copy, active out of t
 <div class="callout info"><div class="h">ℹ Built-in, not a THM folder theme</div>
 <code>&lt;Coverflow&gt;</code> is compiled into RiptOPL and appears in the theme list alongside
 any custom <code>THM/</code> themes you add. You can switch to a different theme in
-<b>Display Settings → Theme</b> and switch back at any time. The <b>Coverflow Settings</b>
-button only appears in <b>Display Settings</b> while a Coverflow-based theme is active.
+<b>Interface → Theme</b> and switch back at any time. The <b>Coverflow Settings</b>
+button only appears in <b>Interface</b> while a Coverflow-based theme is active.
 </div>
 
 <h2 id="how-it-works">How it works</h2>
@@ -91,7 +91,7 @@ defines three variants of this element:</p>
 taller portrait box that matches a standard PS2 case.</p>
 
 <h2 id="coverflow-settings">Coverflow Settings</h2>
-<p>Open <b>Display Settings</b> and press the <b>Coverflow Settings</b> button (it appears only
+<p>Open <b>Interface</b> and press the <b>Coverflow Settings</b> button (it appears only
 when a Coverflow theme is active). Four options are available:</p>
 
 <table data-sortable>

--- a/credits.html
+++ b/credits.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -183,6 +183,23 @@ this fork builds on top of it — traces directly back to that work.</p>
 </div>
 
 <div class="step">
+<h3>Gageformer — Ember (second PS1 core)</h3>
+<p>Author of <b><a href="https://github.com/Gageformer/Ember/releases">Ember</a></b>, an independent PlayStation 1 emulator written from
+scratch for the PlayStation 2 — original recompiler, memory model, geometry pipeline and graphics
+translation. Ember is <b>not</b> part of RiptOPL and is not our work; it ships inside the release
+package as an <code>EMBER/</code> folder and serves as RiptOPL's <b>second PS1 core</b> alongside
+POPSTARTER.</p>
+<p>It is bundled unmodified, with Gageformer's blessing, under the <b>Ember Public Beta Testing
+Licence</b> — included in the package as <code>EMBER/LICENSE-BETA.txt</code>, which governs the
+build it accompanies. He not only permitted RiptOPL driving <code>ember.elf</code> directly in place
+of his own launcher, he encouraged it. Please report Ember problems to
+<a href="https://github.com/NathanNeurotic/Open-PS2-Loader/issues">us</a> first, not to him: the
+launching is ours.</p>
+<p>Ember's own licence credits <b><a href="https://github.com/stenzek/duckstation">DuckStation</a></b>
+as a correctness reference for a small number of routines. Ember is not a fork or port of it.</p>
+</div>
+
+<div class="step">
 <h3>saildot4k — BDMA-ATA / exFAT HDD</h3>
 <p>Contributor of <b>BDMA-ATA</b> (exFAT internal-HDD block-device support via BDMAssault),
 plus the fixes, feedback, and ongoing oversight that shaped this fork's block-device work.
@@ -223,6 +240,35 @@ work described on this page would have been possible. Everything starts here.</p
 
 </div>
 
+<h2 id="companion-tools">Companion PC Tools</h2>
+
+<p>Every release package links to these rather than vendoring copies, so you always get the
+maintained version. All but the first are <b>third-party projects</b>, independently maintained and
+not part of RiptOPL — <b>please report issues with those to their own repository, not here.</b></p>
+
+<ul class="checklist">
+<li><b><a href="https://github.com/NathanNeurotic/PS2-Servers">PS2-Servers</a></b> —
+    all-in-one PC server launcher for <b>SMBv1, UDPFS and UDPBD</b>. This one is ours, from the same
+    author as RiptOPL, so its issues belong on its own tracker but are the same hands. Shipped as
+    <code>PS2-Servers.url</code>.</li>
+<li><b><a href="https://github.com/Luden02/OrbitPS2-Manager">OrbitPS2 Manager</a></b> —
+    cross-platform library manager: import games from disc images, fetch cover art and screenshots,
+    compress ISOs to ZSO, edit per-game settings and manage virtual memory cards. It writes the
+    <code>ART</code> folder and per-game configs in exactly the layout RiptOPL expects, which
+    resolves most "looks wrong on my setup" reports. Shipped as
+    <code>OrbitPS2-Manager.url</code>.</li>
+<li><b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO
+    Converter GUI</a></b> — Windows all-in-one PS1 preparation tool: converts BIN/CUE backups to
+    <code>*.VCD</code> and installs them to USB, MX4SIO, MMCE, exFAT HDD, SMB and the APA internal
+    HDD. Shipped as <code>OPL-PS1-AIO-Converter-GUI.url</code>.</li>
+<li><b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> —
+    manages the PS2RD <code>.cht</code> cheat files RiptOPL reads from a device's <code>CHT</code>
+    folder. Shipped as <code>PS2RD-CHT-Manager.url</code>.</li>
+<li><b><a href="https://github.com/Gageformer/Ember/releases">Ember</a></b> — by <b>Gageformer</b>. The one exception to the shortcut rule:
+    Ember ships <em>inside</em> the package as an <code>EMBER/</code> folder, bundled unmodified
+    under its own licence. See above.</li>
+</ul>
+
 <h2 id="other-credits">Other Credits (from the OPL CREDITS file)</h2>
 
 <p>The full OPL CREDITS file records many more contributors. Selected entries relevant to
@@ -246,13 +292,24 @@ file in the canonical OPL repository.</p>
 
 <h2 id="ps1-note">A Note on PS1 Emulation</h2>
 
-<div class="callout info"><div class="h">ℹ POPS is Sony's emulator</div>
-PS1 game support in RiptOPL (and all OPL forks) runs through <b>POPS</b> — Sony's own
+<p>RiptOPL plays PS1 titles through <b>two independent cores</b>, and they work in completely
+different ways.</p>
+
+<div class="callout info"><div class="h">ℹ POPSTARTER uses POPS, Sony's own emulator</div>
+The <code>*.VCD</code> path in RiptOPL (and in all OPL forks) runs through <b>POPS</b> — Sony's own
 PS1 emulator built into PS2 firmware — combined with the open-source <b>POPSTARTER</b>
 launcher. POPS itself is not distributed here, and its use depends on your console's firmware.
 For the deep reference on PS1 / POPSTARTER internals — the 32-byte config table, IGR, cheats,
 multi-disc, and storage — see the sister site:
 <a href="https://nathanneurotic.github.io/POPSLoader/"><b>POPStarter docs</b></a>.
+</div>
+
+<div class="callout info"><div class="h">ℹ Ember is a real emulator, not a Sony component</div>
+The <code>*.cue</code> path runs through <b>Ember</b>, Gageformer's independent PS1 emulator for the
+PS2. It does not use POPS and does not depend on your console's firmware — but it does need
+<b>your own PS1 BIOS</b>, which you supply as <code>EMBER/bios.bin</code>. No BIOS and no game data
+are distributed with Ember or with RiptOPL. See <a href="ps1-vcd.html#ember">Ember — the second PS1
+core</a>.
 </div>
 
 <h2 id="license">License</h2>

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -158,7 +158,7 @@
  {
   "title": "MMCE: PS1 Games (VCD)",
   "cat": "devices",
-  "text": "Place *.VCD files and POPSTARTER.ELF in POPS/ on the SD card; press L3 on the MMCE Games tab to switch to the VCD list. MMCE is also a valid BDMA source for the exFAT POPSTARTER equip.",
+  "text": "Place *.VCD files and POPSTARTER.ELF in POPS/ on the SD card; press L3 on the MMCE Games tab to switch to the PS1 list. MMCE is also a valid BDMA source for the exFAT POPSTARTER equip.",
   "url": "mmce.html#ps1-vcd"
  },
  {
@@ -254,7 +254,7 @@
  {
   "title": "PS1 games on APA/PFS",
   "cat": "devices",
-  "text": "PS1 VCD files on an APA/PFS HDD live in dedicated __.POPS, __.POPS0–__.POPS9 APA partitions. Press L3 on the HDD tab to switch to the VCD view.",
+  "text": "PS1 VCD files on an APA/PFS HDD live in dedicated __.POPS, __.POPS0–__.POPS9 APA partitions. Press L3 on the HDD tab to switch to the PS1 view.",
   "url": "hdd.html#apa-ps1"
  },
  {
@@ -272,7 +272,7 @@
  {
   "title": "PS1 games on exFAT HDD (BDMA equip)",
   "cat": "devices",
-  "text": "Put *.VCD files in the POPS/ folder on the exFAT HDD. VCD BDMA Apply on Launch (Settings → VCD Settings) ships On, so RiptOPL auto-equips the HDD (exFAT) BDMAssault modules onto the memory card before each launch. Turn it Off to set BDMA Mode → HDD (exFAT) and BDMA Source → Internal HDD by hand.",
+  "text": "Put *.VCD files in the POPS/ folder on the exFAT HDD. VCD BDMA Apply on Launch (Settings → PS Emulation Settings) ships On, so RiptOPL auto-equips the HDD (exFAT) BDMAssault modules onto the memory card before each launch. Turn it Off to set BDMA Mode → HDD (exFAT) and BDMA Source → Internal HDD by hand.",
   "url": "hdd.html#exfat-ps1"
  },
  {
@@ -344,11 +344,11 @@
  {
   "title": "PS1 Games (VCD)",
   "cat": "ps1",
-  "text": "How to play PS1 games in RiptOPL via the VCD view (L3 toggle), POPSTARTER launcher, file layout for every device, and the BDMA exFAT equip.",
+  "text": "How to play PS1 games in RiptOPL via the PS1 view (L3 toggle), POPSTARTER launcher, file layout for every device, and the BDMA exFAT equip.",
   "url": "ps1-vcd.html"
  },
  {
-  "title": "The VCD view (press L3)",
+  "title": "The PS1 view (press L3)",
   "cat": "ps1",
   "text": "Press L3 on any device page to switch between its PS2 disc list and its PS1 VCD list. It is a view toggle on the same page, not a separate tab.",
   "url": "ps1-vcd.html#vcd-view"
@@ -356,7 +356,7 @@
  {
   "title": "Locking the view — Default game view",
   "cat": "ps1",
-  "text": "Settings → Display Settings → Default game view locks every device page to discs (ISO), VCDs (VCD), or keeps both accessible via L3 (Both, the default).",
+  "text": "Settings → Interface → Default game view locks every device page to discs (ISO), VCDs (VCD), or keeps both accessible via L3 (Both, the default).",
   "url": "ps1-vcd.html#default-game-view"
  },
  {
@@ -374,7 +374,7 @@
  {
   "title": "exFAT support — the BDMA equip",
   "cat": "ps1",
-  "text": "To boot PS1 games from an exFAT drive, RiptOPL copies the correct BDMAssault modules to mc?:/POPSTARTER/. VCD BDMA Apply on Launch (Settings → VCD Settings) ships On and equips them automatically before each launch; turn it Off to use the BDMA Mode and BDMA Source pickers yourself.",
+  "text": "To boot PS1 games from an exFAT drive, RiptOPL copies the correct BDMAssault modules to mc?:/POPSTARTER/. VCD BDMA Apply on Launch (Settings → PS Emulation Settings) ships On and equips them automatically before each launch; turn it Off to use the BDMA Mode and BDMA Source pickers yourself.",
   "url": "ps1-vcd.html#bdma"
  },
  {
@@ -458,7 +458,7 @@
  {
   "title": "Coverflow",
   "cat": "themes",
-  "text": "RiptOPL's built-in default theme — a centered cover-art carousel with an alpha-faded reflection, animated scrolling, and aspect-correct cover frames in 4:3 and widescreen. Tunable live via Coverflow Settings in Display Settings.",
+  "text": "RiptOPL's built-in default theme — a centered cover-art carousel with an alpha-faded reflection, animated scrolling, and aspect-correct cover frames in 4:3 and widescreen. Tunable live via Coverflow Settings in Interface.",
   "url": "coverflow.html"
  },
  {
@@ -470,7 +470,7 @@
  {
   "title": "Coverflow Settings",
   "cat": "themes",
-  "text": "Four live options: Cover Count (3 or 5), Center Scale (None/Small/Medium/Large), Animation Speed (Off/Fast/Normal/Slow), and Dim Side Covers. The button appears in Display Settings only while a Coverflow theme is active.",
+  "text": "Four live options: Cover Count (3 or 5), Center Scale (None/Small/Medium/Large), Animation Speed (Off/Fast/Normal/Slow), and Dim Side Covers. The button appears in Interface only while a Coverflow theme is active.",
   "url": "coverflow.html#coverflow-settings"
  },
  {
@@ -770,13 +770,13 @@
  {
   "title": "Settings Reference",
   "cat": "reference",
-  "text": "Every settings menu and option in RiptOPL, grouped by screen: General Settings, Device Settings, Display Settings, Audio, Controller, OSD, Parental Lock, and Network.",
+  "text": "Every settings menu and option in RiptOPL, grouped by screen: General Settings, Device Settings, Interface, Audio, Controller, OSD, Parental Lock, and Network.",
   "url": "settings.html"
  },
  {
   "title": "General Settings",
   "cat": "reference",
-  "text": "Debug Colors, PS2 Logo, IGR Path, Default Loader Core, global Neutrino Launch Args, Neutrino Device, Neutrino Video and GSM Compatibility, Write Operations, Last Played auto-start, folder browsing, menu vibration — plus the Prefix Paths and Cache & Storage splitters. The PS1/BDMA rows moved to VCD Settings.",
+  "text": "Debug Colors, PS2 Logo, IGR Path, Default Loader Core, global Neutrino Launch Args, Neutrino Device, Neutrino Video and GSM Compatibility, Write Operations, Last Played auto-start, folder browsing, menu vibration — plus the Prefix Paths and Cache & Storage splitters. The PS1/BDMA rows moved to PS Emulation Settings.",
   "url": "settings.html#general-settings"
  },
  {
@@ -786,7 +786,7 @@
   "url": "settings.html#device-settings"
  },
  {
-  "title": "Display Settings",
+  "title": "Interface",
   "cat": "reference",
   "text": "Theme, language, cover art, Default game view (Both/ISO/VCD), widescreen, video mode, screen offset, color pickers, GameID barcode, and Coverflow Settings sub-screen.",
   "url": "settings.html#display-settings"
@@ -1028,7 +1028,7 @@
  {
   "title": "Troubleshooting: PS1 / VCD list not showing after a settings change",
   "cat": "reference",
-  "text": "Press L3 on the device page to toggle and refresh the VCD view; confirm Default game view is not locked to ISO, and that VCD files are in the POPS/ folder at the device root.",
+  "text": "Press L3 on the device page to toggle and refresh the PS1 view; confirm Default game view is not locked to ISO, and that VCD files are in the POPS/ folder at the device root.",
   "url": "troubleshooting.html#vcd-list-not-showing"
  },
  {

--- a/favourites.html
+++ b/favourites.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html" class="active"><span class="em">⭐</span>Favourites</a>
@@ -168,9 +168,9 @@ visible list. The moment that device is connected and its game list loads, the e
 automatically — no action needed on your part.</p></details>
 
 <details class="deep"><summary>Can I favourite a PS1 (VCD) game?</summary>
-<p>Yes. PS1 titles shown in the VCD view (accessed with L3 on a device page) can be starred with R3 just like PS2
+<p>Yes. PS1 titles shown in the PS1 view (accessed with L3 on a device page) can be starred with R3 just like PS2
 games. They appear in the Favourites list and launch through POPSTARTER the same way they do from their source
-device. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for how the VCD view works.</p></details>
+device. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for how the PS1 view works.</p></details>
 
 <details class="deep"><summary>Can I favourite a Neutrino-backed game?</summary>
 <p>Yes. Neutrino per-game settings are stored in the game's own per-game config file, not in the Favourites list.

--- a/getting-started.html
+++ b/getting-started.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>

--- a/hdd.html
+++ b/hdd.html
@@ -29,7 +29,7 @@
     <a href="hdd.html" class="active"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -151,7 +151,7 @@ direct APA partition editing can corrupt the drive if done incorrectly.</p>
 <h3 id="apa-ps1">PS1 games on APA/PFS</h3>
 <p>PS1 <code>*.VCD</code> files on an APA/PFS HDD live in dedicated <b><code>__.POPS</code></b> partitions (named
 <code>__.POPS</code>, <code>__.POPS0</code> … <code>__.POPS9</code>). Each partition holds its VCD files at the
-partition root. Press <b>L3</b> on the HDD tab to switch to the VCD view and see them listed. See
+partition root. Press <b>L3</b> on the HDD tab to switch to the PS1 view and see them listed. See
 <a href="ps1-vcd.html">PS1 Games (VCD)</a> for the full VCD workflow.</p>
 
 <h2 id="exfat-bdm">exFAT via Block Device Manager (BDMA)</h2>
@@ -166,7 +166,7 @@ namespace alongside any USB/MX4SIO devices.</p>
 <code>DVD/</code> or <code>CD/</code> folder, just like a USB drive.</li>
 <li><b>MBR up to 2 TB, GPT unlimited</b> — if your drive is larger than 2 TB, GPT breaks the APA ceiling.</li>
 <li><b>PS1 VCDs on the same drive</b> — put <code>*.VCD</code> files in the <code>POPS/</code> folder and they list
-under L3 VCD view exactly like a USB drive (with the BDMA equip for POPSTARTER — see below).</li>
+under L3 PS1 view exactly like a USB drive (with the BDMA equip for POPSTARTER — see below).</li>
 </ul>
 
 <h3 id="exfat-format">Formatting and partition table</h3>
@@ -224,16 +224,16 @@ In <code>conf_apps.cfg</code>, use <code>mass:</code> as the device prefix (the 
 
 <h3 id="exfat-ps1">PS1 games on exFAT (BDMA equip)</h3>
 <p>Put your <code>*.VCD</code> files in the drive's <code>POPS/</code> folder alongside
-<code>POPSTARTER.ELF</code>. Press <b>L3</b> on the HDD Games tab to switch to the VCD view.</p>
+<code>POPSTARTER.ELF</code>. Press <b>L3</b> on the HDD Games tab to switch to the PS1 view.</p>
 <p>POPSTARTER's stock driver only reads FAT32, so booting a PS1 game from the exFAT HDD needs the
 <b>HDD (exFAT)</b> BDMA driver modules equipped. RiptOPL does this <b>automatically by default</b>: the
-<b>VCD BDMA Apply on Launch</b> toggle (in <b>Settings &rarr; VCD Settings</b>) ships <b>On</b>, and each time you launch
+<b>VCD BDMA Apply on Launch</b> toggle (in <b>Settings &rarr; PS Emulation Settings</b>) ships <b>On</b>, and each time you launch
 a VCD it auto-equips that title's matching exFAT driver pair — copying the correct BDMAssault modules onto
 <code>mc?:/POPSTARTER/</code> for you — right before boot. You do not need to touch anything.</p>
 <div class="callout info"><div class="h">ℹ Manual equip (only after turning auto-equip Off)</div>
 The manual <b>BDMA Source</b> / <b>BDMA Mode</b> pickers are hidden while <b>VCD BDMA Apply on Launch</b> is On.
 If you turn that toggle <b>Off</b> to manage the equip yourself, they appear on the same
-<b>Settings &rarr; VCD Settings</b> page — set <b>BDMA Mode</b> to <b>HDD (exFAT)</b> and
+<b>Settings &rarr; PS Emulation Settings</b> page — set <b>BDMA Mode</b> to <b>HDD (exFAT)</b> and
 <b>BDMA Source</b> to <b>Internal HDD</b> (the source identifies your drive by its <code>ata</code> driver and
 reads its <code>POPS/usbd.irx.ata</code> + <code>POPS/usbhdfsd.irx.ata</code>).
 </div>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -51,7 +51,7 @@
   <main class="content">
 <section class="callout info" id="external-tools"><div class="h">External Tools &amp; Services</div>
 <p><b><a href="https://github.com/NathanNeurotic/PS2-Servers">PS2-Servers</a></b> — all-in-one PC server launcher for <b>SMBv1, UDPFS and UDPBD</b>.<br>
-<b><a href="https://github.com/Luden02/OrbitOPL-Toolbox">OrbitOPL Toolbox</a></b> — cross-platform PC library manager for importing discs, artwork/screenshots, ZSO compression, per-game settings and VMC management.<br>
+<b><a href="https://github.com/Luden02/OrbitPS2-Manager">OrbitPS2 Manager</a></b> — cross-platform PC library manager for importing discs, artwork/screenshots, ZSO compression, per-game settings and VMC management.<br>
 <b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO Converter GUI</a></b> — Windows all-in-one PS1/POPStarter preparation tool for BIN/CUE → VCD conversion and installation to USB, MX4SIO, MMCE, exFAT HDD, SMB and APA internal HDD.<br>
 <b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> — PC manager for the PS2RD <code>.cht</code> cheat files RiptOPL reads from your device's <code>CHT</code> folder.<br>
 <b><a href="https://github.com/Gageformer/Ember">Ember</a></b> — a PS1 emulator running natively on the PS2, <b>created by Gageformer</b>, used as RiptOPL's second PS1 core alongside POPSTARTER. Ships as an <code>EMBER/</code> folder inside the release package, bundled unmodified with permission under the Ember Public Beta Testing Licence (<code>EMBER/LICENSE-BETA.txt</code>); <a href="https://github.com/Gageformer/Ember/releases">releases</a>.</p></section><div class="hero">
@@ -83,9 +83,10 @@ every device. Imports an existing uOPL / wOPL <code>favourites.bin</code>.</li>
 <li><b>Neutrino external core (per-game)</b> — hand a game to an external <code>neutrino.elf</code> instead of OPL's
 built-in core, with a <b>Device</b> picker and a structured <b>Launch Args</b> screen.</li>
 <li><b>Network boot</b> — stream games from a PC over the LAN as their own list via <b>UDPBD</b> or <b>UDPFS</b> (Neutrino).</li>
-<li><b>PS1 games via POPSTARTER</b> — a per-device <b>L3</b> "VCD" view lists your PS1 <code>*.VCD</code> games, including
-from an <b>exFAT</b> drive (BDMAssault) and the internal HDD.</li>
-<li><b>Category settings layout</b> — organized category pages (Game Sources, Settings, Interface, Display, Game Launching, POPStarter, MMCE, Network, Controller, Audio, Security, Advanced, Tools, About) instead of one flat list.</li>
+<li><b>PS1 games — two cores, one list</b> — a per-device <b>L3</b> toggle lists your PS1 titles from
+<b>POPSTARTER</b> (<code>*.VCD</code>) and <b>Ember</b> (<code>*.cue</code>) together, sorted as one library,
+including from an <b>exFAT</b> drive (BDMAssault) and the internal HDD.</li>
+<li><b>Category settings layout</b> — organised category pages (Game Sources, General &amp; System, Network, Interface, Game Launching, PS Emulation Settings, Controller Settings, Audio Settings) instead of one flat list.</li>
 <li><b>Ready-to-use defaults</b> — widescreen, cover art, notifications, sound + boot sound, and the PS2 logo are on out of the box; storage devices ship off by default until enabled under Game Sources.</li>
 </ul>
 
@@ -98,7 +99,7 @@ from an <b>exFAT</b> drive (BDMAssault) and the internal HDD.</li>
 <a class="tile" href="smb.html"><span class="em">🌐</span><b>SMB</b><span>Network share</span></a>
 <a class="tile" href="hdd.html"><span class="em">💽</span><b>Internal HDD</b><span>APA/PFS &amp; exFAT (BDMA)</span></a>
 <a class="tile" href="network-boot.html"><span class="em">📡</span><b>Network Boot</b><span>UDPBD &amp; UDPFS</span></a>
-<a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 Games</b><span>VCD view + POPSTARTER</span></a>
+<a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 Games</b><span>POPSTARTER + Ember</span></a>
 <a class="tile" href="neutrino.html"><span class="em">⚛️</span><b>Neutrino Core</b><span>Device + Args pickers</span></a>
 <a class="tile" href="coverflow.html"><span class="em">🎴</span><b>Coverflow</b><span>The default theme</span></a>
 <a class="tile" href="favourites.html"><span class="em">⭐</span><b>Favourites</b><span>R3 to star</span></a>

--- a/install.html
+++ b/install.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -161,19 +161,19 @@ When you enable a device mode in OPL settings and exit back to the game list, OP
 <table data-sortable>
 <thead><tr><th>Setting</th><th>Default</th><th>Where to change</th></tr></thead>
 <tbody>
-<tr><td>Widescreen (16:9)</td><td>ON</td><td>Display Settings</td></tr>
-<tr><td>Cover art display</td><td>ON</td><td>Display Settings</td></tr>
-<tr><td>Notifications (popups)</td><td>ON</td><td>Display Settings</td></tr>
-<tr><td>PS2 logo on boot</td><td>ON</td><td>Display Settings</td></tr>
+<tr><td>Widescreen (16:9)</td><td>ON</td><td>Interface</td></tr>
+<tr><td>Cover art display</td><td>ON</td><td>Interface</td></tr>
+<tr><td>Notifications (popups)</td><td>ON</td><td>Interface</td></tr>
+<tr><td>PS2 logo on boot</td><td>ON</td><td>Interface</td></tr>
 <tr><td>Sound effects (SFX)</td><td>ON (volume 80)</td><td>Audio Settings</td></tr>
 <tr><td>Boot sound</td><td>ON (volume 80)</td><td>Audio Settings</td></tr>
 <tr><td>BGM (background music)</td><td>ON (volume 70)</td><td>Audio Settings</td></tr>
 <tr><td>USB, iLink, MX4SIO, exFAT HDD, UDPBD</td><td>OFF</td><td>Device Settings</td></tr>
 <tr><td>Device start mode (all tabs)</td><td>Off (disabled)</td><td>Device Settings</td></tr>
-<tr><td>Video mode</td><td>Auto (0)</td><td>Display Settings / GSM</td></tr>
+<tr><td>Video mode</td><td>Auto (0)</td><td>Interface / GSM</td></tr>
 <tr><td>Default theme</td><td>&lt;Coverflow&gt; (built-in)</td><td>Theme Settings</td></tr>
 <tr><td>Delete/rename games</td><td>Enabled</td><td>General Settings</td></tr>
-<tr><td>Visual GameID barcode</td><td>OFF</td><td>Display Settings</td></tr>
+<tr><td>Visual GameID barcode</td><td>OFF</td><td>Interface</td></tr>
 <tr><td>UDPBD/UDPFS network boot</td><td>OFF</td><td>Device Settings</td></tr>
 </tbody>
 </table>

--- a/mmce.html
+++ b/mmce.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -187,7 +187,7 @@ Leave this <b>ON</b> (the shipped known-good default) so an occasional card hang
 timeout error rather than a freeze.</p>
 
 <h2 id="ps1-vcd">PS1 games on MMCE</h2>
-<p>MMCE supports the PS1 VCD view exactly like USB. Place <code>*.VCD</code> files and <code>POPSTARTER.ELF</code>
+<p>MMCE supports the PS1 PS1 view exactly like USB. Place <code>*.VCD</code> files and <code>POPSTARTER.ELF</code>
 in the <code>POPS/</code> folder on the SD card. Press <b>L3</b> on the MMCE Games tab to switch between the PS2
 game list and the PS1 VCD list. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for the full setup walkthrough,
 including the Default game view lock and cover-art fallback chain.</p>

--- a/nbd.html
+++ b/nbd.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>

--- a/network-boot.html
+++ b/network-boot.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html" class="active"><span class="em">📡</span>Network Boot (SMB/UDP)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>

--- a/neutrino.html
+++ b/neutrino.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html" class="active"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -113,7 +113,7 @@ The <b>Loader Core</b> selector, the <b>Neutrino Device</b> picker, the structur
 <p>Unsupported sources fall back to the <code>&lt;OPL&gt;</code> core automatically with an on-screen warning. No manual intervention is needed — OPL detects the format and adjusts.</p>
 
 <div class="callout info"><div class="h">ℹ PS1 games are a separate path</div>
-PlayStation 1 titles (<code>*.VCD</code>) always boot through <b>POPSTARTER.ELF</b> — never OPL's core and never Neutrino. The Loader Core selector is locked and has no effect for PS1 games. See <a href="ps1-vcd.html">PS1 Games (VCD)</a>.
+PlayStation 1 titles always boot through their own core — <b>POPSTARTER.ELF</b> for <code>*.VCD</code>, <b>ember.elf</b> for Ember titles — never OPL's core and never Neutrino. The Loader Core selector is locked and has no effect for PS1 games. See <a href="ps1-vcd.html">PS1 Games (VCD)</a>.
 </div>
 
 <h2 id="neutrino-device">3. Neutrino Device picker</h2>

--- a/per-game-settings.html
+++ b/per-game-settings.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -303,11 +303,14 @@ will be silently ignored at launch.</p>
   </tbody>
 </table>
 
-<div class="callout info"><div class="h">i PS1 / VCD games</div>
-PS1 titles shown via the <b>L3 VCD view</b> always launch through <b>POPSTARTER.ELF</b> — never
-OPL's core and never Neutrino. The Loader Core selector is pinned to <code>Default</code> and locked
-for VCD entries, since the choice is inert — no <code>$CoreLoader</code> key is written for them. For PS1-specific settings (IGR hotkeys, multi-disc,
-cheats), see the <a href="https://nathanneurotic.github.io/POPSLoader/">POPStarter docs</a>.
+<div class="callout info"><div class="h">i PS1 games</div>
+PS1 titles shown via the <b>L3 PS1 view</b> launch through their own core — <b>POPSTARTER.ELF</b>
+for a <code>*.VCD</code> row, <b>ember.elf</b> for an Ember row. Neither uses OPL's core or
+Neutrino, so the Loader Core selector is pinned to <code>Default</code> and locked on any PS1
+entry: the choice is inert and no <code>$CoreLoader</code> key is written. For POPSTARTER-specific
+settings (IGR hotkeys, multi-disc, cheats), see the
+<a href="https://nathanneurotic.github.io/POPSLoader/">POPStarter docs</a>; for Ember, see
+<a href="ps1-vcd.html#ember">Ember — the second PS1 core</a>.
 </div>
 
 <h2 id="save-test-remove">Save Changes, Test Changes, Remove Settings</h2>

--- a/ps1-vcd.html
+++ b/ps1-vcd.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>PS1 Games (VCD) · RiptOPL Docs</title>
-<meta name="description" content="Play PS1 games on PS2 via the VCD view and POPSTARTER.">
+<title>PS1 Games · RiptOPL Docs</title>
+<meta name="description" content="Play PS1 games on PS2 through two cores: POPSTARTER (.VCD) and Ember (.cue), in one list.">
 <link rel="stylesheet" href="assets/style.css">
 </head><body data-base="">
 <header class="topbar">
@@ -49,13 +49,27 @@
     <a href="https://nathanneurotic.github.io/POPSLoader/"><span class="em">📚</span>POPStarter docs ↗</a>
   </nav>
   <main class="content">
-<h1>PS1 Games (VCD)</h1>
+<h1>PS1 Games</h1>
 <p class="lead">RiptOPL can list and launch your PlayStation 1 games right alongside your PS2 library,
-on the same device. PS1 titles boot through <b>POPSTARTER</b> — never OPL's built-in core and never
-Neutrino — so this is a self-contained path with its own storage layout and settings.</p>
+on the same device. It does this through <b>two</b> cores — <b>POPSTARTER</b> for <code>*.VCD</code>
+images and <b>Ember</b> for <code>*.cue</code> discs — and both appear together in a single
+<b>PS1</b> list. Neither uses OPL's built-in core or Neutrino, so this is a self-contained path with
+its own storage layout and settings.</p>
+
+<table data-sortable>
+  <thead><tr><th>Core</th><th>Format</th><th>Lives in</th></tr></thead>
+  <tbody>
+    <tr><td><b>POPSTARTER</b></td><td><code>*.VCD</code></td><td><code>&lt;device&gt;:/POPS/</code></td></tr>
+    <tr><td><b>Ember</b></td><td><code>*.cue</code> / <code>*.bin</code> / <code>*.exe</code></td><td><code>&lt;device&gt;:/EMBER/games/&lt;Game Name&gt;/</code></td></tr>
+  </tbody>
+</table>
+
+<p>The two are interleaved and sorted as one library, so a game you keep for both cores simply
+appears twice. Which core runs a title is a property of that row, decided when you launch it —
+there is nothing to configure and no third toggle.</p>
 
 <div class="callout info"><div class="h">ℹ POPSTARTER internals are on the sister site</div>
-This page covers the RiptOPL side: where to put your files, how the VCD view works, and the BDMA
+This page covers the RiptOPL side: where to put your files, how the PS1 view works, and the BDMA
 exFAT equip. For POPSTARTER itself — the 32-byte per-game config table, cheats, IGR/hotkeys,
 multi-disc setups, and memory-card storage — see the
 <a href="https://nathanneurotic.github.io/POPSLoader/"><b>POPStarter docs</b></a>:
@@ -66,18 +80,17 @@ multi-disc setups, and memory-card storage — see the
 <a href="https://nathanneurotic.github.io/POPSLoader/storage.html">storage</a>.
 </div>
 
-<h2 id="vcd-view">The VCD view (press L3)</h2>
+<h2 id="vcd-view">The PS1 view (press L3)</h2>
 
 <p>Every device page — USB, MMCE, MX4SIO, iLink, SMB, and the internal HDD — holds two lists:</p>
 <ul class="checklist">
-  <li>its <b>disc games</b> (PS2 ISO / ZSO / UL format), and</li>
-  <li>its <b>VCD games</b> (PS1 <code>*.VCD</code> images).</li>
+  <li>its <b>PS2 games</b> (ISO / ZSO / UL format), and</li>
+  <li>its <b>PS1 games</b> — POPSTARTER <code>*.VCD</code> images and Ember <code>*.cue</code>
+      titles together, in one list.</li>
 </ul>
 <p>Press <b>L3</b> on any device page to switch between the two. It is a <b>view toggle</b>, not a
 separate tab — the same page, the same covers, favourites, and per-game settings, just a different
-list. An on-screen hint tells you whether you're looking at discs or VCDs.</p>
-<p>The UI calls this the <b>VCD view</b> rather than "PS1" or "POPS" so it reads cleanly next to
-your disc games.</p>
+list. An on-screen hint tells you which one you are looking at.</p>
 
 <div class="callout info"><div class="h">ℹ Favourites follow the active view</div>
 While a device page shows VCDs, starred VCD titles appear in the Favourites tab; while it shows
@@ -87,36 +100,98 @@ until you toggle back — nothing is lost.
 
 <h2 id="default-game-view">Locking the view — Default game view</h2>
 
-<p>If you don't want to press L3 every session, open <b>Settings → Display Settings</b> and set
+<p>If you don't want to press L3 every session, open <b>Settings → Interface</b> and set
 <b>Default game view</b>:</p>
 
 <table data-sortable>
   <thead><tr><th>Value</th><th>Behaviour</th></tr></thead>
   <tbody>
-    <tr><td><b>Both</b> (default)</td><td>Every page starts on its disc list; L3 toggles to the VCD list and back.</td></tr>
-    <tr><td><b>ISO</b></td><td>Every page is locked to its disc list. L3 does nothing.</td></tr>
-    <tr><td><b>VCD</b></td><td>Every page is locked to its VCD list. L3 does nothing.</td></tr>
+    <tr><td><b>Both</b> (default)</td><td>Every page starts on its disc list; L3 toggles to the PS1 list and back.</td></tr>
+    <tr><td><b>PS2</b></td><td>Every page is locked to its PS2 list. L3 does nothing.</td></tr>
+    <tr><td><b>PS1</b></td><td>Every page is locked to its PS1 list. L3 does nothing.</td></tr>
   </tbody>
 </table>
 
-<h2 id="launch">How PS1 games launch (POPSTARTER only)</h2>
+<h2 id="launch">How PS1 games launch</h2>
 
-<p>VCD titles always boot through <code>POPSTARTER.ELF</code>. They never use OPL's built-in core
-or Neutrino. Because of this, the per-game <b>Loader Core</b> selector is shown as an inert label
-on a PS1 game — changing it has no effect. The same applies to GSM, Cheats, PADEMU, and other
-PS2-specific per-game options; POPSTARTER ignores them entirely.</p>
+<p>A PS1 row carries its own core. A <code>*.VCD</code> row boots through
+<code>POPSTARTER.ELF</code>; an Ember row boots through <code>ember.elf</code>. Neither ever uses
+OPL's built-in core or Neutrino, so on any PS1 game the per-game <b>Loader Core</b> selector is an
+inert label and changing it has no effect. The same applies to GSM, Cheats, PADEMU and the other
+PS2-specific per-game options — neither PS1 core reads them.</p>
 
 <p>POPSTARTER only needs the VCD's <em>name</em> to do its job. RiptOPL hands it the selected title
-and POPSTARTER locates the matching <code>*.VCD</code> file itself.</p>
+and POPSTARTER locates the matching <code>*.VCD</code> file itself. Ember is handed the name of the
+game <em>folder</em> and finds its own disc image inside it.</p>
 
 <h3>POPSTARTER.ELF path</h3>
 <p>By default RiptOPL looks for <code>POPSTARTER.ELF</code> in each device's <code>POPS</code>
 folder. To pin it to one device instead, set
-<b>Settings → VCD Settings → POPSTARTER.ELF Device</b> — Default, Memory Card, USB, MX4SIO, MMCE,
+<b>Settings → PS Emulation Settings → POPSTARTER.ELF Device</b> — Default, Memory Card, USB, MX4SIO, MMCE,
 HDD (exFAT), HDD (APA), Custom, or Game's Device. The free-text <b>POPSTARTER.ELF Path</b> field
 below it only appears when the Device is set to <b>Custom</b>. The on-screen editor caps at 31
 characters; for a longer path set <code>popstarter_path</code> in
 <code>settings_riptopl.cfg</code> directly.</p>
+
+<h2 id="ember">Ember — the second PS1 core</h2>
+
+<p><b><a href="https://github.com/Gageformer/Ember/releases">Ember</a> is created by Gageformer.</b> It is an independent PlayStation 1
+emulator written from scratch for the PS2 — it is <b>not</b> part of RiptOPL and is not our work. We
+bundle it unmodified, with the author's blessing, under the <b>Ember Public Beta Testing Licence</b>.
+That licence ships in the release package as <code>EMBER/LICENSE-BETA.txt</code> and governs the
+build it accompanies; please read it. In short: free to use and to bundle non-commercially, no
+selling, and no modifying or repackaging the build.</p>
+
+<div class="callout info"><div class="h">ℹ Report Ember problems to us first</div>
+The launching is ours and most issues turn out to be on our side. Please raise them on the
+<a href="https://github.com/NathanNeurotic/Open-PS2-Loader/issues">RiptOPL issue tracker</a> rather
+than with Gageformer.
+</div>
+
+<h3>Setting Ember up</h3>
+<p>The release package contains a ready-made <code>EMBER/</code> folder. Copy it to the <b>root</b>
+of a device, right beside <code>POPS/</code>. Then add <b>your own PS1 BIOS</b> as
+<code>EMBER/bios.bin</code> — it must be exactly <b>512 KB</b>. A BIOS is copyrighted and is never
+distributed with RiptOPL or with Ember, so the folder ships with a placeholder file whose name
+reminds you. Give each game its own folder:</p>
+
+<pre><code>&lt;device&gt;:/EMBER/
+    ember.elf
+    bios.bin                       &lt;- yours, 512 KB, not included
+    settings.txt                   &lt;- optional, see below
+    games/
+        Spyro 2 (Ripto's Rage)/
+            whatever.cue
+            whatever.bin</code></pre>
+
+<p>The <b>folder name</b> is what you see in the list, and it is also the key for cover art and
+per-game settings — so <code>ART/Spyro 2 (Ripto's Rage)_COV.png</code> on that device just works,
+exactly as it does for a <code>*.VCD</code>. Files inside can be named anything;
+<code>.cue</code> is preferred over <code>.exe</code> over <code>.bin</code>. Ember writes its
+per-game memory cards (<code>MC1.vmc</code>, <code>MC2.vmc</code>) into that same game folder, so it
+has to be on writable media.</p>
+
+<h3>Ember display mode</h3>
+<p>Ember can output 240p or 480p, and there is a setting for it at
+<b>Settings → PS Emulation Settings → Ember Display Mode</b>. Ember's <code>settings.txt</code> is
+an optional file and RiptOPL keeps it that way:</p>
+
+<table data-sortable>
+  <thead><tr><th>Value</th><th>What RiptOPL does</th></tr></thead>
+  <tbody>
+    <tr><td><b>Default</b></td><td>Never creates the file. If one exists, the display key is removed from it — and the file itself is removed when that key was all it held.</td></tr>
+    <tr><td><b>240p</b> / <b>480p</b></td><td>Writes the key to <code>&lt;device&gt;:/EMBER/settings.txt</code> when you launch an Ember title, on that device only — creating the file if it is not there, updating it in place if it is.</td></tr>
+  </tbody>
+</table>
+
+<p>Any other lines in that file — comments, or keys a future Ember adds — are preserved throughout.
+Ember's own default is 480p, so leaving this on <b>Default</b> and having no file mean the same
+thing.</p>
+
+<h3>Device support</h3>
+<p>Ember titles are listed on <b>USB, MX4SIO, iLink, exFAT-ATA and MMCE</b>. <b>SMB</b> and the
+<b>APA internal HDD</b> are POPSTARTER-only for now — a device with no <code>EMBER/</code> folder
+simply contributes no Ember rows, and its POPSTARTER library lists exactly as before.</p>
 
 <h2 id="file-layout">Where to put your VCD files</h2>
 
@@ -149,7 +224,7 @@ launched; it just won't auto-match art by ID.
 
 <p>POPSTARTER's stock FAT driver reads FAT32 only. To boot PS1 games from an <b>exFAT</b> drive,
 POPSTARTER needs extra block-device modules (the BDMAssault / "BDMA" drivers). RiptOPL
-<em>equips</em> them onto your memory card from <b>Settings → VCD Settings</b> — you supply the module
+<em>equips</em> them onto your memory card from <b>Settings → PS Emulation Settings</b> — you supply the module
 files, RiptOPL copies the right pair to <code>mc?:/POPSTARTER/</code>. <b>VCD BDMA Apply on Launch</b>
 ships <b>On</b>, so by default the matching pair is equipped automatically immediately before each VCD
 launch and the manual <b>BDMA Source</b> / <b>BDMA Mode</b> pickers stay hidden; turn it <b>Off</b> to
@@ -202,12 +277,12 @@ volume mounted through the BDM mass-device namespace, never a typed <code>ata0:<
   </div>
   <div class="step">
     <h3>Turn VCD BDMA Apply on Launch off</h3>
-    <p>In <b>Settings → VCD Settings</b>, set <b>VCD BDMA Apply on Launch</b> to <b>Off</b>. The
+    <p>In <b>Settings → PS Emulation Settings</b>, set <b>VCD BDMA Apply on Launch</b> to <b>Off</b>. The
     <b>BDMA Source</b> and <b>BDMA Mode</b> pickers are hidden while it is On (the default).</p>
   </div>
   <div class="step">
     <h3>Set BDMA Source</h3>
-    <p>In <b>Settings → VCD Settings</b>, set <b>BDMA Source</b> to the device that holds the
+    <p>In <b>Settings → PS Emulation Settings</b>, set <b>BDMA Source</b> to the device that holds the
     module files.</p>
   </div>
   <div class="step">
@@ -242,11 +317,11 @@ hanging silently.</p>
 <ul class="checklist">
   <li><b>APA/PFS partitions</b> — the traditional POPS APA volumes (<code>__.POPS</code>,
   <code>__.POPS0</code> … <code>__.POPS9</code>). RiptOPL scans all of them and lists their
-  <code>*.VCD</code> files in the HDD device's VCD view. No BDMA equip is needed here because
+  <code>*.VCD</code> files in the HDD device's PS1 view. No BDMA equip is needed here because
   POPSTARTER reads PFS natively.</li>
   <li><b>exFAT HDD (BDM)</b> — enable <em>HDD (GPT/MBR)</em> in Device Settings. The exFAT volume
   mounts as a normal BDM block device (one of the <code>massN:</code> slots) and its
-  <code>POPS/</code> folder appears in the same VCD view as USB. Equip the
+  <code>POPS/</code> folder appears in the same PS1 view as USB. Equip the
   <b>HDD (exFAT)</b> BDMA mode so POPSTARTER can read back off the exFAT volume at launch time.</li>
 </ul>
 
@@ -255,7 +330,7 @@ hanging silently.</p>
 
 <h2 id="limitations">Notes &amp; limitations</h2>
 <ul class="checklist">
-  <li>The VCD view reuses the normal device pipeline, so covers, favourites, and the theme all work
+  <li>The PS1 view reuses the normal device pipeline, so covers, favourites, and the theme all work
   exactly as they do for disc games.</li>
   <li>POPSTARTER, the BDMA module variants, and the POPS patch file are supplied by you (or bundled
   in the release <code>POPS/</code> folder) — RiptOPL does not embed any of them.</li>

--- a/ps3-bc.html
+++ b/ps3-bc.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>

--- a/releases.html
+++ b/releases.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -51,7 +51,7 @@
   <main class="content">
 <section class="callout info" id="external-tools"><div class="h">External Tools &amp; Services</div>
 <p><b><a href="https://github.com/NathanNeurotic/PS2-Servers">PS2-Servers</a></b> — all-in-one PC server launcher for <b>SMBv1, UDPFS and UDPBD</b>.<br>
-<b><a href="https://github.com/Luden02/OrbitOPL-Toolbox">OrbitOPL Toolbox</a></b> — cross-platform PC library manager for importing discs, artwork/screenshots, ZSO compression, per-game settings and VMC management.<br>
+<b><a href="https://github.com/Luden02/OrbitPS2-Manager">OrbitPS2 Manager</a></b> — cross-platform PC library manager for importing discs, artwork/screenshots, ZSO compression, per-game settings and VMC management.<br>
 <b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO Converter GUI</a></b> — Windows all-in-one PS1/POPStarter preparation tool for BIN/CUE → VCD conversion and installation to USB, MX4SIO, MMCE, exFAT HDD, SMB and APA internal HDD.<br>
 <b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> — PC manager for the PS2RD <code>.cht</code> cheat files RiptOPL reads from your device's <code>CHT</code> folder.<br>
 <b><a href="https://github.com/Gageformer/Ember">Ember</a></b> — a PS1 emulator running natively on the PS2, <b>created by Gageformer</b>, used as RiptOPL's second PS1 core alongside POPSTARTER. Ships as an <code>EMBER/</code> folder inside the release package, bundled unmodified with permission under the Ember Public Beta Testing Licence (<code>EMBER/LICENSE-BETA.txt</code>); <a href="https://github.com/Gageformer/Ember/releases">releases</a>.</p></section>

--- a/settings.html
+++ b/settings.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -63,7 +63,7 @@ Artwork, themes, VMC files and <code>favourites.bin</code> remain shared.</div>
 <h2 id="general-settings">General Settings</h2>
 <p>Reached via <b>Settings &rarr; General Settings</b>. Contains launch-path helpers, global Neutrino
 configuration, housekeeping options, and — below their own splitters — the prefix paths and cache sizes.
-The PS1/BDMA plumbing now lives on its own <a href="#vcd-settings">VCD Settings</a> page.</p>
+The PS1/BDMA plumbing now lives on its own <a href="#vcd-settings">PS Emulation Settings</a> page.</p>
 
 <table data-sortable>
 <thead><tr><th>Option</th><th>Values</th><th>Description</th></tr></thead>
@@ -144,9 +144,9 @@ enabled, their start modes, and the network transport rows. Prefix paths and cac
 </tbody>
 </table>
 
-<h2 id="vcd-settings">VCD Settings</h2>
-<p>Reached via <b>Settings &rarr; VCD Settings</b>. PS1-via-POPSTARTER launch configuration, the BDMA exFAT
-driver equip, and the VCD list display options. See <a href="ps1-vcd.html">PS1 Games</a>.</p>
+<h2 id="vcd-settings">PS Emulation Settings</h2>
+<p>Reached via <b>Settings &rarr; PS Emulation Settings</b>. PS1-via-POPSTARTER launch configuration, the BDMA exFAT
+driver equip, and the PS1 list display options. See <a href="ps1-vcd.html">PS1 Games</a>.</p>
 
 <table data-sortable>
 <thead><tr><th>Option</th><th>Values</th><th>Description</th></tr></thead>
@@ -176,8 +176,8 @@ for full detail.</p>
 </tbody>
 </table>
 
-<h2 id="display-settings">Display Settings</h2>
-<p>Reached via <b>Settings &rarr; Display Settings</b>. Controls the visual appearance, video mode, and
+<h2 id="display-settings">Interface</h2>
+<p>Reached via <b>Settings &rarr; Interface</b>. Controls the visual appearance, video mode, and
 cover-art behavior.</p>
 
 <table data-sortable>
@@ -189,7 +189,7 @@ cover-art behavior.</p>
 <tr><td>Automatic Refresh</td><td>Off / On</td><td>Periodically re-scans for newly plugged-in devices and adds their games without requiring a manual refresh.</td></tr>
 <tr><td>Cover Art</td><td>Off / On</td><td>Enables cover-art display. When off, no cover images are loaded even if present.</td></tr>
 <tr><td>Cover Art .tar Archive</td><td>Off / On</td><td>Off by default. Opt-in loader that also reads cover art from an <code>ART/art.tar</code> archive alongside the loose image files.</td></tr>
-<tr><td>Default game view</td><td>Both / ISO / VCD</td><td>Controls which game list is shown by default on VCD-capable device tabs. <em>Both</em> keeps the per-device L3 toggle active (defaults to ISO). <em>ISO</em> locks every tab to disc games. <em>VCD</em> locks every tab to PS1 games. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>Default game view</td><td>Both / PS2 / PS1</td><td>Controls which game list is shown by default on PS1-capable device tabs. <em>Both</em> keeps the per-device L3 toggle active (defaults to PS2). <em>PS2</em> locks every tab to disc games. <em>PS1</em> locks every tab to PS1 games (POPSTARTER and Ember together). See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
 <tr><td>Notifications</td><td>Off / On</td><td>Shows brief on-screen notifications when a config, theme, or language file is loaded, or when a storage partition is mounted.</td></tr>
 <tr><td>Coverflow Settings</td><td>[sub-screen]</td><td>Opens the <a href="#coverflow-settings">Coverflow Settings</a> sub-screen. See below.</td></tr>
 <tr><td>Text Color</td><td>color picker</td><td>Color of normal UI text.</td></tr>
@@ -208,7 +208,7 @@ cover-art behavior.</p>
 </table>
 
 <h3 id="coverflow-settings">Coverflow Settings</h3>
-<p>Sub-screen opened from the <em>Coverflow Settings</em> button in Display Settings. Tunable live while the
+<p>Sub-screen opened from the <em>Coverflow Settings</em> button in Interface. Tunable live while the
 Coverflow theme is active. See <a href="coverflow.html">Coverflow</a> for full detail.</p>
 
 <table data-sortable>

--- a/smb.html
+++ b/smb.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -220,7 +220,7 @@ If you leave the <b>Share</b> field empty, OPL asks the driver to enumerate the 
 
 <h2 id="ps1-smb">5. PS1 games over SMB</h2>
 
-<p>The L3 VCD view works on SMB just like USB: press <b>L3</b> on the ETH Games page to toggle between your PS2 disc list and your PS1 <code>*.VCD</code> list. Place your VCDs (and <code>POPSTARTER.ELF</code>) in the <code>POPS\</code> subfolder of the share.</p>
+<p>The L3 PS1 view works on SMB just like USB: press <b>L3</b> on the ETH Games page to toggle between your PS2 disc list and your PS1 <code>*.VCD</code> list. Place your VCDs (and <code>POPSTARTER.ELF</code>) in the <code>POPS\</code> subfolder of the share.</p>
 
 <p>Launching a PS1 game over SMB has one extra requirement: POPSTARTER needs its own copy of the network configuration and its SMB modules on the memory card — it cannot read them from the share at launch time.</p>
 
@@ -346,7 +346,7 @@ The <b>SMB Version</b> setting governs OPL's own browsing and its in-game reader
 <h2 id="see-also">See also</h2>
 <div class="grid">
   <a class="tile" href="network-boot.html"><span class="em">📡</span><b>Network Boot</b><span>UDPBD &amp; UDPFS — block-level streaming via Neutrino</span></a>
-  <a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 Games (VCD)</b><span>VCD view, POPSTARTER config, BDMA equip</span></a>
+  <a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 Games (VCD)</b><span>PS1 view, POPSTARTER config, BDMA equip</span></a>
   <a class="tile" href="neutrino.html"><span class="em">⚛️</span><b>Neutrino Core</b><span>External loader core — per-game device &amp; args</span></a>
   <a class="tile" href="nbd.html"><span class="em">🖧</span><b>NBD Server</b><span>Expose the internal HDD to a PC over the network</span></a>
 </div>

--- a/themes.html
+++ b/themes.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -133,7 +133,7 @@ sequence. (A commented-out block counts as a deletion — re-number around it.)<
 The first element of a list <b>must</b> be the <code>Background</code> (the engine inserts a default plasma
 background if you forget). Likewise only the first <code>ItemsList</code> becomes the games list, the second the
 apps list, the third the Favourites list and the fourth the PS1/VCD list — so order matters beyond just draw
-order. The PS1/VCD slot is optional: define only three lists and the VCD view falls back to the games list,
+order. The PS1/VCD slot is optional: define only three lists and the PS1 view falls back to the games list,
 sharing its cover cache. Give it a fourth and it gets its own.</details>
 
 <h2 id="global-properties">3 · Global properties</h2>
@@ -787,7 +787,7 @@ info15:
 <h2 id="see-also">See also</h2>
 <div class="grid">
 <a class="tile" href="coverflow.html"><span class="em">🎴</span><b>Coverflow</b><span>The default theme &amp; its live settings</span></a>
-<a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 / VCD view</b><span>Where the vcdMain family is used</span></a>
+<a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 / PS1 view</b><span>Where the vcdMain family is used</span></a>
 <a class="tile" href="favourites.html"><span class="em">⭐</span><b>Favourites</b><span>The favsMain/favsInfo family</span></a>
 <a class="tile" href="settings.html"><span class="em">🔧</span><b>Settings Reference</b><span>Selecting &amp; applying a theme</span></a>
 <a class="tile" href="https://nathanneurotic.github.io/POPSLoader/"><span class="em">📚</span><b>POPStarter docs ↗</b><span>PS1 internals: config table, IGR, cheats, multi-disc</span></a>

--- a/troubleshooting.html
+++ b/troubleshooting.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -129,7 +129,7 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
 
 <h2 id="vcd-list-empty">PS1/VCD — "my VCDs don't show up" (works elsewhere)</h2>
 
-<p><b>Symptom:</b> A device lists PS2 games fine (or works in another loader), but its PS1/VCD view is empty — or a listed VCD does nothing when selected.</p>
+<p><b>Symptom:</b> A device lists PS2 games fine (or works in another loader), but its PS1/PS1 view is empty — or a listed VCD does nothing when selected.</p>
 
 <p>Work down this ladder; each step isolates a different stage:</p>
 
@@ -144,7 +144,7 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
   </div>
   <div class="step">
     <h3>Press L3 on the device page</h3>
-    <p>The VCD view is per device and only reachable when <b>Default game view</b> is "Both" (or the page is locked to VCD).</p>
+    <p>The PS1 view is per device and only reachable when <b>Default game view</b> is "Both" (or the page is locked to VCD).</p>
   </div>
   <div class="step">
     <h3>Check the folder — root, not your games prefix</h3>
@@ -184,7 +184,7 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
   </div>
   <div class="step">
     <h3>Re-apply the equip</h3>
-    <p>With the files in place, open <b>VCD Settings</b> from the main menu — BDMA has its own page, it is not under General Settings — set <b>BDMA Source</b> / <b>BDMA Mode</b>, and save. (The two manual pickers are hidden while <b>VCD BDMA Apply on Launch</b> is ON, because that option equips automatically; turn it off to set them by hand.) RiptOPL will copy the modules to <code>mc?:/POPSTARTER/</code> and record the equipped state in a marker file (compatible with POPSLoader).</p>
+    <p>With the files in place, open <b>PS Emulation Settings</b> from the main menu — BDMA has its own page, it is not under General Settings — set <b>BDMA Source</b> / <b>BDMA Mode</b>, and save. (The two manual pickers are hidden while <b>VCD BDMA Apply on Launch</b> is ON, because that option equips automatically; turn it off to set them by hand.) RiptOPL will copy the modules to <code>mc?:/POPSTARTER/</code> and record the equipped state in a marker file (compatible with POPSLoader).</p>
   </div>
 </div>
 
@@ -194,19 +194,19 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
 
 <h2 id="vcd-list-not-showing">PS1 / VCD list not showing after a settings change</h2>
 
-<p><b>Symptom:</b> You have VCD files on a device but after changing a setting (such as <b>Default game view</b>, enabling a device, or changing BDMA settings) the VCD list is empty or appears to be stuck on the disc list.</p>
+<p><b>Symptom:</b> You have VCD files on a device but after changing a setting (such as <b>Default game view</b>, enabling a device, or changing BDMA settings) the PS1 list is empty or appears to be stuck on the disc list.</p>
 
 <p><b>Fix:</b> The view state sometimes needs a manual refresh after a settings change.</p>
 
 <ul class="checklist">
   <li>Navigate to the device page that should show your VCDs and press <b>L3</b> to toggle the view. If the view was already on VCDs it will switch to discs; press <b>L3</b> again to return to VCDs. This forces a list refresh.</li>
-  <li>If <b>Default game view</b> is set to <b>ISO</b>, the VCD toggle is disabled by design — L3 does nothing. Change <b>Default game view</b> to <b>Both</b> or <b>VCD</b> in <b>Settings → Display Settings</b>, then save and re-enter the device page.</li>
-  <li>If the VCD list still appears empty, confirm the <code>*.VCD</code> files are in a <code>POPS/</code> folder at the device root (USB / MMCE / MX4SIO / iLink / SMB) or, for the internal APA HDD, inside the correct <code>__.POPS</code> / <code>__.POPS0</code>–<code>__.POPS9</code> partitions. Files in any other location are not scanned.</li>
+  <li>If <b>Default game view</b> is set to <b>PS2</b>, the PS1 toggle is disabled by design — L3 does nothing. Change <b>Default game view</b> to <b>Both</b> or <b>PS1</b> in <b>Settings → Interface</b>, then save and re-enter the device page.</li>
+  <li>If the PS1 list still appears empty, confirm the <code>*.VCD</code> files are in a <code>POPS/</code> folder at the device root (USB / MMCE / MX4SIO / iLink / SMB) or, for the internal APA HDD, inside the correct <code>__.POPS</code> / <code>__.POPS0</code>–<code>__.POPS9</code> partitions. Files in any other location are not scanned.</li>
   <li>For exFAT HDD, confirm <b>HDD (GPT/MBR)</b> is enabled in <b>Device Settings</b> and that the HDD has mounted — the game list should show an <b>HDD Games</b> entry. VCDs on the exFAT HDD live in <code>massN:/POPS/</code>.</li>
 </ul>
 
 <div class="callout info"><div class="h">i Favourites follow the active view</div>
-Favourited VCD titles only appear in the Favourites list while a page is in VCD view mode. If you switch a page to disc view, those favourites are hidden until you switch back — they are not lost.
+Favourited VCD titles only appear in the Favourites list while a page is in PS1 view mode. If you switch a page to disc view, those favourites are hidden until you switch back — they are not lost.
 </div>
 
 <h2 id="quick-reference">Quick-reference button combos</h2>

--- a/usb.html
+++ b/usb.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
@@ -115,7 +115,7 @@ yourself if you want PS1/VCD games.</p>
 <pre>
 DVD/        PS2 DVD5/DVD9 ISO and ZSO images (also supports &gt;4 GB on exFAT)
 CD/         PS2 CD-ROM ISO images (blue-bottom discs)
-POPS/       PS1 VCD game images (*.VCD) — listed under the L3 VCD view
+POPS/       PS1 VCD game images (*.VCD) — listed under the L3 PS1 view
 CFG/        Per-game configuration files
 ART/        Cover art images
 VMC/        Virtual Memory Card images

--- a/vmc.html
+++ b/vmc.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>

--- a/zso.html
+++ b/zso.html
@@ -29,7 +29,7 @@
     <a href="hdd.html"><span class="em">💽</span>Internal HDD (APA &amp; exFAT)</a>
     <a href="network-boot.html"><span class="em">📡</span>Network Boot (UDPBD/UDPFS)</a>
     <h4>Features</h4>
-    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games (VCD)</a>
+    <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
     <a href="favourites.html"><span class="em">⭐</span>Favourites</a>


### PR DESCRIPTION
Docs-site half of the documentation pass. The repo half is [#556](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/556).

The site had **no mention of Ember at all** — the entire second PS1 core was missing — and its
settings navigation was up to two renames out of date. Pages were last touched 2026-07-28.

## Accuracy — every name verified against the source first

| Was | Is | Why |
| --- | --- | --- |
| "Settings → Display Settings" (14×) | **Settings → Interface** | "Display Settings" is the *header* of `diaDisplayConfig`, composed into the Interface page with `suppressSecondaryHeaders=1` — it is never even rendered. Wrong twice over. |
| "VCD Settings" (10×) | **PS Emulation Settings** | Renamed to POPStarter, then to PS Emulation Settings. `_STR_VCD_SETTINGS` is now a dead label with no code references. |
| Default game view "Both / ISO / VCD" | **Both / PS2 / PS1** | |
| "VCD view" (23×) | **PS1 view** | The list is no longer POPSTARTER-only. |

Those terms also lived in `data/search-index.json`, which powers site search, so they are fixed
there too — it still parses, 181 entries intact.

## Ember

`ps1-vcd.html` is now a genuine two-core page: what each core runs and where it lives, that a row
carries its own core, and a full **Ember** section covering setup, the BIOS you must supply, the
folder-name-is-the-key rule, the display mode (including what *Default* does to `settings.txt`), and
the device-support gap — SMB and APA are POPSTARTER-only.

`per-game-settings.html` and `neutrino.html` no longer claim PS1 always means POPSTARTER. The page
title, meta description, sidebar label and home-page tile all drop the "(VCD)" framing.

Also fixed on `index.html`: the feature list named fourteen settings categories that do not exist.

## Credit

`credits.html` had **nothing about Gageformer** despite us shipping his emulator. He now has a
Special Thanks entry naming the licence, the release page, and Ember's own acknowledgement of
DuckStation as a correctness reference.

The "A Note on PS1 Emulation" section assumed one core. It now explains that the two work
differently: POPSTARTER drives **POPS**, Sony's firmware emulator, while **Ember** is a real
emulator that needs *your* BIOS and does not depend on console firmware.

Added a **Companion PC Tools** section, which the site never had. PS2-Servers is marked as ours
rather than third-party — it is the same author, and putting it under a "report elsewhere" heading
would have been wrong.

## Verification

- **0 broken internal links** across all 23 pages, checked page-by-page including fragments.
- The new `#ember` anchor resolves; the on-page TOC picks it up automatically from the `h2` id.
- `search-index.json` still valid JSON.
- OrbitPS2 Manager rename applied here too (see #556) — `index.html` and `releases.html` carry the
  bot-managed external-tools section, which `docs-sync.yml` will keep in sync from now on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
