### PR TITLE
chore: constify gCheatList, mark the unused lang label, move the release banner to the bottom

### DIFF
--- a/.github/scripts/normalize_release_notes.py
+++ b/.github/scripts/normalize_release_notes.py
@@ -28,4 +28,6 @@ downloads = '''## Release downloads
 
 No bare ELF files or SDK/IRX manifests are published as release assets; they are kept inside the appropriate archives where needed.'''
 
-print(f'{banner}\n\n{body}\n\n{downloads}\n\n{resources}', end='')
+# Banner LAST: a release page should open on what the reader came for -- the notes and the
+# download list -- not on artwork they scroll past on every build.
+print(f'{body}\n\n{downloads}\n\n{resources}\n\n{banner}', end='')

--- a/ee_core/include/coreconfig.h
+++ b/ee_core/include/coreconfig.h
@@ -45,7 +45,10 @@ struct EECoreConfig_t
     char g_ps2_gateway[16];
     unsigned char g_ps2_ETHOpMode;
 
-    u32 *gCheatList; // Store hooks/codes addr+val pairs
+    // const: the producer hands over a const buffer (GetCheatsList) and ee_core only READS this --
+    // cheat_api.c indexes it, main.c and padhook.c NULL-test it. Without the qualifier the
+    // assignment in sysLaunchLoaderElf silently discarded it (-Wdiscarded-qualifiers).
+    const u32 *gCheatList; // Store hooks/codes addr+val pairs
     u32 *gImage;     // Prebuilt PS2RD cheat image (.img) patch words, or NULL
 
     void *eeloadCopy;

--- a/ee_core/include/coreconfig.h
+++ b/ee_core/include/coreconfig.h
@@ -49,7 +49,7 @@ struct EECoreConfig_t
     // cheat_api.c indexes it, main.c and padhook.c NULL-test it. Without the qualifier the
     // assignment in sysLaunchLoaderElf silently discarded it (-Wdiscarded-qualifiers).
     const u32 *gCheatList; // Store hooks/codes addr+val pairs
-    u32 *gImage;     // Prebuilt PS2RD cheat image (.img) patch words, or NULL
+    u32 *gImage;           // Prebuilt PS2RD cheat image (.img) patch words, or NULL
 
     void *eeloadCopy;
     void *initUserMemory;

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -1114,6 +1114,9 @@ gui_strings:
   string: UDPFS Access
 - label: MMCE_GAMEID_NEUTRINO_SKIP
   string: MMCE GameID not applied -- neutrino.elf is on this card (switching it would unload Neutrino).
+# UNUSED / RESERVED: no source call site -- it survives only in the generated lang_autogen.h.
+# It CANNOT be deleted: .lng files are consumed by LINE POSITION, so removing a label shifts
+# every later index and silently corrupts all 31 translations. Wire it up or leave it be.
 - label: HDD_BACKEND_RECONCILED
   string: Both APA and exFAT internal HDD backends are enabled; each drive is selected by its partition layout (check Game Sources).
 - label: VCD_SETTINGS


### PR DESCRIPTION
Three small items, no runtime behaviour change.

## 1. `gCheatList` const warning

`GetCheatsList()` returns a `const u32 *` and ee_core only ever **reads** the field — `cheat_api.c` indexes it, `main.c` and `padhook.c` NULL-test it, nothing writes through it. The struct field was non-const, so the assignment in `sysLaunchLoaderElf` silently discarded the qualifier.

Field is now `const u32 *`. **Verified: `-Wdiscarded-qualifiers` count in the build drops from 1 to 0.**

The const widened the declaration, so the trailing comment on the `gImage` line beside it needed realigning — caught by the CI-matching `clang-format` 12 before pushing.

## 2. `HDD_BACKEND_RECONCILED`

No source call site; it survives only in the generated `lang_autogen.h`.

**Deliberately not deleted.** `.lng` files are consumed by **line position**, so removing a label shifts every later index and would silently corrupt all 31 translations. Marked as reserved in the template instead, with that reason recorded so the next reader doesn't have to rediscover it.

Verified the label list is unchanged: 577 labels, identical order before and after.

## 3. Release banner moved to the bottom

The banner printed before the notes. It now prints after the body, downloads and tools block, so a release page opens on what the reader came for rather than on artwork they scroll past on every build.

Verified by actually running the normalizer against sample notes — output now starts with the notes body and ends with the banner markup.

## Validation

- Builds clean in `ps2dev:latest` (`MAKE_EXIT=0`), languages included.
- `clang-format` 12 clean via the CI-matching image.
- `normalize_release_notes.py` parses and was executed to confirm the new ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release pages now open with the release notes and download list before displaying artwork, making key information easier to find.

* **Documentation**
  * Added clarification for a reserved language label to help preserve translation compatibility in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->