### PR TITLE
fix(sound): share one channel for the UI one-shots so the newest press wins

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -85,6 +85,31 @@ static void sfxSetCursorChannelsVolume(int volume)
         audsrv_adpcm_set_volume_and_pan(sfxGetCursorChannel(i), volume, 0);
 }
 
+// THE ONE-SHOT UI SOUNDS SHARE A SINGLE CHANNEL, so only the newest is ever audible.
+//
+// Every sound used to play on a channel of its own (channel == id), which meant nothing could ever
+// interrupt anything: two sounds raised on the same frame simply played on top of each other, and a
+// long one kept going no matter what the user pressed next. Both reported problems are that one
+// fact. Confirming a game rename raises SFX_CONFIRM in diaShowKeyb and then, on the SAME frame,
+// SFX_TRANSITION from the guiSwitchScreen that follows -- two channels, stacked audio (#575). And a
+// sound already playing could not be cut short by the next button press (#504).
+//
+// Replaying a channel replaces whatever it held, so routing these four through one channel makes
+// the newest press win and collapses both cases. Any channel in 1..SFX_COUNT-1 carries gSFXVolume
+// (audioSetVolume), so reusing one costs no new channel and needs no volume work; the channels the
+// other three used simply fall idle.
+//
+// SFX_CURSOR is deliberately NOT in this group -- it owns the rotation channels below precisely so
+// rapid scrolling can overlap, and cutting it would make fast movement sound broken. SFX_BOOT keeps
+// channel 0 (its own gBootSndVolume), and the BD connect/disconnect pair stay separate because they
+// are asynchronous device events rather than a response to a button press.
+#define UI_ONESHOT_SFX_CHANNEL SFX_CONFIRM
+
+static int sfxIsUiOneShot(int id)
+{
+    return (id == SFX_CONFIRM) || (id == SFX_CANCEL) || (id == SFX_MESSAGE) || (id == SFX_TRANSITION);
+}
+
 // Returns 0 if the specified file was read. The sfxEffect structure will not be updated unless the file is successfully read.
 static int sfxRead(const char *full_path, struct sfxEffect *sfx)
 {
@@ -392,7 +417,8 @@ void sfxPlay(int id)
             // rotation channel replaces its old sample in one SIF RPC.
             audsrv_ch_play_adpcm(channel, &sfx[id]);
         } else {
-            audsrv_ch_play_adpcm(id, &sfx[id]);
+            // Shared channel for the UI one-shots (see sfxIsUiOneShot), own channel for the rest.
+            audsrv_ch_play_adpcm(sfxIsUiOneShot(id) ? UI_ONESHOT_SFX_CHANNEL : id, &sfx[id]);
         }
 
         unsigned int costMs = (unsigned int)((cpu_ticks() - sfxStartTicks) / SFX_CLOCKS_PER_MS);


### PR DESCRIPTION
Closes #575, addresses #504. Both reports are the same underlying fact.

## Root cause

Every sound played on a channel of its own (`channel == id` in `sfxPlay`). So **nothing could ever interrupt anything**: two sounds raised on the same frame simply played on top of each other, and a long one kept going regardless of what the user pressed next.

**#575** — confirming a rename with START raises `SFX_CONFIRM` inside `diaShowKeyb`, then on the *same frame* `SFX_TRANSITION` from the `guiSwitchScreen` that `menuRenameGame` calls next. Two channels, stacked audio.

> One correction to the issue: it names `SFX_CONFIRM` and `SFX_SAVE`. **There is no `SFX_SAVE`** — the enum has eight sounds and the reporter guessed the names. The pair actually colliding is `CONFIRM` + `TRANSITION`. The described shape (two sounds, same frame) is exactly right.

**#504** — a sound already playing could not be cut short by the next action.

## Fix

Replaying a channel replaces whatever it held, so routing the four one-shot UI sounds — `CONFIRM`, `CANCEL`, `MESSAGE`, `TRANSITION` — through a single channel makes the newest press win and collapses both cases.

Any channel in `1..SFX_COUNT-1` already carries `gSFXVolume` (`audioSetVolume`), so reusing one costs no new channel and needs no volume work. Channel and sample are independent — the existing cursor rotation already plays `sfx[SFX_CURSOR]` on channels 8–13, which is the same pattern.

## Why not the point fix the issue proposes

#575 suggests suppressing the confirm sound at the rename site. **That would have been wrong.** `diaShowKeyb` is also used by the settings string fields, VMC naming, and the parental-lock password — none of which are followed by a screen transition, so there `SFX_CONFIRM` is the *only* feedback. Silencing it would have made those three silently unresponsive.

## Deliberately out of scope

- **`SFX_CURSOR`** keeps its rotation channels and 45 ms debounce. Those exist precisely so rapid scrolling can overlap; cutting it would make fast movement sound broken. Consequence worth stating plainly: a cursor move still will not cut a playing confirm. That is the one part of #504 this does not change, and it is a choice, not an oversight.
- **`SFX_BOOT`** keeps channel 0 and its own `gBootSndVolume`.
- **BD connect/disconnect** stay separate — asynchronous device events, not a response to a button press.

## Validation

- Builds clean in `ps2dev:latest` (`MAKE_EXIT=0`), no new warnings in `sound.c`; `clang-format` 12 clean via the CI-matching image.
- Change is a channel-number selection only — no new thread or SIO2 interaction, which matters because `pad.c:650` warns that `sfxPlay` runs on threads that must never touch SIO2.
- Verified the volume contract: `audioSetVolume` sets `gSFXVolume` across channels `1..SFX_COUNT-1`, so the shared channel is already correctly configured.

**Not validated by ear.** The reasoning is from the call paths above; nobody has yet heard it on hardware or in an emulator. The audible outcome on rename-confirm is now a single sound, and it is the *transition*, not the confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
