### PR TITLE
fix(disc): bail out of the re-detect budget on an empty tray (#465)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -11,9 +11,16 @@
 #include <delaythread.h> // DelayThread for the bounded disc re-detect polls in sysLaunchDisc
 #include <time.h>        // clock()/CLOCKS_PER_SEC -- the disc waits are budgeted by wall clock
 
-// Disc-probe budgets (issue #465). Both are TOTAL wall-clock caps, not per-poll ones.
+// Disc-probe budgets (issue #465). All are TOTAL wall-clock caps, not per-poll ones.
 #define SYS_DISC_DETECT_MS   1000 // first "still identifying" settle
 #define SYS_DISC_REDETECT_MS 4000 // spin-up + re-detect after a NODISC report
+// Empty-tray shortcut inside the re-detect budget above. A drive that is actually working on a
+// disc reports SCECdDETCT ("identifying") while it spins up; a drive with nothing in it only ever
+// answers NODISC. So NODISC that has never once been punctuated by DETCT means an empty tray, and
+// waiting out the rest of the re-detect budget only makes the user stare at a frozen-looking menu.
+// Generous on purpose: this is a floor for a cold drive to reach DETCT, not a tuned timeout. Once
+// DETCT is seen the FULL budget applies again, so a slow-but-working drive is unaffected.
+#define SYS_DISC_NODISC_MS   2000
 #include "include/opl.h"
 #include "include/gui.h"
 #include "include/lang.h" // _l(_STR_...) -- Neutrino preflight abort toasts
@@ -546,14 +553,22 @@ int sysLaunchDisc(void (*progress)(void))
            frozen UI. That is issue #465's "extended read/poll loop", and the nesting was the whole
            of it: each layer was individually bounded, and the PRODUCT was not. */
         deadline = clock() + (clock_t)SYS_DISC_REDETECT_MS * (CLOCKS_PER_SEC / 1000);
+        clock_t nodiscDeadline = clock() + (clock_t)SYS_DISC_NODISC_MS * (CLOCKS_PER_SEC / 1000);
+        int sawDetct = 0;
         while (clock() < deadline) {
             spin++;
             type = sceCdGetDiskType();
             if (type != SCECdNODISC && type != SCECdDETCT)
                 break;
+            if (type == SCECdDETCT)
+                sawDetct = 1; // the drive is working on something -- it has earned the full budget
+            // Nothing to identify: unbroken NODISC past the shorter cap is an empty tray, and the
+            // remaining budget buys only dead time. See SYS_DISC_NODISC_MS.
+            if (!sawDetct && clock() >= nodiscDeadline)
+                break;
             sysDiscProbeWait(progress);
         }
-        LOG("[DISC] after tray-close re-detect: type=%d (%d re-polls)\n", type, spin);
+        LOG("[DISC] after tray-close re-detect: type=%d (%d re-polls, sawDetct=%d)\n", type, spin, sawDetct);
     }
 
     if (type != SCECdPS2DVD && type != SCECdPS2CD) // no disc / not a PS2 game disc


### PR DESCRIPTION
Addresses the residual in #465, which Zack re-confirmed today on Beta-2706.

## What was already fixed, and what wasn't

The severe half of #465 — a nested poll whose *product* reached ~24 s with a frozen UI — is already fixed, and `menusys.c:1422` pumps a frame per poll so the menu keeps drawing.

What remains is the residual: selecting **Launch Disc** with nothing in the drive sits through the whole 4 s re-detect budget before reporting "no disc". Zack asks for 1–2 s.

## Why not just lower the timeout

The budget exists for a real reason: an idle drive spins a loaded disc **down** and then reports `NODISC`, so the tray-close request that follows needs time to spin it back up. Cutting it blindly would break launching a disc that has been sitting in the drive — a far worse failure than a slow error message.

## The discriminator

A drive actually working on a disc reports `SCECdDETCT` ("identifying") while it spins up. A drive with nothing in it only ever answers `NODISC`.

So `NODISC` unbroken by even one `DETCT` means an empty tray, and the rest of the budget buys only dead time. **Once `DETCT` is seen the full 4 s applies again**, so a slow-but-working drive is completely unaffected.

Empty tray now answers in **~2 s** instead of ~4 s.

The 2 s cap is deliberately generous — it's a floor for a cold drive to reach `DETCT`, not a tuned timeout — precisely because the dangerous direction here is bailing early on a real disc.

Also worth noting: the initial settle already costs an empty tray nothing. `sysDiscSettle` only loops while `DETCT`, and an empty drive answers `NODISC` on the very first call, so the 1 s there was never part of the delay.

## Validation

- Builds clean in `ps2dev:latest` (`MAKE_EXIT=0`); `clang-format` 12 clean via the CI-matching image. The one warning in `system.c` is pre-existing (`config->gCheatList`, line 1766) and unrelated to this change.

⚠️ **This rests on a hardware behaviour assumption and needs confirmation on BOTH paths:**
1. empty tray now errors in ~2 s, and
2. **a real disc left spun down in the drive still launches.**

`sawDetct` was added to the existing `[DISC]` LOG line specifically so a diagnostic build can show which path was taken. If a cold drive turns out to sit in `NODISC` for more than 2 s before reaching `DETCT`, the constant is the single thing to raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disc detection after closing the tray.
  - Empty drives are now recognized sooner when no disc is present.
  - Discs that are still being identified continue to receive additional detection time, improving reliability when inserting or changing discs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->