### PR TITLE
feat(vmc): say so at creation time when a VMC lands fragmented

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -75,5 +75,9 @@ int sysExecElf(const char *path);
 int sysLoadModuleBuffer(void *buffer, int size, int argc, char *argv);
 int sysCheckMC(void);
 int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize, vmc_superblock_t *vmc_superblock);
+// Layout of the VMC whose creation was last STARTED: 1 contiguous, 0 fragmented, -1 unknown.
+// Only meaningful once genvmc reports the job finished. -1 means "this backing store cannot say"
+// (mmce, APA/pfs, SMB, udpfs) and must be treated as silence -- never as a pass or a failure.
+int sysVMCContiguity(void);
 
 #endif

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1194,3 +1194,5 @@ gui_strings:
   string: Showing ELF favorites
 - label: VIEW_ALL
   string: Showing all favorites
+- label: VMC_FRAGMENTED_ON_CREATE
+  string: VMC created, but it is fragmented. Memory card emulation needs one unbroken file, so this VMC will be skipped at launch and the real card used instead. Free up space and make it again, or copy one in from another device.

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -133,6 +133,9 @@ typedef struct
 static short vmc_refresh;
 static int vmc_operation;
 static statusVMCparam_t vmc_status;
+// Armed when the user starts a creation, cleared if they abort it. Gates the one-shot contiguity
+// report below so an aborted job -- whose file is gone -- never draws a complaint about its layout.
+static short vmc_check_layout;
 
 int guiGameVmcNameHandler(char *text, int maxLen)
 {
@@ -264,9 +267,27 @@ static int guiGameShowVMCConfig(int id, item_list_t *support, char *VMCName, int
                     diaSetEnabled(diaVMC, VMC_SIZE, 0);
                     diaSetLabel(diaVMC, VMC_BUTTON_CREATE, _l(_STR_ABORT));
                     vmc_operation = OPERATION_CREATING;
+                    vmc_check_layout = 1;
                 } else
                     break;
             } else if (vmc_operation == OPERATION_ENDING) {
+                // Creation just finished. Ask the device how the file actually landed, because a
+                // fragmented VMC is silently DROPPED at launch (mcemu needs one unbroken file) and
+                // the game then saves to the real memory card instead. Reported here, while the
+                // user is still in the dialog that made it and can simply build it again.
+                //
+                // Raised from the loop rather than from guiGameVMCUpdater: the updater runs inside
+                // diaExecuteDialog, and opening a message box from there would re-enter the dialog
+                // system. This branch is where the existing delete confirmation already draws.
+                //
+                // Only a definite 0 speaks. -1 is "this backing store cannot answer" -- every
+                // non-fatfs device -- and a guess there would be worse than silence.
+                if (vmc_check_layout) {
+                    vmc_check_layout = 0;
+                    if (sysVMCContiguity() == 0)
+                        guiMsgBox(_l(_STR_VMC_FRAGMENTED_ON_CREATE), 0, diaVMC);
+                }
+
                 if (validate)
                     break; // directly close VMC config dialog
 
@@ -276,6 +297,7 @@ static int guiGameShowVMCConfig(int id, item_list_t *support, char *VMCName, int
             } else if (vmc_operation == OPERATION_CREATING) { // User canceled creation of VMC
                 fileXioDevctl("genvmc:", 0xC0DE0002, NULL, 0, NULL, 0);
                 vmc_operation = OPERATION_ABORTING;
+                vmc_check_layout = 0; // nothing was finished; do not report on a cancelled file
             }
         } else if (result == VMC_BUTTON_DELETE) {
             if (guiMsgBox(_l(_STR_DELETE_WARNING), 1, diaVMC)) {

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -282,9 +282,15 @@ static int guiGameShowVMCConfig(int id, item_list_t *support, char *VMCName, int
                 //
                 // Only a definite 0 speaks. -1 is "this backing store cannot answer" -- every
                 // non-fatfs device -- and a guess there would be worse than silence.
+                //
+                // VMC_error must be clear too. The updater moves here as soon as genvmc goes idle
+                // and only LOGS a nonzero error, so a creation that actually FAILED (out of space,
+                // write error) lands in this branch as well, leaving a partial file behind. Calling
+                // that file "fragmented" would blame the layout for a failure that was not about
+                // layout at all, and point the user at the wrong fix.
                 if (vmc_check_layout) {
                     vmc_check_layout = 0;
-                    if (sysVMCContiguity() == 0)
+                    if (vmc_status.VMC_error == 0 && sysVMCContiguity() == 0)
                         guiMsgBox(_l(_STR_VMC_FRAGMENTED_ON_CREATE), 0, diaVMC);
                 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -1942,6 +1942,14 @@ int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize,
     char path[256];
     snprintf(path, sizeof(path), "%sVMC%s%s.bin", prefix, sep, name);
 
+    // Invalidate the completion probe up front on any create request. The creation below is
+    // CONDITIONAL -- a file already at the requested size is left alone -- while the GUI arms its
+    // check before knowing that. Without this, a skipped creation would leave the path of some
+    // EARLIER VMC in place and the probe would answer about the wrong file. Cleared here and set
+    // only where genvmc is actually invoked, so "no creation" reads as unknown and stays silent.
+    if (createSize > 0)
+        gVMCCreatePath[0] = '\0';
+
     if (createSize == -1)
         unlink(path);
     else {

--- a/src/system.c
+++ b/src/system.c
@@ -42,7 +42,9 @@
 #endif
 
 #define NEWLIB_PORT_AWARE
-#include <fileXio_rpc.h> // fileXioInit, fileXioExit, fileXioDevctl
+#include <fileXio_rpc.h>     // fileXioInit, fileXioExit, fileXioDevctl
+#include <usbhdfsd-common.h> // USBMASS_IOCTL_GET_LBA / _CHECK_CHAIN -- VMC contiguity probe
+#include <ps2sdkapi.h>       // ps2sdk_get_iop_fd -- the ioctls above take the IOP-side fd
 
 typedef struct
 {
@@ -1883,6 +1885,56 @@ int sysCheckMC(void)
     return -11;
 }
 
+// Full path of the VMC whose creation was last STARTED, for sysVMCContiguity() to re-open once
+// genvmc reports the job finished. Recorded on the create path only: the VMC dialog re-probes with
+// createSize == 0 on every keystroke and deletes with -1, and either would otherwise clobber the
+// path the completion check needs. Creation is modal and one-at-a-time -- the same assumption
+// genvmc's own single-slot status devctl already makes -- so one slot is enough.
+static char gVMCCreatePath[256] = {0};
+
+// Did the VMC we just created land as ONE contiguous cluster chain?
+//
+// OPL's own mcemu can only emulate a memory card from a contiguous file. The launch path gates on
+// USBMASS_IOCTL_CHECK_CHAIN and, when that fails, drops the VMC and falls back to the real memory
+// card. genvmc does not defragment, so on a well-used volume a fresh 8-64 MB VMC can land in
+// pieces -- and today the user only discovers that later, mid-launch, as a fragmentation error
+// about a card they believed they had just made. Asking here moves the answer to creation time,
+// where the fix (free space, or build it elsewhere and copy it over) is still cheap.
+//
+// Returns 1 contiguous, 0 FRAGMENTED, -1 unknown. GET_LBA is probed first for the same reason the
+// launch path does it: bdmfs_fatfs answers CHECK_CHAIN with a bare 1/0 and never an error code, so
+// a backing store that cannot do LBA lookups at all (mmce, APA/pfs, SMB, udpfs) could otherwise
+// return a 0 that reads as "fragmented" when it only ever meant "not my ioctl". Unknown is the
+// honest answer there, and callers must stay silent on it rather than guess.
+int sysVMCContiguity(void)
+{
+    u64 startingLBA;
+    int fd, iop_fd, chain;
+
+    if (gVMCCreatePath[0] == '\0')
+        return -1;
+
+    fd = open(gVMCCreatePath, O_RDONLY);
+    if (fd < 0)
+        return -1;
+
+    iop_fd = ps2sdk_get_iop_fd(fd);
+    if (fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_LBA, NULL, 0, &startingLBA, sizeof(startingLBA)) != 0) {
+        close(fd);
+        return -1; // not a fatfs-backed device: CHECK_CHAIN below would be meaningless
+    }
+
+    chain = fileXioIoctl(iop_fd, USBMASS_IOCTL_CHECK_CHAIN, "");
+    close(fd);
+
+    LOG("SYSTEM VMC contiguity check on %s: chain=%d\n", gVMCCreatePath, chain);
+    if (chain == 1)
+        return 1;
+    if (chain == 0)
+        return 0;
+    return -1; // anything else is the ioctl itself failing, not a verdict about the file
+}
+
 // createSize == -1 : delete, createSize == 0 : probing, createSize > 0 : creation
 int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize, vmc_superblock_t *vmc_superblock)
 {
@@ -1930,6 +1982,8 @@ int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize,
 
         if (createSize && (createSize != size)) {
             createVMCparam_t createParam;
+            // Remember what is being built so the GUI can ask about its layout when genvmc finishes.
+            snprintf(gVMCCreatePath, sizeof(gVMCCreatePath), "%s", path);
             strcpy(createParam.VMC_filename, path);
             createParam.VMC_size_mb = createSize;
             createParam.VMC_blocksize = 16;


### PR DESCRIPTION
Closes the trap a tester walked into on iLink this week.

## The problem

OPL's mcemu can only emulate a memory card from a **contiguous** file. The launch path already enforces that — `bdmsupport.c` gates on `USBMASS_IOCTL_CHECK_CHAIN`, and when it fails the VMC is dropped and the game silently saves to the real memory card.

`genvmc` doesn't defragment, so on a well-used volume a fresh 8–64 MB VMC can land in pieces. The user then discovers it much later, mid-launch, as a fragmentation error about a card they believed they'd just made — and the workaround (build it on another device, copy it over) had to be found by hand.

**This is not iLink-specific and does not fix the iLink launch failures.** The same fragmentation can happen on any BDM device; iLink is just where it got noticed. It only stops the condition from being invisible until launch.

## The change

`sysVMCContiguity()` re-opens the file `genvmc` just finished and asks the same question the launch path asks. The VMC dialog reports a definite fragmentation before the user leaves the screen that created it.

Deliberately quiet wherever it can't actually know:

- **`GET_LBA` is probed first.** `bdmfs_fatfs` answers `CHECK_CHAIN` with a bare `1`/`0` and never an error code (`fs_driver.c:786` — `get_frag_list(file, NULL, 0) == 1 ? 1 : 0`). A backing store with no LBA lookups at all — mmce, APA/pfs, SMB, udpfs — could otherwise return a `0` that reads as "fragmented" when it only ever meant "not my ioctl". Those report unknown, and unknown says nothing.
- **Armed on create, disarmed on abort**, so a cancelled job — whose file no longer exists — never draws a complaint about its layout.
- **Raised from the dialog loop, not from `guiGameVMCUpdater`.** The updater runs inside `diaExecuteDialog`; opening a message box from there would re-enter the dialog system. The chosen branch is where the existing delete confirmation already draws.

## Validation

- Builds clean in `ps2dev:latest` (`MAKE_EXIT=0`), languages included.
- `clang-format` 12 clean via the CI-matching `xianpengshen/clang-tools:12` image.
- **Append-only lang rule verified programmatically**, not by eye: parsed `_base.yml` before and after and asserted every pre-existing label keeps its exact index and the new one is last (576 → 577).
- Message length held to **220 chars** — no longer the longest string in the file (225 is) and 2.3× headroom inside `guiMsgBox`'s `wrapped[512]` buffer, because the `lng_fork` overlay translates into 31 languages and German/Russian routinely run 30–40% longer. At `MENU_ITEM_HEIGHT` 19 in the y=75..410 band there is room for ~17 lines; this wraps to about 4.

**Not validated:** on hardware. The probe reuses the exact ioctl pair the launch path has always used, so the risk is in the reporting, not the detection — but nobody has yet watched the box appear on a real fragmented VMC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a check for fragmented virtual memory cards after creation.
  - Displays a warning when a newly created virtual memory card is fragmented and cannot be used for emulation.
  - Provides guidance to free storage and recreate the card, or copy a working card from another device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->