### PR TITLE
feat(keyb): movable text caret in the on-screen keyboard (#466)

### DIFF
--- a/src/dia.c
+++ b/src/dia.c
@@ -61,6 +61,13 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
 {
     int i, j, len = strlen(text), selkeyb = 0, x, w;
     int selchar = 0, selcommand = -1;
+    // Insertion point, in characters from the start of the string. Starts at the END, so typing and
+    // backspace behave exactly as they always did until the user actually moves it (#466).
+    //
+    // L1/R1 rather than the d-pad: Left/Right already walk the on-screen key grid and hand off to
+    // the command column at its edges, which is the primary control on this screen. The request
+    // offers the shoulder buttons as its own alternative for that reason.
+    int caret = len;
     char c[2] = "\0\0", *mask_buffer;
     static const char keyb0[KEYB_ITEMS] = {
         '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=',
@@ -113,7 +120,20 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
         }
 
         // Text
-        fntRenderString(gTheme->fonts[0], 50, 120, ALIGN_NONE, 0, 0, hide_text ? mask_buffer : text, gTheme->textColor);
+        {
+            const char *shown = hide_text ? mask_buffer : text;
+            fntRenderString(gTheme->fonts[0], 50, 120, ALIGN_NONE, 0, 0, shown, gTheme->textColor);
+
+            // Caret. Drawn by measuring the substring to its LEFT rather than assuming a character
+            // width -- the theme font is proportional, so a fixed advance would drift along the
+            // line. Rendered as a thin filled rect so it reads as a caret and not as a typed '|'.
+            char pre[maxLen];
+            int n = (caret < len) ? caret : len;
+            memcpy(pre, shown, n);
+            pre[n] = '\0';
+            int caretX = 50 + rmUnScaleX(fntCalcDimensions(gTheme->fonts[0], pre));
+            rmDrawRect(caretX, 120, 2, UI_SPACING_H, gColWhite);
+        }
 
         // separating line for simpler orientation
         rmDrawLine(25, 138, 615, 138, gColWhite);
@@ -147,7 +167,17 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
 
         rmEndFrame();
 
-        if (getKey(KEY_LEFT)) {
+        if (getKey(KEY_L1)) { // caret left
+            if (caret > 0) {
+                sfxPlay(SFX_CURSOR);
+                caret--;
+            }
+        } else if (getKey(KEY_R1)) { // caret right
+            if (caret < len) {
+                sfxPlay(SFX_CURSOR);
+                caret++;
+            }
+        } else if (getKey(KEY_LEFT)) {
             sfxPlay(SFX_CURSOR);
             if (selchar > -1) {
                 if (selchar % KEYB_WIDTH)
@@ -188,33 +218,38 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
         } else if (getKeyOn(gSelectButton)) {
             if (len < (maxLen - 1) && selchar > -1) {
                 sfxPlay(SFX_CONFIRM);
+                // Insert AT the caret: shift the tail (and its NUL) right by one, drop the
+                // character in, and follow it. With the caret at the end this is the old append.
+                memmove(&text[caret + 1], &text[caret], len - caret + 1);
+                text[caret] = keyb[selchar];
                 if (mask_buffer != NULL) {
                     mask_buffer[len] = '*';
                     mask_buffer[len + 1] = '\0';
                 }
 
                 len++;
-                c[0] = keyb[selchar];
-                strcat(text, c);
+                caret++;
             } else if (selcommand == 0) {
                 sfxPlay(SFX_CANCEL);
-                if (len > 0) { // BACKSPACE
+                if (caret > 0) { // BACKSPACE -- removes the character LEFT of the caret
+                    memmove(&text[caret - 1], &text[caret], len - caret + 1);
                     len--;
-                    text[len] = 0;
+                    caret--;
                     if (mask_buffer != NULL)
                         mask_buffer[len] = '\0';
                 }
             } else if (selcommand == 1) {
                 sfxPlay(SFX_CONFIRM);
-                if (len < (maxLen - 1)) { // SPACE
+                if (len < (maxLen - 1)) { // SPACE -- inserted at the caret, like any other character
+                    memmove(&text[caret + 1], &text[caret], len - caret + 1);
+                    text[caret] = ' ';
                     if (mask_buffer != NULL) {
                         mask_buffer[len] = '*';
                         mask_buffer[len + 1] = '\0';
                     }
 
                     len++;
-                    c[0] = ' ';
-                    strcat(text, c);
+                    caret++;
                 }
             } else if (selcommand == 2) {
                 sfxPlay(SFX_CONFIRM);
@@ -230,24 +265,26 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
                     keyb = keyb1;
             }
         } else if (getKey(KEY_SQUARE)) {
-            if (len > 0) { // BACKSPACE
+            if (caret > 0) { // BACKSPACE -- same caret-relative delete as the command column
                 sfxPlay(SFX_CANCEL);
+                memmove(&text[caret - 1], &text[caret], len - caret + 1);
                 len--;
-                text[len] = 0;
+                caret--;
                 if (mask_buffer != NULL)
                     mask_buffer[len] = '\0';
             }
         } else if (getKey(KEY_TRIANGLE)) {
             if (len < (maxLen - 1) && selchar > -1) { // SPACE
                 sfxPlay(SFX_CONFIRM);
+                memmove(&text[caret + 1], &text[caret], len - caret + 1);
+                text[caret] = ' ';
                 if (mask_buffer != NULL) {
                     mask_buffer[len] = '*';
                     mask_buffer[len + 1] = '\0';
                 }
 
                 len++;
-                c[0] = ' ';
-                strcat(text, c);
+                caret++;
             }
         } else if (getKeyOn(KEY_START)) {
             sfxPlay(SFX_CONFIRM);


### PR DESCRIPTION
Closes #466.

## Problem

Typing only ever appended, and backspace only ever ate the last character. A typo near the start of a long name meant deleting the whole thing and retyping it.

## What changed

**L1/R1** move an insertion point through the string. Characters and space insert **at** it; backspace removes the character to its **left**.

The caret starts at the end, so **anyone who never presses L1/R1 sees exactly the old behaviour**.

### Why L1/R1 and not the d-pad

The FR asked for "D-pad Left/Right **(or L1/R1)**". It has to be the shoulder buttons: Left/Right already walk the on-screen key grid and hand off to the command column at its edges, which is the primary control on this screen.

### Caret rendering

Drawn by **measuring** the substring to its left (`fntCalcDimensions`) rather than assuming a character width — the theme font is proportional, so a fixed advance would drift along the line. It's a thin filled rect, so it reads as a caret rather than a typed `|`.

## Scope note

All **four** edit paths share the new behaviour, not just the obvious one — the command column's BACKSPACE and SPACE, plus the Square and Triangle shortcuts, which each had their own copy of the append/truncate logic.

## Validation

- Builds clean in `ps2dev:latest` (`MAKE_EXIT=0`), no new warnings; `clang-format` 12 clean via the CI-matching image.
- **Bounds checked with a standalone harness** over the extremes — filling to `maxLen`, inserting mid-string, backspacing the first and last character — since this is pointer arithmetic on a caller-owned buffer. All passed.
- Password path unaffected: the mask is uniform `*`, so its length tracks as before and the caret measures against it correctly.

**Not validated by hand on a console** — the caret's visual position and the L1/R1 feel are worth one look before this is called done.

One thing I deliberately did **not** add: an on-screen hint that L1/R1 move the caret. That needs a new language string and bottom-bar layout work, and it felt like scope creep here — but without it the feature is not discoverable. Happy to add it as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
