### PR TITLE
feat(hdd): Ember on the internal APA/PFS drive

### DIFF
--- a/.github/rolling-release-notes-block.md
+++ b/.github/rolling-release-notes-block.md
@@ -74,18 +74,16 @@ writable media. Available on USB, MX4SIO, iLink, exFAT-ATA, MMCE, SMB and the in
 hard drive.
 
 **On an internal APA/PFS drive** there is no filesystem root to copy to, so the `EMBER/` folder goes
-on a partition. Both of these are scanned, and titles from both are listed together:
+on a partition of its own — **`__.EMBER`**, or `__.EMBER0` … `__.EMBER9` for more than one. Same
+naming shape as the `__.POPS` containers that hold your `.VCD` files.
 
-| Partition | Use it when |
-| --- | --- |
-| `__common` | Simplest — the shared partition POPSTARTER already lives on. Fine for a small library. |
-| `__.EMBER`, `__.EMBER0` … `__.EMBER9` | A partition you create for the job. Same naming shape as the `__.POPS` containers, and the right choice for a real library. |
+The partition is self-contained: `EMBER/ember.elf`, `EMBER/bios.bin` and `EMBER/games/<Game Name>/`
+all start at its root. Cover art does **not** go here — `ART/<Game Name>_COV.png` stays on your OPL
+data partition, exactly as for a `.VCD`.
 
-The layout inside is the one above, starting at the partition root: `EMBER/ember.elf`,
-`EMBER/bios.bin`, `EMBER/games/<Game Name>/`. Cover art is unchanged — `ART/<Game Name>_COV.png` on
-your OPL data partition. An APA title launches with its partition **still mounted read/write**:
-Ember inherits that live mount rather than re-opening the drive, and writes its memory cards and
-`settings.txt` straight through it.
+An APA title launches with its partition **still mounted read/write**: Ember inherits that live mount
+rather than re-opening the drive, and writes its memory cards and `settings.txt` straight through
+it.
 
 **Display mode.** *Settings → PS Emulation Settings → Ember Display Mode* (Default / 240p / 480p).
 Ember's `settings.txt` is optional and stays that way: **240p** or **480p** writes the key to

--- a/.github/rolling-release-notes-block.md
+++ b/.github/rolling-release-notes-block.md
@@ -70,7 +70,22 @@ The **folder name** is what you see in the list, and it is the key for cover art
 settings — so `ART/Spyro 2 (Ripto's Rage)_COV.png` on that device just works, exactly as for a
 `.VCD`. Files inside can be named anything; `.cue` is preferred over `.exe` over `.bin`. Ember
 writes its per-game memory cards (`MC1.vmc`, `MC2.vmc`) into that game folder, so it must be on
-writable media.
+writable media. Available on USB, MX4SIO, iLink, exFAT-ATA, MMCE, SMB and the internal APA/PFS
+hard drive.
+
+**On an internal APA/PFS drive** there is no filesystem root to copy to, so the `EMBER/` folder goes
+on a partition. Both of these are scanned, and titles from both are listed together:
+
+| Partition | Use it when |
+| --- | --- |
+| `__common` | Simplest — the shared partition POPSTARTER already lives on. Fine for a small library. |
+| `__.EMBER`, `__.EMBER0` … `__.EMBER9` | A partition you create for the job. Same naming shape as the `__.POPS` containers, and the right choice for a real library. |
+
+The layout inside is the one above, starting at the partition root: `EMBER/ember.elf`,
+`EMBER/bios.bin`, `EMBER/games/<Game Name>/`. Cover art is unchanged — `ART/<Game Name>_COV.png` on
+your OPL data partition. An APA title launches with its partition **still mounted read/write**:
+Ember inherits that live mount rather than re-opening the drive, and writes its memory cards and
+`settings.txt` straight through it.
 
 **Display mode.** *Settings → PS Emulation Settings → Ember Display Mode* (Default / 240p / 480p).
 Ember's `settings.txt` is optional and stays that way: **240p** or **480p** writes the key to

--- a/README.md
+++ b/README.md
@@ -224,18 +224,26 @@ This build layers several features on top of upstream OPL:
   APA/PFS hard drive.
 
   **On an internal APA/PFS drive**, where there is no filesystem root to copy a folder to, the
-  `EMBER/` folder goes on a partition instead. RiptOPL looks in two places and lists whatever it
-  finds in both:
+  `EMBER/` folder goes on a partition of its own: **`__.EMBER`**, or `__.EMBER0` … `__.EMBER9` if you
+  want more than one. That is deliberately the same naming shape as the `__.POPS` containers that
+  hold your `.VCD` files, so there is only one convention to remember.
 
-  - **`__common`** — the shared partition POPSTARTER already lives on. Simplest option, and the one
-    to use if your library is small enough to fit beside everything else that partition holds.
-  - **`__.EMBER`** (or `__.EMBER0` … `__.EMBER9`) — a partition you create for the purpose. Deliberately
-    the same naming shape as the `__.POPS` containers, and the right choice for a real library, since
-    PS1 disc images are large and `__common` usually is not.
+  The partition is self-contained — the layout inside it is exactly the one above, starting at the
+  partition root:
 
-  Inside the partition the layout is exactly the one above, starting at the partition root:
-  `EMBER/ember.elf`, `EMBER/bios.bin`, `EMBER/games/<Game Name>/`. Cover art is unchanged too —
-  `ART/<Game Name>_COV.png` on your OPL data partition, the same key a `.VCD` uses.
+  ```
+  hdd0:__.EMBER
+      EMBER/
+          ember.elf
+          bios.bin                   <- yours, 512 KB
+          games/
+              Spyro 2 (Ripto's Rage)/
+                  whatever.cue
+                  whatever.bin
+  ```
+
+  Cover art is unchanged and does **not** go here — `ART/<Game Name>_COV.png` on your OPL data
+  partition, the same place and the same key a `.VCD` uses.
 
   One difference is worth knowing about, because it is the reason this works at all: an APA Ember
   title is launched with its partition **still mounted**. Ember inherits that live mount instead of

--- a/README.md
+++ b/README.md
@@ -220,7 +220,27 @@ This build layers several features on top of upstream OPL:
   settings — so `ART/Spyro 2 (Ripto's Rage)_COV.png` on that device just works, exactly as it does
   for a `.VCD`. Files inside can be named anything; `.cue` is preferred over `.exe` over `.bin`.
   Ember writes its per-game memory cards (`MC1.vmc`, `MC2.vmc`) into that same folder, so it must be
-  on writable media. Currently available on USB, MX4SIO, iLink, exFAT-ATA and MMCE.
+  on writable media. Available on USB, MX4SIO, iLink, exFAT-ATA, MMCE, SMB and the internal
+  APA/PFS hard drive.
+
+  **On an internal APA/PFS drive**, where there is no filesystem root to copy a folder to, the
+  `EMBER/` folder goes on a partition instead. RiptOPL looks in two places and lists whatever it
+  finds in both:
+
+  - **`__common`** — the shared partition POPSTARTER already lives on. Simplest option, and the one
+    to use if your library is small enough to fit beside everything else that partition holds.
+  - **`__.EMBER`** (or `__.EMBER0` … `__.EMBER9`) — a partition you create for the purpose. Deliberately
+    the same naming shape as the `__.POPS` containers, and the right choice for a real library, since
+    PS1 disc images are large and `__common` usually is not.
+
+  Inside the partition the layout is exactly the one above, starting at the partition root:
+  `EMBER/ember.elf`, `EMBER/bios.bin`, `EMBER/games/<Game Name>/`. Cover art is unchanged too —
+  `ART/<Game Name>_COV.png` on your OPL data partition, the same key a `.VCD` uses.
+
+  One difference is worth knowing about, because it is the reason this works at all: an APA Ember
+  title is launched with its partition **still mounted**. Ember inherits that live mount instead of
+  re-opening the drive for itself, which is also why the partition is mounted read/write — Ember's
+  memory cards and `settings.txt` are written straight through it.
 
   **Credit and licence — Ember is created by [Gageformer](https://github.com/Gageformer), and its
   official release page is <https://github.com/Gageformer/Ember/releases>.** Ember is an

--- a/docs/EMBER-INTEGRATION-PLAN.md
+++ b/docs/EMBER-INTEGRATION-PLAN.md
@@ -16,8 +16,9 @@ agent should read.
 | Phase 0 — prove the handoff | **code landed, HARDWARE PENDING** | `sysLaunchEmber()` + `cuesupport.c` + an OPLDIAG-only interception in `appLaunchItem`. See "How to run the Phase 0 test" below. |
 | Phase 1 — view engine | **landed** | `libview.c/.h` own the ring; the binary `vcdView` API is deleted, not shadowed. Both audit gates pass. |
 | One PS1 list, both cores | **landed** | `ps1FillGameList()`; row-kind dispatch for launch and art. Wired for **BDM and MMCE**. |
-| SMB / ETH | **deliberately POPSTARTER-only** | Risk R4 (RiptOPL uses `\`, Ember uses `/`) is untested. One line to flip once proven; the reason is in the code. |
-| APA-HDD, UDPFS | not started | HDD needs its own layout decision (APA has no filesystem root — `POPS` lives on `__common`). |
+| SMB / ETH | **landed** | R4 resolved: the Ember helpers build paths with `cueSep()`, so the separator follows the device. |
+| APA-HDD | **landed, HARDWARE PENDING** | `__.EMBER[0-9]?` partitions, self-contained. Needed a new `KEEPIOP_EXCEPTION` — see below. |
+| UDPFS | not started | |
 | Favourites (OFAV v3 `kind`) | not started | A CUE favourite currently has no way to record which core it belongs to. |
 | Ember settings page / `ember_folder` | not started | Nothing is required for basic operation — the list is driven by what is on disk, exactly like `POPS`. |
 
@@ -227,9 +228,26 @@ read reports success — never block a launch on a failed probe.
 | --- | --- |
 | USB / MX4SIO / iLink / exFAT-ATA (BDM) | `massN:/` — the device **root**, not `gBDMPrefix` |
 | MMCE | `mmceN:/` |
-| SMB / ETH | the share root — **POPSTARTER-only for now**, see R4 |
-| APA / PFS HDD | needs its own decision: APA has no filesystem root, and `POPS` lives on `__common` |
+| SMB / ETH | the share root |
+| APA / PFS HDD | `hdd0:__.EMBER[0-9]?` — a partition of its own, mounted on `pfs0:` and **kept mounted** across the handoff. Self-contained: `EMBER/ember.elf`, `EMBER/bios.bin` and `EMBER/games/` all start at the partition root. |
 | UDPBD / UDPFS | not enabled |
+
+#### ⛔ `__common` is NOT a library location — say what actually lives there
+
+An earlier draft of this document said *"`POPS` lives on `__common`"*, and that sentence is
+ambiguous enough to have produced a real bug: the first version of the APA implementation scanned
+`__common` for `EMBER/games/` on exactly that reasoning.
+
+Precisely:
+
+| Partition | Holds |
+| --- | --- |
+| `__common` | `POPS/POPSTARTER.ELF` — the **loader binary**, which `hddResolveHddPopstarter` mounts and loads. Also the OPL **data** home (`__common/OPL/ART/`, config) when `+OPL` is not in use. |
+| `__.POPS`, `__.POPS0`…`9`, `PP.*.POPS.*` | The **`.VCD` games**. This is the only place POPS titles come from. |
+| `__.EMBER`, `__.EMBER0`…`9` | The **Ember install and its games**, self-contained. |
+
+The rule generalises: one location per kind of thing. A second place being mountable is not a reason
+to look in it.
 
 ### Art and per-game config
 
@@ -781,9 +799,19 @@ config keys, the language labels appended to `_base.yml`, `docs/EMBER.md`.
 
 ### Phase 4 — Favourites v3 + APA HDD
 
-OFAV v3 with the `kind` byte and the v2 migration, and the Favourites ring PS2 → PS1 → APPS (Part 2);
-`hddsupport.c` (`pfs0:/EMBER/`). There is no merged-list setting — merging is the behaviour, see
-Part 4.
+OFAV v3 with the `kind` byte and the v2 migration, and the Favourites ring PS2 → PS1 → APPS (Part 2).
+There is no merged-list setting — merging is the behaviour, see Part 4.
+
+**APA HDD: landed.** `hddBuildVcdGameList` grows a second phase that mounts each `__.EMBER[0-9]?`
+partition on the `pfs1:` scan slot and hands it to `cueScanDir`; rows join the existing VCD arrays
+and are told apart by their `.CUE` extension. `hddDoLaunchEmber` quiesces art, remounts `pfs0:` on
+the owning partition **RDWR**, and hands off with that mount live.
+
+That last part needed a new teardown bit. `UNMOUNT_EXCEPTION` stops the `pfs0:` unmount, but
+`hddCleanUp` also issues `PDIOC_CLOSEALL`, which drops every pfs descriptor in the IOP — safe under
+its stated assumption that *"every path that reaches here hands off to an ELF that resets the IOP"*,
+which Ember is the first launch to break. `KEEPIOP_EXCEPTION` (`include/iosupport.h`, `0x02`) now
+gates that call.
 
 Validate the migration explicitly: take a v2 `favourites.bin` holding ISO, VCD **and** app
 favourites, confirm all three land on the right shelf after the upgrade, **and that a v3 file still

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -87,9 +87,11 @@ int hddIsPopsPartitionGame(const char *name);
 // list; returns the count, 0 on a complete walk with none, or a negative error for an incomplete walk.
 // Free via hddFreePopsPartitionList.
 int hddGetPopsPartitionList(hdd_pops_list_t *list);
-// Enumerate the APA/PFS partitions that may hold an Ember install: __.EMBER[0-9]? and __common.
-// Same walk, same return contract and the same hddFreePopsPartitionList as the POPS list above --
-// the list type is a plain name array, not a POPS-specific one.
+// Enumerate the APA/PFS partitions that may hold an Ember install: __.EMBER[0-9]? and nothing else.
+// NOT __common -- that is the OPL data home and the partition POPSTARTER.ELF is loaded from, not a
+// place any PS1 library lives. Same walk, same return contract and the same
+// hddFreePopsPartitionList as the POPS list above -- the list type is a plain name array, not a
+// POPS-specific one.
 int hddGetEmberPartitionList(hdd_pops_list_t *list);
 void hddFreePopsPartitionList(hdd_pops_list_t *list);
 int hddSetHDLGameInfo(hdl_game_info_t *ginfo);

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -87,6 +87,10 @@ int hddIsPopsPartitionGame(const char *name);
 // list; returns the count, 0 on a complete walk with none, or a negative error for an incomplete walk.
 // Free via hddFreePopsPartitionList.
 int hddGetPopsPartitionList(hdd_pops_list_t *list);
+// Enumerate the APA/PFS partitions that may hold an Ember install: __.EMBER[0-9]? and __common.
+// Same walk, same return contract and the same hddFreePopsPartitionList as the POPS list above --
+// the list type is a plain name array, not a POPS-specific one.
+int hddGetEmberPartitionList(hdd_pops_list_t *list);
 void hddFreePopsPartitionList(hdd_pops_list_t *list);
 int hddSetHDLGameInfo(hdl_game_info_t *ginfo);
 int hddDeleteHDLGame(hdl_game_info_t *ginfo);

--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -64,6 +64,14 @@ enum ERROR_CODE {
 
 #define NO_EXCEPTION      0x00
 #define UNMOUNT_EXCEPTION 0x01
+// The child ELF keeps the IOP: it inherits the live modules, mounts and file descriptors instead of
+// resetting them away. Set by the Ember launch paths, which hand off through sysLoadELFKeepIOP.
+//
+// UNMOUNT_EXCEPTION alone is not enough on APA. It stops the pfs0: UNMOUNT, but hddCleanUp also
+// issues PDIOC_CLOSEALL, which drops every pfs descriptor in the IOP -- fine when the next thing to
+// run resets the IOP anyway, fatal when it does not. A driver only OPL knows about is still the
+// driver Ember has to read its game through.
+#define KEEPIOP_EXCEPTION 0x02
 
 #define MODE_FLAG_NO_COMPAT  0x01 // no compat support
 #define MODE_FLAG_COMPAT_DMA 0x02 // Supports DMA compat flags

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -298,21 +298,17 @@ static int hddIsPopsContainerName(const char *name)
     return name[7] == '\0' || (name[7] >= '0' && name[7] <= '9' && name[8] == '\0');
 }
 
-// __.EMBER / __.EMBER0..9, plus the shared __common partition. Deliberately the same shape as the
-// __.POPS[0-9]? containers above, so a user who already understands where their PS1 library lives on
-// an APA drive does not have to learn a second convention.
+// __.EMBER / __.EMBER0..9 -- ONE library location, deliberately the same shape as the __.POPS[0-9]?
+// containers above, so a user who already knows where their PS1 library lives on an APA drive does
+// not have to learn a second convention.
 //
-// __common earns its place because POPSTARTER already lives there (hddResolveHddPopstarter mounts
-// it), so a drive that runs PS1 at all usually has one; a dedicated __.EMBER is for libraries too
-// big to sit in it. Both are scanned, and a partition with no EMBER folder costs one mount and one
-// open() before it is dropped -- cueScanDir gates itself on the core being readable.
+// NOT __common. That partition is the OPL DATA home (ART, config) and the place POPSTARTER.ELF is
+// loaded FROM by hddResolveHddPopstarter -- it is not where POPS keeps its games, and it is not
+// where Ember keeps its games either. An __.EMBER partition is self-contained: ember.elf, bios.bin
+// and games/ all sit at its root, so one mount serves the core and the library both.
 static int hddIsEmberContainerName(const char *name)
 {
-    if (name == NULL)
-        return 0;
-    if (strcmp(name, "__common") == 0)
-        return 1;
-    if (strncmp(name, "__.EMBER", 8) != 0)
+    if (name == NULL || strncmp(name, "__.EMBER", 8) != 0)
         return 0;
     return name[8] == '\0' || (name[8] >= '0' && name[8] <= '9' && name[9] == '\0');
 }

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -298,6 +298,25 @@ static int hddIsPopsContainerName(const char *name)
     return name[7] == '\0' || (name[7] >= '0' && name[7] <= '9' && name[8] == '\0');
 }
 
+// __.EMBER / __.EMBER0..9, plus the shared __common partition. Deliberately the same shape as the
+// __.POPS[0-9]? containers above, so a user who already understands where their PS1 library lives on
+// an APA drive does not have to learn a second convention.
+//
+// __common earns its place because POPSTARTER already lives there (hddResolveHddPopstarter mounts
+// it), so a drive that runs PS1 at all usually has one; a dedicated __.EMBER is for libraries too
+// big to sit in it. Both are scanned, and a partition with no EMBER folder costs one mount and one
+// open() before it is dropped -- cueScanDir gates itself on the core being readable.
+static int hddIsEmberContainerName(const char *name)
+{
+    if (name == NULL)
+        return 0;
+    if (strcmp(name, "__common") == 0)
+        return 1;
+    if (strncmp(name, "__.EMBER", 8) != 0)
+        return 0;
+    return name[8] == '\0' || (name[8] >= '0' && name[8] <= '9' && name[9] == '\0');
+}
+
 int hddIsPopsPartitionGame(const char *name)
 {
     if (name == NULL)
@@ -310,10 +329,20 @@ int hddIsPopsPartitionGame(const char *name)
 }
 
 // Enumerate the HDD's PS1/VCD APA partitions: exact __.POPS / __.POPS0..9 multi-VCD containers and
+// The candidate test the POPS walk has always applied, unchanged, now named so the shared walk
+// below can take it as a parameter.
+static int hddIsPopsCandidateName(const char *name)
+{
+    return hddIsPopsContainerName(name) || hddIsPopsPartitionGame(name);
+}
+
 // PP.<name> / __.<name> one-game installs. Mirror POPSLoader's APA-table filter: only main PFS records
 // can be mounted and scanned. In particular, ordinary HDL games also commonly use PP.* labels but have
 // mode 0x1337; filtering them here avoids a failed PFS mount for every PS2 game during a VCD refresh.
-int hddGetPopsPartitionList(hdd_pops_list_t *list)
+//
+// ONE walk, two callers: the dedupe, the grow-on-demand array, the refusal to publish a partial walk
+// and the sort are all the POPS enumerator's own body. Only the name test is passed in.
+static int hddCollectPartitions(hdd_pops_list_t *list, int (*keep)(const char *))
 {
     iox_dirent_t dirent;
     int fd, i, count = 0, readResult = 0, ret = 0;
@@ -329,8 +358,8 @@ int hddGetPopsPartitionList(hdd_pops_list_t *list)
     while ((readResult = fileXioDread(fd, &dirent)) > 0) {
         if (dirent.stat.attr != HDD_APA_ATTR_MAIN_PARTITION || dirent.stat.mode != HDD_APA_FS_TYPE_PFS)
             continue; // skip APA sub-partitions and HDL/raw/system formats
-        if (!hddIsPopsContainerName(dirent.name) && !hddIsPopsPartitionGame(dirent.name))
-            continue; // not an HDD-resident PS1/VCD source
+        if (!keep(dirent.name))
+            continue; // not a PS1 source of the kind this caller is enumerating
 
         int dup = 0;
         for (i = 0; i < count; i++) {
@@ -363,7 +392,7 @@ int hddGetPopsPartitionList(hdd_pops_list_t *list)
 
     if (count == 0) {
         free(names);
-        return 0; // successful enumeration, no POPS candidates
+        return 0; // successful enumeration, no candidates of the requested kind
     }
 
     qsort(names, count, sizeof(*names), hddPopsNameCompare);
@@ -371,6 +400,18 @@ int hddGetPopsPartitionList(hdd_pops_list_t *list)
     list->names = names;
     list->count = count;
     return count;
+}
+
+//-------------------------------------------------------------------------
+int hddGetPopsPartitionList(hdd_pops_list_t *list)
+{
+    return hddCollectPartitions(list, hddIsPopsCandidateName);
+}
+
+//-------------------------------------------------------------------------
+int hddGetEmberPartitionList(hdd_pops_list_t *list)
+{
+    return hddCollectPartitions(list, hddIsEmberContainerName);
 }
 
 //-------------------------------------------------------------------------

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -4,6 +4,7 @@
 #include "include/gui.h"
 #include "include/supportbase.h"
 #include "include/hddsupport.h"
+#include "include/cuesupport.h" // Ember rows share the HDD PS1 list with the VCD ones
 #include "include/vcdsupport.h" // HDD VCD view: vcdScanDirRoot + vcd_entry_t
 #include "include/libview.h"    // libViewActive / libListViewActive -- which list this page shows
 #include "include/util.h"
@@ -1010,6 +1011,97 @@ static int hddBuildVcdGameList(void)
     }
 
     hddFreePopsPartitionList(&parts);
+
+    // ---- second phase: EMBER --------------------------------------------------------------------
+    // ONE list, BOTH cores -- the APA restatement of what ps1FillGameList does for every other
+    // device. The rows land in the SAME arrays, so the PS1 view, Favourites resolution, art lookup
+    // and the sort all keep working with no idea that two different emulators are involved. What
+    // tells them apart is the row's extension, exactly as on USB and SMB.
+    hdd_pops_list_t emberParts;
+    int emberCount = hddGetEmberPartitionList(&emberParts);
+    if (emberCount < 0) {
+        // A failed walk is not an empty Ember library, and it must not blank the VCD rows already
+        // collected above either. Mark the refresh incomplete and let the transaction below decide.
+        LOG("HDD EMBER: APA partition enumeration failed (%d)\n", emberCount);
+        scanIncomplete = 1;
+    } else {
+        for (int p = 0; p < emberParts.count; p++) {
+            char mountSrc[64];
+            snprintf(mountSrc, sizeof(mountSrc), "hdd0:%s", emberParts.names[p]);
+
+            if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDONLY) < 0) {
+                scanIncomplete = 1;
+                continue;
+            }
+
+            // cueScanDir gates itself on open()ing the core, so a partition with no EMBER folder
+            // costs this mount plus one failed open and returns 0. That is what makes it safe to
+            // scan __common unconditionally: the usual drive pays almost nothing for the attempt.
+            cue_entry_t *cues = NULL;
+            int n = cueScanDir("pfs1:/", &cues);
+            fileXioUmount("pfs1:");
+            if (n < 0) {
+                free(cues);
+                scanIncomplete = 1;
+                continue;
+            }
+            if (n == 0) {
+                free(cues);
+                continue;
+            }
+
+            base_game_info_t *grownGames = realloc(newGames, (total + n) * sizeof(base_game_info_t));
+            if (grownGames == NULL) {
+                free(cues);
+                scanIncomplete = 1;
+                break;
+            }
+            newGames = grownGames;
+            char(*grownParts)[APA_IDMAX + 1] = realloc(newParts, (total + n) * sizeof(*newParts));
+            if (grownParts == NULL) {
+                free(cues);
+                scanIncomplete = 1;
+                break;
+            }
+            newParts = grownParts;
+
+            int kept = 0;
+            for (int i = 0; i < n; i++) {
+                // Names are resolved back to a partition by hddFindVcdByName, which matches on name
+                // alone. An Ember folder that collides with a VCD title (or with an Ember folder on
+                // another partition) would otherwise always launch whichever came first, so drop
+                // the duplicate rather than list a row that launches someone else's game.
+                int taken = 0;
+                for (int j = 0; j < total + kept; j++) {
+                    if (strcmp(newGames[j].name, cues[i].name) == 0) {
+                        taken = 1;
+                        break;
+                    }
+                }
+                if (taken) {
+                    LOG("HDD EMBER: '%s' on %s shadowed by an earlier row; skipped\n", cues[i].name, emberParts.names[p]);
+                    continue;
+                }
+
+                base_game_info_t *g = &newGames[total + kept];
+                memset(g, 0, sizeof(base_game_info_t));
+                // IDENTITY IS THE FOLDER NAME, unchanged: it is Ember's launch argument, and art,
+                // per-game config and Favourites all key off it. ART/<folder name>_COV.png resolves
+                // through the ordinary hddGetImage path with no special case.
+                snprintf(g->name, sizeof(g->name), "%s", cues[i].name);
+                snprintf(g->startup, sizeof(g->startup), "%s", cues[i].name);
+                snprintf(g->extension, sizeof(g->extension), "%s", CUE_ROW_EXTENSION);
+                g->parts = 1;
+                g->format = GAME_FORMAT_ISO; // harmless; the row's extension gates the launch path
+                snprintf(newParts[total + kept], APA_IDMAX + 1, "%s", emberParts.names[p]);
+                kept++;
+            }
+            free(cues);
+            total += kept;
+        }
+        hddFreePopsPartitionList(&emberParts);
+    }
+
     fileXioUmount("pfs1:");
 
     // If a refresh could not inspect every candidate, a non-empty last-good list has more authority
@@ -1483,7 +1575,7 @@ static void hddRenameVcd(int id, const char *newName)
 {
     char oldName[VCD_NAME_MAX];
     char part[APA_IDMAX + 1];
-    int renamed = 0;
+    int renamed = 0, isEmber = 0;
 
     // The list builder owns pfs1: and the backing arrays on the IO worker. Block it before copying
     // the selected storage identity and before temporarily mounting a pooled POPS partition RW.
@@ -1491,8 +1583,20 @@ static void hddRenameVcd(int id, const char *newName)
     if (hddVcdGames != NULL && hddVcdParts != NULL && id >= 0 && id < hddVcdGameCount) {
         snprintf(oldName, sizeof(oldName), "%s", hddVcdGames[id].name);
         snprintf(part, sizeof(part), "%s", hddVcdParts[id]);
+        isEmber = cueIsCueEntry(&hddVcdGames[id]);
 
-        if (vcdPopsPartitionTitleOffset(part) > 0) {
+        if (isEmber) {
+            // An Ember title IS its folder, on the partition the scan recorded. Mount that partition
+            // RW on the scan slot, exactly as the pooled-VCD branch below does for a loose file.
+            char mountSrc[APA_IDMAX + 6];
+
+            snprintf(mountSrc, sizeof(mountSrc), "hdd0:%s", part);
+            fileXioUmount("pfs1:");
+            if (fileXioMount("pfs1:", mountSrc, FIO_MT_RDWR) == 0) {
+                renamed = (cueRenameGame("pfs1:/", oldName, newName) == 0);
+                fileXioUmount("pfs1:");
+            }
+        } else if (vcdPopsPartitionTitleOffset(part) > 0) {
             // One-game PP.* POPS installs boot from their partition label, so a file rename would
             // change nothing. Rename the APA record while retaining its required prefix instead.
             renamed = (hddRenamePopsPartition(part, newName) == 0);
@@ -1541,6 +1645,19 @@ static int hddFindVcdByName(const char *vcdName)
     return -1;
 }
 
+// Put pfs0: back on the OPL data partition after a launch attempt borrowed the slot. A list-only
+// APA session may legitimately have no persistent data home, in which case there is nothing truthful
+// to remount and an empty gOPLPart must never be passed to fileXioMount.
+static void hddRestoreDataHome(void)
+{
+    fileXioUmount(hddPrefix);
+    if (gOPLPart[0] != '\0' && fileXioMount(hddPrefix, gOPLPart, FIO_MT_RDWR) < 0) {
+        // Never leave a non-NULL prefix advertising an unmounted pfs0:.
+        gHDDPrefix = NULL;
+        gOPLPart[0] = '\0';
+    }
+}
+
 // Resolve POPSTARTER.ELF for an HDD VCD launch from hdd0:__common/POPS/ only. APA VCD data can live
 // in its normal __.POPS / PP.* partitions and OPL data can be redirected elsewhere, but loose
 // POPS/POPSTARTER support payloads are always owned by __common. On success returns 1 with
@@ -1561,17 +1678,86 @@ static int hddResolveHddPopstarter(char *elfOut, int elfLen)
         }
     }
 
-    // Not found: restore the default OPL data-partition mount when one exists. A list-only
-    // APA session may legitimately have no persistent data home, in which case there is nothing
-    // truthful to remount and an empty gOPLPart must never be passed to fileXioMount.
-    fileXioUmount(hddPrefix);
-    if (gOPLPart[0] != '\0' && fileXioMount(hddPrefix, gOPLPart, FIO_MT_RDWR) < 0) {
-        // The restore mount is part of the persistent-home invariant. Never leave a non-NULL
-        // prefix advertising an unmounted pfs0: after POPSTARTER discovery borrowed the slot.
-        gHDDPrefix = NULL;
-        gOPLPart[0] = '\0';
-    }
+    // Not found: restore the default OPL data-partition mount. The restore is part of the
+    // persistent-home invariant -- never leave a non-NULL prefix advertising an unmounted pfs0:
+    // after POPSTARTER discovery borrowed the slot.
+    hddRestoreDataHome();
     return 0;
+}
+
+// Hand an APA/PFS Ember title off with pfs0: STILL MOUNTED on the partition that holds it.
+//
+// This is the one launch in OPL where the mount is not a means of finding an ELF but the thing the
+// child actually runs on: Ember does not reset the IOP (sysLoadELFKeepIOP), so the ps2fs driver, the
+// pfs0: mount and the descriptors under it are all inherited live, and every read Ember makes from
+// here on goes through them. Both the core and the game data are on this one partition, which is why
+// a single mount is enough where POPSTARTER needs a partition passed out of band.
+//
+// Three consequences, all load-bearing:
+//   RDWR, not RDONLY. Ember writes memory cards and settings.txt through this mount. The POPSTARTER
+//   resolver mounts read-only because its mount dies at the IOP reset moments later; this one has to
+//   survive and stay writable.
+//   UNMOUNT_EXCEPTION keeps hddCleanUp from unmounting pfs0:.
+//   KEEPIOP_EXCEPTION keeps it from issuing PDIOC_CLOSEALL, which would drop every pfs descriptor in
+//   the IOP -- harmless before an IOP reset, fatal before a handoff that does not reset.
+static void hddDoLaunchEmber(item_list_t *itemList, const char *name, const char *part)
+{
+    char emberElf[256], biosPath[288], mountSrc[APA_IDMAX + 6];
+
+    if (name == NULL || name[0] == '\0' || part == NULL || part[0] == '\0')
+        return;
+
+    // Refuse what Ember itself would refuse, while a dialog can still be drawn and before anything
+    // has been torn down. Same order as every other device's Ember leg.
+    if (!cueNameLaunchable(name)) {
+        guiMsgBox(_l(_STR_EMBER_BAD_NAME), 0, NULL);
+        return;
+    }
+
+    // There is exactly ONE pfs0: slot and the remount below is destructive to any HDD art read still
+    // in flight, so quiesce first -- the same discipline, and the same reason, as the VCD leg.
+    cacheAbortMmceImageLoadsTimed(HDD_ART_QUIESCE_MS);
+    if (!cacheCancelPendingImageLoadsTimed(HDD_ART_QUIESCE_MS)) {
+        LOG("HDD EMBER: art did not quiesce; refusing the pfs0: remount\n");
+        guiMsgBox(_l(_STR_PLEASE_WAIT), 0, NULL);
+        return;
+    }
+    ioBlockOps(1);
+
+    snprintf(mountSrc, sizeof(mountSrc), "hdd0:%s", part);
+    fileXioUmount(hddPrefix);
+    if (fileXioMount(hddPrefix, mountSrc, FIO_MT_RDWR) < 0) {
+        hddRestoreDataHome();
+        ioBlockOps(0);
+        guiMsgBox(_l(_STR_EMBER_NOT_FOUND), 0, NULL);
+        return;
+    }
+
+    // Verify against the partition as it is mounted RIGHT NOW, not against what the scan saw: the
+    // scan read this partition read-only through pfs1: and may be minutes old.
+    if (!cueResolveEmber("pfs0:/", emberElf, sizeof(emberElf))) {
+        hddRestoreDataHome();
+        ioBlockOps(0);
+        guiMsgBox(_l(_STR_EMBER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    if (!cueResolveEmberBios("pfs0:/", biosPath, sizeof(biosPath))) {
+        hddRestoreDataHome();
+        ioBlockOps(0);
+        guiMsgBox(_l(_STR_EMBER_BIOS_MISSING), 0, NULL);
+        return;
+    }
+    if (!cueGameHasImage("pfs0:/", name)) {
+        hddRestoreDataHome();
+        ioBlockOps(0);
+        guiMsgBox(_l(_STR_EMBER_NO_DISC), 0, NULL);
+        return;
+    }
+    cueApplyDisplaySetting("pfs0:/"); // best-effort marker, never a launch gate -- needs the RDWR mount
+
+    // Past this point pfs0: stays where it is and IO stays blocked; deinit re-blocks anyway.
+    deinit(UNMOUNT_EXCEPTION | KEEPIOP_EXCEPTION, itemList->mode);
+    sysLaunchEmber(emberElf, name);
 }
 
 // Shared POPSTARTER handoff for an HDD VCD. argv[0] differs by partition shape: PP.<name> / __.<name>
@@ -1642,13 +1828,19 @@ static void hddLaunchVcd(item_list_t *itemList, const char *vcdName, config_set_
         hddBuildVcdGameList();
         idx = hddFindVcdByName(vcdName);
     }
+    int isEmber = 0;
     if (idx >= 0) {
         snprintf(resolvedName, sizeof(resolvedName), "%s", hddVcdGames[idx].name);
         snprintf(resolvedPart, sizeof(resolvedPart), "%s", hddVcdParts[idx]);
+        isEmber = cueIsCueEntry(&hddVcdGames[idx]); // kind read while the worker is still blocked
     }
     ioBlockOps(0); // resolvedName/resolvedPart are now independent of the mutable backing arrays
     if (idx < 0) {
         guiMsgBox(_l(_STR_POPSTARTER_NOT_FOUND), 0, NULL);
+        return;
+    }
+    if (isEmber) {
+        hddDoLaunchEmber(itemList, resolvedName, resolvedPart);
         return;
     }
     hddDoLaunchVcd(itemList, resolvedName, resolvedPart);
@@ -1780,9 +1972,13 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         }
         snprintf(vcdName, sizeof(vcdName), "%s", vcd->name);
         snprintf(vcdPart, sizeof(vcdPart), "%s", hddVcdParts[id]);
+        int isEmber = cueIsCueEntry(vcd); // read the row's kind while the list is still locked
         guiUnlock();
 
-        hddDoLaunchVcd(itemList, vcdName, vcdPart);
+        if (isEmber)
+            hddDoLaunchEmber(itemList, vcdName, vcdPart);
+        else
+            hddDoLaunchVcd(itemList, vcdName, vcdPart);
         return;
     }
 
@@ -2090,7 +2286,13 @@ static void hddCleanUp(item_list_t *itemList, int exception)
 
     // UI may have loaded modules outside of HDD mode, so deinitialize regardless of the enabled status.
     if (hddSupportModulesLoaded) {
-        fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
+        // PDIOC_CLOSEALL closes EVERY pfs descriptor in the IOP. That is free when the next thing to
+        // run resets the IOP and reclaims them anyway -- the assumption stated above, and the one
+        // every launch made until Ember. An Ember handoff keeps the IOP precisely so the child
+        // inherits this pfs0: mount and reads its game through it; closing the descriptors out from
+        // under it would leave Ember holding a mount it can no longer open anything on.
+        if ((exception & KEEPIOP_EXCEPTION) == 0)
+            fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
 
         hddSupportModulesLoaded = 0;
         gHDDPrefix = NULL; // pfs0: is no longer a valid persistent data-home mount marker

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1034,9 +1034,8 @@ static int hddBuildVcdGameList(void)
                 continue;
             }
 
-            // cueScanDir gates itself on open()ing the core, so a partition with no EMBER folder
-            // costs this mount plus one failed open and returns 0. That is what makes it safe to
-            // scan __common unconditionally: the usual drive pays almost nothing for the attempt.
+            // cueScanDir gates itself on open()ing the core, so an __.EMBER partition that does
+            // not actually hold an install costs this mount plus one failed open and returns 0.
             cue_entry_t *cues = NULL;
             int n = cueScanDir("pfs1:/", &cues);
             fileXioUmount("pfs1:");


### PR DESCRIPTION
## What

Ember runs PS1 titles from every device that has a filesystem root. The internal APA drive has none, so its PS1 list has been POPSTARTER-only. This adds the missing leg.

## Where EMBER goes on an APA drive

**`__.EMBER`**, or `__.EMBER0` … `__.EMBER9` for more than one. Deliberately the same naming shape as the `__.POPS[0-9]?` containers that hold `.VCD` files, so there is one convention, not two.

The partition is self-contained — `EMBER/ember.elf`, `EMBER/bios.bin` and `EMBER/games/<Game Name>/` all start at its root, so a single mount serves the core and the library both.

**Not `__common`.** That partition is the OPL data home (ART, config) and the place `hddResolveHddPopstarter` loads `POPSTARTER.ELF` *from* — it is not where POPS keeps its games, and it is not where Ember keeps its games either. Cover art is unchanged and does not live on the Ember partition: `ART/<Game Name>_COV.png` on the OPL data partition, the same place and key a `.VCD` uses.

## How

**Scan** — `hddBuildVcdGameList` grows a second phase. The APA table walk that finds `__.POPS` containers is factored behind a name filter (`hddCollectPartitions`), so the same proven walk, dedupe, transactional ownership and sort serve a second caller with only the name test swapped. Each candidate is mounted on the `pfs1:` scan slot and handed to `cueScanDir`, which gates itself on `open()`ing the core, so an `__.EMBER` partition without a real install costs one mount and one failed open. Rows land in the **same arrays** as the VCD rows and are told apart by their `.CUE` extension, exactly as on USB and SMB.

**Launch** — `hddDoLaunchEmber` quiesces art first (the single `pfs0:` slot is about to move, and umounting it under a live cover read is the known HDD-freeze hazard), remounts `pfs0:` on the owning partition, re-verifies core, BIOS and disc against the mount *as it stands now* rather than trusting a scan that may be minutes old, then hands off with that mount **live**.

**Teardown** — this needed a new bit. `UNMOUNT_EXCEPTION` stops the `pfs0:` unmount, but `hddCleanUp` also issues `PDIOC_CLOSEALL`, which drops every pfs descriptor in the IOP. Its own comment states the assumption it rested on:

> Every path that reaches here hands off to an ELF that resets the IOP, which reclaims the mounts and the descriptors wholesale.

Ember does not reset the IOP — that is the entire point of the handoff — so `KEEPIOP_EXCEPTION` now gates that call.

The mount is **RDWR**, unlike the POPSTARTER resolver's read-only one, because Ember writes its memory cards and `settings.txt` straight through it. The POPSTARTER mount can be read-only precisely because it dies at the IOP reset moments later.

## Also

- Rename works on Ember folders (mounts the recorded partition RW on the scan slot, same as the pooled-VCD branch).
- Favourites resolves Ember rows by name and dispatches to the right leg.
- **Art needs no special case.** `ART/<folder name>_COV.png` is already what a folder-named row looks up through `hddGetImage`. No second art location, no fallback.
- Name collisions are dropped rather than listed, since `hddFindVcdByName` matches on name alone and a shadowed row would silently launch someone else's game.

## Verification

- Full clean `make release` in the ps2dev container: **exit 0**, zero diagnostics from `hdd.c` or `hddsupport.c`.
- `clang-format 12 --dry-run -Werror`: clean.

**HW-UNVERIFIED, and worth stating plainly:** that Ember actually reads through an inherited `pfs0:` mount is the one leg no emulator can prove. Every other piece here is ordinary code. If an APA title black-screens where the same game folder works on USB, that inheritance is the first thing to look at — not the scan and not the launch path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Ember games stored on internal APA/PFS hard drives.
  - Ember installations on dedicated `__.EMBER` partitions are now detected and shown alongside other HDD games.
  - Added support for launching Ember titles while preserving their settings and memory-card data.
  - Added Ember game renaming from the HDD game list.

- **Documentation**
  - Expanded setup guidance with supported storage options, partition layouts, cover-art placement, and installation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->