### PR TITLE
docs(site): credit tool authors, drop the home-page stats row

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -157,11 +157,6 @@ blockquote{margin:1em 0;padding:.5em 1.1em;border-left:3px solid var(--ps-sq);co
   box-shadow:0 8px 26px rgba(46,98,230,.4)}
 .btn:hover{text-decoration:none;transform:translateY(-1px);filter:brightness(1.1)}
 .btn.ghost{background:rgba(20,32,72,.5);color:var(--accent2);box-shadow:none;font-weight:600}
-.stat-row{display:flex;flex-wrap:wrap;gap:14px 34px;margin:26px 0 8px}
-.stat{background:none;border:none;border-left:2px solid var(--line2);border-radius:0;padding:1px 0 1px 13px}
-.stat b{font-size:22px;color:var(--accent2);font-weight:800}
-.stat span{color:var(--ink3);font-size:11.5px;display:block;text-transform:uppercase;letter-spacing:.5px}
-
 /* ---- tiles (OSD menu items, face-button colour rhythm) ---- */
 .grid{display:grid;gap:15px;grid-template-columns:repeat(auto-fill,minmax(232px,1fr));margin:22px 0}
 .tile{display:block;padding:16px 18px;background:var(--panel);border:1px solid var(--line2);

--- a/credits.html
+++ b/credits.html
@@ -247,24 +247,24 @@ maintained version. All but the first are <b>third-party projects</b>, independe
 not part of RiptOPL — <b>please report issues with those to their own repository, not here.</b></p>
 
 <ul class="checklist">
-<li><b><a href="https://github.com/NathanNeurotic/PS2-Servers">PS2-Servers</a></b> —
+<li><b><a href="https://github.com/NathanNeurotic/PS2-Servers">PS2-Servers</a></b> by <b><a href="https://github.com/NathanNeurotic">Ripto</a></b> —
     all-in-one PC server launcher for <b>SMBv1, UDPFS and UDPBD</b>. This one is ours, from the same
     author as RiptOPL, so its issues belong on its own tracker but are the same hands. Shipped as
     <code>PS2-Servers.url</code>.</li>
-<li><b><a href="https://github.com/Luden02/OrbitPS2-Manager">OrbitPS2 Manager</a></b> —
+<li><b><a href="https://github.com/Luden02/OrbitPS2-Manager">OrbitPS2 Manager</a></b> by <b><a href="https://github.com/Luden02">Luden</a></b> —
     cross-platform library manager: import games from disc images, fetch cover art and screenshots,
     compress ISOs to ZSO, edit per-game settings and manage virtual memory cards. It writes the
     <code>ART</code> folder and per-game configs in exactly the layout RiptOPL expects, which
     resolves most "looks wrong on my setup" reports. Shipped as
     <code>OrbitPS2-Manager.url</code>.</li>
 <li><b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO
-    Converter GUI</a></b> — Windows all-in-one PS1 preparation tool: converts BIN/CUE backups to
+    Converter GUI</a></b> by <b><a href="https://github.com/shaanhomebrew-cloud">shaan</a></b> — Windows all-in-one PS1 preparation tool: converts BIN/CUE backups to
     <code>*.VCD</code> and installs them to USB, MX4SIO, MMCE, exFAT HDD, SMB and the APA internal
     HDD. Shipped as <code>OPL-PS1-AIO-Converter-GUI.url</code>.</li>
-<li><b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> —
+<li><b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> by <b><a href="https://github.com/TheRealNextria">TheRealNextria</a></b> —
     manages the PS2RD <code>.cht</code> cheat files RiptOPL reads from a device's <code>CHT</code>
     folder. Shipped as <code>PS2RD-CHT-Manager.url</code>.</li>
-<li><b><a href="https://github.com/Gageformer/Ember/releases">Ember</a></b> — by <b>Gageformer</b>. The one exception to the shortcut rule:
+<li><b><a href="https://github.com/Gageformer/Ember/releases">Ember</a></b> by <b><a href="https://github.com/Gageformer">Gageformer</a></b> — The one exception to the shortcut rule:
     Ember ships <em>inside</em> the package as an <code>EMBER/</code> folder, bundled unmodified
     under its own licence. See above.</li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,6 @@ reorganized <b>Game Sources</b> category settings layout, PS1 support via POPSTA
   <a class="btn" href="getting-started.html">🚀 New here? Launch your first game</a>
   <a class="btn ghost" href="#sections">Browse the full reference</a>
 </div>
-<div class="stat-row"><div class="stat"><b>8</b><span>storage backends</span></div><div class="stat"><b>31</b><span>UI languages</span></div><div class="stat"><b>2</b><span>loader cores (OPL + Neutrino)</span></div><div class="stat"><b>PS1+PS2</b><span>game support</span></div></div>
 </div>
 
 <div class="callout info"><div class="h">ℹ New to OPL? Read this first</div>Open PS2 Loader (OPL) is a 100% open-source


### PR DESCRIPTION
Two small site changes.

## Credit each companion tool's author

Every companion tool now names its author beside the project, the same treatment Ember already gave Gageformer.

| Tool | Author |
| --- | --- |
| PS2-Servers | [Ripto](https://github.com/NathanNeurotic) |
| OrbitPS2 Manager | [Luden](https://github.com/Luden02) |
| OPL PS1 AIO Converter GUI | [shaan](https://github.com/shaanhomebrew-cloud) |
| PS2RD CHT Manager | [TheRealNextria](https://github.com/TheRealNextria) |
| Ember | [Gageformer](https://github.com/Gageformer) |

Names taken from each account's public GitHub profile. The matching change to the README and the bot-generated external-tools section shipped in [#556](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/556).

## Drop the stats row from the home page

The `8 storage backends / 31 UI languages / 2 loader cores / PS1+PS2` strip was generic landing-page filler — template padding rather than information. None of those numbers help anyone install or use RiptOPL, and two of them go stale the moment a backend or a language is added.

Removed the markup and the four CSS rules that existed only to style it; `.stat` and `.stat-row` are now referenced nowhere on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)