### PR TITLE
Make the on-screen keyboard caret actually blink (#466)

### DIFF
--- a/src/dia.c
+++ b/src/dia.c
@@ -70,6 +70,11 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
     // the command column at its edges, which is the primary control on this screen. The request
     // offers the shoulder buttons as its own alternative for that reason.
     int caret = len;
+    // Blink phase. NOT guiFrameId: that only advances in guiStartFrame(), which this screen never
+    // calls -- it drives its own rmStartFrame/rmEndFrame loop -- so guiFrameId is frozen for as
+    // long as the keyboard is open and the caret held whatever state it was in (#466: "the cursor
+    // is now complete but lacks the flicking behaviour").
+    int caretFrame = 0;
     char c[2] = "\0\0", *mask_buffer;
     static const char keyb0[KEYB_ITEMS] = {
         '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=',
@@ -108,6 +113,7 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
 
     while (1) {
         readPads();
+        caretFrame++;
 
         rmStartFrame();
         if (guiDrawBGSettings() == 0)
@@ -133,7 +139,7 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
             int n = (caret < len) ? caret : len;
             memcpy(pre, shown, n);
             pre[n] = '\0';
-            if ((guiFrameId >> 4) & 1)
+            if ((caretFrame >> 4) & 1)
                 rmDrawRect(50 + rmUnScaleX(fntCalcDimensions(gTheme->fonts[0], pre)), 120, 2, 20, gColWhite);
         }
 


### PR DESCRIPTION
Zack on Beta-2734: *"the cursor is now complete but lacks the flicking behaviour, like a normal cursor."*

The blink was already written — `if ((guiFrameId >> 4) & 1)` — but `guiFrameId` only increments in `guiStartFrame()`, and this screen never calls it: `diaShowKeyb` drives its own `rmStartFrame`/`rmEndFrame` loop. So the counter is **frozen** for as long as the keyboard is open and the caret holds whichever state it was in. The bit sits at 1, so the caret is solid rather than absent — exactly what was reported.

Fixed with a local counter advanced once per rendered frame in this screen's own loop, which is what `guiFrameId` was standing in for. Same `>> 4` cadence, so the blink rate is the one the original expression intended.

Not a time source deliberately: `clock()` would need a phase rather than a deadline to stay safe across its ~71 minute wrap, and a per-frame counter is both simpler and exactly what a per-frame blink wants.

Builds clean, clang-format 12 clean. 7 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)