### PR TITLE
chore: trim the comments down to what the code actually needs

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -2452,24 +2452,11 @@ static void bdmShutdown(item_list_t *itemList)
     // pDeviceData may be NULL here (shutdown without init, or a second deinit pass after priv was freed below),
     // so guard the dereference and fall back to the constructed mass%d: path.
     //
-    // TERMINAL TEARDOWN ONLY. Parking the heads is a POWEROFF courtesy; it is not something a game
-    // launch ever wanted. moduleCleanup sends every page that is NOT the selected one down this
-    // shutdown path, so on a launch this used to spin down every other BDM device on the way out --
-    // while the handoff that follows still has to read from them.
-    //
-    // That is not theoretical, and it is not new: hddShutdown carries the same gate for the same
-    // reason, added after powering DEV9 off here killed the ATA bus before a post-deinit
-    // POPSTARTER.ELF read (the 4236edf6-class black screen). Same shape, same page-by-page
-    // shutdown, one device layer down.
-    //
-    // It bites hardest where a stopped drive does not quietly come back: an external 1394/USB
-    // enclosure. Ember and POPSTARTER keep the IOP and read their ELF, BIOS and game folder through
-    // the mount they inherit, so a spun-down spindle under them reads as "nothing there" -- Ember's
-    // documented answer to which is to run the PS1 BIOS shell. "Drive shuts off" is the most
-    // repeated phrase in the iLink hardware reports.
-    //
-    // The poweroff case is unchanged: gDeinitTerminal is 1 for exit/poweroff, so the park still
-    // happens exactly where it was wanted.
+    // TERMINAL TEARDOWN ONLY. Parking the heads is a poweroff courtesy, and moduleCleanup sends
+    // every NON-selected page down this path -- so on a launch it used to spin down the other BDM
+    // devices while the handoff that follows still had to read from them. hddShutdown carries the
+    // same gate for the same reason (DEV9 off here once killed the ATA bus before a post-deinit
+    // POPSTARTER read). Worst on an external enclosure, which may not spin back up.
     if (gDeinitTerminal)
         fileXioDevctl((pDeviceData != NULL && pDeviceData->bdmDeviceRoot[0] != '\0') ? pDeviceData->bdmDeviceRoot : path, USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
     else

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -271,23 +271,13 @@ static int guiGameShowVMCConfig(int id, item_list_t *support, char *VMCName, int
                 } else
                     break;
             } else if (vmc_operation == OPERATION_ENDING) {
-                // Creation just finished. Ask the device how the file actually landed, because a
-                // fragmented VMC is silently DROPPED at launch (mcemu needs one unbroken file) and
-                // the game then saves to the real memory card instead. Reported here, while the
-                // user is still in the dialog that made it and can simply build it again.
+                // Creation finished: a fragmented VMC is silently dropped at launch, so say so now,
+                // in the dialog that made it. Raised from the loop, not guiGameVMCUpdater, which
+                // runs inside diaExecuteDialog and cannot open a message box.
                 //
-                // Raised from the loop rather than from guiGameVMCUpdater: the updater runs inside
-                // diaExecuteDialog, and opening a message box from there would re-enter the dialog
-                // system. This branch is where the existing delete confirmation already draws.
-                //
-                // Only a definite 0 speaks. -1 is "this backing store cannot answer" -- every
-                // non-fatfs device -- and a guess there would be worse than silence.
-                //
-                // VMC_error must be clear too. The updater moves here as soon as genvmc goes idle
-                // and only LOGS a nonzero error, so a creation that actually FAILED (out of space,
-                // write error) lands in this branch as well, leaving a partial file behind. Calling
-                // that file "fragmented" would blame the layout for a failure that was not about
-                // layout at all, and point the user at the wrong fix.
+                // Only a definite 0 speaks: -1 means the backing store cannot answer. VMC_error
+                // must be clear too -- the updater lands here on a FAILED creation as well, and
+                // blaming "fragmented" for an out-of-space would point at the wrong fix.
                 if (vmc_check_layout) {
                     vmc_check_layout = 0;
                     if (vmc_status.VMC_error == 0 && sysVMCContiguity() == 0)

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -2289,11 +2289,8 @@ static void hddCleanUp(item_list_t *itemList, int exception)
     // is how a clean exit becomes a black-screen hang: the next read returns permanent EOF and the
     // thread that owns it never comes back, so whoever waits for it waits forever.
     //
-    // Skipping both is the safe side of this trade either way, but the REASON has narrowed. This
-    // used to say every path here hands off to an ELF that RESETS the IOP, reclaiming the mounts
-    // and descriptors wholesale. That is not true of the keep-IOP handoffs -- Ember and the elfldr
-    // paths inherit whatever we leave behind. Leaving the mount up is still right for them; what
-    // would never be right is unmounting under a live reader.
+    // Skipping both is safe either way. NOT because the handoff resets the IOP -- the keep-IOP
+    // paths inherit whatever we leave behind -- but because unmounting under a live reader never is.
     if (gArtAbandoned) {
         LOG("HDDSUPPORT CleanUp: art worker abandoned mid-read -- leaving pfs mounted\n");
         if (hddGameList.enabled) {

--- a/src/system.c
+++ b/src/system.c
@@ -1434,13 +1434,11 @@ void sysLaunchNeutrino(const char *driver, const char *path, const char *startup
            did its job) and then the screen stays black, because Neutrino reset away the stack the
            game path depends on. -qb keeps the inherited environment and skips that reset.
 
-           USB AND ILINK ONLY, deliberately. Both launch through this inherited BDM environment, and
-           revision 2692 hardware produced the same reset-boundary symptom on iLink that originally
-           established the USB exception. This also matches Neutrino's documented quick-boot contract
-           and NHDDL's iLink forward-boot behavior. The new iLink leg still needs a hardware retest to
-           prove that this mismatch was the complete cause. Other backends stay on the normal boot path
-           until hardware gives a reason to move them. A user-typed -qb in either the global or per-game
-           args wins -- do not emit a second copy.
+           USB AND ILINK ONLY, deliberately: both launch through this inherited BDM environment, and
+           rev 2692 hardware showed the same reset-boundary symptom on iLink that established the USB
+           exception (iLink leg still needs a retest to prove it was the whole cause). Other backends
+           stay on the normal boot path until hardware says otherwise. A user-typed -qb in the global
+           or per-game args wins -- do not emit a second copy.
 
            Emitted ABOVE coreArgc so the pool-fit drop loop can never shed it: a dropped -qb would
            silently reinstate the reset and reproduce the black screen with no way to tell why. */
@@ -1907,20 +1905,13 @@ int sysCheckMC(void)
 // genvmc's own single-slot status devctl already makes -- so one slot is enough.
 static char gVMCCreatePath[256] = {0};
 
-// Did the VMC we just created land as ONE contiguous cluster chain?
+// Did the VMC just created land as ONE contiguous chain? mcemu needs that, and genvmc does not
+// defragment, so on a used volume a fresh VMC can land in pieces -- which the user otherwise only
+// learns mid-launch, as an error about a card they thought they had just made.
 //
-// OPL's own mcemu can only emulate a memory card from a contiguous file. The launch path gates on
-// USBMASS_IOCTL_CHECK_CHAIN and, when that fails, drops the VMC and falls back to the real memory
-// card. genvmc does not defragment, so on a well-used volume a fresh 8-64 MB VMC can land in
-// pieces -- and today the user only discovers that later, mid-launch, as a fragmentation error
-// about a card they believed they had just made. Asking here moves the answer to creation time,
-// where the fix (free space, or build it elsewhere and copy it over) is still cheap.
-//
-// Returns 1 contiguous, 0 FRAGMENTED, -1 unknown. GET_LBA is probed first for the same reason the
-// launch path does it: bdmfs_fatfs answers CHECK_CHAIN with a bare 1/0 and never an error code, so
-// a backing store that cannot do LBA lookups at all (mmce, APA/pfs, SMB, udpfs) could otherwise
-// return a 0 that reads as "fragmented" when it only ever meant "not my ioctl". Unknown is the
-// honest answer there, and callers must stay silent on it rather than guess.
+// 1 contiguous, 0 FRAGMENTED, -1 unknown. GET_LBA is probed first because bdmfs_fatfs answers
+// CHECK_CHAIN with a bare 1/0 and never an error, so a store that cannot do LBA lookups at all
+// (mmce, pfs, SMB, udpfs) would otherwise return a 0 meaning only "not my ioctl".
 int sysVMCContiguity(void)
 {
     u64 startingLBA;

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -87,21 +87,10 @@ typedef struct load_image_request
 // Teardown join budgets in MILLISECONDS -- the join sleeps via DelayThread(1000) = 1 ms, NOT via
 // util.c's delay(), whose "tick" is a ~0.25 s NOP spin (the units trap that made the old
 // LAUNCH_IO_DRAIN_TICKS "10 s" actually forty minutes).
-// THE LAUNCH BUDGET MUST OUTLAST A FAILING COVER OPEN, and it did not. A cover open that MISSES
-// costs ~4.3 s (measured: 4292/4399 ms on USB, against 53 ms for a hit -- a fixed driver-side
-// timeout, not a slow read). Joining with 500 ms therefore could not succeed against the exact
-// case that matters, so a worker parked in a miss was abandoned nearly every time.
-//
-// Abandoning is only harmless if the handoff resets the IOP -- which is precisely what cacheEnd's
-// own comment below assumed. THE KEEP-IOP PATHS BREAK THAT ASSUMPTION: Ember and the other elfldr
-// handoffs deliberately do NOT reset the IOP, so ExecPS2 tears the EE thread down while its fileXio
-// RPC is still in flight and the target inherits a half-used channel on the very device it has to
-// read from. Ember's answer to a read that returns nothing is to run the PS1 BIOS shell, silently.
-//
-// The budgets were also inverted against the risk: TERMINAL (safe -- the console is powering off)
-// had 1500 ms while LAUNCH (dangerous) had 500. The join is a poll that exits the moment the worker
-// stops, so a larger cap costs nothing when art is idle or hitting; it is paid only when a real
-// miss is in flight, and deinit already holds "Please wait" on screen for the whole teardown.
+// LAUNCH must outlast a MISSED cover open (~4.3 s measured, vs 53 ms for a hit -- a fixed
+// driver-side timeout), or a worker parked in one is abandoned; on the keep-IOP paths that leaves
+// the target reading through a half-used RPC channel. The join exits as soon as the worker stops,
+// so the larger cap is only ever paid against a real miss.
 #define ART_JOIN_MS_LAUNCH      6000
 #define ART_JOIN_MS_TERMINAL    1500
 #define ART_FOREGROUND_DRAIN_MS 500
@@ -1152,17 +1141,10 @@ int cacheEnd(int forceStop)
     if (gArtRunning) {
         // ABANDON, never TerminateThread. Killing a thread parked inside fileXio leaves the shared
         // IOP RPC channel half-used, and every later fileXio call from ANY thread is then undefined.
-        // We leak strictly less than the fork does -- there is no semaphore to reclaim, because
-        // this design has none.
         //
-        // ⚠ THIS IS NOT FREE ON THE KEEP-IOP PATHS. The older claim here was that "every caller is
-        // on its way to an IOP reset or a power-off, so the leaked thread cannot outlive the
-        // handoff" -- that is no longer true. Ember and the other sysLoadELFKeepIOP handoffs
-        // deliberately keep the IOP, so ExecPS2 destroys the EE thread while its RPC is still in
-        // flight and the target inherits exactly the half-used channel described above, on the
-        // device it is about to read. Reaching here at all is now the anomaly, not the routine
-        // case: the launch budget was raised past the measured worst-case open so that a miss in
-        // flight can actually be waited out. Treat this log line as a real diagnostic.
+        // ⚠ NOT free on the keep-IOP paths: they do not reset the IOP, so the target inherits that
+        // half-used channel on the device it is about to read. Getting here is an anomaly worth
+        // reading in the log, not the routine case.
         gArtShutdownAbandoned = 1;
         LOG("cacheEnd: art worker still running after %d ms -- abandoned, not terminated\n",
             forceStop ? ART_JOIN_MS_TERMINAL : ART_JOIN_MS_LAUNCH);


### PR DESCRIPTION
Comments only. No behaviour change.

## The measurement

Half of everything I added today was comment — **178 comment lines against 168 of code** — and it was worst exactly where the fix was *smallest*:

| file | code+ | comment+ |
|---|---|---|
| `texcache.c` | **1** | **26** |
| `bdmsupport.c` | **5** | **24** |
| `hddsupport.c` | **0** | **5** |
| `guigame.c` | 8 | 24 |

26 lines of prose for a one-constant change isn't justifiable. Most of it was narrative already recorded in the commit message *and* the PR — keeping a third copy in the source is what made the tree look like it was bulking.

## What was kept

The load-bearing facts, which are the ones a future reader can't re-derive:

- the measured **~4.3 s** failing cover open (vs 53 ms for a hit)
- that the **keep-IOP paths don't reset the IOP**, so abandoning isn't free there
- why `GET_LBA` is probed before `CHECK_CHAIN`
- why `VMC_error` has to be clear before blaming fragmentation

The retelling around them is gone.

## Result

**51 comment lines removed**, 51% → 43% comment ratio on the day's additions.

Verified comments-only: the only non-`//` lines in the diff are interior lines of a `/* */` block.

Builds clean (`MAKE_EXIT=0`), `clang-format` 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal comments covering terminal shutdown, drive-head parking, and cleanup safety.
  * Improved explanations for VMC fragmentation warnings and contiguous-chain checks.
  * Refined quick-boot messaging and iLink retest guidance.
  * Documented launch timing requirements and abandoned-thread handling more concisely.

* **Bug Fixes**
  * None. Runtime behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->