### PR TITLE
Document iLink, unified game displays, and Ember device support

### DIFF
--- a/cheats.html
+++ b/cheats.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html" class="active"><span class="em">🎮</span>Cheats</a>

--- a/coverflow.html
+++ b/coverflow.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html" class="active"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>

--- a/credits.html
+++ b/credits.html
@@ -144,6 +144,12 @@ contributed code, ideas, or directly-ported features:</p>
   <td><a href="https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2">GitHub</a></td>
 </tr>
 <tr>
+  <td><b>PS2-Launcher</b></td>
+  <td>Irfanlesnar</td>
+  <td>UI and feature ideas across the wider OPL fork ecosystem</td>
+  <td><a href="https://github.com/Irfanlesnar/PS2-Launcher">GitHub</a></td>
+</tr>
+<tr>
   <td><b>Open PS2 Loader (canonical)</b></td>
   <td>ps2homebrew team</td>
   <td>The project this fork is based on; every OPL feature RiptOPL inherits</td>
@@ -244,6 +250,20 @@ idea of navigating game subfolders came from seeing it there. Thank you for the 
 </div>
 
 <div class="step">
+<h3>Irfanlesnar — PS2-Launcher</h3>
+<p>Creator of <a href="https://github.com/Irfanlesnar/PS2-Launcher"><b>PS2-Launcher</b></a>,
+whose UI and feature ideas contributed to the wider OPL fork ecosystem and inspired parts of
+RiptOPL's presentation.</p>
+</div>
+
+<div class="step">
+<h3>pcm720 — udpfsd / nhddl</h3>
+<p>For <a href="https://github.com/pcm720/udpfsd"><b>udpfsd</b></a> and
+<a href="https://github.com/pcm720/nhddl"><b>nhddl</b></a>, key foundations for modern PS2
+network streaming and Neutrino HDD-launch conventions.</p>
+</div>
+
+<div class="step">
 <h3>Berion — Artwork &amp; Theme Design</h3>
 <p>Responsible for the UI design and artwork that has defined how OPL looks for years. The
 visual language this fork builds on — icon style, layout sensibility, theme conventions —
@@ -300,8 +320,8 @@ PS2-Servers are <b>third-party projects</b>, independently maintained and not pa
     <code>OrbitPS2-Manager.url</code>.</li>
 <li><b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO
     Converter GUI</a></b> by <b><a href="https://github.com/shaanhomebrew-cloud">shaan</a></b> — Windows all-in-one PS1 preparation tool: converts BIN/CUE backups to
-    <code>*.VCD</code> and installs them to USB, MX4SIO, MMCE, exFAT HDD, SMB and the APA internal
-    HDD. Shipped as <code>OPL-PS1-AIO-Converter-GUI.url</code>.</li>
+    <code>*.VCD</code> and installs them to USB, MX4SIO, MMCE, iLink, exFAT HDD, SMB and the APA
+    internal HDD. Shipped as <code>OPL-PS1-AIO-Converter-GUI.url</code>.</li>
 <li><b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> by <b><a href="https://github.com/TheRealNextria">TheRealNextria</a></b> —
     manages the PS2RD <code>.cht</code> cheat files RiptOPL reads from a device's <code>CHT</code>
     folder. Shipped as <code>PS2RD-CHT-Manager.url</code>.</li>

--- a/credits.html
+++ b/credits.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -110,7 +110,7 @@ contributed code, ideas, or directly-ported features:</p>
 <tr>
   <td><b>wOPL</b></td>
   <td>KrahJohlito</td>
-  <td>Continuation of KrahJohlito's earlier uOPL (Unofficial Open PS2 Loader). Coverflow cover-art carousel; Favourites tab and <code>favourites.bin</code> format; per-game Neutrino args; PS2RD cheat-image loader</td>
+  <td>Continuation of KrahJohlito's earlier uOPL (Unofficial Open PS2 Loader). Coverflow cover-art carousel; Favorites tab and <code>favourites.bin</code> format; per-game Neutrino args; PS2RD cheat-image loader</td>
   <td><a href="https://github.com/KrahJohlito/wOPL">GitHub</a></td>
 </tr>
 <tr>
@@ -163,7 +163,7 @@ that directly shaped this fork.</p>
 <h3>KrahJohlito — uOPL / wOPL</h3>
 <p>The legend, and the single biggest influence on this fork. Creator of <b>uOPL (Unofficial Open PS2
 Loader)</b> and its continuation <b>wOPL</b>, where the modern OPL experience was invented. The Neutrino
-external-core launcher, the Coverflow interface, and the Favourites tab — the features that define
+external-core launcher, the Coverflow interface, and the Favorites tab — the features that define
 RiptOPL — were designed and pioneered by him, and everything this fork does with them is a
 reimplementation of his work. We learned more reading his code than anywhere else. RiptOPL is,
 above all, a tribute to it.</p>

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -506,7 +506,7 @@
  {
   "title": "Favorites — Quick start",
   "cat": "features",
-  "text": "How to enable the Favorites tab in Game Sources, star a game with R3, and open the aggregated Favorites page.",
+  "text": "How to enable the Favorites tab in Device Settings, star a game with R3, and open the aggregated Favorites page.",
   "url": "favourites.html#quick-start"
  },
  {
@@ -522,9 +522,9 @@
   "url": "favourites.html#persistence"
  },
  {
-  "title": "Favorites — Game Sources option",
+  "title": "Favorites — Device Settings option",
   "cat": "features",
-  "text": "The Favorites Start Mode setting (Off / Manual / Auto) in Game Sources controls whether the tab is visible and whether R3 is active. Off is the default; R3 does nothing while Off.",
+  "text": "The Favorites Start Mode setting (Off / Manual / Auto) in Device Settings controls whether the tab is visible and whether R3 is active. Off is the default; R3 does nothing while Off.",
   "url": "favourites.html#device-settings"
  },
  {

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -1070,7 +1070,7 @@
  {
   "title": "Credits & Sources",
   "cat": "reference",
-  "text": "The people and projects RiptOPL is built on — from the ps2homebrew foundation and PS2SDK through the wider OPL family (rickgaiser, neutrino, sOPL, uOPL, wOPL, OPL DB, POPSLoader, RetroGEM ID, nhddl) to special thanks for Wolf3s, KrahJohlito, bbsan2k, saildot4k, Berion, Ifcaro, jimmikaelkael, and testers eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz, and nuno6573.",
+  "text": "The people and projects RiptOPL is built on — from the ps2homebrew foundation and PS2SDK through the wider OPL family (rickgaiser, neutrino, sOPL, uOPL, wOPL, OPL DB, POPSLoader, RetroGEM ID, nhddl, Modulo-R1 and PS2-Launcher) to special thanks for Wolf3s, KrahJohlito, bbsan2k, saildot4k, Irfanlesnar, pcm720, Berion, Ifcaro, jimmikaelkael, and the real-hardware testers.",
   "url": "credits.html"
  },
  {
@@ -1082,13 +1082,13 @@
  {
   "title": "Credits: The OPL Family",
   "cat": "reference",
-  "text": "RiptOPL is a direct agglomeration of rickgaiser OPL, Neutrino, sOPL, uOPL (Wolf3s), wOPL (KrahJohlito), OPL Daily Builds, POPSLoader, OPL RetroGEM ID (CosmicScale), nhddl, and canonical OPL — table with per-project source links.",
+  "text": "RiptOPL is a direct agglomeration of rickgaiser OPL, Neutrino, sOPL, uOPL (Wolf3s), wOPL (KrahJohlito), OPL Daily Builds, POPSLoader, OPL RetroGEM ID (CosmicScale), nhddl, Modulo-R1, PS2-Launcher, and canonical OPL — table with per-project source links.",
   "url": "credits.html#opl-family"
  },
  {
   "title": "Credits: Special Thanks",
   "cat": "reference",
-  "text": "Individual thanks to Wolf3s & KrahJohlito (uOPL/wOPL — Neutrino launcher, Coverflow, Favorites), bbsan2k (MMCE protocol), saildot4k (BDMA-ATA exFAT HDD), the testers eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573 (testing & feedback), Berion (artwork & theme design), and Ifcaro & jimmikaelkael (original OPL authors).",
+  "text": "Individual thanks to Wolf3s & KrahJohlito (uOPL/wOPL — Neutrino launcher, Coverflow, Favorites), bbsan2k (MMCE protocol), saildot4k (BDMA-ATA exFAT HDD), Irfanlesnar (PS2-Launcher), pcm720 (udpfsd and nhddl), the real-hardware testers, Berion (artwork and theme design), and Ifcaro & jimmikaelkael (original OPL authors).",
   "url": "credits.html#special-thanks"
  },
  {
@@ -1102,6 +1102,12 @@
   "cat": "reference",
   "text": "PS1 support runs through Sony's POPS emulator and the open-source POPSTARTER launcher; POPS is not distributed by RiptOPL. Deep PS1/POPSTARTER reference lives at the sister POPStarter docs site.",
   "url": "credits.html#ps1-note"
+ },
+ {
+  "title": "Credits: Companion Tools",
+  "cat": "reference",
+  "text": "Maintained companion tools linked from the release: PS2-Servers for SMBv1, UDPFS and UDPBD; udpfs-server for Android UDPFS hosting; OrbitPS2 Manager for library management; OPL PS1 AIO Converter GUI for VCD conversion and installation including iLink; and PS2RD CHT Manager for cheat files.",
+  "url": "credits.html#companion-tools"
  },
  {
   "title": "Credits: License",

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -74,7 +74,7 @@
  {
   "title": "Config file: settings_riptopl.cfg",
   "cat": "start",
-  "text": "RiptOPL saves to settings_riptopl.cfg so it coexists with OPL and wOPL on the same memory card without collision; art, themes, VMC, and favourites.bin remain shared.",
+  "text": "RiptOPL saves to settings_riptopl.cfg so it coexists with OPL and wOPL on the same memory card without collision; art, themes, VMC, and the compatibility file favourites.bin remain shared.",
   "url": "install.html#config-file"
  },
  {
@@ -254,7 +254,7 @@
  {
   "title": "PS1 games on APA/PFS",
   "cat": "devices",
-  "text": "PS1 VCD files on an APA/PFS HDD live in dedicated __.POPS, __.POPS0–__.POPS9 APA partitions. Press L3 on the HDD tab to switch to the PS1 view.",
+  "text": "APA/PFS PS1 support uses __.POPS through __.POPS9 for POPSTARTER and self-contained __.EMBER through __.EMBER9 for Ember. Ember-only drives are scanned and launch from a live read/write PFS mount.",
   "url": "hdd.html#apa-ps1"
  },
  {
@@ -291,6 +291,12 @@
   "title": "The Network rows",
   "cat": "devices",
   "text": "Device Settings carries four network rows: Network Protocol is the start mode (Off / Manual / Auto, default Off); Protocol picks SMB, UDPFS or UDPBD; SMB Version picks SMBv1 (default) or SMB2; Access picks Files or IMG. Because the PS2 has a single NIC, choosing one protocol automatically excludes the others.",
+  "url": "network-boot.html#protocols"
+ },
+ {
+  "title": "PS1 over UDPFS / UDPBD — Ember only",
+  "cat": "devices",
+  "text": "UDPFS and UDPBD expose a PS1 page that lists Ember folders only. Ember inherits the live network mount; POPSTARTER resets the IOP and cannot restore either transport, so VCD rows are deliberately excluded.",
   "url": "network-boot.html#protocols"
  },
  {
@@ -344,25 +350,25 @@
  {
   "title": "PS1 Games (VCD)",
   "cat": "ps1",
-  "text": "How to play PS1 games in RiptOPL via the PS1 view (L3 toggle), POPSTARTER launcher, file layout for every device, and the BDMA exFAT equip.",
+  "text": "How to play PS1 games in RiptOPL through POPSTARTER or Ember, choose Both, Mixed, PS2, or PS1 display, lay out every device, and equip external BDMA files.",
   "url": "ps1-vcd.html"
  },
  {
-  "title": "The PS1 view (press L3)",
+  "title": "PS2 and PS1 device libraries",
   "cat": "ps1",
-  "text": "Press L3 on any device page to switch between its PS2 disc list and its PS1 VCD list. It is a view toggle on the same page, not a separate tab.",
+  "text": "PS2/PS1 Game Display offers separate PS2 and PS1 views via Both (L3), a combined Mixed list whose L3 ring cycles Mixed, PS2, and PS1, or a locked PS2/PS1 library.",
   "url": "ps1-vcd.html#vcd-view"
  },
  {
-  "title": "Locking the view — Default game view",
+  "title": "PS2/PS1 Game Display",
   "cat": "ps1",
-  "text": "Settings → Interface → Default game view locks every device page to discs (ISO), VCDs (VCD), or keeps both accessible via L3 (Both, the default).",
+  "text": "The shared Interface and PS Emulation picker offers Both (L3), Mixed, PS2, and PS1. Locked PS2/PS1 modes make L3 fully inert. APPS and Favorites are independent.",
   "url": "ps1-vcd.html#default-game-view"
  },
  {
   "title": "How PS1 games launch (POPSTARTER only)",
   "cat": "ps1",
-  "text": "VCD titles always boot through POPSTARTER.ELF. The Loader Core selector, GSM, Cheats, and PADEMU options are inert for PS1 games.",
+  "text": "VCD titles always boot through POPSTARTER.ELF. iLink uses the normal local-device selector mass:/POPS/XX.<game>.ELF, with the same XX. rules as USB and MX4SIO. The Loader Core selector, GSM, Cheats, and PADEMU options are inert for PS1 games.",
   "url": "ps1-vcd.html#launch"
  },
  {
@@ -374,7 +380,7 @@
  {
   "title": "exFAT support — the BDMA equip",
   "cat": "ps1",
-  "text": "To boot PS1 games from an exFAT drive, RiptOPL copies the correct BDMAssault modules to mc?:/POPSTARTER/. VCD BDMA Apply on Launch (Settings → PS Emulation Settings) ships On and equips them automatically before each launch; turn it Off to use the BDMA Mode and BDMA Source pickers yourself.",
+  "text": "RiptOPL copies the correct loose BDMAssault pair from the source device's POPS/ folder to mc?:/POPSTARTER/. iLink uses usbd.irx.ilink + usbhdfsd.irx.ilink, with .ilink removed on the card. No BDMA pair is embedded. Apply on Launch equips automatically; turn it Off to use the Mode and Source pickers.",
   "url": "ps1-vcd.html#bdma"
  },
  {
@@ -422,7 +428,7 @@
  {
   "title": "Neutrino Device picker",
   "cat": "neutrino",
-  "text": "Pick the device TYPE that holds neutrino.elf: Auto / Memory Card / USB / MX4SIO / MMCE / HDD (exFAT) / HDD (APA) / Game's Device. OPL probes <root>:/neutrino/neutrino.elf on the chosen device type; Auto probes the active game device first, then a legacy custom path, then mc0/mc1. Game's Device probes only the game's own device — a miss aborts the launch.",
+  "text": "Pick the device TYPE that holds neutrino.elf: Auto / Memory Card / USB / MX4SIO / MMCE / HDD (exFAT) / HDD (APA) / Game's Device / iLink. OPL probes <root>:/neutrino/neutrino.elf on the chosen device type; Auto probes the active game device first, then a legacy custom path, then mc0/mc1. Game's Device probes only the game's own device — a miss aborts the launch.",
   "url": "neutrino.html#neutrino-device"
  },
  {
@@ -492,39 +498,45 @@
   "url": "coverflow.html#cfg-reference"
  },
  {
-  "title": "Favourites",
+  "title": "Favorites",
   "cat": "features",
-  "text": "Press R3 on any game to star it; a virtual Favourites page gathers starred titles from every connected device into one list. Stored in a shared favourites.bin that imports an existing uOPL or wOPL favourites file automatically.",
+  "text": "Press R3 on any game to star it; a virtual Favorites page gathers titles from every connected device. Its independent L3 ring always cycles All in One, PS2, PS1, and ELF. Stored in the shared compatibility file favourites.bin.",
   "url": "favourites.html"
  },
  {
-  "title": "Favourites — Quick start",
+  "title": "Favorites — Quick start",
   "cat": "features",
-  "text": "How to enable the Favourites tab in Device Settings, star a game with R3, and open the aggregated Favourites page.",
+  "text": "How to enable the Favorites tab in Game Sources, star a game with R3, and open the aggregated Favorites page.",
   "url": "favourites.html#quick-start"
  },
  {
-  "title": "Favourites — How it works",
+  "title": "Favorites — How it works",
   "cat": "features",
-  "text": "The Favourites page is a live proxy to each game's source device — launch, cover art, per-game settings, and Options all forward to the original device list. Starred titles on absent devices are hidden but not lost.",
+  "text": "The Favorites page is a live proxy to each game's source device — launch, cover art, per-game settings, and Options all forward to the original device list. Starred titles on absent devices are hidden but not lost.",
   "url": "favourites.html#how-it-works"
  },
  {
-  "title": "Favourites — Persistence and compatibility",
+  "title": "Favorites — Persistence and compatibility",
   "cat": "features",
-  "text": "Favourites are stored in favourites.bin in the shared OPL config directory. RiptOPL automatically imports an existing uOPL or wOPL favourites.bin as a one-way carry-over. The OFAV format holds up to 512 entries with a 255-character title limit.",
+  "text": "Favorites are stored in favourites.bin in the shared OPL config directory. RiptOPL automatically imports an existing uOPL or wOPL file as a one-way carry-over. OFAV v3 records ISO, VCD, CUE, and ELF kinds.",
   "url": "favourites.html#persistence"
  },
  {
-  "title": "Favourites — Device Settings options",
+  "title": "Favorites — Game Sources option",
   "cat": "features",
-  "text": "The Favourites Start Mode setting (Off / Manual / Auto) in Device Settings controls whether the tab is visible and whether R3 is active. Off is the default; R3 does nothing while Off.",
+  "text": "The Favorites Start Mode setting (Off / Manual / Auto) in Game Sources controls whether the tab is visible and whether R3 is active. Off is the default; R3 does nothing while Off.",
   "url": "favourites.html#device-settings"
  },
  {
-  "title": "Favourites — Theme support",
+  "title": "Favorites — Four L3 views",
   "cat": "features",
-  "text": "The Favourites page uses the standard game-list theme element family. App favourites use the apps element family for correct art geometry. The fav and fav_mark texture slots are overridable in custom themes.",
+  "text": "Favorites always cycles All in One, PS2, PS1, and ELF independently; the global PS2/PS1 Game Display setting does not pin or disable it.",
+  "url": "favourites.html#views"
+ },
+ {
+  "title": "Favorites — Theme support",
+  "cat": "features",
+  "text": "The Favorites page uses the standard game-list theme element family. App favorites use the apps element family for correct art geometry. The fav and fav_mark texture slots are overridable in custom themes.",
   "url": "favourites.html#theme-support"
  },
  {
@@ -768,9 +780,15 @@
   "url": "themes.html#regular-opl-compat"
  },
  {
-  "title": "Settings Reference",
+ "title": "Settings Reference",
+ "cat": "reference",
+ "text": "Every settings menu and option in RiptOPL, grouped by screen: General Settings, Device Settings, PS Emulation Settings, Interface, Audio, Controller, OSD, Parental Lock, and Network.",
+ "url": "settings.html"
+ },
+ {
+  "title": "Page return retention",
   "cat": "reference",
-  "text": "Every settings menu and option in RiptOPL, grouped by screen: General Settings, Device Settings, Interface, Audio, Controller, OSD, Parental Lock, and Network.",
+  "text": "Opening Start or Settings remembers the game or source page where you paused. Closing the menu returns to that same page when it is still available, rather than falling back to USB; only a removed or disabled source needs a fallback.",
   "url": "settings.html"
  },
  {
@@ -780,15 +798,21 @@
   "url": "settings.html#general-settings"
  },
  {
-  "title": "Device Settings",
+ "title": "Device Settings",
+ "cat": "reference",
+ "text": "Strictly device selection: Default Menu, BDM/HDD (APA)/Applications/Favorites/MMCE start modes, per-device enable toggles, and the four network rows. Prefix paths and cache sizes are on General Settings.",
+ "url": "settings.html#device-settings"
+ },
+ {
+  "title": "PS Emulation Settings",
   "cat": "reference",
-  "text": "Strictly device selection: Default Menu, BDM/HDD (APA)/Applications/Favourites/MMCE start modes, per-device enable toggles (USB/iLink/MX4SIO/HDD GPT-MBR), and the four network rows — Network Protocol (Off/Manual/Auto), Protocol (SMB/UDPFS/UDPBD), SMB Version (SMBv1/SMB2) and Access (Files/IMG). Prefix paths and cache sizes are on General Settings; the MMCE tuning rows have their own MMCE Settings page.",
-  "url": "settings.html#device-settings"
+  "text": "PS1 and POPSTARTER controls, including the shared PS2/PS1 Game Display picker (Both, Mixed, PS2, PS1), Ember Display Mode, external BDMA source/mode including iLink, and POPSTARTER path.",
+  "url": "settings.html#vcd-settings"
  },
  {
   "title": "Interface",
   "cat": "reference",
-  "text": "Theme, language, cover art, Default game view (Both/ISO/VCD), widescreen, video mode, screen offset, color pickers, GameID barcode, and Coverflow Settings sub-screen.",
+  "text": "Theme, language, cover art, PS2/PS1 Game Display (Both, Mixed, PS2, PS1), and Applications Display (Mixed or Apps/PS1ELF), plus video, colors, GameID barcode, and Coverflow settings.",
   "url": "settings.html#display-settings"
  },
  {
@@ -824,7 +848,7 @@
  {
   "title": "Network Settings",
   "cat": "reference",
-  "text": "PS2 IP address (Static/DHCP), subnet, gateway, DNS, Ethernet link mode, SMB server address/share/credentials, and Write POPSTARTER Network Config.",
+  "text": "PS2 IP, subnet, gateway, DNS, link mode, SMB server/share/credentials, and POPSTARTER network config. OK applies and reconnects immediately; Select/Refresh retries a failed page.",
   "url": "settings.html#network-settings"
  },
  {
@@ -962,7 +986,7 @@
  {
   "title": "Releases — What the rolling release contains",
   "cat": "reference",
-  "text": "Each rolling build publishes the installable package zip (two SDK-labelled loader folders, bundled Neutrino, POPSTARTER/POPS, and PS2-Servers.url), bare ELFs, ready-made -ds5 DualSense ELFs, VARIANTS and DEBUG zips, a source snapshot, a separate SHA256SUMS.txt asset, and languages.",
+  "text": "Each rolling build publishes an installable package zip with the loader folders, bundled Neutrino and Ember, one canonical POPS/ folder, companion-tool shortcuts, bare ELFs, VARIANTS and DEBUG zips, a source snapshot, checksums, and languages. Every BDMA pair stays loose in POPS/, including the iLink pair; none is embedded.",
   "url": "releases.html#rolling-assets"
  },
  {
@@ -1022,13 +1046,13 @@
  {
   "title": "Troubleshooting: BDMA — module files not found on source device",
   "cat": "reference",
-  "text": "The BDMA driver files for exFAT PS1 support must be placed in a POPS/ folder at the root of the BDMA Source device; the USB source scans the entire mass namespace including the internal exFAT HDD.",
+  "text": "The loose BDMA driver pair must be placed in POPS/ at the root of the selected Source device. Sources are driver-specific: USB, MX4SIO, iLink, MMCE, and internal ATA do not scan one another. For iLink use usbd.irx.ilink + usbhdfsd.irx.ilink; RiptOPL removes the suffix only on the memory-card copy.",
   "url": "troubleshooting.html#bdma-module-not-found"
  },
  {
   "title": "Troubleshooting: PS1 / VCD list not showing after a settings change",
   "cat": "reference",
-  "text": "Press L3 on the device page to toggle and refresh the PS1 view; confirm Default game view is not locked to ISO, and that VCD files are in the POPS/ folder at the device root.",
+  "text": "Check PS2/PS1 Game Display: Both (L3) switches separate PS2 and PS1 pages, Mixed cycles Mixed, PS2, and PS1, while PS2 or PS1 locks the page and completely disables L3. VCD files belong in POPS/ at the device root.",
   "url": "troubleshooting.html#vcd-list-not-showing"
  },
  {
@@ -1040,7 +1064,7 @@
  {
   "title": "PS1/VCD list is empty (works elsewhere)",
   "cat": "reference",
-  "text": "Triage ladder: device enables (APA vs exFAT auto-reconcile toast), PS2 ISOs prove the exFAT layer (byte-identical to wOPL), L3 + Default game view, VCDs scan from device-root /POPS not the games prefix, 160-char and POPSTARTER.VCD name rules, post-select failures are POPSTARTER-side.",
+  "text": "Triage ladder: confirm device enablement, choose a PS2/PS1 Game Display mode that includes PS1, scan VCDs from device-root /POPS rather than the games prefix, enforce the 160-character and POPSTARTER.VCD name rules, then treat post-selection failures as POPSTARTER-side.",
   "url": "troubleshooting.html#vcd-list-empty"
  },
  {
@@ -1064,7 +1088,7 @@
  {
   "title": "Credits: Special Thanks",
   "cat": "reference",
-  "text": "Individual thanks to Wolf3s & KrahJohlito (uOPL/wOPL — Neutrino launcher, Coverflow, Favourites), bbsan2k (MMCE protocol), saildot4k (BDMA-ATA exFAT HDD), the testers eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573 (testing & feedback), Berion (artwork & theme design), and Ifcaro & jimmikaelkael (original OPL authors).",
+  "text": "Individual thanks to Wolf3s & KrahJohlito (uOPL/wOPL — Neutrino launcher, Coverflow, Favorites), bbsan2k (MMCE protocol), saildot4k (BDMA-ATA exFAT HDD), the testers eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz and nuno6573 (testing & feedback), Berion (artwork & theme design), and Ifcaro & jimmikaelkael (original OPL authors).",
   "url": "credits.html#special-thanks"
  },
  {

--- a/favourites.html
+++ b/favourites.html
@@ -54,7 +54,7 @@
 title from every connected device into one list — no matter which drive it lives on.</p>
 
 <div class="callout info"><div class="h">ℹ Favorites Start Mode ships Off</div>
-The Favorites tab ships <b>Off</b> under <b>Game Sources → Favorites Start Mode</b> — set it to
+The Favorites tab ships <b>Off</b> under <b>Settings → Device Settings → Favorites Start Mode</b> — set it to
 <b>Manual</b> or <b>Auto</b> before the tab appears and R3 does anything. Use <b>Manual</b> to show the tab and
 control it yourself, <b>Auto</b> to have OPL manage it the same way it manages other device tabs, or
 <b>Off</b> to hide the tab and disable R3 entirely.</div>
@@ -63,7 +63,7 @@ control it yourself, <b>Auto</b> to have OPL manage it the same way it manages o
 <div class="steps">
   <div class="step">
     <h3>Enable the Favorites tab</h3>
-    <p>Open <b>Settings → Game Sources</b> and set <b>Favorites Start Mode</b> to <b>Manual</b> (or <b>Auto</b>).
+    <p>Open <b>Settings → Device Settings</b> and set <b>Favorites Start Mode</b> to <b>Manual</b> (or <b>Auto</b>).
     Save settings. A <b>Favorites</b> tab now appears alongside your device pages.</p>
   </div>
   <div class="step">
@@ -130,8 +130,8 @@ read.</p>
   </tbody>
 </table>
 
-<h2 id="device-settings">Game Sources option</h2>
-<p>Favorites has one enable/startup option in <b>Settings → Game Sources</b>:</p>
+<h2 id="device-settings">Device Settings option</h2>
+<p>Favorites has one enable/startup option in <b>Settings → Device Settings</b>:</p>
 
 <table data-sortable>
   <thead><tr><th>Setting</th><th>Values</th><th>Notes</th></tr></thead>
@@ -181,8 +181,9 @@ visible list. The moment that device is connected and its game list loads, the e
 automatically — no action needed on your part.</p></details>
 
 <details class="deep"><summary>Can I favorite a PS1 game?</summary>
-<p>Yes. PS1 titles shown in the PS1 view (accessed with L3 on a device page) can be starred with R3 just like PS2
-games. They appear in Favorites and launch through the same row-specific core: POPSTARTER for VCD rows, Ember for
+<p>Yes. PS1 titles shown on a device page can be starred with R3 just like PS2 games. In <b>Both (L3)</b> mode,
+L3 opens the PS1 page; in <b>Mixed</b> mode, L3 cycles to the PS1-only view. In <b>PS1</b> mode, the PS1 list is
+already shown and L3 is disabled. They appear in Favorites and launch through the same row-specific core: POPSTARTER for VCD rows, Ember for
 CUE/game-folder rows. UDPFS and UDPBD can contribute Ember favorites but never POPSTARTER rows. See
 <a href="ps1-vcd.html">PS1 Games</a> for how the PS1 view works.</p></details>
 

--- a/favourites.html
+++ b/favourites.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Favourites · RiptOPL Docs</title>
-<meta name="description" content="Star games with R3; one Favourites page across all devices.">
+<title>Favorites · RiptOPL Docs</title>
+<meta name="description" content="Star games with R3; browse Favorites as All in One, PS2, PS1, or ELF.">
 <link rel="stylesheet" href="assets/style.css">
 </head><body data-base="">
 <header class="topbar">
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html" class="active"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html" class="active"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -49,12 +49,12 @@
     <a href="https://nathanneurotic.github.io/POPSLoader/"><span class="em">📚</span>POPStarter docs ↗</a>
   </nav>
   <main class="content">
-<h1>Favourites</h1>
-<p class="lead">Press <b>R3</b> on any game or app to star it. A virtual <b>Favourites</b> page gathers every starred
+<h1>Favorites</h1>
+<p class="lead">Press <b>R3</b> on any game or app to star it. A virtual <b>Favorites</b> page gathers every starred
 title from every connected device into one list — no matter which drive it lives on.</p>
 
-<div class="callout info"><div class="h">ℹ Favourites Start Mode ships Off</div>
-The Favourites tab ships <b>Off</b> under <b>Device Settings → Favourites Start Mode</b> — set it to
+<div class="callout info"><div class="h">ℹ Favorites Start Mode ships Off</div>
+The Favorites tab ships <b>Off</b> under <b>Game Sources → Favorites Start Mode</b> — set it to
 <b>Manual</b> or <b>Auto</b> before the tab appears and R3 does anything. Use <b>Manual</b> to show the tab and
 control it yourself, <b>Auto</b> to have OPL manage it the same way it manages other device tabs, or
 <b>Off</b> to hide the tab and disable R3 entirely.</div>
@@ -62,9 +62,9 @@ control it yourself, <b>Auto</b> to have OPL manage it the same way it manages o
 <h2 id="quick-start">Quick start</h2>
 <div class="steps">
   <div class="step">
-    <h3>Enable the Favourites tab</h3>
-    <p>Open <b>Settings → Device Settings</b> and set <b>Favourites Start Mode</b> to <b>Manual</b> (or <b>Auto</b>).
-    Save settings. A <b>Favourites</b> tab now appears alongside your device pages.</p>
+    <h3>Enable the Favorites tab</h3>
+    <p>Open <b>Settings → Game Sources</b> and set <b>Favorites Start Mode</b> to <b>Manual</b> (or <b>Auto</b>).
+    Save settings. A <b>Favorites</b> tab now appears alongside your device pages.</p>
   </div>
   <div class="step">
     <h3>Star a game</h3>
@@ -73,31 +73,31 @@ control it yourself, <b>Auto</b> to have OPL manage it the same way it manages o
     it is starred. Press R3 again on the same title to remove the star.</p>
   </div>
   <div class="step">
-    <h3>Open the Favourites page</h3>
-    <p>Switch to the <b>Favourites</b> tab. Every starred game you have, across all connected devices, appears here
+    <h3>Open the Favorites page</h3>
+    <p>Switch to the <b>Favorites</b> tab. Every starred game you have, across all connected devices, appears here
     in one list. Cover art, per-game settings, Options — everything works exactly as it does on the source device
     page.</p>
   </div>
   <div class="step">
     <h3>Launch normally</h3>
-    <p>Select a title on the Favourites page and press <b>Cross</b> to launch it. The game boots through the same
+    <p>Select a title on the Favorites page and press <b>Cross</b> to launch it. The game boots through the same
     path it would on its source device (OPL core or Neutrino, depending on your per-game settings).</p>
   </div>
 </div>
 
 <h2 id="how-it-works">How it works</h2>
-<p>The Favourites page is a virtual aggregator — it does not copy or move games. Each entry is a live proxy to the
+<p>The Favorites page is a virtual aggregator — it does not copy or move games. Each entry is a live proxy to the
 original item on its source device list. Launching, cover art lookups, per-game config, and the Options/Info menu
 all forward to the source device as if you had selected the game there directly.</p>
 
 <ul class="checklist">
   <li>Stars are visible everywhere: a small star mark is drawn next to the title on both the source device page and
-  the Favourites page.</li>
+  the Favorites page.</li>
   <li>If a device is disconnected (USB drive unplugged, SMB share unreachable, etc.) its starred titles are hidden
-  from the Favourites list but are not lost — they reappear automatically when the device becomes available again.</li>
+  from the Favorites list but are not lost — they reappear automatically when the device becomes available again.</li>
   <li>BDM devices (USB, MX4SIO, iLink) can move between bus slots; RiptOPL re-matches the item by game ID and title
-  across all slots, so a favourite does not break just because a drive appeared on a different port.</li>
-  <li>Rename and Delete are blocked on favourited titles and on any game accessed through the Favourites page.
+  across all slots, so a favorite does not break just because a drive appeared on a different port.</li>
+  <li>Rename and Delete are blocked on favorited titles and on any game accessed through the Favorites page.
   Un-star the game first if you need to rename or delete it.</li>
 </ul>
 
@@ -109,11 +109,11 @@ config.</p>
 <div class="callout info"><div class="h">ℹ Shared with uOPL and wOPL</div>
 <code>favourites.bin</code> sits in the <b>shared OPL folder</b>, not in the RiptOPL-private settings area. If you
 have an existing <code>favourites.bin</code> written by <b>uOPL</b> or <b>wOPL</b>, RiptOPL will read it
-automatically on first boot and carry your starred games over. Your favourites will then be saved in RiptOPL's own
+automatically on first boot and carry your starred games over. Your favorites will then be saved in RiptOPL's own
 versioned <code>OFAV</code> format on the next write. That OFAV format is RiptOPL's own — uOPL and wOPL cannot read it back, so the carry-over is one-way only.</div>
 
 <p>The on-disk format uses an <code>OFAV</code> magic header, a version number, and an explicit record count,
-followed by one record per favourite. Every field is written as an explicit scalar (no raw struct dumps), and the
+followed by one record per favorite. Every field is written as an explicit scalar (no raw struct dumps), and the
 reader validates the header, version, record count, and every text-length field before accepting a file — a
 corrupt or truncated <code>favourites.bin</code> is rejected cleanly rather than causing a crash or out-of-bounds
 read.</p>
@@ -123,21 +123,21 @@ read.</p>
   <tbody>
     <tr><td>File name</td><td><code>favourites.bin</code> (shared OPL config dir)</td></tr>
     <tr><td>Format magic</td><td><code>OFAV</code> (0x4641464F, little-endian)</td></tr>
-    <tr><td>Format version</td><td>2 (v1 files still readable; v2 adds a per-record <code>isVcd</code> byte marking PS1/<code>.VCD</code> favourites)</td></tr>
-    <tr><td>Maximum favourites</td><td>512 entries</td></tr>
+    <tr><td>Format version</td><td>3 (v1/v2 remain readable; v3 uses the old byte as an ISO / VCD / CUE / ELF kind)</td></tr>
+    <tr><td>Maximum favorites</td><td>512 entries</td></tr>
     <tr><td>Maximum title length</td><td>255 characters + NUL (256 bytes)</td></tr>
     <tr><td>Import from uOPL / wOPL</td><td>Automatic, read-only (one-way carry-over)</td></tr>
   </tbody>
 </table>
 
-<h2 id="device-settings">Device Settings options</h2>
-<p>Favourites has one option in <b>Settings → Device Settings</b>:</p>
+<h2 id="device-settings">Game Sources option</h2>
+<p>Favorites has one enable/startup option in <b>Settings → Game Sources</b>:</p>
 
 <table data-sortable>
   <thead><tr><th>Setting</th><th>Values</th><th>Notes</th></tr></thead>
   <tbody>
     <tr>
-      <td><b>Favourites Start Mode</b></td>
+      <td><b>Favorites Start Mode</b></td>
       <td>Off / Manual / Auto</td>
       <td><b>Off</b> (default) hides the tab and disables R3 entirely. <b>Manual</b> shows the tab but does not
       auto-start into it. <b>Auto</b> behaves like Auto mode on a regular device tab.</td>
@@ -145,36 +145,50 @@ read.</p>
   </tbody>
 </table>
 
-<div class="callout info"><div class="h">ℹ R3 only works when Favourites Start Mode is on</div>
-When Favourites Start Mode is set to <b>Off</b>, pressing R3 does nothing — no star is set and nothing is written
+<div class="callout info"><div class="h">ℹ R3 only works when Favorites Start Mode is on</div>
+When Favorites Start Mode is set to <b>Off</b>, pressing R3 does nothing — no star is set and nothing is written
 to disk. Enable the tab first.</div>
 
-<h2 id="theme-support">Theme support</h2>
-<p>The Favourites page renders using the <code>favsMain</code> element family (which falls back to the regular
-game-list <code>main</code> family when the theme defines no <code>favsMain</code> override). The star mark drawn beside favourited titles in any list uses the embedded <code>fav_mark</code>
-texture. Themes can override the appearance of the Favourites tab icon via the <code>fav</code> texture slot.</p>
+<h2 id="views">All in One, PS2, PS1, and ELF views</h2>
+<p>Favorites keeps its own independent L3 ring. It is not pinned by the shared
+<b>PS2/PS1 Game Display</b> setting. Press <b>L3</b> on Favorites to cycle:</p>
+<ol>
+  <li><b>All in One</b> — PS2, PS1, and ELF favorites together.</li>
+  <li><b>PS2</b> — PS2 disc favorites only.</li>
+  <li><b>PS1</b> — POPSTARTER and Ember favorites together.</li>
+  <li><b>ELF</b> — homebrew/app favorites only.</li>
+</ol>
+<p>The mixed view keeps each row's real behavior: PS1 rows open PS1 options and launch through their
+own core; ELF rows use the app path; PS2 rows retain normal game options. All four stops remain
+available regardless of how ordinary device game pages are displayed.</p>
 
-<p>App favourites (items sourced from the Apps tab) are handled specially: they use the <b>apps</b> theme element
-family (correct art box geometry and case overlay) rather than the game-cover family, so a favourited app looks right
-even on the Favourites page.</p>
+<h2 id="theme-support">Theme support</h2>
+<p>The Favorites page renders using the <code>favsMain</code> element family (which falls back to the regular
+game-list <code>main</code> family when the theme defines no <code>favsMain</code> override). The star mark drawn beside favorited titles in any list uses the embedded <code>fav_mark</code>
+texture. Themes can override the appearance of the Favorites tab icon via the <code>fav</code> texture slot.</p>
+
+<p>App favorites (items sourced from the Apps tab) are handled specially: they use the <b>apps</b> theme element
+family (correct art box geometry and case overlay) rather than the game-cover family, so a favorited app looks right
+even on the Favorites page.</p>
 
 <p>For full details on element families and texture slots, see the <a href="themes.html">Theme Engine</a> reference.</p>
 
-<details class="deep"><summary>What happens to a favourite when a device is not connected?</summary>
+<details class="deep"><summary>What happens to a favorite when a device is not connected?</summary>
 <p>The record stays in <code>favourites.bin</code> — it is never deleted just because the source device is absent.
-When you open the Favourites tab, RiptOPL tries to resolve each stored entry against the currently loaded device
+When you open the Favorites tab, RiptOPL tries to resolve each stored entry against the currently loaded device
 lists. Any entry whose device is not available (drive unplugged, share offline, etc.) is simply hidden from the
 visible list. The moment that device is connected and its game list loads, the entry becomes visible again
 automatically — no action needed on your part.</p></details>
 
-<details class="deep"><summary>Can I favourite a PS1 (VCD) game?</summary>
+<details class="deep"><summary>Can I favorite a PS1 game?</summary>
 <p>Yes. PS1 titles shown in the PS1 view (accessed with L3 on a device page) can be starred with R3 just like PS2
-games. They appear in the Favourites list and launch through POPSTARTER the same way they do from their source
-device. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for how the PS1 view works.</p></details>
+games. They appear in Favorites and launch through the same row-specific core: POPSTARTER for VCD rows, Ember for
+CUE/game-folder rows. UDPFS and UDPBD can contribute Ember favorites but never POPSTARTER rows. See
+<a href="ps1-vcd.html">PS1 Games</a> for how the PS1 view works.</p></details>
 
-<details class="deep"><summary>Can I favourite a Neutrino-backed game?</summary>
-<p>Yes. Neutrino per-game settings are stored in the game's own per-game config file, not in the Favourites list.
-A favourited game that is set to use Neutrino will still launch via Neutrino when opened from the Favourites page,
+<details class="deep"><summary>Can I favorite a Neutrino-backed game?</summary>
+<p>Yes. Neutrino per-game settings are stored in the game's own per-game config file, not in the Favorites list.
+A favorited game that is set to use Neutrino will still launch via Neutrino when opened from the Favorites page,
 because the launch path proxies to the source device entry with all its settings intact.</p></details>
 
 </main>

--- a/getting-started.html
+++ b/getting-started.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -68,7 +68,7 @@ If <code>RIPTOPL.ELF</code> is already on your PS2 and booting, skip ahead to
 </ul>
 
 <details class="deep"><summary>Which release should I download?</summary>
-<p>The <b>rolling</b> pre-release is rebuilt from <code>master</code> on every push and normally includes the bundled Neutrino core. It may occasionally be unstable. Tagged <b>v*</b> releases are manually cut, known-good snapshots. Either way, the full installable package zip (<code>RIPTOPL-&lt;rel&gt;-&lt;sha&gt;.zip</code>) contains the ELF, the <code>POPSTARTER/</code> and <code>POPS/</code> folders, and the already-extracted <code>neutrino/</code> folder — download the zip rather than a bare ELF if you intend to use Neutrino. The language pack is a separate <code>RIPTOPL-LANGS-*.zip</code> release asset. See <a href="releases.html">Releases</a> for details.</p>
+<p>The <b>rolling</b> pre-release is rebuilt from <code>rebuild/main</code> on every push and normally includes the bundled Neutrino core. It may occasionally be unstable. Tagged <b>v*</b> releases are manually cut, known-good snapshots. Either way, the full installable package zip (<code>RIPTOPL-&lt;rel&gt;-&lt;sha&gt;.zip</code>) contains the loader folders, one canonical <code>POPS/</code> folder (including every loose BDMA pair and the iLink <code>.ilink</code> pair), <code>EMBER/</code>, and the already-extracted <code>neutrino/</code> folder. No duplicate release-root <code>POPSTARTER/</code> folder or embedded BDMA pair is used. The language pack is a separate <code>RIPTOPL-LANGS-*.zip</code> release asset. See <a href="releases.html">Releases</a> for details.</p>
 </details>
 
 <h2 id="pick-a-device">Pick a device</h2>
@@ -164,7 +164,7 @@ USB root
 <h3>5. Save your settings</h3>
 <p>After a successful launch, go back to the main menu (press <b>Start</b>) and choose <b>Save Changes</b>. This writes <code>settings_riptopl.cfg</code> to your storage device so RiptOPL remembers your configuration on every subsequent boot.</p>
 <div class="callout info"><div class="h">ℹ Where the config file lives</div>
-RiptOPL saves its master config as <code>settings_riptopl.cfg</code> — distinct from upstream OPL's <code>conf_opl.cfg</code>. Both builds can share the same memory card or storage device without overwriting each other's settings. Art, themes, VMCs, per-game configs, and favourites in the shared <code>OPL/</code> folders are visible to all OPL builds.</div>
+RiptOPL saves its master config as <code>settings_riptopl.cfg</code> — distinct from upstream OPL's <code>conf_opl.cfg</code>. Both builds can share the same memory card or storage device without overwriting each other's settings. Art, themes, VMCs, per-game configs, and favorites in the shared <code>OPL/</code> folders are visible to all OPL builds.</div>
 </div>
 
 </div>

--- a/hdd.html
+++ b/hdd.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -149,10 +149,15 @@ direct APA partition editing can corrupt the drive if done incorrectly.</p>
 </details>
 
 <h3 id="apa-ps1">PS1 games on APA/PFS</h3>
-<p>PS1 <code>*.VCD</code> files on an APA/PFS HDD live in dedicated <b><code>__.POPS</code></b> partitions (named
-<code>__.POPS</code>, <code>__.POPS0</code> … <code>__.POPS9</code>). Each partition holds its VCD files at the
-partition root. Press <b>L3</b> on the HDD tab to switch to the PS1 view and see them listed. See
-<a href="ps1-vcd.html">PS1 Games (VCD)</a> for the full VCD workflow.</p>
+<p>POPSTARTER <code>*.VCD</code> files on an APA/PFS HDD live in dedicated <b><code>__.POPS</code></b>
+partitions (named <code>__.POPS</code>, <code>__.POPS0</code> … <code>__.POPS9</code>). Each partition
+holds its VCD files at the partition root.</p>
+<p>Ember uses a separate exact namespace: <b><code>__.EMBER</code></b> or
+<code>__.EMBER0</code> … <code>__.EMBER9</code>. Each is self-contained and holds
+<code>EMBER/ember.elf</code>, <code>EMBER/bios.bin</code>, and <code>EMBER/games/</code>. RiptOPL scans
+these partitions even when the drive has no POPSTARTER partitions, mounts them on <code>pfs1:</code>
+for listing, then remounts the selected one read/write on <code>pfs0:</code> and hands that live mount
+to Ember. See <a href="ps1-vcd.html">PS1 Games</a> for the display-mode and launch workflow.</p>
 
 <h2 id="exfat-bdm">exFAT via Block Device Manager (BDMA)</h2>
 <p>RiptOPL can also treat the internal HDD as a plain exFAT mass-storage device, mounted through the same
@@ -224,7 +229,8 @@ In <code>conf_apps.cfg</code>, use <code>mass:</code> as the device prefix (the 
 
 <h3 id="exfat-ps1">PS1 games on exFAT (BDMA equip)</h3>
 <p>Put your <code>*.VCD</code> files in the drive's <code>POPS/</code> folder alongside
-<code>POPSTARTER.ELF</code>. Press <b>L3</b> on the HDD Games tab to switch to the PS1 view.</p>
+<code>POPSTARTER.ELF</code>. Use <b>PS2/PS1 Game Display</b> to show the PS1 library separately,
+combined with PS2 rows, or pinned by itself.</p>
 <p>POPSTARTER's stock driver only reads FAT32, so booting a PS1 game from the exFAT HDD needs the
 <b>HDD (exFAT)</b> BDMA driver modules equipped. RiptOPL does this <b>automatically by default</b>: the
 <b>VCD BDMA Apply on Launch</b> toggle (in <b>Settings &rarr; PS Emulation Settings</b>) ships <b>On</b>, and each time you launch
@@ -248,7 +254,7 @@ including the BDMA Source setting.</p>
 <tr><td>Install method</td><td>HDL-Dump via NBD server</td><td>Copy files from PC (no tools)</td></tr>
 <tr><td>PS2 game format</td><td>HDLoader partitions</td><td>ISO / ZSO in <code>DVD/</code> or <code>CD/</code></td></tr>
 <tr><td>OPL data location</td><td>Standard folders at the OPL partition root (<code>pfs0:</code>)</td><td>Standard folders at drive root</td></tr>
-<tr><td>PS1 VCD support</td><td><code>__.POPS*</code> APA partitions</td><td><code>POPS/</code> folder + BDMA equip</td></tr>
+<tr><td>PS1 support</td><td><code>__.POPS*</code> (POPSTARTER) and <code>__.EMBER*</code> (Ember) APA partitions</td><td><code>POPS/</code> + BDMA equip, and/or <code>EMBER/</code></td></tr>
 <tr><td>Fragmentation risk</td><td>None (partition-based)</td><td>Yes — add files one at a time</td></tr>
 <tr><td>Tool ecosystem</td><td>HDL-Dump, pfs-shell, uLaunchELF</td><td>Any PC file manager</td></tr>
 <tr><td>Enable in RiptOPL</td><td>Device Settings → HDD (APA) Start Mode</td><td>Device Settings → HDD (GPT/MBR)</td></tr>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Home · RiptOPL Docs</title>
-<meta name="description" content="RiptOPL — an opinionated Open PS2 Loader fork. Cover-art Coverflow, Favourites, per-game Neutrino, a Device Settings hub, every storage backend (USB/MMCE/MX4SIO/iLink/SMB/HDD-APA/HDD-exFAT/UDPBD), PS1 via POPSTARTER, and a deep theme engine.">
+<meta name="description" content="RiptOPL — an opinionated Open PS2 Loader fork. Cover-art Coverflow, Favorites, per-game Neutrino, every storage backend, PS1 through POPSTARTER and Ember, and a deep theme engine.">
 <link rel="stylesheet" href="assets/style.css">
 </head><body data-base="">
 <header class="topbar">
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -53,14 +53,14 @@
 <p><b><a href="https://github.com/NathanNeurotic/PS2-Servers">PS2-Servers</a></b> by <b><a href="https://github.com/NathanNeurotic">Ripto</a></b> — all-in-one PC server launcher for <b>SMBv1, UDPFS and UDPBD</b>.<br>
 <b><a href="https://github.com/YouKnow-sys/udpfs-server">udpfs-server</a></b> by <b><a href="https://github.com/YouKnow-sys">YouKnow-sys</a></b> — the same idea from a phone: an <b>Android</b> app that shares folders and disk images to the PS2 over <b>UDPFS</b>, found by broadcast so there is no server address to type in on the console. Built on <a href="https://github.com/pcm720/udpfsd">udpfsd</a> by pcm720; MIT licensed.<br>
 <b><a href="https://github.com/Luden02/OrbitPS2-Manager">OrbitPS2 Manager</a></b> by <b><a href="https://github.com/Luden02">Luden</a></b> — cross-platform PC library manager for importing discs, artwork/screenshots, ZSO compression, per-game settings and VMC management.<br>
-<b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO Converter GUI</a></b> by <b><a href="https://github.com/shaanhomebrew-cloud">shaan</a></b> — Windows all-in-one PS1/POPStarter preparation tool for BIN/CUE → VCD conversion and installation to USB, MX4SIO, MMCE, exFAT HDD, SMB and APA internal HDD.<br>
+<b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO Converter GUI</a></b> by <b><a href="https://github.com/shaanhomebrew-cloud">shaan</a></b> — Windows all-in-one PS1/POPStarter preparation tool for BIN/CUE → VCD conversion and installation to USB, MX4SIO, MMCE, iLink, exFAT HDD, SMB and APA internal HDD.<br>
 <b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> by <b><a href="https://github.com/TheRealNextria">TheRealNextria</a></b> — PC manager for the PS2RD <code>.cht</code> cheat files RiptOPL reads from your device's <code>CHT</code> folder.<br>
 <b><a href="https://github.com/Gageformer/Ember">Ember</a></b> by <b><a href="https://github.com/Gageformer">Gageformer</a></b> — a PS1 emulator running natively on the PS2, used as RiptOPL's second PS1 core alongside POPSTARTER. Ships as an <code>EMBER/</code> folder inside the release package, bundled unmodified with permission under the Ember Public Beta Testing Licence (<code>EMBER/LICENSE-BETA.txt</code>); <a href="https://github.com/Gageformer/Ember/releases">releases</a>.<br>
-<b><a href="https://www.psx-place.com/resources/popstarter.683/">POPStarter</a></b> by <b>krHACKen</b> — a PS1 launcher built around Sony's native <b>POPS</b> emulator for the PS2, used as RiptOPL's primary PS1 core alongside Ember. POPStarter provides the compatibility and launch layer for running PS1 VCDs from USB, internal HDD, and SMB. The official POPStarter r13 package contains no Sony emulator binaries, libraries, or BIOS files; those components must be supplied separately by the user. Official download, documentation, compatibility information, and releases are maintained on <a href="https://www.psx-place.com/resources/popstarter.683/">PSX-Place</a>.<br>
+<b><a href="https://www.psx-place.com/resources/popstarter.683/">POPStarter</a></b> by <b>krHACKen</b> — a PS1 launcher built around Sony's native <b>POPS</b> emulator for the PS2, used as RiptOPL's primary PS1 core alongside Ember. POPStarter provides the compatibility and launch layer for running PS1 VCDs from USB, MX4SIO, MMCE, iLink, internal HDD, and SMB. The official POPStarter r13 package contains no Sony emulator binaries, libraries, or BIOS files; those components must be supplied separately by the user. Official download, documentation, compatibility information, and releases are maintained on <a href="https://www.psx-place.com/resources/popstarter.683/">PSX-Place</a>.<br>
 <b><a href="https://github.com/rickgaiser/neutrino">Neutrino</a></b> by <b><a href="https://github.com/rickgaiser">rickgaiser</a></b> — a small, fast, modular PS2 device emulator, and RiptOPL's second PS2 loader core alongside OPL's own. Ships as a ready-to-use <code>neutrino/</code> folder inside the release package (drag-and-drop to <code>mc?:/neutrino/</code>), under the <b>AFL-3.0</b> licence; <a href="https://github.com/rickgaiser/neutrino/releases">releases</a>.</p></section><div class="hero">
 <h1>RiptOPL <span class="g">Documentation</span></h1>
 <p class="lead">An opinionated fork of <b>Open PS2 Loader</b> aiming to be the "definitive build" — a cover-art
-<b>Coverflow</b> menu by default, a <b>Favourites</b> tab, per-game <b>Neutrino</b> external-core launching, a
+<b>Coverflow</b> menu by default, a <b>Favorites</b> tab, per-game <b>Neutrino</b> external-core launching, a
 reorganized <b>Game Sources</b> category settings layout, PS1 support via POPSTARTER, and every storage backend the PS2 can reach.</p>
 <div class="btn-row">
   <a class="btn" href="getting-started.html">🚀 New here? Launch your first game</a>
@@ -71,7 +71,7 @@ reorganized <b>Game Sources</b> category settings layout, PS1 support via POPSTA
 <div class="callout info"><div class="h">ℹ New to OPL? Read this first</div>Open PS2 Loader (OPL) is a 100% open-source
 game/app loader for the PS2 and backward-compatible PS3. <b>RiptOPL</b> is a downstream fork with opinionated
 defaults and extra features layered on top. Its settings live in their own <code>settings_riptopl.cfg</code> so it
-never collides with stock OPL or wOPL on the same memory card — while artwork, themes, VMCs and <b>favourites stay
+never collides with stock OPL or wOPL on the same memory card — while artwork, themes, VMCs and <b>favorites stay
 shared</b>. The <a href="getting-started.html"><b>Getting Started</b></a> guide walks you through your first game;
 the sections below are the deep reference. For the canonical project, see
 <a href="https://github.com/ps2homebrew/Open-PS2-Loader">ps2homebrew/Open-PS2-Loader</a>.</div>
@@ -80,14 +80,15 @@ the sections below are the deep reference. For the canonical project, see
 <ul class="checklist">
 <li><b>Coverflow theme (default)</b> — a centered cover-art carousel with reflection, animated scrolling, a
 configurable cover count, and aspect-correct covers in 4:3 and widescreen. Tunable live under <b>Coverflow Settings</b>.</li>
-<li><b>Favourites tab</b> — press <b>R3</b> to star any game; a virtual Favourites page gathers starred games from
+<li><b>Favorites tab</b> — press <b>R3</b> to star any game; a virtual Favorites page gathers starred games from
 every device. Imports an existing uOPL / wOPL <code>favourites.bin</code>.</li>
 <li><b>Neutrino external core (per-game)</b> — hand a game to an external <code>neutrino.elf</code> instead of OPL's
 built-in core, with a <b>Device</b> picker and a structured <b>Launch Args</b> screen.</li>
 <li><b>Network boot</b> — stream games from a PC over the LAN as their own list via <b>UDPBD</b> or <b>UDPFS</b> (Neutrino).</li>
-<li><b>PS1 games — two cores, one list</b> — a per-device <b>L3</b> toggle lists your PS1 titles from
-<b>POPSTARTER</b> (<code>*.VCD</code>) and <b>Ember</b> (<code>*.cue</code>) together, sorted as one library,
-including from an <b>exFAT</b> drive (BDMAssault) and the internal HDD.</li>
+<li><b>PS1 games — two cores, flexible display</b> — <b>POPSTARTER</b> (<code>*.VCD</code>) and
+<b>Ember</b> (<code>*.cue</code>) share one PS1 library, while <b>PS2/PS1 Game Display</b> offers
+separate L3 views, a combined Mixed list with filters, or a locked PS2/PS1 list. UDPFS and UDPBD
+publish Ember only; APA HDD supports <code>__.EMBER</code> and <code>__.EMBER0</code>–<code>9</code>.</li>
 <li><b>Category settings layout</b> — organised category pages (Game Sources, General &amp; System, Network, Interface, Game Launching, PS Emulation Settings, Controller Settings, Audio Settings) instead of one flat list.</li>
 <li><b>Ready-to-use defaults</b> — widescreen, cover art, notifications, sound + boot sound, and the PS2 logo are on out of the box; storage devices ship off by default until enabled under Game Sources.</li>
 </ul>
@@ -104,7 +105,7 @@ including from an <b>exFAT</b> drive (BDMAssault) and the internal HDD.</li>
 <a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 Games</b><span>POPSTARTER + Ember</span></a>
 <a class="tile" href="neutrino.html"><span class="em">⚛️</span><b>Neutrino Core</b><span>Device + Args pickers</span></a>
 <a class="tile" href="coverflow.html"><span class="em">🎴</span><b>Coverflow</b><span>The default theme</span></a>
-<a class="tile" href="favourites.html"><span class="em">⭐</span><b>Favourites</b><span>R3 to star</span></a>
+<a class="tile" href="favourites.html"><span class="em">⭐</span><b>Favorites</b><span>R3 to star · four L3 views</span></a>
 <a class="tile" href="themes.html"><span class="em">🎨</span><b>Theme Engine</b><span>Author your own themes</span></a>
 <a class="tile" href="settings.html"><span class="em">🔧</span><b>Settings Reference</b><span>Every menu &amp; option</span></a>
 </div>
@@ -113,10 +114,10 @@ including from an <b>exFAT</b> drive (BDMAssault) and the internal HDD.</li>
 <p><b>Open PS2 Loader (OPL)</b> is the canonical, community-maintained loader at
 <a href="https://github.com/ps2homebrew/Open-PS2-Loader">ps2homebrew/Open-PS2-Loader</a>. <b>wOPL</b> — KrahJohlito's
 continuation of his earlier <b>uOPL</b> (Unofficial Open PS2 Loader) — is the fork where much of the modern
-Coverflow / Favourites / Neutrino work originated. <b>RiptOPL</b>
+Coverflow / Favorites / Neutrino work originated. <b>RiptOPL</b>
 is a downstream "agglomeration" fork that brings those features together with opinionated defaults and additional device
 support, while staying compatible with stock OPL on the same memory card (separate <code>settings_riptopl.cfg</code>,
-shared art/themes/VMC/favourites). It is a labor of love, <b>not</b> a replacement for upstream — please support the
+shared art/themes/VMC/favorites). It is a labor of love, <b>not</b> a replacement for upstream — please support the
 canonical project.</p></details>
 </main>
   <aside class="toc"><div class="toc-h">On this page</div><nav id="toc-nav"></nav></aside>

--- a/install.html
+++ b/install.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -86,7 +86,7 @@ RiptOPL saves its master settings to <code>settings_riptopl.cfg</code> — a dif
 <ul>
   <li><code>APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF</code> — built with <code>ps2dev/ps2dev:latest</code>, the current SDK RiptOPL is developed and tested against. This is the recommended one.</li>
   <li><code>APP_RIPTOPL-PS2DEVPINNEDSDK/RIPTOPL.ELF</code> — the same ps2dev SDK, pinned by digest to a day it was known good. Use this if the recommended build has a regression on your console.</li>
-  <li><code>POPSTARTER/</code> and <code>POPS/</code> folders — structure for PS1 support. <code>POPSTARTER.ELF</code> and its BDMA <code>usbd</code> / <code>usbhdfsd</code> variants <b>are</b> bundled in <code>POPS/</code> (together with <code>PATCH_5.BIN</code>); <code>POPSTARTER/</code> carries the SMB network stack. Only <code>POPS.ELF</code> — Sony's PS1 emulator — is not distributed here.</li>
+  <li><code>POPS/</code> — the single canonical release folder for POPSTARTER support. It contains <code>POPSTARTER.ELF</code>, the SMB externals, <code>PATCH_5.BIN</code>, and every loose BDMA <code>usbd.irx.*</code> / <code>usbhdfsd.irx.*</code> pair, including <code>.ilink</code>. No BDMA pair is embedded in <code>RIPTOPL.ELF</code>, and there is no duplicate release-root <code>POPSTARTER/</code> folder. Only <code>POPS.ELF</code> — Sony's PS1 emulator — is not distributed here.</li>
   <li><code>neutrino/</code> — the bundled Neutrino external core, shipped extracted as a drag-and-drop folder (<code>neutrino.elf</code> + <code>config/</code> + <code>modules/</code>) used by the <b>network-boot (UDPBD/UDPFS)</b> subsystem (pre-populated with the UDPFS config). Copy it to <code>mc?:/neutrino/</code> — that path is exactly what <b>Neutrino ELF Path</b> auto-detect looks for, and the same copy serves both per-game Neutrino launching and network boot. No separate download is needed.</li>
   <li><code>PS2-Servers.url</code> — opens the maintained <a href="https://github.com/NathanNeurotic/PS2-Servers">PS2 Servers</a> UDPFS / SMBv1 / UDPBD all-in-one PC launcher. The server software itself is no longer embedded in the RiptOPL package.</li>
 </ul>

--- a/mmce.html
+++ b/mmce.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -187,10 +187,11 @@ Leave this <b>ON</b> (the shipped known-good default) so an occasional card hang
 timeout error rather than a freeze.</p>
 
 <h2 id="ps1-vcd">PS1 games on MMCE</h2>
-<p>MMCE supports the PS1 PS1 view exactly like USB. Place <code>*.VCD</code> files and <code>POPSTARTER.ELF</code>
-in the <code>POPS/</code> folder on the SD card. Press <b>L3</b> on the MMCE Games tab to switch between the PS2
-game list and the PS1 VCD list. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for the full setup walkthrough,
-including the Default game view lock and cover-art fallback chain.</p>
+<p>MMCE supports PS1 games exactly like USB. Place <code>*.VCD</code> files and <code>POPSTARTER.ELF</code>
+in the <code>POPS/</code> folder on the SD card. <b>PS2/PS1 Game Display</b> controls whether MMCE shows
+separate PS2 / PS1 views, a combined list, or one locked type; L3 is available only in <b>Both (L3)</b>
+and <b>Mixed</b>. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for the full setup walkthrough and cover-art
+fallback chain.</p>
 
 <p>MMCE is also a supported BDMA source for the exFAT POPSTARTER equip (BDMA Mode → <b>MMCE (exFAT)</b>),
 meaning POPSTARTER can read BDMA module files from the MMCE card when you use an exFAT-formatted SD.</p>

--- a/nbd.html
+++ b/nbd.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>

--- a/network-boot.html
+++ b/network-boot.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -57,7 +57,7 @@ and <b>Access</b> (<b>Files</b> or <b>IMG</b>). Because the PS2 has one Ethernet
 transport is ever active, so the Protocol row is exclusive <i>by construction</i>. <b>UDPFS</b> is the modern
 network-boot protocol (Rick Gaiser's <b>UDPRDMA</b> transport); <b>UDPBD</b> is the older SUDPBDv2
 protocol, kept for users still running the <code>udpbd-server</code>. Both appear in RiptOPL as their own
-games list — with covers, Favourites, and per-game settings, just like a local drive — and always
+games list — with covers, Favorites, and per-game settings, just like a local drive — and always
 launch through <a href="neutrino.html">Neutrino</a> (there is no OPL built-in core fallback for them).
 SMB is the exception: it is a mounted file share served by OPL's own core, and needs no Neutrino.</p>
 
@@ -116,6 +116,20 @@ table below, <b>Off</b> is row 1's value; the other three are row 2's.</p>
 </tr>
 </tbody>
 </table>
+
+<div class="callout info"><div class="h">ℹ PS1 over UDP: Ember only</div>
+UDPFS and UDPBD now expose the same PS1 page as other game devices, but their scan is deliberately
+limited to <b>Ember</b> folders under <code>EMBER/games/</code>. Ember performs no IOP reset and inherits
+the live <code>udpfs:</code> or <code>massN:</code> network mount. POPSTARTER resets the IOP and cannot
+restore either transport, so <code>POPS/*.VCD</code> rows are not listed on these two pages.
+<b>Both (L3)</b> reaches this Ember-only PS1 view via L3; <b>Mixed</b> combines those Ember rows with
+PS2 titles and cycles Mixed / PS2 / PS1; <b>PS1</b> pins it directly.</div>
+
+<div class="callout info"><div class="h">ℹ Apply and retry without leaving the page</div>
+Confirming <b>Network Settings</b> applies the current values and begins a new connection attempt
+immediately. If a router or server was slow and the page reports a failed connection, press
+<b>Select / Refresh</b> on that network page to retry it; reopening settings or saving every setting
+is no longer required.</div>
 
 <p><b>UDPFS</b> is the one modern network-boot protocol (Rick Gaiser's <b>UDPRDMA</b> transport). It
 comes in two shapes, chosen with the <b>Access</b> row (see the comparison below): <b>Files</b>

--- a/neutrino.html
+++ b/neutrino.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html" class="active"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -124,7 +124,7 @@ PlayStation 1 titles always boot through their own core — <b>POPSTARTER.ELF</b
 
 <h2 id="neutrino-device">3. Neutrino Device picker</h2>
 
-<p>Under <b>Settings &rarr; General Settings &rarr; Neutrino Device</b> you can pin Neutrino to a specific storage device <b>type</b>, or leave it on <b>Auto</b>. This is a device <em>type</em> (not a fixed device-name slot): OPL resolves the chosen type to its live device token(s) at launch — USB / MX4SIO / HDD (exFAT) resolve to <code>massN:</code>, MMCE resolves to <code>mmceN:</code>, and HDD (APA) resolves to a <code>pfs</code> mount. It then probes <code>&lt;root&gt;:/neutrino/neutrino.elf</code> (plus case variants) on that device type only. When set to <b>Auto</b>, OPL first probes the <b>active game device</b> for a co-located <code>neutrino.elf</code>, then honours a legacy custom Neutrino ELF path, and only then falls back to the <code>mc0</code>/<code>mc1</code> candidate list. A separate <b>Game's Device</b> choice narrows the search to the active game's own device and nothing else — no legacy custom path and no memory-card fallback.</p>
+<p>Under <b>Settings &rarr; Game Launching &rarr; Neutrino Defaults &rarr; Default Device</b> you can pin Neutrino to a specific storage device <b>type</b>, or leave it on <b>Auto</b>. This is a device <em>type</em> (not a fixed device-name slot): OPL resolves the chosen type to its live device token(s) at launch — USB / MX4SIO / iLink / HDD (exFAT) resolve to <code>massN:</code>, MMCE resolves to <code>mmceN:</code>, and HDD (APA) resolves to a <code>pfs</code> mount. It then probes <code>&lt;root&gt;:/neutrino/neutrino.elf</code> (plus case variants) on that device type. When set to <b>Auto</b>, OPL first probes the <b>active game device</b> for a co-located <code>neutrino.elf</code>, then honours a legacy custom Neutrino ELF path, and only then falls back to the <code>mc0</code>/<code>mc1</code> candidate list. A separate <b>Game's Device</b> choice narrows the search to the active game's own device and nothing else — no legacy custom path and no memory-card fallback.</p>
 
 <p>Available choices:</p>
 <ul class="checklist">
@@ -136,6 +136,7 @@ PlayStation 1 titles always boot through their own core — <b>POPSTARTER.ELF</b
 <li><b>HDD (exFAT)</b> — internal BDM/exFAT HDD (resolves to <code>massN:</code>)</li>
 <li><b>HDD (APA)</b> — internal APA HDD (resolves to a <code>pfs</code> mount)</li>
 <li><b>Game's Device</b> — resolves <em>only</em> on the active game's own device (a co-located <code>neutrino/neutrino.elf</code>); there is no legacy custom path and no <code>mc0</code>/<code>mc1</code> fallback, so a miss shows a "not found" message and aborts the launch</li>
+<li><b>iLink</b> — IEEE 1394 / SBP-2 storage (resolves to the matching mounted <code>massN:</code> device)</li>
 </ul>
 
 <p>In all cases the path searched on the chosen device type is <code>&lt;device&gt;:NEUTRINO/neutrino.elf</code> and its capitalisation variants; the leading-slash form <code>&lt;device&gt;:/neutrino/neutrino.elf</code> is also tried.</p>

--- a/per-game-settings.html
+++ b/per-game-settings.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html" class="active"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>

--- a/ps1-vcd.html
+++ b/ps1-vcd.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html" class="active"><span class="em">💿</span>PS1 Games (VCD)</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -52,8 +52,8 @@
 <h1>PS1 Games</h1>
 <p class="lead">RiptOPL can list and launch your PlayStation 1 games right alongside your PS2 library,
 on the same device. It does this through <b>two</b> cores — <b>POPSTARTER</b> for <code>*.VCD</code>
-images and <b>Ember</b> for <code>*.cue</code> discs — and both appear together in a single
-<b>PS1</b> list. Neither uses OPL's built-in core or Neutrino, so this is a self-contained path with
+images and <b>Ember</b> for game folders containing <code>*.cue</code>, <code>*.bin</code>, or
+<code>*.exe</code> discs. Ordinary devices merge both into one <b>PS1</b> list. Neither uses OPL's built-in core or Neutrino, so this is a self-contained path with
 its own storage layout and settings.</p>
 
 <table data-sortable>
@@ -80,37 +80,44 @@ multi-disc setups, and memory-card storage — see the
 <a href="https://nathanneurotic.github.io/POPSLoader/storage.html">storage</a>.
 </div>
 
-<h2 id="vcd-view">The PS1 view (press L3)</h2>
+<h2 id="vcd-view">PS2 and PS1 libraries on each device</h2>
 
-<p>Every device page — USB, MMCE, MX4SIO, iLink, SMB, and the internal HDD — holds two lists:</p>
+<p>Every supported game page holds a PS2 list and a PS1 list:</p>
 <ul class="checklist">
   <li>its <b>PS2 games</b> (ISO / ZSO / UL format), and</li>
   <li>its <b>PS1 games</b> — POPSTARTER <code>*.VCD</code> images and Ember <code>*.cue</code>
       titles together, in one list.</li>
 </ul>
-<p>Press <b>L3</b> on any device page to switch between the two. It is a <b>view toggle</b>, not a
-separate tab — the same page, the same covers, favourites, and per-game settings, just a different
-list. An on-screen hint tells you which one you are looking at.</p>
+<p><b>PS2/PS1 Game Display</b> controls whether these are separate L3-switched views, a combined
+list with filters, or one locked library. They remain views of the same device page — with the same
+covers, favorites, and per-game settings — rather than separate device tabs.</p>
 
-<div class="callout info"><div class="h">ℹ Favourites follow the active view</div>
-While a device page shows VCDs, starred VCD titles appear in the Favourites tab; while it shows
-discs, starred disc titles appear. Favourites that don't match the current view are simply not shown
-until you toggle back — nothing is lost.
+<div class="callout info"><div class="h">ℹ UDPFS and UDPBD list Ember only</div>
+Their PS1 pages are enabled, but never publish POPSTARTER/VCD rows. Ember inherits the already-live
+<code>udpfs:</code> or network block-device mount; POPSTARTER resets the IOP and cannot restore either
+transport. Hiding rows that cannot launch keeps the network PS1 page honest.
 </div>
 
-<h2 id="default-game-view">Locking the view — Default game view</h2>
+<h2 id="default-game-view">PS2/PS1 Game Display</h2>
 
-<p>If you don't want to press L3 every session, open <b>Settings → Interface</b> and set
-<b>Default game view</b>:</p>
+<p>The same picker appears on both <b>Settings → Interface</b> and
+<b>Settings → PS Emulation Settings</b>. They edit one value:</p>
 
 <table data-sortable>
-  <thead><tr><th>Value</th><th>Behaviour</th></tr></thead>
+  <thead><tr><th>Value</th><th>Behavior</th></tr></thead>
   <tbody>
-    <tr><td><b>Both</b> (default)</td><td>Every page starts on its disc list; L3 toggles to the PS1 list and back.</td></tr>
-    <tr><td><b>PS2</b></td><td>Every page is locked to its PS2 list. L3 does nothing.</td></tr>
-    <tr><td><b>PS1</b></td><td>Every page is locked to its PS1 list. L3 does nothing.</td></tr>
+    <tr><td><b>Both (L3)</b> (default)</td><td>Each device page has separate PS2 and PS1 views; L3 switches between them and each page retains its own position.</td></tr>
+    <tr><td><b>Mixed</b></td><td>Each device starts with PS2 and PS1 rows combined; L3 cycles <b>Mixed → PS2 → PS1</b> on that page.</td></tr>
+    <tr><td><b>PS2</b></td><td>Applicable device pages show PS2 only; L3 is fully inert, with no hint, sound, notification, or pause.</td></tr>
+    <tr><td><b>PS1</b></td><td>Applicable device pages show PS1 only; L3 is fully inert, with no hint, sound, notification, or pause.</td></tr>
   </tbody>
 </table>
+
+<p>APPS and Favorites do not inherit this setting. Favorites always has its independent
+<b>All in One → PS2 → PS1 → ELF</b> ring. <b>Applications Display</b> either keeps all ELFs in one
+inert Mixed list or splits Apps / titles containing <code>[PS1]</code> (case-insensitive) across L3;
+either side still launches an ordinary ELF. Switching back to an L3-enabled device mode restores
+each device page's retained position.</p>
 
 <h2 id="launch">How PS1 games launch</h2>
 
@@ -124,11 +131,15 @@ PS2-specific per-game options — neither PS1 core reads them.</p>
 and POPSTARTER locates the matching <code>*.VCD</code> file itself. Ember is handed the name of the
 game <em>folder</em> and finds its own disc image inside it.</p>
 
+<p>For an iLink VCD, RiptOPL uses the same local block-device handoff as USB and MX4SIO:
+<code>mass:/POPS/XX.&lt;game&gt;.ELF</code>. The normal <code>XX.</code> filename rules therefore
+apply unchanged.</p>
+
 <h3>POPSTARTER.ELF path</h3>
 <p>By default RiptOPL looks for <code>POPSTARTER.ELF</code> in each device's <code>POPS</code>
 folder. To pin it to one device instead, set
 <b>Settings → PS Emulation Settings → POPSTARTER.ELF Device</b> — Default, Memory Card, USB, MX4SIO, MMCE,
-HDD (exFAT), HDD (APA), Custom, or Game's Device. The free-text <b>POPSTARTER.ELF Path</b> field
+HDD (exFAT), HDD (APA), Custom, Game's Device, or iLink. The free-text <b>POPSTARTER.ELF Path</b> field
 below it only appears when the Device is set to <b>Custom</b>. The on-screen editor caps at 31
 characters; for a longer path set <code>popstarter_path</code> in
 <code>settings_riptopl.cfg</code> directly.</p>
@@ -189,9 +200,10 @@ Ember's own default is 480p, so leaving this on <b>Default</b> and having no fil
 thing.</p>
 
 <h3>Device support</h3>
-<p>Ember titles are listed on <b>USB, MX4SIO, iLink, exFAT-ATA and MMCE</b>. <b>SMB</b> and the
-<b>APA internal HDD</b> are POPSTARTER-only for now — a device with no <code>EMBER/</code> folder
-simply contributes no Ember rows, and its POPSTARTER library lists exactly as before.</p>
+<p>Ember titles are supported on <b>USB, MX4SIO, iLink, exFAT-ATA, MMCE, SMB, APA/PFS HDD,
+UDPFS and UDPBD</b>. Ordinary device pages merge Ember folders with their POPSTARTER rows; the two
+UDP network pages are Ember-only. A device with no <code>EMBER/</code> library simply contributes no
+Ember rows, and every ordinary device's POPSTARTER library lists exactly as before.</p>
 
 <h2 id="file-layout">Where to put your VCD files</h2>
 
@@ -222,8 +234,8 @@ launched; it just won't auto-match art by ID.
 
 <h2 id="bdma">exFAT support — the BDMA equip</h2>
 
-<p>POPSTARTER's stock FAT driver reads FAT32 only. To boot PS1 games from an <b>exFAT</b> drive,
-POPSTARTER needs extra block-device modules (the BDMAssault / "BDMA" drivers). RiptOPL
+<p>POPSTARTER's stock driver handles ordinary USB FAT32. USB exFAT and the MX4SIO, MMCE, ATA and
+iLink transports need matching external block-device modules (the BDMAssault / "BDMA" drivers). RiptOPL
 <em>equips</em> them onto your memory card from <b>Settings → PS Emulation Settings</b> — you supply the module
 files, RiptOPL copies the right pair to <code>mc?:/POPSTARTER/</code>. <b>VCD BDMA Apply on Launch</b>
 ships <b>On</b>, so by default the matching pair is equipped automatically immediately before each VCD
@@ -238,6 +250,9 @@ default) that is the game's own device; with it <b>Off</b>, whichever device you
 folder holding a custom <code>POPSTARTER.ELF</code>, if you set one — ahead of either. The release
 <code>POPS/</code> folder includes what ships with the build; check the
 <a href="releases.html">Releases</a> page for details.
+For iLink the loose source pair is <code>usbd.irx.ilink</code> +
+<code>usbhdfsd.irx.ilink</code>. RiptOPL removes only the <code>.ilink</code> suffix when it
+copies them to the card as <code>usbd.irx</code> + <code>usbhdfsd.irx</code>.
 </div>
 
 <h3>BDMA Mode</h3>
@@ -251,6 +266,7 @@ POPSTARTER should use:</p>
     <tr><td><b>MX4SIO (exFAT)</b></td><td>Equips the MX4SIO exFAT BDMAssault modules.</td></tr>
     <tr><td><b>MMCE (exFAT)</b></td><td>Equips the MMCE exFAT BDMAssault modules.</td></tr>
     <tr><td><b>HDD (exFAT)</b></td><td>Equips the internal ATA HDD BDMAssault modules. Requires <em>HDD (GPT/MBR)</em> enabled in Device Settings.</td></tr>
+    <tr><td><b>iLink</b></td><td>Equips the iLink / IEEE 1394 BDMAssault modules from the <code>.ilink</code> pair.</td></tr>
   </tbody>
 </table>
 
@@ -258,9 +274,9 @@ POPSTARTER should use:</p>
 <p>Shown only when <b>VCD BDMA Apply on Launch</b> is <b>Off</b> — with it <b>On</b> the source is
 the game's own device family instead. Selects which device RiptOPL reads the module files from (the
 device whose <code>POPS/</code> folder holds the variant you want to equip): <b>USB</b>,
-<b>MX4SIO</b>, <b>MMCE</b>, or
+<b>MX4SIO</b>, <b>MMCE</b>, <b>iLink</b>, or
 <b>Internal HDD</b>. RiptOPL identifies the device by its block-device <em>driver</em>
-(<code>usb</code> / <code>mx4sio</code> / <code>ata</code> / <code>mmce</code>) and reads from that
+(<code>usb</code> / <code>mx4sio</code> / <code>ata</code> / <code>ilink</code> / <code>mmce</code>) and reads from that
 specific device, so pick the one your module files actually sit on. For an internally attached exFAT
 HDD choose <b>Internal HDD</b> — RiptOPL reads it from its mounted <code>massN:</code> root (the exFAT
 volume mounted through the BDM mass-device namespace, never a typed <code>ata0:</code> filesystem), so its
@@ -273,7 +289,7 @@ volume mounted through the BDM mass-device namespace, never a typed <code>ata0:<
   <div class="step">
     <h3>Place module files</h3>
     <p>Copy the appropriate BDMA variant's module files into the <code>POPS/</code> folder of the
-    device you will select as the Source (USB, MX4SIO, MMCE, or the internal HDD).</p>
+    device you will select as the Source (USB, MX4SIO, MMCE, iLink, or the internal HDD).</p>
   </div>
   <div class="step">
     <h3>Turn VCD BDMA Apply on Launch off</h3>
@@ -288,7 +304,8 @@ volume mounted through the BDM mass-device namespace, never a typed <code>ata0:<
   <div class="step">
     <h3>Set BDMA Mode</h3>
     <p>Set <b>BDMA Mode</b> to the variant matching your target drive type (e.g. <b>USB (exFAT)</b>
-    for an exFAT USB stick, <b>HDD (exFAT)</b> for the internal ATA drive).</p>
+    for an exFAT USB stick, <b>HDD (exFAT)</b> for the internal ATA drive, or <b>iLink</b> for
+    IEEE 1394 storage).</p>
   </div>
   <div class="step">
     <h3>Save settings</h3>
@@ -307,7 +324,7 @@ modules. RiptOPL can write those config files for you: enable
 <b>Settings → Network Settings → Write POPSTARTER Network Config</b> (off by default). On save it
 mirrors the same IP and share values OPL already uses into <code>mc?:/POPSTARTER/</code>.</p>
 
-<p>The SMB modules themselves ship in the release's <code>POPSTARTER/</code> folder — copy them to
+<p>The SMB modules themselves ship in the release's <code>POPS/</code> folder — copy them to
 <code>mc?:/POPSTARTER/</code>. If they are missing, an SMB VCD launch warns you rather than
 hanging silently.</p>
 
@@ -330,10 +347,10 @@ hanging silently.</p>
 
 <h2 id="limitations">Notes &amp; limitations</h2>
 <ul class="checklist">
-  <li>The PS1 view reuses the normal device pipeline, so covers, favourites, and the theme all work
+  <li>The PS1 view reuses the normal device pipeline, so covers, favorites, and the theme all work
   exactly as they do for disc games.</li>
-  <li>POPSTARTER, the BDMA module variants, and the POPS patch file are supplied by you (or bundled
-  in the release <code>POPS/</code> folder) — RiptOPL does not embed any of them.</li>
+  <li>POPSTARTER, every loose BDMA pair (including <code>.ilink</code>), and the POPS patch file
+  ship as separate files in the release <code>POPS/</code> folder — RiptOPL does not embed any of them.</li>
   <li>The per-game Loader Core, GSM, Cheats, PADEMU, and OSD options do not apply to PS1 games;
   POPSTARTER ignores them and the UI reflects this.</li>
   <li>SMB PS1 requires POPSTARTER's own network modules on the memory card in addition to the

--- a/ps3-bc.html
+++ b/ps3-bc.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>

--- a/releases.html
+++ b/releases.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -53,10 +53,10 @@
 <p><b><a href="https://github.com/NathanNeurotic/PS2-Servers">PS2-Servers</a></b> by <b><a href="https://github.com/NathanNeurotic">Ripto</a></b> — all-in-one PC server launcher for <b>SMBv1, UDPFS and UDPBD</b>.<br>
 <b><a href="https://github.com/YouKnow-sys/udpfs-server">udpfs-server</a></b> by <b><a href="https://github.com/YouKnow-sys">YouKnow-sys</a></b> — the same idea from a phone: an <b>Android</b> app that shares folders and disk images to the PS2 over <b>UDPFS</b>, found by broadcast so there is no server address to type in on the console. Built on <a href="https://github.com/pcm720/udpfsd">udpfsd</a> by pcm720; MIT licensed.<br>
 <b><a href="https://github.com/Luden02/OrbitPS2-Manager">OrbitPS2 Manager</a></b> by <b><a href="https://github.com/Luden02">Luden</a></b> — cross-platform PC library manager for importing discs, artwork/screenshots, ZSO compression, per-game settings and VMC management.<br>
-<b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO Converter GUI</a></b> by <b><a href="https://github.com/shaanhomebrew-cloud">shaan</a></b> — Windows all-in-one PS1/POPStarter preparation tool for BIN/CUE → VCD conversion and installation to USB, MX4SIO, MMCE, exFAT HDD, SMB and APA internal HDD.<br>
+<b><a href="https://github.com/shaanhomebrew-cloud/OPL-PS1-AIO-Converter-GUI">OPL PS1 AIO Converter GUI</a></b> by <b><a href="https://github.com/shaanhomebrew-cloud">shaan</a></b> — Windows all-in-one PS1/POPStarter preparation tool for BIN/CUE → VCD conversion and installation to USB, MX4SIO, MMCE, iLink, exFAT HDD, SMB and APA internal HDD.<br>
 <b><a href="https://github.com/TheRealNextria/PS2RD-CHT-Manager">PS2RD CHT Manager</a></b> by <b><a href="https://github.com/TheRealNextria">TheRealNextria</a></b> — PC manager for the PS2RD <code>.cht</code> cheat files RiptOPL reads from your device's <code>CHT</code> folder.<br>
 <b><a href="https://github.com/Gageformer/Ember">Ember</a></b> by <b><a href="https://github.com/Gageformer">Gageformer</a></b> — a PS1 emulator running natively on the PS2, used as RiptOPL's second PS1 core alongside POPSTARTER. Ships as an <code>EMBER/</code> folder inside the release package, bundled unmodified with permission under the Ember Public Beta Testing Licence (<code>EMBER/LICENSE-BETA.txt</code>); <a href="https://github.com/Gageformer/Ember/releases">releases</a>.<br>
-<b><a href="https://www.psx-place.com/resources/popstarter.683/">POPStarter</a></b> by <b>krHACKen</b> — a PS1 launcher built around Sony's native <b>POPS</b> emulator for the PS2, used as RiptOPL's primary PS1 core alongside Ember. POPStarter provides the compatibility and launch layer for running PS1 VCDs from USB, internal HDD, and SMB. The official POPStarter r13 package contains no Sony emulator binaries, libraries, or BIOS files; those components must be supplied separately by the user. Official download, documentation, compatibility information, and releases are maintained on <a href="https://www.psx-place.com/resources/popstarter.683/">PSX-Place</a>.<br>
+<b><a href="https://www.psx-place.com/resources/popstarter.683/">POPStarter</a></b> by <b>krHACKen</b> — a PS1 launcher built around Sony's native <b>POPS</b> emulator for the PS2, used as RiptOPL's primary PS1 core alongside Ember. POPStarter provides the compatibility and launch layer for running PS1 VCDs from USB, MX4SIO, MMCE, iLink, internal HDD, and SMB. The official POPStarter r13 package contains no Sony emulator binaries, libraries, or BIOS files; those components must be supplied separately by the user. Official download, documentation, compatibility information, and releases are maintained on <a href="https://www.psx-place.com/resources/popstarter.683/">PSX-Place</a>.<br>
 <b><a href="https://github.com/rickgaiser/neutrino">Neutrino</a></b> by <b><a href="https://github.com/rickgaiser">rickgaiser</a></b> — a small, fast, modular PS2 device emulator, and RiptOPL's second PS2 loader core alongside OPL's own. Ships as a ready-to-use <code>neutrino/</code> folder inside the release package (drag-and-drop to <code>mc?:/neutrino/</code>), under the <b>AFL-3.0</b> licence; <a href="https://github.com/rickgaiser/neutrino/releases">releases</a>.</p></section>
 <h1>Releases</h1>
 <p class="lead">RiptOPL ships on two channels: a continuously-rebuilt <b>rolling</b> pre-release (every
@@ -113,7 +113,9 @@ The headline item is a full installable package zip; all other assets are publis
   <td><b>The installable package.</b> Contains labeled SDK loader folders:
   <code>APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF</code> (#1, built with the current <code>ps2dev/ps2dev:latest</code> SDK),
   and <code>APP_RIPTOPL-PS2DEVPINNEDSDK/RIPTOPL.ELF</code> (#2, built on a digest-pinned ps2dev SDK as the safe fallback),
-  the <code>POPSTARTER/</code> and <code>POPS/</code> folders for PS1 support, the bundled <code>neutrino/</code> folder, and a <code>PS2-Servers.url</code> shortcut.
+  one canonical <code>POPS/</code> folder for POPSTARTER support (every BDMA pair stays loose there,
+  including <code>usbd.irx.ilink</code> + <code>usbhdfsd.irx.ilink</code>; none is embedded),
+  the bundled <code>EMBER/</code> and <code>neutrino/</code> folders, and the companion-tool shortcuts.
   Extract it and use <code>APP_RIPTOPL-PS2DEVLATESTSDK/RIPTOPL.ELF</code>.</td>
 </tr>
 <tr>
@@ -259,8 +261,8 @@ copy to your memory card or USB drive root:</p>
   RIPTOPL.ELF          ← use this (ps2dev:latest, recommended)
 APP_RIPTOPL-PS2DEVPINNEDSDK/
   RIPTOPL.ELF          ← digest-pinned fallback if the recommended build misbehaves
-POPSTARTER/            ← SMB network stack + bdma_config.txt
-POPS/                  ← POPSTARTER.ELF and BDMA variants
+POPS/                  ← POPSTARTER.ELF and every loose BDMA variant (including .ilink)
+EMBER/                 ← official Ember core; add your own BIOS and games
 neutrino/              ← official Neutrino core (already extracted, drag-and-drop)
 PS2-Servers.url        ← link to the UDPFS / SMBv1 / UDPBD all-in-one PC launcher</pre>
 </div>

--- a/settings.html
+++ b/settings.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -60,6 +60,11 @@ appears in the UI, with its values and a brief description. Options that open a 
 loaded from). RiptOPL uses its own file so it never collides with stock OPL or wOPL on the same card.
 Artwork, themes, VMC files and <code>favourites.bin</code> remain shared.</div>
 
+<div class="callout info"><div class="h">i Page return retention</div>
+Opening Start or Settings remembers the game/source page you paused on. Returning keeps that page
+selected while it is still visible; RiptOPL falls back to the first visible page only when the old
+page was disabled or removed.</div>
+
 <h2 id="general-settings">General Settings</h2>
 <p>Reached via <b>Settings &rarr; General Settings</b>. Contains launch-path helpers, global Neutrino
 configuration, housekeeping options, and — below their own splitters — the prefix paths and cache sizes.
@@ -73,7 +78,7 @@ The PS1/BDMA plumbing now lives on its own <a href="#vcd-settings">PS Emulation 
 <tr><td>IGR Path</td><td>text (path)</td><td>Path to a custom ELF that is loaded instead of returning to the browser on an in-game reset (IGR). Leave blank to return to the browser. Hint: <em>Boots custom ELF after an IGR.</em></td></tr>
 <tr><td>Default Loader Core</td><td>&lt;OPL&gt; / Neutrino</td><td>Global default core for games whose per-game <em>Loader Core</em> is set to <em>Default</em>. <em>&lt;OPL&gt;</em> (the default) is the native EE core; <em>Neutrino</em> chains the external <code>neutrino.elf</code>. A per-game choice always overrides this. See <a href="neutrino.html">Neutrino Core</a>.</td></tr>
 <tr><td>Neutrino Launch Args</td><td>[sub-screen]</td><td>Opens the structured global <a href="neutrino.html">Neutrino Args</a> editor. Flags set here apply to every game that uses the Neutrino core unless overridden per-game. Prefix a flag with <code>$</code> to disable it without deleting it.</td></tr>
-<tr><td>Neutrino Device</td><td>Auto / Memory Card / USB / MX4SIO / MMCE / HDD (exFAT) / HDD (APA) / Game's Device</td><td>Which device <em>type</em> to scan for <code>&lt;root&gt;:/neutrino/neutrino.elf</code>. <em>Auto</em> probes the active game device first, then a legacy custom path, then mc0 and mc1. <em>Game's Device</em> probes the game's own device <em>only</em> — there is no memory-card fallback, so a miss aborts the launch with a "not found" message. Choose a specific type if your ELF is on USB, MMCE, or an HDD. See <a href="neutrino.html">Neutrino Core</a>.</td></tr>
+<tr><td>Neutrino Device</td><td>Auto / Memory Card / USB / MX4SIO / MMCE / HDD (exFAT) / HDD (APA) / Game's Device / iLink</td><td>Which device <em>type</em> to scan for <code>&lt;root&gt;:/neutrino/neutrino.elf</code>. <em>Auto</em> probes the active game device first, then a legacy custom path, then mc0 and mc1. <em>Game's Device</em> probes the game's own device <em>only</em> — there is no memory-card fallback, so a miss aborts the launch with a "not found" message. Choose a specific type if your ELF is on USB, iLink, MMCE, or an HDD. See <a href="neutrino.html">Neutrino Core</a>.</td></tr>
 <tr><td>Neutrino Video</td><td>Off / 240p / 480p / 1080i x1 / 1080i x2 / 1080i x3</td><td>Global default for Neutrino's <code>-gsm</code> video mode. Games whose per-game <em>Neutrino Video</em> picker is left on <em>Default</em> follow this value. Off by default (no forced mode). See <a href="neutrino.html">Neutrino Core</a>.</td></tr>
 <tr><td>Neutrino GSM Compatibility</td><td>Off / Type 1 (GSM/OPL) / Type 2 / Type 3</td><td>Field-flipping fix for games that shake or tear under a forced Neutrino video mode — the <code>:c</code> half of <code>-gsm</code>. Only emitted when a video mode is actually set. Off by default.</td></tr>
 <tr><td>Write Operations</td><td>Off / On</td><td>Enables write access to storage media. Required for VMC creation and some other write operations. Disable if you want a read-only mode.</td></tr>
@@ -127,7 +132,7 @@ enabled, their start modes, and the network transport rows. Prefix paths and cac
 <table data-sortable>
 <thead><tr><th>Option</th><th>Values</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td>Default Menu</td><td>BDM Games / ETH Games / HDD Games / Apps / MMCE / Favourites</td><td>Which tab is shown first on boot.</td></tr>
+<tr><td>Default Menu</td><td>BDM Games / ETH Games / HDD Games / Apps / MMCE / Favorites</td><td>Which tab is shown first on boot.</td></tr>
 <tr><td>BDM Start Mode</td><td>Off / Manual / Auto</td><td>Block-Device Manager (USB, MX4SIO, iLink) startup mode. <em>Auto</em> starts immediately; <em>Manual</em> waits for you to press Start; <em>Off</em> disables the whole BDM subsystem.</td></tr>
 <tr><td>USB</td><td>Off / On</td><td>Enables the USB mass-storage driver. Disabling frees IOP RAM. See <a href="usb.html">USB / MX4SIO / iLink</a>.</td></tr>
 <tr><td>iLink</td><td>Off / On</td><td>Enables the iLink (IEEE 1394) mass-storage driver.</td></tr>
@@ -139,7 +144,7 @@ enabled, their start modes, and the network transport rows. Prefix paths and cac
 <tr><td>SMB Version</td><td>SMBv1 / SMB2</td><td>Which SMB dialect to speak. <em>SMBv1</em> is the default. Live only while <em>Protocol</em> is SMB and greyed otherwise, but the chosen value is preserved rather than reset. It applies to both browsing and in-game reading, and takes effect on the next boot. See <a href="smb.html">SMB (network share)</a>.</td></tr>
 <tr><td>Access</td><td>Files / IMG</td><td><em>Files</em> uses the <code>udpfs_ioman</code> filesystem to serve loose ISOs from a folder (<code>-bsd=udpfs</code>); <em>IMG</em> uses the <code>udpfs_bd</code> block device to serve a served disk image (<code>-bsd=udpfsbd</code>). Only UDPFS lets you choose: SMB locks the row to <em>Files</em> and UDPBD locks it to <em>IMG</em> — greyed, not hidden. See <a href="network-boot.html">Network Boot</a>.</td></tr>
 <tr><td>Applications Start Mode</td><td>Off / Manual / Auto</td><td>Startup mode for the Apps tab.</td></tr>
-<tr><td>Favourites Start Mode</td><td>Off / Manual / Auto</td><td>Startup mode for the Favourites tab. Set to <em>Off</em> to hide the Favourites tab entirely. See <a href="favourites.html">Favourites</a>.</td></tr>
+<tr><td>Favorites Start Mode</td><td>Off / Manual / Auto</td><td>Startup mode for the Favorites tab. Set to <em>Off</em> to hide the Favorites tab entirely. See <a href="favourites.html">Favorites</a>.</td></tr>
 <tr><td>MMCE Start Mode</td><td>Off / Manual / Auto</td><td>Startup mode for MMCE (SD2PSX / MemCard PRO2) game loading. See <a href="mmce.html">MMCE</a>.</td></tr>
 </tbody>
 </table>
@@ -151,13 +156,15 @@ driver equip, and the PS1 list display options. See <a href="ps1-vcd.html">PS1 G
 <table data-sortable>
 <thead><tr><th>Option</th><th>Values</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td>POPSTARTER Device</td><td>Default / Memory Card / USB / MX4SIO / MMCE / HDD (exFAT) / HDD (APA) / Custom / Game's Device</td><td>Which device <em>type</em> holds <code>POPS/POPSTARTER.ELF</code>. <em>Default</em> resolves the launch device automatically; <em>Game's Device</em> pins it to the device the PS1 game itself lives on. Selecting <em>Custom</em> reveals the free-text <em>POPSTARTER Path</em> field below. SMB PS1 VCDs additionally use an <code>SB.&lt;name&gt;.ELF</code> selector. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>PS2/PS1 Game Display</td><td>Both (L3) / Mixed / PS2 / PS1</td><td>The same persisted picker shown on Interface. <em>Both (L3)</em> switches separate PS2 and PS1 views on each device. <em>Mixed</em> combines them and L3 cycles Mixed / PS2 / PS1. <em>PS2</em> or <em>PS1</em> locks applicable device pages and makes L3 fully inert — no hint, sound, notification, pause, or state change. APPS and Favorites are independent.</td></tr>
+<tr><td>POPSTARTER Device</td><td>Default / Memory Card / USB / MX4SIO / MMCE / HDD (exFAT) / HDD (APA) / Custom / Game's Device / iLink</td><td>Which device <em>type</em> holds <code>POPS/POPSTARTER.ELF</code>. <em>Default</em> resolves the launch device automatically; <em>Game's Device</em> pins it to the device the PS1 game itself lives on. Selecting <em>Custom</em> reveals the free-text <em>POPSTARTER Path</em> field below. SMB PS1 VCDs additionally use an <code>SB.&lt;name&gt;.ELF</code> selector. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
 <tr><td>POPSTARTER Path</td><td>text (path)</td><td>Custom path to <code>POPSTARTER.ELF</code> (up to 31 characters in the UI; longer paths can be set directly in <code>settings_riptopl.cfg</code>). Shown only when <em>POPSTARTER Device</em> is set to <em>Custom</em>. Blank silently falls back to the device POPS folder. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
 <tr><td>VCD BDMA Apply on Launch</td><td>Off / On</td><td>On by default. When on, launching a PS1 VCD auto-equips its matching exFAT driver to the memory card before boot, and the manual <em>BDMA Source</em> and <em>BDMA Mode</em> pickers below are hidden. Turn it off to manage those pickers yourself. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
-<tr><td>BDMA Source</td><td>USB / MX4SIO / MMCE / HDD</td><td>Which device holds the BDMAssault driver files (<code>usbd.irx.*</code>, <code>usbhdfsd.irx.*</code>). Only relevant when playing PS1 games from an exFAT drive. Shown only when <em>VCD BDMA Apply on Launch</em> is Off. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
-<tr><td>BDMA Mode</td><td>USB (FAT32) / USB (exFAT) / MX4SIO (exFAT) / MMCE (exFAT) / HDD (exFAT)</td><td>Block-device driver POPSTARTER loads for exFAT media. Changing this copies the appropriate modules to the memory card. FAT32 uses the built-in driver (no copy needed). Shown only when <em>VCD BDMA Apply on Launch</em> is Off. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
-<tr><td>Hide PS1 Game ID (VCD list)</td><td>Off / On</td><td>On by default. Cosmetic only — hides a leading game-ID prefix (e.g. <code>SLUS_005.51.</code>) from PS1/VCD list names, for both display and sorting. Names without an ID are shown as-is. Does not change launch, cover art, or favourites. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
-<tr><td>First disc only (multi-disc PS1)</td><td>Off / On</td><td>On by default. Shows only Disc 1 of a multi-disc PS1 game in the device lists (POPSLoader style), hiding files named <code>(Disc 2)</code>, <code>(CD 2)</code>, etc. All discs stay on the card for in-game swapping, and Favourites are not filtered. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>BDMA Source</td><td>USB / MX4SIO / MMCE / HDD / iLink</td><td>Which device's <code>POPS/</code> folder holds the loose BDMAssault driver files (<code>usbd.irx.*</code>, <code>usbhdfsd.irx.*</code>). Shown only when <em>VCD BDMA Apply on Launch</em> is Off. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>BDMA Mode</td><td>USB (FAT32) / USB (exFAT) / MX4SIO (exFAT) / MMCE (exFAT) / HDD (exFAT) / iLink</td><td>Block-device driver POPSTARTER loads for the selected transport. Changing this copies the matching loose pair from the source device's <code>POPS/</code> folder to the memory card; no BDMA pair is embedded in RiptOPL. FAT32 uses POPSTARTER's built-in driver. Shown only when <em>VCD BDMA Apply on Launch</em> is Off. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>Ember Display Mode</td><td>Default / 240p / 480p</td><td>Writes Ember's display key to <code>EMBER/settings.txt</code> on the launching device. Default removes that key and removes an otherwise-empty file.</td></tr>
+<tr><td>Hide PS1 Game ID (VCD list)</td><td>Off / On</td><td>On by default. Cosmetic only — hides a leading game-ID prefix (e.g. <code>SLUS_005.51.</code>) from PS1/VCD list names, for both display and sorting. Names without an ID are shown as-is. Does not change launch, cover art, or favorites. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>First disc only (multi-disc PS1)</td><td>Off / On</td><td>On by default. Shows only Disc 1 of a multi-disc PS1 game in the device lists (POPSLoader style), hiding files named <code>(Disc 2)</code>, <code>(CD 2)</code>, etc. All discs stay on the card for in-game swapping, and Favorites are not filtered. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
 </tbody>
 </table>
 
@@ -189,7 +196,8 @@ cover-art behavior.</p>
 <tr><td>Automatic Refresh</td><td>Off / On</td><td>Periodically re-scans for newly plugged-in devices and adds their games without requiring a manual refresh.</td></tr>
 <tr><td>Cover Art</td><td>Off / On</td><td>Enables cover-art display. When off, no cover images are loaded even if present.</td></tr>
 <tr><td>Cover Art .tar Archive</td><td>Off / On</td><td>Off by default. Opt-in loader that also reads cover art from an <code>ART/art.tar</code> archive alongside the loose image files.</td></tr>
-<tr><td>Default game view</td><td>Both / PS2 / PS1</td><td>Controls which game list is shown by default on PS1-capable device tabs. <em>Both</em> keeps the per-device L3 toggle active (defaults to PS2). <em>PS2</em> locks every tab to disc games. <em>PS1</em> locks every tab to PS1 games (POPSTARTER and Ember together). See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>PS2/PS1 Game Display</td><td>Both (L3) / Mixed / PS2 / PS1</td><td>The same persisted picker shown on PS Emulation Settings. <em>Both (L3)</em> switches separate PS2 and PS1 views. <em>Mixed</em> combines them and L3 cycles Mixed / PS2 / PS1. <em>PS2</em> and <em>PS1</em> lock applicable device pages and make L3 fully inert. APPS and Favorites remain independent. See <a href="ps1-vcd.html">PS1 Games</a>.</td></tr>
+<tr><td>Applications Display</td><td>Mixed / Apps / PS1ELF (L3)</td><td><em>Mixed</em> keeps every configured ELF together and disables L3. <em>Apps / PS1ELF (L3)</em> moves titles containing <code>[PS1]</code> (case-insensitive) to a second L3 view. Both sides remain ordinary ELF launches.</td></tr>
 <tr><td>Notifications</td><td>Off / On</td><td>Shows brief on-screen notifications when a config, theme, or language file is loaded, or when a storage partition is mounted.</td></tr>
 <tr><td>Coverflow Settings</td><td>[sub-screen]</td><td>Opens the <a href="#coverflow-settings">Coverflow Settings</a> sub-screen. See below.</td></tr>
 <tr><td>Text Color</td><td>color picker</td><td>Color of normal UI text.</td></tr>
@@ -312,9 +320,11 @@ An <em>Advanced Options</em> toggle reveals Ethernet link-mode controls.</p>
 </tbody>
 </table>
 
-<div class="callout info"><div class="h">i Reconnect button</div>After changing network settings you can press the
-<b>Reconnect</b> button to apply them immediately without closing the dialog. This re-attempts the SMB
-connection from the login stage.</div>
+<div class="callout info"><div class="h">i Apply and reconnect immediately</div>Confirming the Network
+Settings dialog applies the current values and begins a fresh SMB connection attempt immediately;
+the explicit <b>Reconnect</b> action does the same without leaving the dialog. If the network page
+already shows a failed connection, <b>Select / Refresh</b> retries it there, without reopening
+settings or saving the whole configuration.</div>
 
 <h2 id="per-game-reference">Per-game Settings (quick reference)</h2>
 <p>Per-game settings are opened by pressing <b>Triangle</b> on any game and choosing <b>Game Settings</b>.

--- a/smb.html
+++ b/smb.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -239,7 +239,7 @@ If you leave the <b>Share</b> field empty, OPL asks the driver to enumerate the 
 <div class="callout amber"><div class="h">⚠ The PS1 leg is SMBv1 regardless of the SMB Version row</div>
 The <b>SMB Version</b> setting governs OPL's own browsing and its in-game reader. It does not reach POPSTARTER: the module set OPL checks for on the memory card is the SMBv1 one (<code>smbman.irx</code>), and POPSTARTER reads its own <code>SMBCONFIG.DAT</code>, not OPL's dialect choice. So a PS1 VCD launched over SMB still needs a server that answers <b>SMBv1</b>, even if you have set OPL to SMB2 for PS2 games. If your server is SMB2-only, PS2 games over SMB will work and PS1 VCDs over SMB will not.</div>
 
-<p>For deeper PS1 coverage — cover art by PS1 disc ID, the Default game view lock, and BDMA module equipping for exFAT — see <a href="ps1-vcd.html">PS1 Games (VCD)</a>.</p>
+<p>For deeper PS1 coverage — cover art by PS1 disc ID, the four <b>PS2/PS1 Game Display</b> modes, and BDMA module equipping for block devices — see <a href="ps1-vcd.html">PS1 Games (VCD)</a>.</p>
 
 <details class="deep"><summary>Does the BDMA exFAT equip apply to SMB?</summary>
 <p>No. The BDMA equip copies block-device driver modules for POPSTARTER to use when reading an exFAT drive. SMB is a pure network path — there is no block device involved. The BDMA Mode and BDMA Source settings in General Settings have no effect on an SMB VCD launch. The only prerequisite for PS1 over SMB is the four network IRX modules above plus the POPSTARTER network config files.</p>

--- a/themes.html
+++ b/themes.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -106,7 +106,7 @@ chain — so you override only what differs and inherit the rest.</p>
 <tbody>
 <tr><td><code>main0…</code> / <code>info0…</code></td><td>The <b>games</b> list / info — the base layout</td><td><em>(none — this is the base)</em></td></tr>
 <tr><td><code>appsMain0…</code> / <code>appsInfo0…</code></td><td>The <b>apps</b> device list / info</td><td>→ <code>mainN</code> / <code>infoN</code></td></tr>
-<tr><td><code>favsMain0…</code> / <code>favsInfo0…</code></td><td>The <b>Favourites</b> tab list / info</td><td>→ <code>mainN</code> / <code>infoN</code></td></tr>
+<tr><td><code>favsMain0…</code> / <code>favsInfo0…</code></td><td>The <b>Favorites</b> tab list / info</td><td>→ <code>mainN</code> / <code>infoN</code></td></tr>
 <tr><td><code>vcdMain0…</code> / <code>vcdInfo0…</code></td><td>A device's <b>PS1 / VCD</b> view (toggle with <b>L3</b>)</td><td>main: → <code>appsMainN</code> → <code>mainN</code> · info: → <code>infoN</code></td></tr>
 </tbody>
 </table>
@@ -115,7 +115,7 @@ chain — so you override only what differs and inherit the rest.</p>
 <code>0…N</code> resolves every family against that chain. Practically:</p>
 <ul class="checklist">
 <li>A theme with <em>only</em> <code>main*</code>/<code>info*</code> blocks looks identical on the games, apps,
-Favourites and PS1 views — every family inherits the base.</li>
+Favorites and PS1 views — every family inherits the base.</li>
 <li>Define <code>appsMain5</code> to give the <b>apps</b> cover its own (square) box while games keep their
 portrait box; everything else still inherits <code>main*</code>.</li>
 <li>The <b>VCD/PS1</b> main family falls back to <code>appsMain</code> <em>before</em> <code>main</code>, so a
@@ -132,7 +132,7 @@ sequence. (A commented-out block counts as a deletion — re-number around it.)<
 <details class="deep"><summary>Why does a <code>Background</code> have to be element 0?</summary>
 The first element of a list <b>must</b> be the <code>Background</code> (the engine inserts a default plasma
 background if you forget). Likewise only the first <code>ItemsList</code> becomes the games list, the second the
-apps list, the third the Favourites list and the fourth the PS1/VCD list — so order matters beyond just draw
+apps list, the third the Favorites list and the fourth the PS1/VCD list — so order matters beyond just draw
 order. The PS1/VCD slot is optional: define only three lists and the PS1 view falls back to the games list,
 sharing its cover cache. Give it a fourth and it gets its own.</details>
 
@@ -221,7 +221,7 @@ work instead of hard-coding resolution-specific numbers.</p>
 <tr><td><code>AttributeImage</code> <b>(item)</b></td><td>A badge image chosen by a game attribute — see §6.</td></tr>
 <tr><td><code>MenuIcon</code></td><td>The current device/menu icon.</td></tr>
 <tr><td><code>MenuText</code></td><td>The current menu name, with left/right arrows when there are sibling menus.</td></tr>
-<tr><td><code>ItemsList</code> <b>(item)</b></td><td>The scrolling list of games/apps. First one = games list, second = apps, third = Favourites, fourth = PS1/VCD. Auto-added if omitted. A list with <code>devices=</code> is a per-device <em>override</em> and doesn't count toward those slots.</td></tr>
+<tr><td><code>ItemsList</code> <b>(item)</b></td><td>The scrolling list of games/apps. First one = games list, second = apps, third = Favorites, fourth = PS1/VCD. Auto-added if omitted. A list with <code>devices=</code> is a per-device <em>override</em> and doesn't count toward those slots.</td></tr>
 <tr><td><code>ItemIcon</code> <b>(item)</b></td><td>A per-item icon element (a <code>GameImage</code> bound to the <code>ICO</code> cache).</td></tr>
 <tr><td><code>ItemCover</code> <b>(item)</b></td><td>The selected item's cover (a <code>GameImage</code> bound to the <code>COV</code> cache), with optional overlay.</td></tr>
 <tr><td><code>ItemText</code> <b>(item)</b></td><td>The selected item's startup filename.</td></tr>
@@ -286,7 +286,7 @@ y=24</code></pre>
 <tr><td><code>udpbd</code></td><td>UDPBD network boot</td></tr>
 <tr><td><code>udpfs</code></td><td>UDPFS network boot</td></tr>
 <tr><td><code>app</code></td><td>The Apps tab</td></tr>
-<tr><td><code>fav</code></td><td>The Favourites tab</td></tr>
+<tr><td><code>fav</code></td><td>The Favorites tab</td></tr>
 <tr><td><code>bdm</code></td><td>The generic BDM page before its driver is identified (auto/manual start)</td></tr>
 </tbody>
 </table>
@@ -788,7 +788,7 @@ info15:
 <div class="grid">
 <a class="tile" href="coverflow.html"><span class="em">🎴</span><b>Coverflow</b><span>The default theme &amp; its live settings</span></a>
 <a class="tile" href="ps1-vcd.html"><span class="em">💿</span><b>PS1 / PS1 view</b><span>Where the vcdMain family is used</span></a>
-<a class="tile" href="favourites.html"><span class="em">⭐</span><b>Favourites</b><span>The favsMain/favsInfo family</span></a>
+<a class="tile" href="favourites.html"><span class="em">⭐</span><b>Favorites</b><span>The favsMain/favsInfo family</span></a>
 <a class="tile" href="settings.html"><span class="em">🔧</span><b>Settings Reference</b><span>Selecting &amp; applying a theme</span></a>
 <a class="tile" href="https://nathanneurotic.github.io/POPSLoader/"><span class="em">📚</span><b>POPStarter docs ↗</b><span>PS1 internals: config table, IGR, cheats, multi-disc</span></a>
 </div>

--- a/troubleshooting.html
+++ b/troubleshooting.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -80,7 +80,7 @@ on PSX-Place. For PS1 internals (IGR, cheats, multi-disc, config table), see the
 </div>
 
 <details class="deep"><summary>Why does RiptOPL have its own config file?</summary>
-<p>RiptOPL saves its master config as <code>settings_riptopl.cfg</code> (auto-migrated from the older <code>conf_riptopl.cfg</code>). This is intentionally separate from stock OPL's <code>conf_opl.cfg</code> so both builds can coexist on the same memory card without clobbering each other's settings. Everything else — artwork, themes, VMCs, per-game configs, and favourites — lives in the shared <code>OPL/</code> folder and is readable by all OPL-family builds.</p>
+<p>RiptOPL saves its master config as <code>settings_riptopl.cfg</code> (auto-migrated from the older <code>conf_riptopl.cfg</code>). This is intentionally separate from stock OPL's <code>conf_opl.cfg</code> so both builds can coexist on the same memory card without clobbering each other's settings. Everything else — artwork, themes, VMCs, per-game configs, and favorites — lives in the shared <code>OPL/</code> folder and is readable by all OPL-family builds.</p>
 </details>
 
 <h2 id="white-screen">Game stops on a white screen</h2>
@@ -129,7 +129,7 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
 
 <h2 id="vcd-list-empty">PS1/VCD — "my VCDs don't show up" (works elsewhere)</h2>
 
-<p><b>Symptom:</b> A device lists PS2 games fine (or works in another loader), but its PS1/PS1 view is empty — or a listed VCD does nothing when selected.</p>
+<p><b>Symptom:</b> A device lists PS2 games fine (or works in another loader), but its PS1 view is empty — or a listed VCD does nothing when selected.</p>
 
 <p>Work down this ladder; each step isolates a different stage:</p>
 
@@ -143,8 +143,8 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
     <p>If yes, the filesystem/mount layer is proven working, so "but it works in another loader" adds no new information past this step. Both published builds — <code>PS2DEVLATESTSDK</code> (recommended) and <code>PS2DEVPINNEDSDK</code> (the digest-pinned fallback) — take their exFAT/BDM drivers from the stock ps2dev SDK, so the flavour you picked does not change this answer.</p>
   </div>
   <div class="step">
-    <h3>Press L3 on the device page</h3>
-    <p>The PS1 view is per device and only reachable when <b>Default game view</b> is "Both" (or the page is locked to VCD).</p>
+    <h3>Check PS2/PS1 Game Display</h3>
+    <p><b>Both (L3)</b> switches separate PS2 and PS1 views. <b>Mixed</b> combines them and L3 cycles Mixed / PS2 / PS1. The locked <b>PS2</b> and <b>PS1</b> modes intentionally make L3 fully inert; choose PS1 to pin the PS1 view without L3.</p>
   </div>
   <div class="step">
     <h3>Check the folder — root, not your games prefix</h3>
@@ -162,25 +162,25 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
 
 <h2 id="bdma-module-not-found">BDMA — "module files not found on source device"</h2>
 
-<p><b>Symptom:</b> You have set a <b>BDMA Mode</b> (e.g. <code>USB (exFAT)</code>, <code>MX4SIO (exFAT)</code>, or <code>HDD (exFAT)</code>) and a <b>BDMA Source</b>, but when you save or apply the equip RiptOPL reports that the module files were not found on the source device.</p>
+<p><b>Symptom:</b> You have set a <b>BDMA Mode</b> (e.g. <code>USB (exFAT)</code>, <code>MX4SIO (exFAT)</code>, <code>HDD (exFAT)</code>, or <code>iLink</code>) and a <b>BDMA Source</b>, but when you save or apply the equip RiptOPL reports that the module files were not found on the source device.</p>
 
 <p><b>Cause:</b> The BDMA module files (<code>.irx</code> driver pair for the chosen variant) are missing from or in the wrong location on the source device. RiptOPL does not embed these files — you supply them from the release's <code>POPS/</code> folder.</p>
 
 <div class="steps">
   <div class="step">
     <h3>Locate the module files</h3>
-    <p>The BDMA module files ship inside the RiptOPL release archive. Find the <code>POPS/</code> folder in the release zip — it contains the driver variants for each equip mode (e.g. the <code>.ata</code> files for the HDD exFAT variant, equivalent sets for USB exFAT and MX4SIO exFAT).</p>
+    <p>The BDMA module files ship loose inside the RiptOPL release archive; none is embedded in <code>RIPTOPL.ELF</code>. Find the <code>POPS/</code> folder in the release zip — it contains the driver variants for each equip mode, including <code>usbd.irx.ilink</code> + <code>usbhdfsd.irx.ilink</code> for iLink.</p>
   </div>
   <div class="step">
     <h3>Copy them to the correct location</h3>
-    <p>Place the module files in a <code>POPS/</code> folder at the root of whichever device you have set as the <b>BDMA Source</b> — USB, MX4SIO, MMCE, or Internal HDD. The path must be exactly:</p>
+    <p>Place the module files in a <code>POPS/</code> folder at the root of whichever device you have set as the <b>BDMA Source</b> — USB, MX4SIO, MMCE, iLink, or Internal HDD. The path must be exactly:</p>
     <pre>POPS/        ← folder at device root
   POPSTARTER.ELF
   &lt;module files for your chosen variant&gt;</pre>
   </div>
   <div class="step">
     <h3>Note: the source must match the device's driver</h3>
-    <p>RiptOPL resolves the <b>BDMA Source</b> by its block-device <b>driver</b>, not by scanning the whole <code>massN:</code> namespace. A <b>USB</b> source reads only from slots whose driver is <code>usb</code>; <b>MX4SIO</b> reads only <code>mx4sio</code> slots; <b>Internal HDD</b> reads only the <code>ata</code> (exFAT) HDD. So if your <code>POPS/</code> module folder sits on the internal HDD but the source is set to USB, the files will <b>not</b> be found — set the source to match the driver of the device the files actually live on.</p>
+    <p>RiptOPL resolves the <b>BDMA Source</b> by its block-device <b>driver</b>, not by scanning the whole <code>massN:</code> namespace. A <b>USB</b> source reads only <code>usb</code> slots; <b>MX4SIO</b> reads only <code>mx4sio</code> slots; <b>iLink</b> reads only <code>ilink</code> slots; and <b>Internal HDD</b> reads only the <code>ata</code> (exFAT) HDD. Set the source to match the driver of the device where the loose pair actually lives.</p>
   </div>
   <div class="step">
     <h3>Re-apply the equip</h3>
@@ -189,24 +189,30 @@ If you saved an incompatible GSM (Graphics Synthesizer Mode) override and your s
 </div>
 
 <details class="deep"><summary>What exactly does "equipping" BDMA do?</summary>
-<p>POPSTARTER's stock driver reads FAT32. To boot PS1 games from an exFAT volume, POPSTARTER needs extra block-device modules. When you change BDMA Mode or Source and save, RiptOPL copies the chosen variant's <code>.irx</code> driver pair from your source device's <code>POPS/</code> folder to <code>mc?:/POPSTARTER/</code>. On the next PS1 launch POPSTARTER finds and loads those modules from the memory card, giving it access to the exFAT volume. Setting <b>BDMA Mode</b> back to <code>USB (FAT32)</code> removes the exFAT modules so POPSTARTER falls back to its built-in FAT32 driver. SMB is excluded because it is network-only and has no block device to equip.</p>
+<p>POPSTARTER's built-in path handles ordinary USB FAT32; the other supported block transports use matching external modules. When you change BDMA Mode or Source and save, RiptOPL copies the chosen suffixed pair from your source device's <code>POPS/</code> folder to <code>mc?:/POPSTARTER/</code>, removing the variant suffix on the card. For example, <code>*.ilink</code> becomes plain <code>usbd.irx</code> + <code>usbhdfsd.irx</code>. Setting <b>BDMA Mode</b> back to <code>USB (FAT32)</code> removes the external pair so POPSTARTER falls back to its built-in driver. SMB is excluded because it is network-only and has no block device to equip.</p>
 </details>
 
 <h2 id="vcd-list-not-showing">PS1 / VCD list not showing after a settings change</h2>
 
-<p><b>Symptom:</b> You have VCD files on a device but after changing a setting (such as <b>Default game view</b>, enabling a device, or changing BDMA settings) the PS1 list is empty or appears to be stuck on the disc list.</p>
+<p><b>Symptom:</b> You have VCD files on a device but after changing <b>PS2/PS1 Game Display</b>, enabling a device, or changing BDMA settings, the PS1 list is empty or appears stuck on PS2.</p>
 
-<p><b>Fix:</b> The view state sometimes needs a manual refresh after a settings change.</p>
+<p><b>Fix:</b> First distinguish a pinned view from missing content:</p>
 
 <ul class="checklist">
-  <li>Navigate to the device page that should show your VCDs and press <b>L3</b> to toggle the view. If the view was already on VCDs it will switch to discs; press <b>L3</b> again to return to VCDs. This forces a list refresh.</li>
-  <li>If <b>Default game view</b> is set to <b>PS2</b>, the PS1 toggle is disabled by design — L3 does nothing. Change <b>Default game view</b> to <b>Both</b> or <b>PS1</b> in <b>Settings → Interface</b>, then save and re-enter the device page.</li>
+  <li>If <b>PS2/PS1 Game Display</b> is <b>PS2</b> or <b>PS1</b>, L3 is completely disabled by design — no hint, sound, notification, pause, or response. Choose <b>Both (L3)</b> or <b>Mixed</b> on either <b>Interface</b> or <b>PS Emulation Settings</b> to enable an L3 ring.</li>
+  <li>Under <b>Both (L3)</b>, L3 switches PS2 / PS1. Under <b>Mixed</b>, it cycles Mixed / PS2 / PS1. A setting change queues the affected lists automatically; a separate restart is not required.</li>
   <li>If the PS1 list still appears empty, confirm the <code>*.VCD</code> files are in a <code>POPS/</code> folder at the device root (USB / MMCE / MX4SIO / iLink / SMB) or, for the internal APA HDD, inside the correct <code>__.POPS</code> / <code>__.POPS0</code>–<code>__.POPS9</code> partitions. Files in any other location are not scanned.</li>
   <li>For exFAT HDD, confirm <b>HDD (GPT/MBR)</b> is enabled in <b>Device Settings</b> and that the HDD has mounted — the game list should show an <b>HDD Games</b> entry. VCDs on the exFAT HDD live in <code>massN:/POPS/</code>.</li>
 </ul>
 
-<div class="callout info"><div class="h">i Favourites follow the active view</div>
-Favourited VCD titles only appear in the Favourites list while a page is in PS1 view mode. If you switch a page to disc view, those favourites are hidden until you switch back — they are not lost.
+<div class="callout info"><div class="h">i UDPFS / UDPBD are Ember-only PS1 pages</div>
+No VCD rows on either network page is expected, not a failed scan. POPSTARTER cannot restore those
+connections after its IOP reset; Ember inherits the live mount, so only Ember titles are listed.
+</div>
+
+<div class="callout info"><div class="h">i Favorites always has four views</div>
+Press L3 on Favorites to cycle <b>All in One → PS2 → PS1 → ELF</b>. This independent ring is not
+pinned or disabled by PS2/PS1 Game Display.
 </div>
 
 <h2 id="quick-reference">Quick-reference button combos</h2>

--- a/usb.html
+++ b/usb.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -126,9 +126,13 @@ APPS/       Homebrew ELF files
 </pre>
 
 <div class="callout info"><div class="h">i PS1 games on USB / MX4SIO / iLink</div>
-Put your <code>*.VCD</code> files in the <code>POPS/</code> folder. Press <b>L3</b> on the device's game page
-to toggle the VCD (PS1) view. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for the full setup — you will
-also need POPSTARTER on the same device.</div>
+Put your <code>*.VCD</code> files in the <code>POPS/</code> folder. <b>PS2/PS1 Game Display</b> can show
+separate PS2 / PS1 pages, a combined list, or one locked type; L3 is available only in <b>Both (L3)</b>
+and <b>Mixed</b>. See <a href="ps1-vcd.html">PS1 Games (VCD)</a> for the full setup — you will
+also need POPSTARTER on the same device. For iLink, keep the loose
+<code>usbd.irx.ilink</code> + <code>usbhdfsd.irx.ilink</code> pair in that <code>POPS/</code>
+folder; RiptOPL strips <code>.ilink</code> only when copying the pair to the memory card and launches
+with the normal <code>mass:/POPS/XX.&lt;game&gt;.ELF</code> selector.</div>
 
 <h2 id="fragmentation">Fragmentation</h2>
 <p>OPL's BDM driver supports <b>up to 64 fragments</b> per file (since OPL v1.2.0 beta rev1893). Games with

--- a/vmc.html
+++ b/vmc.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html" class="active"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>
@@ -175,7 +175,7 @@ Earlier OPL builds had a bug where VMC filenames containing spaces were truncate
 <p>You are free to rename the VMC to anything you prefer. The suggestion is just a starting point; the actual filename written to disk is whatever name you confirm in the dialog.</p>
 
 <h2 id="shared-vmc">Sharing VMCs across devices and builds</h2>
-<p>VMC image files are plain binary files and are not tied to any particular OPL build. A VMC created in RiptOPL can be read by stock OPL, wOPL, or uOPL — and vice versa — as long as the image is stored at the path those builds expect. Artwork, themes, VMCs, and favourites are shared between RiptOPL and other OPL variants on the same drive.</p>
+<p>VMC image files are plain binary files and are not tied to any particular OPL build. A VMC created in RiptOPL can be read by stock OPL, wOPL, or uOPL — and vice versa — as long as the image is stored at the path those builds expect. Artwork, themes, VMCs, and favorites are shared between RiptOPL and other OPL variants on the same drive.</p>
 
 <details class="deep"><summary>Can I use a real Memory Card dump as a VMC?</summary>
 <p>In principle, a raw Memory Card dump in the correct PS2 format (valid superblock, matching size) should work as a VMC image — but this depends on how the dump was made. Tools that produce a bit-for-bit dump of the card's flash layout are compatible. Dumps made by software that reconstructs a logical filesystem may not match the expected superblock format that OPL validates. The safest approach is to create a fresh VMC in OPL and use a save manager (such as MyMC or OPL itself via the built-in transfer feature, if available) to copy individual saves into it.</p>

--- a/zso.html
+++ b/zso.html
@@ -32,7 +32,7 @@
     <a href="ps1-vcd.html"><span class="em">💿</span>PS1 Games</a>
     <a href="neutrino.html"><span class="em">⚛️</span>Neutrino Core</a>
     <a href="coverflow.html"><span class="em">🎴</span>Coverflow</a>
-    <a href="favourites.html"><span class="em">⭐</span>Favourites</a>
+    <a href="favourites.html"><span class="em">⭐</span>Favorites</a>
     <a href="per-game-settings.html"><span class="em">🎚️</span>Per-game Settings</a>
     <a href="vmc.html"><span class="em">💾</span>VMC</a>
     <a href="cheats.html"><span class="em">🎮</span>Cheats</a>


### PR DESCRIPTION
Companion GitHub Pages update for #572.

## Documentation updates

- external-only iLink POPSTARTER BDMA packaging and memory-card activation behavior
- normal `XX.` iLink POPSTARTER argument handling and Neutrino iLink option
- PS2/PS1 Game Display modes: Both, Mixed, PS2, and PS1
- APPS/PS1ELF split behavior and independent Favorites All/PS2/PS1/ELF filters
- American Favorite(s) display text and page-return retention
- immediate Network Settings apply and Select/Refresh reconnect
- UDPFS/UDPBD PS1 pages listing Ember titles only
- APA `__.EMBER` and `__.EMBER0` through `__.EMBER9` containers
- updated searchable site index

## Validation

- `git diff --check` passed
- `data/search-index.json` parsed successfully
- stale display strings were audited across the rendered HTML and search index

The source implementation is in #572.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized “Favorites” terminology across the documentation.
  * Added guidance for PS2/PS1 display modes, independent Favorites views, and Ember PS1 support.
  * Documented iLink support across Neutrino, POPStarter, BDMA, USB, and release packages.
  * Clarified Network Settings retry behavior and UDPFS/UDPBD PS1 limitations.
  * Updated installation, release, configuration, troubleshooting, and package-layout guidance.
  * Added PS2-Launcher and udpfsd/nhddl credits and refreshed companion-tool information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->