### PR TITLE
ci: a superseded Rolling Release is not a failure

### DIFF
--- a/.github/workflows/promote-rolling-latest.yml
+++ b/.github/workflows/promote-rolling-latest.yml
@@ -36,7 +36,29 @@ jobs:
             exit 1
           fi
 
-          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+          # A SUPERSEDED RUN IS NOT A FAILURE. rolling-release.yml uses
+          # `concurrency: cancel-in-progress`, deliberately, so the release always reflects the
+          # NEWEST push. Two merges inside one release cycle (~20 min) therefore cancel the first
+          # publish on purpose -- and `gh run watch --exit-status` reports a cancelled run exactly
+          # like a broken one, which turned that intended behaviour into a red CI run with nothing
+          # wrong. It is also self-correcting: the push that cancelled it started its own promote,
+          # which enforces the state for the build that actually shipped.
+          #
+          # So distinguish the two. Cancelled/skipped => this promote is obsolete, stand down
+          # quietly. Anything else that is not success stays loud, because that IS a broken publish.
+          if gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status; then
+            echo "Rolling Release $run_id succeeded."
+          else
+            concl="$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" --json conclusion --jq .conclusion 2>/dev/null || echo unknown)"
+            if [ "$concl" = "cancelled" ] || [ "$concl" = "skipped" ]; then
+              echo "Rolling Release $run_id was $concl -- superseded by a newer push to $GITHUB_REF_NAME."
+              echo "That push runs its own promote for the build that shipped; nothing to enforce here."
+              echo "SUPERSEDED=1" >> "$GITHUB_ENV"
+            else
+              echo "Rolling Release $run_id concluded '$concl' -- the publish is broken." >&2
+              exit 1
+            fi
+          fi
 
       # rolling-release.yml sets this state itself. Keep this post-publish normalization as an
       # idempotent guard against GitHub or a future workflow edit leaving the moving channel stale.
@@ -48,6 +70,10 @@ jobs:
       # is the natural second layer: asserting the published state here costs one idempotent call and
       # closes the only window in which users could find the rolling download page missing.
       - name: Enforce rolling as Latest, published and non-pre-release
+        # Skipped when the publish we were waiting on was superseded: the release on the tag right
+        # now belongs to a NEWER build whose own promote is enforcing it. Asserting here would race
+        # that run and could fail on a release mid-update through no fault of its own.
+        if: env.SUPERSEDED != '1'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
The promote job went red on `rebuild/main` today and **nothing was broken**. Fixing the cause.

## What happened

| time | commit | Rolling Release | Enforce |
|---|---|---|---|
| 00:50 | `f55d3d43` (#583) | **cancelled** | **failure** |
| 01:07 | `6e976945` (#584) | success | success |

`rolling-release.yml` sets `concurrency: cancel-in-progress` **deliberately**, so the release always reflects the newest push. Merging #583 and #584 about seventeen minutes apart — inside one ~20 minute release cycle — cancelled the first publish exactly as designed.

But the promote job still watching it runs:

```bash
gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
```

and `--exit-status` reports a **cancelled** run identically to a broken one. So intended behaviour surfaced as failed CI.

It's also **already self-correcting**: the push that did the cancelling starts its own promote, which enforces the state for the build that actually shipped. Both runs for `6e976945` were green, and the live release is correct.

## The fix

Distinguish the two outcomes:

- **cancelled / skipped** → this promote is obsolete. Say so, stand down quietly, and skip the enforcement step too — the release on the tag now belongs to a newer build whose own promote is asserting it, so racing that could fail on a release mid-update through no fault of its own.
- **any other non-success** → stays loud. That is a genuinely broken publish and must not be swallowed.

## Why it matters beyond today

This wasn't a one-off. **Any two merges inside a release cycle reproduce it**, which is normal working cadence and will happen again — it's how it surfaced in the first place.

## Validation

- YAML parses; both `run:` blocks pass `bash -n`.
- Trigger unchanged (`rebuild/main` only).
- The failure path is preserved deliberately — this narrows what is tolerated to cancelled/skipped, and does not weaken detection of a real publish failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
