### PR TITLE
fix(bdm): stop parking drives on the launch path, only on exit

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -2451,7 +2451,30 @@ static void bdmShutdown(item_list_t *itemList)
     // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
     // pDeviceData may be NULL here (shutdown without init, or a second deinit pass after priv was freed below),
     // so guard the dereference and fall back to the constructed mass%d: path.
-    fileXioDevctl((pDeviceData != NULL && pDeviceData->bdmDeviceRoot[0] != '\0') ? pDeviceData->bdmDeviceRoot : path, USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+    //
+    // TERMINAL TEARDOWN ONLY. Parking the heads is a POWEROFF courtesy; it is not something a game
+    // launch ever wanted. moduleCleanup sends every page that is NOT the selected one down this
+    // shutdown path, so on a launch this used to spin down every other BDM device on the way out --
+    // while the handoff that follows still has to read from them.
+    //
+    // That is not theoretical, and it is not new: hddShutdown carries the same gate for the same
+    // reason, added after powering DEV9 off here killed the ATA bus before a post-deinit
+    // POPSTARTER.ELF read (the 4236edf6-class black screen). Same shape, same page-by-page
+    // shutdown, one device layer down.
+    //
+    // It bites hardest where a stopped drive does not quietly come back: an external 1394/USB
+    // enclosure. Ember and POPSTARTER keep the IOP and read their ELF, BIOS and game folder through
+    // the mount they inherit, so a spun-down spindle under them reads as "nothing there" -- Ember's
+    // documented answer to which is to run the PS1 BIOS shell. "Drive shuts off" is the most
+    // repeated phrase in the iLink hardware reports.
+    //
+    // The poweroff case is unchanged: gDeinitTerminal is 1 for exit/poweroff, so the park still
+    // happens exactly where it was wanted.
+    if (gDeinitTerminal)
+        fileXioDevctl((pDeviceData != NULL && pDeviceData->bdmDeviceRoot[0] != '\0') ? pDeviceData->bdmDeviceRoot : path, USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+    else
+        LOG("BDMSUPPORT Shutdown: launch teardown -- NOT stopping %s\n",
+            (pDeviceData != NULL && pDeviceData->bdmDeviceRoot[0] != '\0') ? pDeviceData->bdmDeviceRoot : path);
 
     if (itemList->enabled && pDeviceData != NULL) {
         LOG("BDMSUPPORT Shutdown free data\n");


### PR DESCRIPTION
A concrete candidate for the iLink "drive shuts off" family, including Ember dropping to the PS1 BIOS shell.

## What it does today

`bdmShutdown` issues the SCSI **STOP UNIT** command unconditionally:

```c
fileXioDevctl(..., USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
```

That is a **poweroff courtesy** — park the heads so the drive doesn't emergency-park. It is not something a game launch ever wanted.

And `moduleCleanup` sends every page that is **not** the selected one down the shutdown path:

```c
if ((mod->support->mode != modeSelected) && (modeSelected != IO_MODE_SELECTED_ALL))
    mod->support->itemShutdown(mod->support);   // ← STOP UNIT, no exception honoured
else
    mod->support->itemCleanUp(mod->support, exception);   // ← honours UNMOUNT_EXCEPTION
```

Note `itemShutdown` takes **no exception argument at all**, so it cannot honour `UNMOUNT_EXCEPTION`. Every BDM slot is its own page, so a launch spun down every other BDM device on the way out — while the handoff that follows still has to read from them.

## This exact bug was already found one layer down

`hddShutdown` carries the same gate, with this comment:

> *"only on a **TERMINAL teardown** (exit/poweroff). **On the launch path this shutdown runs for every non-selected page**, and powering DEV9 off here kills the ATA bus BEFORE bdmLaunchVcd's post-deinit POPSTARTER.ELF read ... the 4236edf6-class black-screen freeze."*

Same page-by-page shutdown, same launch-vs-exit confusion, same fix. `bdmShutdown` simply never got it.

## Why iLink feels it worst

A stopped drive that quietly spins back up on next access hides this. An **external 1394 or USB enclosure** often doesn't. Ember and POPSTARTER **keep the IOP** and read their ELF, BIOS and game folder through the mount they inherit — so a spun-down spindle underneath reads as "nothing there", and [Ember's documented answer to that is to run the PS1 BIOS shell](https://github.com/NathanNeurotic/Open-PS2-Loader/blob/rebuild/main/include/system.h).

That is exactly what FifthFox reports. And **"drive shuts off" is the most repeated phrase across his four-flavour matrix** — it appears on the *failing* legs, while the leg that worked was described as *"drive is staying on"*.

## Scope

- Poweroff is unchanged: `gDeinitTerminal` is 1 for exit/poweroff, so the park still happens exactly where it was wanted.
- The launch path now logs the device it declined to stop, so a diagnostic build can confirm the new behaviour directly.

## Honest status

**Not claimed as the proven cause.** It is a real defect that matches the reported symptom family, and it needs hardware to confirm.

Also worth recording, since it was assumed otherwise: **the "we lost Ember on 2708" report is not a regression from the recent merges.** I diffed it — between 2692 and 2708 `src/bdmsupport.c` changed by *comments only*, and `sysLaunchEmber`, `cuesupport.c` and `appsupport.c` are untouched. Ember's launch path is byte-identical across those builds.

While checking this I also confirmed something counter-intuitive worth writing down: in `bdmfs_fatfs` the two devctl names are **inverted relative to their behaviour** — `USBMASS_DEVCTL_STOP_UNIT` (0x0000) calls `stop_all_bd()`, and `USBMASS_DEVCTL_STOP_ALL` (0x0001) calls `stop_single_bd()`. OPL uses `STOP_ALL`, so it stops only the addressed volume, not every drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
