### PR TITLE
Stop the Colours page wiping the game-title colour (#464)

### DIFF
--- a/src/themes.c
+++ b/src/themes.c
@@ -2555,9 +2555,21 @@ static void thmSetColors(theme_t *theme)
     theme->titleColor = GS_SETREG_RGBA(gDefaultTitleColor[0], gDefaultTitleColor[1], gDefaultTitleColor[2], 0x80);
     theme->selTextColor = GS_SETREG_RGBA(gDefaultSelTextColor[0], gDefaultSelTextColor[1], gDefaultSelTextColor[2], 0x80);
 
+    /* Re-colour the LIVE elements. This runs against a theme whose elements already exist, which
+       is what lets the Colours page apply without a reload -- and it is why the title picker has
+       to be honoured HERE as well as at element construction.
+
+       Game titles take titleColor, everything else textColor (#464). initBasic() already hands the
+       right colour to each element when a theme loads, but this loop forced textColor onto every
+       element, so the moment the user touched ANY colour the title choice was overwritten. The row
+       saved its value and the list went straight back to the general text colour -- which reads
+       exactly as "the option does nothing".
+
+       ITEMS_LIST is the game list in List mode; ITEM_TEXT is the title under the cover in
+       Coverflow. Both ARE the game title, so both follow the title picker. */
     theme_element_t *elem = theme->mainElems.first;
     while (elem) {
-        elem->color = theme->textColor;
+        elem->color = (elem->type == ELEM_TYPE_ITEMS_LIST || elem->type == ELEM_TYPE_ITEM_TEXT) ? theme->titleColor : theme->textColor;
         elem = elem->next;
     }
 }


### PR DESCRIPTION
#592 added the title-colour row; Zack reported on Beta-2734 that it still did nothing — *"the game title option does not work. Game titles share the same color as dialog color."*

#592 was right as far as it went: `initBasic()` hands `theme->titleColor` to the ItemsList and ItemText elements, and `drawItemsList()` paints unselected rows in `elem->color`, so a freshly **loaded** theme already showed the chosen colour.

What it missed is `thmSetColors()`, which walked every element in `mainElems` and forced `elem->color = theme->textColor` unconditionally. That function is exactly what runs when a colour changes — it is how the Colours page applies without a theme reload:

    pick a title colour → applyConfig → thmSetColors →
    titleColor set on the theme, then immediately overwritten on every element

The value saved fine and was thrown away on the way to the screen. Titles fell back to the general text colour, which out of the box is the same value dialogs render at — which is precisely the reported symptom, and why the row looked inert.

The loop now gives `ELEM_TYPE_ITEMS_LIST` and `ELEM_TYPE_ITEM_TEXT` the title colour and everything else the text colour. Those two *are* the game title: the list in List mode, the title under the cover in Coverflow.

Scope checked first: `elem->color` is assigned in exactly three places — `initBasic`'s cfg override, its passed default, and this loop — so no second path can still clobber it. Disk themes are unaffected: excluded from the live call on purpose (#537), and at load their `title_color` is applied before any element is built.

Verified: builds clean, `text` +32 bytes for the added test, `data`/`bss` unchanged, clang-format 12 clean.

⚠️ Not hardware-verified — but unlike the previous attempt, a build containing this will have something new to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)