### PR TITLE
fix(keyb): the hint's width budget could wrap and disable its own clipping

### DIFF
--- a/src/dia.c
+++ b/src/dia.c
@@ -175,17 +175,20 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
             int r1W = r1Tex ? (r1Tex->Width * 20) / r1Tex->Height : 0;
             int hintX = 50;
 
-            if (l1Tex && l1Tex->Mem)
-                rmDrawPixmap(l1Tex, hintX, 417, ALIGN_NONE, l1W, 20, SCALING_RATIO, gDefaultCol, 0);
-            hintX += rmWideScale(l1W) + 8;
-            // Clip the label so a long translation cannot push R1 into CANCEL at x=500 or off the
-            // edge. fntRenderString honours a width, so hand it what is actually left.
-            hintX = fntRenderString(gTheme->fonts[0], hintX, 417, ALIGN_NONE,
-                                    KEYB_HINT_END - rmWideScale(r1W) - 8 - hintX, 20,
-                                    _l(_STR_KEYB_MOVE_CURSOR), gTheme->selTextColor);
-            hintX += 8;
-            if (r1Tex && r1Tex->Mem && hintX + rmWideScale(r1W) <= KEYB_HINT_END)
-                rmDrawPixmap(r1Tex, hintX, 417, ALIGN_NONE, r1W, 20, SCALING_RATIO, gDefaultCol, 0);
+            // fntRenderString's width is size_t, and 0 means UNBOUNDED -- so a negative budget
+            // would wrap to a huge value and disable the very clipping this computes. Work it out
+            // signed first and draw nothing at all if it does not fit.
+            int avail = KEYB_HINT_END - rmWideScale(l1W) - rmWideScale(r1W) - 16 - hintX;
+            if (avail > 0) {
+                if (l1Tex && l1Tex->Mem)
+                    rmDrawPixmap(l1Tex, hintX, 417, ALIGN_NONE, l1W, 20, SCALING_RATIO, gDefaultCol, 0);
+                hintX += rmWideScale(l1W) + 8;
+                hintX = fntRenderString(gTheme->fonts[0], hintX, 417, ALIGN_NONE, avail, 20,
+                                        _l(_STR_KEYB_MOVE_CURSOR), gTheme->selTextColor);
+                hintX += 8;
+                if (r1Tex && r1Tex->Mem && hintX + rmWideScale(r1W) <= KEYB_HINT_END)
+                    rmDrawPixmap(r1Tex, hintX, 417, ALIGN_NONE, r1W, 20, SCALING_RATIO, gDefaultCol, 0);
+            }
         }
 
         guiDrawIconAndText(gSelectButton == KEY_CIRCLE ? CROSS_ICON : CIRCLE_ICON, _STR_CANCEL, gTheme->fonts[0], 500, 417, gTheme->selTextColor);


### PR DESCRIPTION
A real bug in merged code, found by auditing what CodeRabbit never saw.

## The audit

Of the 12 PRs I merged today, **11 had their final head reviewed. #590 did not** — CodeRabbit was rate-limited, so its last commit went in unreviewed. That commit contained the fix for CodeRabbit's *own* earlier finding, which is the worst possible thing to leave unchecked.

## The bug

`fntRenderString` takes `width` as **`size_t`**, and `if (width)` gates the clipping — so **0 means unbounded**.

My clipping fix computed the remaining space inline and passed it straight in:

```c
KEYB_HINT_END - rmWideScale(r1W) - 8 - hintX
```

A theme shipping wide `L1`/`R1` icons makes that negative, which converts to a huge `size_t`, overflows `xmax = x + width`, and **disables the very clipping it was added to perform** — in exactly the case it was guarding.

## Fix

Compute it signed first, and draw no hint at all when it doesn't fit rather than a mangled one.

## Worth saying

This is the second time this one line bit me: CodeRabbit flagged it as unbounded, I "fixed" it, and the fix had a signedness hole. The lesson isn't about this line — it's that the fix for a review finding is the thing most worth re-reviewing, and that's precisely what the rate limit ate.

Builds clean (`MAKE_EXIT=0`), `clang-format` 12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
