### PR TITLE
fix(art): wait out a failing cover open before a keep-IOP handoff

### DIFF
--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -2289,8 +2289,11 @@ static void hddCleanUp(item_list_t *itemList, int exception)
     // is how a clean exit becomes a black-screen hang: the next read returns permanent EOF and the
     // thread that owns it never comes back, so whoever waits for it waits forever.
     //
-    // Skipping both costs nothing. Every path that reaches here hands off to an ELF that resets the
-    // IOP, which reclaims the mounts and the descriptors wholesale.
+    // Skipping both is the safe side of this trade either way, but the REASON has narrowed. This
+    // used to say every path here hands off to an ELF that RESETS the IOP, reclaiming the mounts
+    // and descriptors wholesale. That is not true of the keep-IOP handoffs -- Ember and the elfldr
+    // paths inherit whatever we leave behind. Leaving the mount up is still right for them; what
+    // would never be right is unmounting under a live reader.
     if (gArtAbandoned) {
         LOG("HDDSUPPORT CleanUp: art worker abandoned mid-read -- leaving pfs mounted\n");
         if (hddGameList.enabled) {

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -87,7 +87,22 @@ typedef struct load_image_request
 // Teardown join budgets in MILLISECONDS -- the join sleeps via DelayThread(1000) = 1 ms, NOT via
 // util.c's delay(), whose "tick" is a ~0.25 s NOP spin (the units trap that made the old
 // LAUNCH_IO_DRAIN_TICKS "10 s" actually forty minutes).
-#define ART_JOIN_MS_LAUNCH      500
+// THE LAUNCH BUDGET MUST OUTLAST A FAILING COVER OPEN, and it did not. A cover open that MISSES
+// costs ~4.3 s (measured: 4292/4399 ms on USB, against 53 ms for a hit -- a fixed driver-side
+// timeout, not a slow read). Joining with 500 ms therefore could not succeed against the exact
+// case that matters, so a worker parked in a miss was abandoned nearly every time.
+//
+// Abandoning is only harmless if the handoff resets the IOP -- which is precisely what cacheEnd's
+// own comment below assumed. THE KEEP-IOP PATHS BREAK THAT ASSUMPTION: Ember and the other elfldr
+// handoffs deliberately do NOT reset the IOP, so ExecPS2 tears the EE thread down while its fileXio
+// RPC is still in flight and the target inherits a half-used channel on the very device it has to
+// read from. Ember's answer to a read that returns nothing is to run the PS1 BIOS shell, silently.
+//
+// The budgets were also inverted against the risk: TERMINAL (safe -- the console is powering off)
+// had 1500 ms while LAUNCH (dangerous) had 500. The join is a poll that exits the moment the worker
+// stops, so a larger cap costs nothing when art is idle or hitting; it is paid only when a real
+// miss is in flight, and deinit already holds "Please wait" on screen for the whole teardown.
+#define ART_JOIN_MS_LAUNCH      6000
 #define ART_JOIN_MS_TERMINAL    1500
 #define ART_FOREGROUND_DRAIN_MS 500
 
@@ -1137,9 +1152,17 @@ int cacheEnd(int forceStop)
     if (gArtRunning) {
         // ABANDON, never TerminateThread. Killing a thread parked inside fileXio leaves the shared
         // IOP RPC channel half-used, and every later fileXio call from ANY thread is then undefined.
-        // Every caller of this is on its way to an IOP reset or a power-off, so the leaked thread
-        // cannot outlive the handoff. We leak strictly less than the fork does -- there is no
-        // semaphore to reclaim, because this design has none.
+        // We leak strictly less than the fork does -- there is no semaphore to reclaim, because
+        // this design has none.
+        //
+        // ⚠ THIS IS NOT FREE ON THE KEEP-IOP PATHS. The older claim here was that "every caller is
+        // on its way to an IOP reset or a power-off, so the leaked thread cannot outlive the
+        // handoff" -- that is no longer true. Ember and the other sysLoadELFKeepIOP handoffs
+        // deliberately keep the IOP, so ExecPS2 destroys the EE thread while its RPC is still in
+        // flight and the target inherits exactly the half-used channel described above, on the
+        // device it is about to read. Reaching here at all is now the anomaly, not the routine
+        // case: the launch budget was raised past the measured worst-case open so that a miss in
+        // flight can actually be waited out. Treat this log line as a real diagnostic.
         gArtShutdownAbandoned = 1;
         LOG("cacheEnd: art worker still running after %d ms -- abandoned, not terminated\n",
             forceStop ? ART_JOIN_MS_TERMINAL : ART_JOIN_MS_LAUNCH);


### PR DESCRIPTION
A second, stronger candidate for Ember dropping to the PS1 BIOS shell on iLink — found by widening the search to things that don't look related to Ember at all.

## The numbers don't line up

The art worker's **launch** join budget is 500 ms:

```c
#define ART_JOIN_MS_LAUNCH   500
```

A cover open that **misses** costs **~4.3 s** — measured at 4292/4399 ms on USB against 53 ms for a hit, because it's a fixed driver-side timeout rather than a slow read.

So the join could never succeed against the one case that matters. A worker parked in a miss was **abandoned nearly every time** the user launched while art was still working.

## Why abandoning stopped being safe

`cacheEnd` justifies abandoning like this:

> *"Every caller of this is on its way to an IOP reset or a power-off, so the leaked thread cannot outlive the handoff."*

`hddsupport` carried the same claim. **Both are now false**, and the keep-IOP handoffs are the counter-example by design: Ember and the other `sysLoadELFKeepIOP` paths deliberately do **not** reset the IOP. `ExecPS2` destroys the EE thread while its fileXio RPC is still in flight, and the target inherits exactly the half-used channel that same comment warns about — on the very device it then has to read.

Ember's documented answer to a read that returns nothing is to run the **PS1 BIOS shell**, silently.

## It fits every property of the report

- **Device-speed dependent** — iLink is the slowest backend and the likeliest to sit in a miss. Explains USB working and iLink not, with byte-identical code.
- **Intermittent** — depends on whether art happened to be mid-miss at the keypress. Matches "Ember is working" earlier and not later.
- **Silent** — every guard in `bdmLaunchEmber` (`EMBER_BAD_NAME` / `NOT_FOUND` / `BIOS_MISSING` / `NO_DISC`) passes long before `deinit` runs, so there's nothing to report.

## The fix

The budgets were **inverted against the risk**: TERMINAL — where abandoning is harmless because the console is powering off — had 1500 ms, while LAUNCH — where it poisons a handoff — had 500.

Launch now gets **6000 ms**, comfortably past the measured worst case. The join is a poll that exits the moment the worker stops, so this costs nothing when art is idle or hitting; it's paid only when a real miss is in flight, and `deinit` already holds "Please wait" on screen for the whole teardown.

Both false comments are corrected in place rather than deleted, and reaching the abandon path is now the anomaly worth reading in a log.

## Honest status

**Not proven to be the cause.** It is a real defect on the keep-IOP path that matches every property of the report, and it needs hardware to confirm.

This is the *second* candidate from this pass — [#584](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/584) (drives being spun down on the launch path) was the first. If a retest fixes iLink, the `[ART]`/`cacheEnd` and `BDMSUPPORT Shutdown` log lines distinguish which one did it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch shutdown handling by allowing additional time for slow operations to complete.
  * Reduced the likelihood of failures during cover-open events and handoffs between launch environments.

* **Documentation**
  * Clarified shutdown behavior and documented exceptional conditions that may occur during launch transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->