### PR TITLE
docs: credit Akilluminati47 for the RiptOPL name

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -104,6 +104,14 @@ Testing, bug reports and real-hardware feedback
 by eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz, nuno6573, Blade1984
 and zackcage6
 
+The RiptOPL name
+by Akilluminati47 (https://github.com/akilluminati47)
+who coined it before the project existed
+
+The RiptOPL name
+by Akilluminati47 (https://github.com/akilluminati47)
+who coined it before the project existed
+
 Financial support
 by Akilluminati47
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,18 @@ Enormous thanks to the testers who run every rolling build on real consoles and 
 reports that shape the fixes — **eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz,
 nuno6573, zackcage6 and Blade1984**.
 
+### The name (this fork)
+
+**RiptOPL is named by [Akilluminati47](https://github.com/akilluminati47)** — he came up with it
+before the project existed, and it stuck. Every release, every build, every thread carries a name
+he thought of first.
+
+### The name (this fork)
+
+**RiptOPL is named by [Akilluminati47](https://github.com/akilluminati47)** — he came up with it
+before the project existed, and it stuck. Every release, every build, every thread carries a name
+he thought of first.
+
 ### Financial support (this fork)
 
 Heartfelt thanks to **Akilluminati47** for generously **funding this fork's development** — a


### PR DESCRIPTION
**Akilluminati47 came up with the name RiptOPL** — before the project started.

It's on every release, every build, every thread and every artifact we've ever published. That's exactly the kind of contribution that's easy to forget precisely *because* it's on everything.

Added to `CREDITS` and to the README acknowledgements, beside the funding credit he already had — with a link to [his GitHub](https://github.com/akilluminati47).

The docs-site half is a separate PR against `gh-pages`; while adding it I found the site was missing his **funding** credit entirely, which both `CREDITS` and the README already carried. Both now sit together there in a new *The Name* section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README section explaining the origin of the RiptOPL name.
  * Added acknowledgment credits for the name’s contributor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->