### PR TITLE
fix(art): ART lives in the ART folder — remove every secondary cover location

### DIFF
--- a/docs/EMBER-INTEGRATION-PLAN.md
+++ b/docs/EMBER-INTEGRATION-PLAN.md
@@ -54,8 +54,8 @@ if the release build also works, the premise needs re-examining.
 5. Do `MC1.vmc` / `MC2.vmc` appear in the game folder afterwards? (Confirms it can write there.)
 6. Anything that looks like IOP memory exhaustion — a late, unexplained failure.
 
-Covers: an Ember row uses the device's normal `ART/<name>_COV.png` first, then falls back to
-`EMBER/games/<name>/cover.png`.
+Covers: an Ember row uses the device's normal `ART/<name>_COV.png`, and nothing else. **ART lives in
+the ART folder** — there is no second location for any game type.
 
 ## Part 0 — What Ember actually is (measured, not guessed)
 
@@ -234,8 +234,9 @@ read reports success — never block a launch on a failed probe.
 ### Art and per-game config
 
 Identity is the game folder name, so the device's normal rules apply unchanged:
-`<devroot>ART/<Name>_COV.png` and `<devroot>CFG/<Name>.cfg`. The Ember-specific fallback, peer of
-`vcdLoadPopsCover`, looks inside the game folder: `cover.png`, then `<Name>.png`.
+`<devroot>ART/<Name>_COV.png` and `<devroot>CFG/<Name>.cfg`. There is no Ember-specific art
+fallback. **One art location, ART/, for every game type; only the KEY differs** — a VCD keys on its
+filename, an Ember title on its folder name, an app on its filename, and a PS2 title is unchanged.
 
 Badges reuse `sbSetDiscAttributes(config, isPS1=1, isCD=1)` → `#System=PS1`, `#Media=CD`,
 `#DiscType=PS1CD`, so an Ember row looks right in every shipped theme on day one.
@@ -348,9 +349,9 @@ int cueFillGameList(const char *devPrefix, base_game_info_t **outGames);
 // length <= CUE_NAME_LAUNCH_MAX). Pure string work, no device access.
 int cueNameLaunchable(const char *name);
 
-// Cover fallback inside the game folder (cover.png, then <name>.png). Only called after the
-// device's own ART/ lookup misses, and only in the CUE view.
-int cueLoadFolderCover(const char *devPrefix, const char *value, const char *suffix, GSTEXTURE *tex);
+// NOTE: an earlier revision of this plan specified a cueLoadFolderCover() that searched inside the
+// game folder when the ART/ lookup missed. That was never asked for and has been removed: covers
+// come from ART/<name>_COV.png and nowhere else.
 ```
 
 `cueFillGameList` fills `base_game_info_t` per entry:

--- a/include/cuesupport.h
+++ b/include/cuesupport.h
@@ -184,10 +184,5 @@ int cueRenameGame(const char *devPrefix, const char *oldName, const char *newNam
 // games prefix, is the right home for them.
 int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames);
 
-// PS1 (Ember) cover FALLBACK inside the game's own folder: "<games>/<name>/cover.png", then
-// "<games>/<name>/<name>.png". Cover/icon suffixes only; a device getImage calls this ONLY after
-// its own <dev>ART/<name>_<suffix>.png misses, and only for a CUE row. The POPSTARTER peer is
-// vcdLoadPopsCover. Returns texDiscoverLoad's result (>= 0 hit, negative miss).
-int cueLoadFolderCover(const char *devPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex);
 
 #endif

--- a/include/vcdsupport.h
+++ b/include/vcdsupport.h
@@ -74,11 +74,6 @@ int vcdResolvePopstarter(const char *devPrefix, char *out, int outSize);
 // Build the POPSTARTER argv[0] selector "<devPrefix>POPS/<prefix><name>.ELF" into out.
 void vcdBuildSelector(const char *devPrefix, const char *prefix, const char *name, char *out, int outSize);
 
-// VCD (PS1) cover FALLBACK to the POPSLoader-style "<scanPrefix>POPS/<value>.png" (suffixless, next to
-// the .VCD). Cover/icon suffixes only; a device getImage calls this ONLY after its own <dev>ART/<name>_
-// <suffix>.png misses, and only in the VCD view. `scanPrefix` = the prefix passed to vcdFillGameList.
-// Returns texDiscoverLoad's result (>= 0 hit, negative miss).
-int vcdLoadPopsCover(const char *scanPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex);
 
 // ---- PS1 list display --------------------------------------------------------------
 // The view state itself lives in libview.h; ask libViewActive(mode) == LIB_VIEW_PS1. Note that one

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -2340,17 +2340,10 @@ static int bdmGetImage(item_list_t *itemList, char *folder, int isRelative, char
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_PS1)) {
-        char ps1Prefix[BDM_DEVICE_ROOT_MAX + 2];
-        bdmBuildPs1Prefix(ps1Prefix, sizeof(ps1Prefix), itemList->mode);
-        // The cache hands us a NAME, not the row, so resolve the kind against the published list
-        // (pure memory scan, no device IO on the art path). An unknown name falls back to the
-        // POPSTARTER layout, which is what every pre-Ember library is.
-        if (cueRowIsCueByName(pDeviceData->bdmPs1Games, pDeviceData->bdmPs1GameCount, value) == 1)
-            r = cueLoadFolderCover(ps1Prefix, value, suffix, resultTex);
-        else
-            r = vcdLoadPopsCover(ps1Prefix, value, suffix, resultTex);
-    }
+    // ART LIVES IN THE ART FOLDER, and nowhere else. A PS1 cover is
+    // ART/<name>_COV.png -- the same rule as a PS2 title -- which the texDiscoverLoad
+    // above already tried. A miss is simply "no cover": there is no second directory to
+    // search, which also means a missing cover costs one failed open instead of several.
     return r;
 }
 

--- a/src/cuesupport.c
+++ b/src/cuesupport.c
@@ -371,6 +371,7 @@ void cueApplyDisplaySetting(const char *devPrefix)
             if (fd >= 0) {
                 int back = write(fd, before, len);
                 close(fd);
+                (void)back; // read only by LOG, which compiles to nothing in a release build
                 LOG("[CUE] write failed on %s -- original %s\n", path,
                     (back == len) ? "restored" : "COULD NOT be restored");
                 return;
@@ -625,33 +626,4 @@ int ps1FillGameList(const char *devPrefix, base_game_info_t **outGames)
 
     *outGames = merged;
     return total;
-}
-
-int cueLoadFolderCover(const char *devPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex)
-{
-    char path[320];
-    char gamesDir[288];
-    int r;
-
-    // Cover/icon only, matching vcdLoadPopsCover: the other art suffixes have no in-folder
-    // convention and probing for them would be pure IO on the miss path.
-    if (devPrefix == NULL || value == NULL || suffix == NULL)
-        return ERR_BAD_FILE;
-    if (strcmp(suffix, "COV") != 0 && strcmp(suffix, "ICO") != 0)
-        return ERR_BAD_FILE;
-
-    cueBuildGamesDir(devPrefix, gamesDir, sizeof(gamesDir));
-    if (gamesDir[0] == '\0')
-        return ERR_BAD_FILE;
-
-    // "<games>/<name>/cover" first: one obvious filename a user can drop in without knowing the
-    // title's exact spelling. texDiscoverLoad appends the extension it supports.
-    snprintf(path, sizeof(path), "%s/%s/cover", gamesDir, value);
-    r = texDiscoverLoad(resultTex, path, -1);
-    if (r >= 0)
-        return r;
-
-    // Then "<games>/<name>/<name>", the POPSLoader-style suffixless peer of vcdLoadPopsCover.
-    snprintf(path, sizeof(path), "%s/%s/%s", gamesDir, value, value);
-    return texDiscoverLoad(resultTex, path, -1);
 }

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -1026,8 +1026,10 @@ static int ethGetImage(item_list_t *itemList, char *folder, int isRelative, char
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_PS1))
-        r = vcdLoadPopsCover(ethPrefix, value, suffix, resultTex);
+    // ART LIVES IN THE ART FOLDER, and nowhere else. A PS1 cover is
+    // ART/<name>_COV.png -- the same rule as a PS2 title -- which the texDiscoverLoad
+    // above already tried. A miss is simply "no cover": there is no second directory to
+    // search, which also means a missing cover costs one failed open instead of several.
     return r;
 }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -1223,18 +1223,10 @@ static config_set_t *mmceGetConfig(item_list_t *itemList, int id)
 static int mmceGetImage(item_list_t *itemList, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
     int r = mmceTryLoadImage(mmceArtPrimary, folder, isRelative, value, suffix, resultTex);
-    if (r == ERR_BAD_FILE && isRelative && (libViewActive(itemList->mode) == LIB_VIEW_PS1)) {
-        // This runs on the ART thread while the list scan runs on the IO worker, so the root goes in
-        // a LOCAL -- a shared buffer would be rewritten underneath one of them by the other.
-        char ps1Root[sizeof(mmcePrefix)];
-        mmceGetDeviceRoot(ps1Root, sizeof(ps1Root));
-        // The cache hands us a NAME, so resolve which core owns the row against the published list
-        // (memory scan, no card IO on the art path). Unknown falls back to the POPSTARTER layout.
-        if (cueRowIsCueByName(mmcePs1Games, mmcePs1GameCount, value) == 1)
-            r = cueLoadFolderCover(ps1Root, value, suffix, resultTex);
-        else
-            r = vcdLoadPopsCover(ps1Root, value, suffix, resultTex);
-    }
+    // ART LIVES IN THE ART FOLDER, and nowhere else. A PS1 cover is
+    // ART/<name>_COV.png -- the same rule as a PS2 title -- which the texDiscoverLoad
+    // above already tried. A miss is simply "no cover": there is no second directory to
+    // search, which also means a missing cover costs one failed open instead of several.
     return r;
 }
 

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -368,8 +368,10 @@ static int udpfsGetImage(item_list_t *itemList, char *folder, int isRelative, ch
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
     int r = texDiscoverLoad(resultTex, path, -1);
-    if (r == ERR_BAD_FILE && isRelative && (libListViewActive(itemList) == LIB_VIEW_PS1))
-        r = vcdLoadPopsCover(udpfsPrefix, value, suffix, resultTex);
+    // ART LIVES IN THE ART FOLDER, and nowhere else. A PS1 cover is
+    // ART/<name>_COV.png -- the same rule as a PS2 title -- which the texDiscoverLoad
+    // above already tried. A miss is simply "no cover": there is no second directory to
+    // search, which also means a missing cover costs one failed open instead of several.
     return r;
 }
 

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -784,29 +784,6 @@ int vcdRenameFile(const char *devPrefix, const char *oldName, const char *newNam
     return vcdRenameFileInDir(dirPath, oldName, newName);
 }
 
-// VCD (PS1) cover FALLBACK. OPL's own art (<dev>ART/<name>_COV.png) is the PRIMARY -- each device's
-// getImage tries it first; this only runs on a genuine miss. It loads the POPSLoader-style cover named
-// exactly like the .VCD (suffixless "<name>.png"), sitting NEXT TO the game in the same POPS/ folder the
-// VCD scan reads -- so a cover whose name matches the VCD minus the extension still shows (FifthFox, HW
-// 2026-07-16; the tier removed by 86da2023's #120 single-lookup simplification). `scanPrefix` MUST be the
-// SAME prefix the device passes to vcdFillGameList (the device root for BDM, mmcePrefix for MMCE, etc.),
-// so the cover is looked up beside the .VCD. COVER/ICON ONLY -- background/logo/screenshot must never
-// fall back to the single suffixless file or each would render the cover instead. Returns
-// texDiscoverLoad's result (>= 0 hit, negative miss). No miss-memo: kept deliberately simple -- callers
-// gate this on a genuine ERR_BAD_FILE + the VCD view, so a PS2 list and a hit never pay the extra probe.
-int vcdLoadPopsCover(const char *scanPrefix, const char *value, const char *suffix, GSTEXTURE *resultTex)
-{
-    char path[256];
-
-    if (scanPrefix == NULL || value == NULL || suffix == NULL || resultTex == NULL)
-        return ERR_BAD_FILE; // resultTex too: texDiscoverLoad dereferences it (CodeRabbit review of #203)
-    if (strcmp(suffix, "COV") != 0 && strcmp(suffix, "ICO") != 0)
-        return ERR_BAD_FILE; // only the cover/icon fall back to the suffixless POPS name
-
-    // Same directory the scan reads: "<scanPrefix>POPS<sep><value>"; texDiscoverLoad appends the extension.
-    snprintf(path, sizeof(path), "%s%s%c%s", scanPrefix, POPS_FOLDER, vcdSep(scanPrefix), value);
-    return texDiscoverLoad(resultTex, path, -1);
-}
 
 // Probe POPS/POPSTARTER.ELF on a device root given WITHOUT a trailing separator ("mass0", "mc0", "pfs0").
 // Tries "<root>:/POPS/..." then "<root>:POPS/..." and returns 1 with `out` filled on the first hit.


### PR DESCRIPTION
**ART IS IN THE ART FOLDER. NO SECOND ART LOCATIONS.**

The rule per type is only ever about the **key**, never about the place:

| Type | Art |
| --- | --- |
| PS2 | unchanged |
| VCD | `ART/<VCD filename>_COV.png` |
| Ember | `ART/<folder name>_COV.png` |
| APPS / ELF | `ART/<filename>_COV.png` |

Every support already builds exactly that one path, because `value` **is** the row name in each
case. The fallbacks below were not doing anything the primary lookup didn't already do correctly.

## What I removed, and why it's mine to remove

**`cueLoadFolderCover`** — searched `EMBER/games/<name>/cover.png`, then `<name>.png`. **I invented
this in [#546](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/546) and it shipped.** It was
never asked for. My own documentation says the folder name is simply the *key* for
`ART/<name>_COV.png` — I added an undocumented parallel path anyway, and was about to add a third
call site in [#562](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/562).

**`vcdLoadPopsCover`** — searched `POPS/<name>.png`, the POPSLoader arrangement. Older than the Ember
work, but it's the same mistake and falls under the same rule.

Gone from all five call sites — `bdmsupport`, `mmcesupport`, `ethsupport`, `udpfssupport` — plus both
loaders and their declarations. A missed cover is now simply *no cover*.

## This is also faster, by a number we already measured

A failed cover open costs **~4.3s on USB** against ~53ms for a hit, and the single FIFO art worker
means each one blocks every row behind it.

Each removed fallback was up to **two further guaranteed-miss opens** on any PS1 row without a cover.
Worse, for an Ember row the POPS fallback could *never* hit — it searched `POPS/` for a name that only
exists under `EMBER/games/`. That was a guaranteed ~4.3s stall per uncovered Ember title.

## Also in here

- Fixes an unused-variable warning in `cueApplyDisplaySetting`'s restore path (`back` is read only by
  `LOG`, which compiles away in release builds).
- Corrects the three places in `docs/EMBER-INTEGRATION-PLAN.md` that specified the invented fallback,
  so the plan states the one-location rule.

Both flavours build clean; clang-format clean.

> [#562](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/562) still contains the third call
> site. It needs updating on top of this — I'll do that once this lands, or fold it in, whichever you
> prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
