### PR TITLE
ci: actually refresh the rolling date, and cut master out of publishing

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -3,8 +3,11 @@ name: Sync Project Links & Badges
 on:
   push:
     branches:
+      # rebuild/main ONLY. This job regenerates the External Tools block and pushes it to BOTH the
+      # source branch and gh-pages, so running it from master -- the old lineage -- would rewrite the
+      # live documentation site from a stale template and silently revert whatever the rebuild line
+      # has since published there. Dropped 2026-09-02 alongside the rolling-release publish trigger.
       - rebuild/main
-      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/promote-rolling-latest.yml
+++ b/.github/workflows/promote-rolling-latest.yml
@@ -40,7 +40,14 @@ jobs:
 
       # rolling-release.yml sets this state itself. Keep this post-publish normalization as an
       # idempotent guard against GitHub or a future workflow edit leaving the moving channel stale.
-      - name: Enforce rolling as Latest and non-pre-release
+      #
+      # --draft=false is the important one now. rolling-release.yml refreshes published_at with a
+      # draft -> published flip (the only mechanism GitHub honours), and although that flip is
+      # trap-guarded on its own side, a hard runner failure between its two edits could still strand
+      # the moving channel as an invisible draft. This job runs after that workflow completes, so it
+      # is the natural second layer: asserting the published state here costs one idempotent call and
+      # closes the only window in which users could find the rolling download page missing.
+      - name: Enforce rolling as Latest, published and non-pre-release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -48,5 +55,16 @@ jobs:
           gh release edit rolling \
             --repo "$GITHUB_REPOSITORY" \
             --title "Rolling" \
+            --draft=false \
             --prerelease=false \
             --latest
+
+          # Report the settled state, and fail loudly rather than leaving a hidden release behind.
+          DRAFT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/rolling" --jq .draft)
+          PRE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/rolling" --jq .prerelease)
+          PUB=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/rolling" --jq .published_at)
+          echo "rolling: draft=$DRAFT prerelease=$PRE published_at=$PUB"
+          if [ "$DRAFT" != "false" ] || [ "$PRE" != "false" ]; then
+            echo "ERROR: rolling did not settle as a published, non-pre-release" >&2
+            exit 1
+          fi

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -2,11 +2,11 @@ name: Rolling Release
 
 # Continuously publishes the current build of the PUBLISHING BRANCH to a single "rolling"
 # development release. It is a full (non-pre-release) GitHub release marked Latest, and it can be
-# pulled directly from a stable URL as development progresses. The publishing branch is `master`
-# (after cutover) or `rebuild/main` (during
-# the rebuild): rebuild/main is the physical publish knob -- it is fast-forwarded to a
+# pulled directly from a stable URL as development progresses. The publishing branch is
+# `rebuild/main`, and only rebuild/main: it is the physical publish knob, fast-forwarded to a
 # tested step-chain tip exactly when Nathan wants a rolling build to go out, never
-# automatically per step. See the NOTE(rebuild) on the publish-rolling gate below.
+# automatically per step. `master` is the OLD LINEAGE and is deliberately not wired to this
+# workflow at all -- see the NOTE(rebuild) on the publish-rolling gate below.
 #
 # Builds four flavours across the ps2dev and official ps2homebrew toolchain lineages so a regression
 # in either moving SDK or either pinned control is visible from the rolling channel (and a hardware
@@ -46,7 +46,9 @@ name: Rolling Release
 on:
   push:
     branches:
-      - master
+      # rebuild/main is THE publishing branch. master is the old lineage: it is kept
+      # around for history, and a push to it must never republish the rolling channel with
+      # pre-rebuild code. Deliberately not a trigger.
       - rebuild/main
     tags:
       - 'v*'
@@ -454,13 +456,14 @@ jobs:
     needs: [build-rolling-pinned, build-rolling-ps2dev-latest, build-rolling-officialsdk, build-rolling-official-pinned]
     # NOTE(rebuild): publish gate. Downstream this job has NO ref check -- anything that is not a
     # v* tag falls through to TAG="rolling" and updates the PUBLIC rolling release (see the tag/title block
-    # below). The gate therefore names the branches allowed to publish: master (post-cutover) and
-    # rebuild/main (the rebuild-line publish knob -- fast-forwarded to a tested step tip only when
-    # a rolling build is meant to go out). Any OTHER ref -- a step branch, workflow_dispatch from
-    # one, a feature branch -- still runs the build jobs (the part worth rehearsing) and uploads
-    # their artifacts, while withholding only the publish. On master, rebuild/main and v* tags the
-    # condition is true, so shipping behaviour is byte-for-byte what the fork does today.
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rebuild/main' || startsWith(github.ref, 'refs/tags/v') }}
+    # below). The gate therefore names the only branch allowed to publish: rebuild/main (the
+    # publish knob -- fast-forwarded to a tested step tip only when a rolling build is meant to go
+    # out). Any OTHER ref -- master, a step branch, workflow_dispatch from one, a feature branch --
+    # still runs the build jobs (the part worth rehearsing) and uploads their artifacts, while
+    # withholding only the publish. master is excluded on purpose: it is the abandoned lineage, and
+    # a push to it publishing over the rolling channel would ship pre-rebuild code as Latest. This
+    # gate is belt-and-braces with the push trigger above, which no longer lists master either.
+    if: ${{ github.ref == 'refs/heads/rebuild/main' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -991,39 +994,71 @@ jobs:
             # REFRESH THE ROLLING RELEASE DATE. `gh release edit` updates the body and the assets
             # but never touches published_at, which is what GitHub renders as the relative time --
             # so a package rebuilt today sat under "last month" and read as abandoned. Recreating
-            # the release would fix the date but reset the download counters, so it is patched in
+            # the release would fix the date but reset the download counters, so it is moved in
             # place.
             #
             # ROLLING ONLY. A refs/tags/v* run reaches this same branch for an existing release, and
             # a stable release must keep the date it was actually published -- rewriting that would
             # be a lie about history, not a cosmetic fix.
             #
-            # NO DRAFT FLIP. published_at is not in the documented body for "Update a release", so
-            # this may simply not take. The documented way to move it is a draft -> published
-            # transition, but that emits a `release: published` event, and release-normalize.yml
-            # subscribes to exactly that (on top of its workflow_run trigger) -- so the fallback
-            # would kick off a second, concurrent normalize of the release we are still publishing.
-            # A stale date is cosmetic; a re-entrant asset normalize is not. If the PATCH does not
-            # take, say so in the log and move on.
+            # WHY A DRAFT FLIP. PATCHing published_at does not work: GitHub accepts the request,
+            # returns 200, and silently ignores the field -- measured 2026-09-02 against this very
+            # release, where the before and after reads were byte-identical. It is not in the
+            # documented body for "Update a release", so there is no error to catch and the previous
+            # implementation could only ever log that it had failed. The one documented way to move
+            # published_at is a draft -> published transition.
+            #
+            # WHY THE OLD OBJECTION TO THAT FLIP DID NOT HOLD. It was refused because the flip emits
+            # a `release: published` event and release-normalize.yml subscribes to that event, which
+            # read like a re-entrant normalize of the release still being published. It is not:
+            # GitHub does not start a workflow run from an event raised with GITHUB_TOKEN, and that
+            # is the only token this job holds. Confirmed against history as well as the docs --
+            # every one of the last 30 release-normalize runs was triggered by workflow_run and not
+            # one by a release event, over a window that includes the run which CREATED this release
+            # (a genuine publish that would have fired the event if it could).
+            #
+            # A HIDDEN ROLLING RELEASE IS WORSE THAN A STALE DATE, so the flip is bounded twice: a
+            # trap republishes if anything between the two edits dies, and the state is asserted
+            # afterwards -- still-draft fails the job loudly rather than leaving users with an
+            # invisible download page. promote-rolling-latest.yml re-asserts it again after this
+            # workflow finishes.
             if [ "$TAG" = "rolling" ]; then
               RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq .id 2>/dev/null || echo "")
               if [ -n "$RELEASE_ID" ]; then
-                # Compare against the value BEFORE the patch, not against today's date. A rolling
+                # Compare against the value BEFORE the flip, not against today's date. A rolling
                 # release republished twice in one day already carries today's date, so a
-                # date-only test would report success for a PATCH that did nothing.
+                # date-only test would report success for a flip that did nothing.
                 WAS=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq .published_at 2>/dev/null || echo "")
-                gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
-                  -f published_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" >/dev/null 2>&1 || true
+                # set -eu is active in this step, so a failed draft=true aborts the script: this
+                # trap is what puts the channel back. INT/TERM are covered too, because a cancelled
+                # job does not run a bare EXIT trap.
+                trap 'gh release edit "rolling" --draft=false --prerelease=false --latest >/dev/null 2>&1 || true' EXIT INT TERM
+                gh release edit "$TAG" --draft=true >/dev/null
+                # Re-assert the channel's intended state on the way back up: a draft cannot hold the
+                # Latest marker, so it has to be claimed again as part of republishing.
+                gh release edit "$TAG" --draft=false --prerelease=false --latest >/dev/null
+                trap - EXIT INT TERM
                 GOT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq .published_at 2>/dev/null || echo "")
                 # Only a comparison between two SUCCESSFUL reads proves anything. A failed read
                 # leaves its variable empty, and empty-vs-anything would otherwise look like a
-                # change and log a success the patch never earned.
+                # change and log a success the flip never earned.
                 if [ -z "$WAS" ] || [ -z "$GOT" ]; then
                   echo "NOTE: could not read published_at back (before='$WAS' after='$GOT'); date refresh unverified"
                 elif [ "$GOT" != "$WAS" ]; then
                   echo "Release date refreshed: $WAS -> $GOT"
                 else
-                  echo "NOTE: published_at could not be updated (still '$WAS'); the release date will read stale"
+                  echo "NOTE: published_at did not move (still '$WAS'); the release date will read stale"
+                fi
+                # Visibility is not optional. Check it independently of whether the date moved.
+                DRAFT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq .draft 2>/dev/null || echo "")
+                if [ "$DRAFT" = "true" ]; then
+                  echo "WARNING: rolling is still a draft after the refresh; republishing" >&2
+                  gh release edit "$TAG" --draft=false --prerelease=false --latest >/dev/null 2>&1 || true
+                  DRAFT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq .draft 2>/dev/null || echo "")
+                fi
+                if [ "$DRAFT" = "true" ]; then
+                  echo "ERROR: rolling release is a DRAFT and could not be republished -- it is invisible to users" >&2
+                  exit 1
                 fi
               fi
             fi
@@ -1051,12 +1086,11 @@ jobs:
       # record, every rolling build is ALSO archived to MEGA as ONE immutable, self-contained
       # zip of the entire release payload. Runs AFTER Publish so the GitHub release is completely
       # unchanged and a MEGA hiccup can never block or alter it -- MEGA is purely additive. Gated to
-      # the publishing branches (master, rebuild/main) + secrets present, so v* tag cuts and
-      # secret-less forks skip it cleanly. rebuild/main included per Nathan 2026-08-13: the new
-      # lineage moves far faster than the old one ever did, so it needs the overwrite protection
-      # more, not less; per-run remote folders cannot collide.
+      # the publishing branch (rebuild/main) + secrets present, so v* tag cuts and secret-less
+      # forks skip it cleanly. master was dropped 2026-09-02 along with its publish trigger: the
+      # old lineage must not archive over the new one's history either.
       - name: Build all-in-one MEGA archive
-        if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rebuild/main') && env.USERNAME != '' && env.PASSWORD != ''
+        if: github.ref == 'refs/heads/rebuild/main' && env.USERNAME != '' && env.PASSWORD != ''
         run: |
           set -eu
           # Validate the payload BEFORE archiving so a broken publish fails loudly instead of pushing
@@ -1132,7 +1166,7 @@ jobs:
           ls -la mega-out
 
       - name: Upload archive and regular ELFs in all 4 flavours to MEGA
-        if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rebuild/main') && env.USERNAME != '' && env.PASSWORD != ''
+        if: github.ref == 'refs/heads/rebuild/main' && env.USERNAME != '' && env.PASSWORD != ''
         # Pinned to a full commit SHA rather than @master: this third-party action runs with the
         # MEGA credentials, so freeze it to a reviewed snapshot instead of trusting whatever is on
         # its master branch at build time. bf698c6 == the action's v1.4.0 release == the master HEAD

--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -4,7 +4,8 @@ This fork publishes a continuously-updated **`rolling`** development release so 
 publishing-branch build can be pulled straight from GitHub as development progresses, without
 touching the curated `v*` tagged releases. `rolling` is a full (non-pre-release) release and
 intentionally owns GitHub's **Latest** marker. The publishing branch is `rebuild/main` during the
-rebuild and `master` after cutover.
+rebuild. `master` is the OLD LINEAGE and is no longer wired to the release workflow at all: a
+push to it builds nothing and publishes nothing.
 
 ## What the rolling release contains
 
@@ -80,8 +81,9 @@ whether the bleeding-edge build succeeded.
 
 [`.github/workflows/rolling-release.yml`](.github/workflows/rolling-release.yml):
 
-- Triggers on every push to `rebuild/main` or `master` (updates `rolling`), on every `v*` **tag** push (cuts a
+- Triggers on every push to `rebuild/main` (updates `rolling`), on every `v*` **tag** push (cuts a
   curated per-version release with identical packaging), and on manual **Run workflow** (workflow_dispatch).
+  `master` is deliberately absent from both the trigger list and the publish gate.
 - Builds four labelled flavours across two toolchain lineages: moving and digest-pinned
   `ps2dev/ps2dev`, plus moving and digest-pinned official `ps2homebrew/ps2homebrew`.
 - The `ps2dev/ps2dev:latest` build is **required to compile**: if it fails to build, the publish
@@ -93,20 +95,25 @@ whether the bleeding-edge build succeeded.
 - Publishes/updates the single `rolling` release from the host runner as GitHub Latest and explicitly
   clears the pre-release flag.
 - `concurrency` cancels superseded in-flight runs, so the release reflects the newest push.
+- Refreshes the rolling release's **date**. GitHub silently ignores `published_at` on the update
+  API, so the only mechanism that moves it is a draft → published flip; the workflow performs that
+  flip, guarded so the channel cannot be left sitting as an invisible draft, and
+  `promote-rolling-latest.yml` re-asserts the published state afterwards. Curated `v*` releases are
+  never re-dated — they keep the date they were actually published.
 
 ## One pipeline, two channels
 
 This workflow is the **single** place release packaging lives. The pushed ref picks the target:
 
-- **`rebuild/main` or `master` push** → updates the `rolling` Latest release (the development channel).
+- **`rebuild/main` push** → updates the `rolling` Latest release (the development channel).
 - **`v*` tag push** → cuts the **curated per-version release** for that tag (a full release; an
   `-rc*` tag stays a pre-release). Curated tags do not displace `rolling` from GitHub's Latest marker.
   It runs through the **same normalized asset pipeline** as rolling — the same installable bundle,
   source snapshot, VARIANTS archive, and DEBUG/language archives when produced, with the same
   best-effort flavour rules — so the two channels cannot drift into different package formats.
 
-`compilation.yml` no longer cuts releases (its release step is retired); on `master` it only runs
-CI + uploads run artifacts. Per-ref `concurrency` keeps a `master` push and a tag release from
+`compilation.yml` no longer cuts releases (its release step is retired); it only runs CI +
+uploads run artifacts. Per-ref `concurrency` keeps a `rebuild/main` push and a tag release from
 cancelling each other.
 
 ## Not a stable release


### PR DESCRIPTION
The two items left open after #576.

## 1. The rolling release date never moved

The refresh step `PATCH`ed `published_at`. **GitHub accepts that with a 200 and silently ignores the field.** Measured against the live release:

```
BEFORE: 2026-08-13T20:37:05Z
PATCH  -> 200, returns 2026-08-13T20:37:05Z
AFTER:  2026-08-13T20:37:05Z
```

Because it succeeds, `|| true` never fired and the step could only ever log its own failure. That's why a package built today sat under an August date and read as abandoned.

The only mechanism GitHub honours is a **draft → published transition**. That was previously refused for a stated reason:

> the fallback would kick off a second, concurrent normalize of the release we are still publishing

**That objection does not hold.** GitHub does not start a workflow run from an event raised with `GITHUB_TOKEN`, and that is the only token `publish-rolling` has. History confirms it independently: all 30 most recent `release-normalize` runs were triggered by `workflow_run` and **not one** by a `release` event — across a window that includes the run which *created* this release, i.e. a genuine publish that would have fired the event if it could.

A hidden rolling release is much worse than a stale date, so the flip is bounded three times:
1. an `EXIT INT TERM` trap republishes if anything between the two edits dies (`set -eu` is active, so a failed `draft=true` aborts straight into it);
2. the job then re-reads `.draft`, retries once, and **fails loudly** rather than leaving an invisible download page;
3. `promote-rolling-latest.yml` re-asserts published / non-prerelease / latest after this workflow ends, and now fails if it can't.

Curated `v*` releases are still never re-dated — rewriting those would be a lie about history.

`--latest` is re-asserted on the way back up, because a draft cannot hold the Latest marker.

## 2. master could still publish

`rolling-release.yml` triggered on `master` and its publish gate accepted it, so a push to the abandoned lineage would have overwritten the rolling channel with pre-rebuild code **and marked it Latest**. Removed from the push trigger, the publish gate, and both MEGA archive gates.

Auditing for the same shape found a second and worse instance: **`docs-sync.yml` also ran on `master`**, and it pushes to *both* the source branch and `gh-pages`. A master push would have regenerated the live documentation site from a stale template and silently reverted whatever the rebuild line had published there — including the iLink caveat merged yesterday. Same fix.

`flavours.yml` keeps its `master` trigger deliberately: it only builds, and never publishes or pushes.

## Validation

- All five touched/related workflows parse as YAML; every `run:` block in `rolling-release.yml` (36 of them) and `promote-rolling-latest.yml` passes `bash -n`.
- Trigger audit after the change: `rolling-release`, `promote-rolling-latest` and `docs-sync` are all `['rebuild/main']`; `flavours` intentionally retains master.
- `ROLLING_RELEASE.md` updated to match, and now documents the date behaviour it never described.

**Not validated:** the draft flip itself has not been executed. I attempted to prove it on the live release and the sandbox blocked the mutation, which is correct behaviour for a public release edit — I did not work around it. The `published_at` no-op above *was* measured; that the flip moves the date is GitHub's documented behaviour, not something I observed here. The step is self-verifying either way: it compares the value before and after and logs honestly, so the worst case is the same honest NOTE as today rather than a silent regression. First real proof will be the next `rebuild/main` push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
