### PR TITLE
Remove unreachable settings screens and undefined declarations

### DIFF
--- a/include/appsupport.h
+++ b/include/appsupport.h
@@ -33,7 +33,6 @@ typedef struct
 
 void appInit(item_list_t *itemList);
 item_list_t *appGetObject(int initOnly);
-void appPostUpdateCallback(int mode);
 int appGetArtMode(const char *startup);
 
 #endif

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -355,7 +355,6 @@ extern struct UIItem diaConfig[];
 extern struct UIItem diaAbout[];
 extern struct UIItem diaVMC[];
 extern struct UIItem diaNetCompatUpdate[];
-extern struct UIItem diaParentalLockConfig[];
 
 extern struct UIItem diaOSDConfig[];
 extern struct UIItem diaCoverflowConfig[];
@@ -377,7 +376,5 @@ extern struct UIItem diaMmceCommConfig[];
 extern struct UIItem diaMmcePathConfig[];
 extern struct UIItem diaSecurityConfig[];
 extern struct UIItem diaAdvancedConfig[];
-extern struct UIItem diaPathPrefixConfig[];
-extern struct UIItem diaStorageConfig[];
 
 #endif

--- a/include/gui.h
+++ b/include/gui.h
@@ -132,16 +132,8 @@ void guiShowUIConfig();
 void guiShowSettings(void);
 // Settings-layout category pages (rebuild step 06)
 void guiShowDeviceConfig(void);
-void guiShowDisplayConfig(void);
-void guiShowLaunchConfig(void);
 int guiShowControllerConfig(void);
-void guiShowSecurityConfig(void);
-void guiShowAdvancedConfig(void);
-void guiShowPathPrefixConfig(void);
 int guiShowMmceConfig(void);
-void guiShowMmceCommConfig(void);
-void guiShowMmcePathConfig(void);
-void guiShowStorageConfig(void);
 void guiShowArtworkConfig(void);
 void guiShowCoverflowConfig(void);
 void guiShowColorsConfig(void);
@@ -167,14 +159,12 @@ int guiGetResidentNetProtocol(void);
 // at picker time would tear OPL down before the change was ever written to disk.
 int guiNetProtocolNeedsRestart(void);
 
-void guiShowVcdConfig(void); // POPStarter settings hub (device/path/RetroGEM; chains BDMA/List/Net sub-pages)
 // One-shot POPSTARTER USB driver pick (FAT32 vs exFAT), shown on EVERY USB VCD launch
 // (maintainer directive 2026-08-01: the user picks per launch, never a sticky default).
 int guiShowVcdUsbMode(void);
 void guiShowBdmaConfig(void);    // BDMA (exFAT driver stack) source/mode equip page
 void guiShowVcdListConfig(void); // VCD list options (hide game-id prefix, first-disc-only)
 void guiShowPopsNetConfig(void); // POPSTARTER's OWN IPCONFIG.DAT/SMBCONFIG.DAT editor
-void guiShowParentalLockConfig();
 
 void guiCheckNotifications(int checkTheme, int checkLang);
 

--- a/include/gui.h
+++ b/include/gui.h
@@ -108,8 +108,6 @@ void guiExecDeferredOps(void);
 /** Allocates a new deffered operation */
 struct gui_update_t *guiOpCreate(gui_op_type_t type);
 
-/** For completeness, the deffered operations are destroyed automatically */
-void guiDestroyOp(struct gui_update_t *op);
 
 int guiShowKeyboard(char *value, int maxLength);
 int guiMsgBox(const char *text, int addAccept, struct UIItem *ui);

--- a/include/ioman.h
+++ b/include/ioman.h
@@ -50,8 +50,6 @@ int ioHasPendingRequests(void);
 int ioGetPending(int type);
 unsigned int ioGetTotal(int type);
 
-/** returns nonzero if the io thread is running */
-int ioIsRunning(void);
 
 /** Helper thread safe printf */
 int ioPrintf(const char *format, ...);

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -76,7 +76,6 @@ void sbCreateFolders(const char *path, int createDiscImgFolders);
 // ISO9660 filesystem management functions.
 u32 sbGetISO9660MaxLBA(const char *path);
 int sbProbeISO9660(const char *path, base_game_info_t *game, u32 layer1_offset);
-int sbProbeISO9660_64(const char *path, base_game_info_t *game, u32 layer1_offset);
 
 int sbLoadCheats(const char *path, const char *file);
 

--- a/include/system.h
+++ b/include/system.h
@@ -71,7 +71,6 @@ int sysInitDECI2(void);
 
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags);
 
-int sysExecElf(const char *path);
 int sysLoadModuleBuffer(void *buffer, int size, int argc, char *argv);
 int sysCheckMC(void);
 int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize, vmc_superblock_t *vmc_superblock);

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -143,11 +143,6 @@ unsigned int cacheDebugTransientFail(void);
  */
 void cacheDebugLastLoad(int *lastMs, int *lastOkMs, int *width, int *height);
 
-/** May speculative art (viewport warming, far-row thumbnails, the Coverflow lookahead) be issued
- * now? Looser than cacheHasPendingArt(): it allows prefetch while a few loads are already in
- * flight, so the device stays busy instead of prefetch running one image at a time.
- */
-int cacheMayPrefetchArt(void);
 void cacheInvalidateFailMemo(void);
 
 /** Nonzero while any cover art is queued for, or currently being, read+decoded by the IO worker.

--- a/include/util.h
+++ b/include/util.h
@@ -11,10 +11,6 @@ void checkMCFolder(void);
  */
 void checkMCSaveIcons(const char *cfgFilePath);
 
-/** As checkMCSaveIcons, for a folder that already exists (the POPSTARTER folder). Writes the
- * icon.sys + .icn PAIR -- icon.sys names the .icn, so neither is any use alone. No-op off mc.
- */
-void checkMCSaveIconsDir(const char *dir);
 int openFile(char *path, int mode);
 void *readFile(char *path, int align, int *size);
 int listDir(char *path, const char *separator, int maxElem,

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -976,66 +976,6 @@ struct UIItem diaAdvancedConfig[] = {
     // end of dialog
     {UI_TERMINATOR}};
 
-// Advanced -> Path Prefixes. Rows moved out of the old General Settings (diaConfig).
-struct UIItem diaPathPrefixConfig[] = {
-    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_PATH_PREFIXES}}},
-    {UI_SPLITTER},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_BDM_PREFIX}}},
-    {UI_SPACER},
-    {UI_STRING, CFG_BDMPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ETH_PREFIX}}},
-    {UI_SPACER},
-    {UI_STRING, CFG_ETHPREFIX, 1, 1, -1, 0, 0, {.stringvalue = {"", "", NULL}}},
-    {UI_BREAK},
-
-    // buttons
-    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
-    {UI_BREAK},
-
-    // end of dialog
-    {UI_TERMINATOR}};
-
-// Advanced -> Storage and Cache. Rows moved out of the old General Settings (diaConfig).
-struct UIItem diaStorageConfig[] = {
-    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_STORAGE_CACHE}}},
-    {UI_SPLITTER},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HDD_SPINDOWN}}},
-    {UI_SPACER},
-    {UI_INT, CFG_HDDSPINDOWN, 1, 1, _STR_HINT_SPINDOWN, 0, 0, {.intvalue = {20, 20, 0, 20}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_CACHE_HDD_GAME_LIST}}},
-    {UI_SPACER},
-    {UI_BOOL, CFG_HDDGAMELISTCACHE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"BDM Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_BDMCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 8, 0, 32, NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"HDD Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_HDDCACHE, 1, 1, -1, 0, 0, {.intvalue = {8, 0, 0, 32, NULL}}},
-    {UI_BREAK},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"SMB Cache", -1}}},
-    {UI_SPACER},
-    {UI_INT, CFG_SMBCACHE, 1, 1, -1, 0, 0, {.intvalue = {16, 4, 0, 32, NULL}}},
-    {UI_BREAK},
-
-    // buttons
-    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
-    {UI_BREAK},
-
-    // end of dialog
-    {UI_TERMINATOR}};
-
-
 // Per-Game Modes Menu (row order per the settings-layout restructure tree: Loader Core, DMA,
 // Game ID, Alternate Startup, Modes 1-7, then the Neutrino overrides)
 struct UIItem diaCompatConfig[] = {
@@ -1682,23 +1622,6 @@ struct UIItem diaNetCompatUpdate[] = {
     {UI_BUTTON, NETUPD_BTN_START, 1, 1, -1, 0, 0, {.label = {NULL, _STR_START}}},
     {UI_SPACER},
     {UI_BUTTON, NETUPD_BTN_CANCEL, 1, 1, -1, 0, 0, {.label = {NULL, _STR_CANCEL}}},
-    {UI_BREAK},
-
-    // end of dialog
-    {UI_TERMINATOR}};
-
-// Parental Lock Config Menu
-struct UIItem diaParentalLockConfig[] = {
-    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_PARENLOCKCONFIG}}},
-    {UI_SPLITTER},
-
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_PARENLOCK_PASSWORD}}},
-    {UI_SPACER},
-    {UI_PASSWORD, CFG_PARENLOCK_PASSWORD, 1, 1, _STR_PARENLOCK_PASSWORD_HINT, 0, 0, {.stringvalue = {"", "", NULL}}},
-    {UI_BREAK},
-
-    // buttons
-    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
     {UI_BREAK},
 
     // end of dialog

--- a/src/gui.c
+++ b/src/gui.c
@@ -868,40 +868,6 @@ int guiShowMmceConfig(void)
     return ret;
 }
 
-// MMCE -> Communication Settings (SIO2 ack-wait pacing, alarm usage).
-void guiShowMmceCommConfig(void)
-{
-    const char *deviceAckWaitCycles[] = {"0", "1", "2", "3", "4", "5", NULL};
-    const char *deviceOnOff[] = {"OFF", "ON", NULL};
-
-    diaSetEnum(diaMmceCommConfig, CFG_MMCE_WAIT_CYCLES, deviceAckWaitCycles);
-    diaSetInt(diaMmceCommConfig, CFG_MMCE_WAIT_CYCLES, gMMCEAckWaitCycles);
-    diaSetEnum(diaMmceCommConfig, CFG_MMCE_USE_ALARMS, deviceOnOff);
-    diaSetInt(diaMmceCommConfig, CFG_MMCE_USE_ALARMS, gMMCEUseAlarms);
-
-    int ret = diaExecuteDialog(diaMmceCommConfig, -1, 1, NULL);
-    if (ret) {
-        diaGetInt(diaMmceCommConfig, CFG_MMCE_WAIT_CYCLES, &gMMCEAckWaitCycles);
-        diaGetInt(diaMmceCommConfig, CFG_MMCE_USE_ALARMS, &gMMCEUseAlarms);
-        applyConfig(-1, -1, 0);
-        menuReinitMainMenu();
-    }
-}
-
-// MMCE -> Path Settings (MMCE library prefix).
-void guiShowMmcePathConfig(void)
-{
-    diaSetString(diaMmcePathConfig, CFG_MMCEPREFIX, gMMCEPrefix);
-
-    int ret = diaExecuteDialog(diaMmcePathConfig, -1, 1, NULL);
-    if (ret) {
-        diaGetString(diaMmcePathConfig, CFG_MMCEPREFIX, gMMCEPrefix, sizeof(gMMCEPrefix));
-        applyConfig(-1, -1, 0);
-        menuReinitMainMenu();
-    }
-}
-
-
 // Deep-copy a NULL-terminated name list for handing to diaSetEnum. The CALLER must hold guiLock
 // across BOTH the getter fetch (thmGetGuiList/lngGetGuiList) and this copy: the source lists live
 // on the heap and are freed+rebuilt under guiLock on the IO worker (thmRebuildGuiNames/
@@ -1427,77 +1393,6 @@ int guiShowVcdUsbMode(void)
     return diaExecuteDialog(diaVcdUsbMode, -1, 1, NULL);
 }
 
-// POPStarter page (settings-layout restructure, was VCD Settings): PS1-via-POPSTARTER launch
-// config (POPSTARTER.ELF device/path). The BDMA equip, VCD list display options and POPStarter
-// network settings are chained sub-dialogs (guiShowBdmaConfig / guiShowVcdListConfig /
-// guiShowPopsNetConfig). CFG ids are shared with the old rows, so saved config values map through
-// unchanged.
-// SUPERSEDED AND UNREFERENCED. The live PS Emulation Settings page is guiSettingsShowPopstarter(),
-// which COMPOSES a copy of diaVcdConfig + diaBdmaConfig and drives that copy. Nothing calls this
-// function any more; it is kept only because its declaration is still published in gui.h.
-//
-// Wiring a new row here does NOTHING. That mistake was made once already, with CFG_EMBER_DISPLAY:
-// the row rendered on the composed page with no enum list and never saved, because its diaSetEnum
-// ran against the template in here instead of against the composed `ui`. Add new rows to
-// guiSettingsShowPopstarter().
-void guiShowVcdConfig(void)
-{
-    // POPSTARTER.ELF device TYPE (POPS_DEV_*). MUST stay in sync with vcdResolvePopstarter() (vcdsupport.c).
-    const char *popsDevStrs[] = {_l(_STR_DEFAULT), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", "Custom", _l(_STR_GAMES_DEVICE), "iLink", NULL}; // iLink is appended after Game's Device to preserve every saved POPS_DEV_* value
-    // diaSetEnum stores the ARRAY POINTER rather than copying, so this must outlive every render of
-    // the dialog -- static, like the BDMA option arrays on the peer page.
-    static const char *emberDisplayStrs[] = {NULL, "240p", "480p", NULL};
-    emberDisplayStrs[0] = _l(_STR_DEFAULT);
-    diaSetEnum(diaVcdConfig, CFG_EMBER_DISPLAY, emberDisplayStrs);
-    diaSetInt(diaVcdConfig, CFG_EMBER_DISPLAY, gEmberDisplay);
-    guiSetGameViewPicker(diaVcdConfig);
-
-    diaSetEnum(diaVcdConfig, CFG_POPSTARTER_DEVICE, popsDevStrs);
-    diaSetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, gPopstarterDevice);
-    diaSetString(diaVcdConfig, CFG_POPSTARTER_PATH, gPopstarterPath);
-    diaSetShowDefaultWhenEmpty(diaVcdConfig, CFG_POPSTARTER_PATH, 1);
-    diaSetInt(diaVcdConfig, CFG_POPSTARTER_RETROGEM_GAMEID, gPopstarterRetroGemGameID);
-
-    // POPSTARTER Path is the Custom-only escape hatch (guiVcdUpdater re-reveals it live).
-    diaSetVisible(diaVcdConfig, CFG_LBL_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
-    diaSetVisible(diaVcdConfig, CFG_POPSTARTER_PATH, gPopstarterDevice == POPS_DEV_CUSTOM);
-
-    int ret;
-reshow_vcd:
-    ret = diaExecuteDialog(diaVcdConfig, -1, 1, &guiVcdUpdater);
-    if (ret == VCD_BDMA_BUTTON) {
-        guiShowBdmaConfig();
-        goto reshow_vcd;
-    }
-    if (ret == VCD_LIST_BUTTON) {
-        guiShowVcdListConfig();
-        goto reshow_vcd;
-    }
-    if (ret == VCD_NET_BUTTON) {
-        guiShowPopsNetConfig();
-        goto reshow_vcd;
-    }
-    if (ret) {
-        int gameViewChanged = guiReadGameViewPicker(diaVcdConfig);
-        diaGetInt(diaVcdConfig, CFG_POPSTARTER_DEVICE, &gPopstarterDevice);
-        diaGetInt(diaVcdConfig, CFG_POPSTARTER_RETROGEM_GAMEID, &gPopstarterRetroGemGameID);
-        diaGetInt(diaVcdConfig, CFG_EMBER_DISPLAY, &gEmberDisplay);
-
-        {
-            // The dialog field is char[32]; only adopt the typed value if it actually changed, so
-            // opening+saving this page never truncates a longer path stored via the cfg.
-            char tmpPop[sizeof(gPopstarterPath)];
-            diaGetString(diaVcdConfig, CFG_POPSTARTER_PATH, tmpPop, sizeof(tmpPop));
-            if (strncmp(tmpPop, gPopstarterPath, 31) != 0)
-                snprintf(gPopstarterPath, sizeof(gPopstarterPath), "%s", tmpPop);
-        }
-        applyConfig(-1, -1, 0);
-        if (gameViewChanged)
-            guiRefreshGameViews();
-        menuReinitMainMenu();
-    }
-}
-
 static void guiSetBdmaSettings(struct UIItem *ui)
 {
     static const char *bdmaSourceStrs[] = {NULL, NULL, NULL, NULL, NULL, NULL};
@@ -1944,15 +1839,6 @@ static void guiSaveAdvancedSettings(struct UIItem *ui)
     diaGetInt(ui, CFG_SMBCACHE, &smbCacheSize);
 }
 
-void guiShowParentalLockConfig(void)
-{
-    guiSetParentalLockValue(diaParentalLockConfig);
-
-    int result = diaExecuteDialog(diaParentalLockConfig, -1, 1, NULL);
-    if (result) {
-        guiSaveParentalLockValue(diaParentalLockConfig);
-    }
-}
 // Neutrino Defaults live-updater: the ":c" comp half is only ever emitted alongside a video mode
 // (-gsm=v:c grammar) -- grey it while the global Neutrino Video default is Off (same rule as the
 // per-game rows).
@@ -2077,100 +1963,6 @@ void guiShowNeutrinoArgsConfig(char *argsBuf, int bufSize)
     }
 }
 
-
-void guiShowLaunchConfig(void)
-{
-    // Global default Loader Core: the core a game uses when its per-game selector is "Default".
-    // <OPL> = OPL's native ee-core; Neutrino = the external neutrino.elf. Indices 0/1 match the
-    // stored value (0=<OPL>, 1=Neutrino) and the first two per-game COMPAT_LOADER options.
-    const char *defaultCoreStrs[] = {"<OPL>", "Neutrino", NULL};
-    diaSetEnum(diaLaunchConfig, CFG_DEFAULT_CORE, defaultCoreStrs);
-    diaSetInt(diaLaunchConfig, CFG_DEFAULT_CORE, gDefaultCoreLoader);
-    diaSetInt(diaLaunchConfig, CFG_PS2LOGO, gPS2Logo);
-
-    int ret;
-reshow_launch:
-    ret = diaExecuteDialog(diaLaunchConfig, -1, 1, NULL);
-    if (ret == LAUNCH_NEUTRINO_DEFAULTS_BUTTON) {
-        guiShowNeutrinoDefaults();
-        goto reshow_launch;
-    }
-    if (ret == LAUNCH_OSD_DEFAULTS_BUTTON) {
-        guiGameShowOSDLanguageConfig(1);
-        goto reshow_launch;
-    }
-    if (ret) {
-        diaGetInt(diaLaunchConfig, CFG_DEFAULT_CORE, &gDefaultCoreLoader);
-        diaGetInt(diaLaunchConfig, CFG_PS2LOGO, &gPS2Logo);
-
-        applyConfig(-1, -1, 0);
-        menuReinitMainMenu();
-    }
-}
-
-void guiShowSecurityConfig(void)
-{
-    diaSetInt(diaSecurityConfig, CFG_ENWRITEOP, gEnableWrite);
-    guiSetParentalLockValue(diaSecurityConfig);
-
-    int ret = diaExecuteDialog(diaSecurityConfig, -1, 1, NULL);
-    if (ret) {
-        diaGetInt(diaSecurityConfig, CFG_ENWRITEOP, &gEnableWrite);
-        guiSaveParentalLockValue(diaSecurityConfig);
-
-        applyConfig(-1, -1, 0);
-        menuReinitMainMenu();
-    }
-}
-
-void guiShowAdvancedConfig(void)
-{
-    diaSetInt(diaAdvancedConfig, CFG_DEBUG, gEnableDebug);
-    guiSetAdvancedSettings(diaAdvancedConfig);
-
-    int ret = diaExecuteDialog(diaAdvancedConfig, -1, 1, NULL);
-    if (ret) {
-        diaGetInt(diaAdvancedConfig, CFG_DEBUG, &gEnableDebug);
-        guiSaveAdvancedSettings(diaAdvancedConfig);
-
-        applyConfig(-1, -1, 0);
-        menuReinitMainMenu();
-    }
-}
-
-void guiShowPathPrefixConfig(void)
-{
-    diaSetString(diaPathPrefixConfig, CFG_BDMPREFIX, gBDMPrefix);
-    diaSetString(diaPathPrefixConfig, CFG_ETHPREFIX, gETHPrefix);
-
-    int ret = diaExecuteDialog(diaPathPrefixConfig, -1, 1, NULL);
-    if (ret) {
-        diaGetString(diaPathPrefixConfig, CFG_BDMPREFIX, gBDMPrefix, sizeof(gBDMPrefix));
-        diaGetString(diaPathPrefixConfig, CFG_ETHPREFIX, gETHPrefix, sizeof(gETHPrefix));
-
-        applyConfig(-1, -1, 0);
-    }
-}
-
-void guiShowStorageConfig(void)
-{
-    diaSetInt(diaStorageConfig, CFG_HDDSPINDOWN, gHDDSpindown);
-    diaSetInt(diaStorageConfig, CFG_HDDGAMELISTCACHE, gHDDGameListCache);
-    diaSetInt(diaStorageConfig, CFG_BDMCACHE, bdmCacheSize);
-    diaSetInt(diaStorageConfig, CFG_HDDCACHE, hddCacheSize);
-    diaSetInt(diaStorageConfig, CFG_SMBCACHE, smbCacheSize);
-
-    int ret = diaExecuteDialog(diaStorageConfig, -1, 1, NULL);
-    if (ret) {
-        diaGetInt(diaStorageConfig, CFG_HDDSPINDOWN, &gHDDSpindown);
-        diaGetInt(diaStorageConfig, CFG_HDDGAMELISTCACHE, &gHDDGameListCache);
-        diaGetInt(diaStorageConfig, CFG_BDMCACHE, &bdmCacheSize);
-        diaGetInt(diaStorageConfig, CFG_HDDCACHE, &hddCacheSize);
-        diaGetInt(diaStorageConfig, CFG_SMBCACHE, &smbCacheSize);
-
-        applyConfig(-1, -1, 0);
-    }
-}
 
 static const char *artDelayNames[] = {"0 (Instant)", "2 (Fast)", "5 (Medium)", "8 (Standard)", NULL};
 static const int artDelayValues[] = {0, 2, 5, 8};
@@ -2311,78 +2103,6 @@ static void guiApplyGameIdMode(int mode)
 {
     gApplyGameID = mode == 0 || mode == 2;
     gPopstarterRetroGemGameID = mode == 0 || mode == 1;
-}
-
-void guiShowDisplayConfig(void)
-{
-    // clang-format off
-    const char *vmodeNames[] = {_l(_STR_AUTO)
-        , "PAL 640x512i @50Hz 24bit"
-        , "NTSC 640x448i @60Hz 24bit"
-        , "EDTV 640x448p @60Hz 24bit"
-        , "EDTV 640x512p @50Hz 24bit"
-        , "VGA 640x480p @60Hz 24bit"
-        , "PAL 704x576i @50Hz 24bit (HIRES)"
-        , "NTSC 704x480i @60Hz 24bit (HIRES)"
-        , "EDTV 704x480p @60Hz 24bit (HIRES)"
-        , "EDTV 704x576p @50Hz 24bit (HIRES)"
-        , "HDTV 1280x720p @60Hz 16bit (HIRES)"
-        , "HDTV 1920x1080i @60Hz 16bit (HIRES)"
-        , "PAL 640x256p @50Hz 24bit"
-        , "NTSC 640x224p @60Hz 24bit"
-        , NULL};
-    // clang-format on
-    const char *gameIDModes[] = {_l(_STR_GAMEID_MODE_ALL), _l(_STR_GAMEID_MODE_POPSTARTER),
-                                 _l(_STR_GAMEID_MODE_PS2), _l(_STR_GAMEID_MODE_OFF), NULL};
-    int previousVMode;
-    int ret;
-
-reselect_video_mode:
-    previousVMode = gVMode;
-    diaSetEnum(diaDisplayConfig, UICFG_VMODE, vmodeNames);
-    diaSetEnum(diaDisplayConfig, CFG_APPLYGAMEID, gameIDModes);
-    diaSetInt(diaDisplayConfig, UICFG_VMODE, gVMode);
-    diaSetInt(diaDisplayConfig, UICFG_WIDESCREEN, gWideScreen);
-    diaSetInt(diaDisplayConfig, UICFG_XOFF, gXOff);
-    diaSetInt(diaDisplayConfig, UICFG_YOFF, gYOff);
-    diaSetInt(diaDisplayConfig, UICFG_OVERSCAN, gOverscan);
-    diaSetInt(diaDisplayConfig, CFG_APPLYGAMEID, guiGameIdModeFromGlobals());
-
-reshow_display:
-    ret = diaExecuteDialog(diaDisplayConfig, -1, 1, guiDisplayUpdater);
-
-    // The GSM defaults sub-page writes straight into the global config set, so re-enter WITHOUT
-    // going back through the diaSetInt block above -- otherwise the rows the user already changed
-    // on this page would be reset from the (not yet committed) globals.
-    if (ret == DISPLAY_GSM_DEFAULTS_BUTTON) {
-        guiGameShowGSConfig(1);
-        goto reshow_display;
-    }
-
-    if (ret) {
-        diaGetInt(diaDisplayConfig, UICFG_VMODE, &gVMode);
-        diaGetInt(diaDisplayConfig, UICFG_WIDESCREEN, &gWideScreen);
-        diaGetInt(diaDisplayConfig, UICFG_XOFF, &gXOff);
-        diaGetInt(diaDisplayConfig, UICFG_YOFF, &gYOff);
-        diaGetInt(diaDisplayConfig, UICFG_OVERSCAN, &gOverscan);
-        int gameIDMode;
-        diaGetInt(diaDisplayConfig, CFG_APPLYGAMEID, &gameIDMode);
-        guiApplyGameIdMode(gameIDMode);
-
-        // Same #172 contract as _guiShowUIConfig above: play out the confirm bump before the GS
-        // teardown/rebuild below, on the GUI thread -- never inside applyConfig itself.
-        padRumbleFlush();
-        applyConfig(-1, -1, 1);
-    }
-
-    if (previousVMode != gVMode) {
-        if (guiConfirmVideoMode() == 0) {
-            // Restore previous video mode.
-            gVMode = previousVMode;
-            applyConfig(-1, -1, 1);
-            goto reselect_video_mode;
-        }
-    }
 }
 
 void guiShowCoverflowConfig(void)
@@ -3096,6 +2816,16 @@ static int guiSettingsPopstarterUpdater(int modified)
     return 0;
 }
 
+// PS Emulation Settings: PS1-via-POPSTARTER launch config (POPSTARTER.ELF device/path).
+//
+// This page COMPOSES a copy of diaVcdConfig + diaBdmaConfig and drives that copy, so a new row
+// belongs HERE, against the composed `ui` -- never against either template. A row wired into a
+// template renders on the composed page with no enum list and never saves; that happened once
+// with CFG_EMBER_DISPLAY.
+//
+// The BDMA equip, VCD list display options and POPStarter network settings are chained
+// sub-dialogs (guiShowBdmaConfig / guiShowVcdListConfig / guiShowPopsNetConfig). CFG ids are
+// shared with the pre-shell rows, so saved config values map through unchanged.
 static int guiSettingsShowPopstarter(void)
 {
     const struct UIItem *parts[] = {diaVcdConfig, diaBdmaConfig};

--- a/src/vcdsupport.c
+++ b/src/vcdsupport.c
@@ -26,7 +26,7 @@
 #include "include/gui.h"         // guiWarning (passing toast on a failed launch-path BDMA equip)
 #include "include/texcache.h"    // cosmetic ID resolver yields while artwork is pending
 #include "include/sound.h"       // cosmetic ID resolver yields to BGM low-water protection
-#include "include/util.h"        // checkMCSaveIconsDir -- browser icon pair for the POPSTARTER folder
+#include "include/util.h"        // kept for its transitive declarations; the checkMCSaveIconsDir this once named never existed
 #include "include/lang.h"        // _l + _STR_BDMA_ERR_* (same texts the Settings-screen equip shows)
 #include "include/textures.h"    // texDiscoverLoad + ERR_BAD_FILE (VCD POPS cover fallback)
 #include "include/vcdsupport.h"


### PR DESCRIPTION
Two removals, both proven not to change what ships.

**Ten settings screens superseded by PR #527's eight-page peer shell.** Each still had a definition, a `gui.h` declaration and no caller; there is no dispatch table reaching them (checked). They were not merely dead — `guiShowVcdConfig` carried its own warning:

> SUPERSEDED AND UNREFERENCED. […] Nothing calls this function any more; it is kept only because its declaration is still published in gui.h. Wiring a new row here does NOTHING. That mistake was made once already, with `CFG_EMBER_DISPLAY`.

So they were the obvious-looking place to add a setting, and a row added there rendered with no enum list and silently never saved. Also removes three `UIItem` arrays left with no reader — every `CFG_` id they carried also lives in `diaSecurityConfig` or `diaAdvancedConfig`, which the live General page composes, checked id by id first. The other five templates stay; live pages compose them.

Three language labels lose their last user and are **deliberately left in `_base.yml`**: `.lng` is consumed by line position, so deleting one shifts every later label and corrupts all 31 translations.

**Seven declarations with no definition anywhere** — a call site would fail at link, not runtime. Four carried doc comments describing behaviour that was never written, which read as available API.

Conservative on purpose: only declarations with no definition at all, and `vcdsupport.c` keeps its `util.h` include (it may carry transitive declarations; that breaks only on a clean build) with its comment corrected instead.

Verified in ps2dev:latest against `rebuild/main` in the same container: `text` 1848952 → 1848824, `data` and `bss` byte-identical, packed ELF the same size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)