### PR TITLE
Fix the README header broken by the banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 <p align="center"><img alt="RiptOPL" src="https://raw.githubusercontent.com/NathanNeurotic/Open-PS2-Loader/rebuild/main/docs/assets/riptopl.png" /></p>
+
 ```HAS THIS EVER HAPPENED TO YOU?```
 ```You download another OPL fork. It has a new theme. A new menu. Maybe even a file browser, because apparently launching games was too direct and somebody needed a side quest.```
 ```Then the game still does not work.```


### PR DESCRIPTION
Fixes the README header broken by #603.

## Cause

The banner replaced a **markdown image** with a **raw HTML block**. In CommonMark an HTML block runs until a **blank line** — and there wasn't one. So everything after it (the whole ```` ``` ```` pitch, the `# RiptOPL` heading, the licence lines) was absorbed into that block and emitted as raw HTML: one run-on paragraph with the backticks showing literally.

The `![logo](...)` it replaced never started an HTML block, which is why those same lines rendered correctly before.

## Fix

One blank line after the `</p>`. Keeps the centering.

## Verified through GitHub's own `/markdown` API, not by eye

Rendering the first 26 lines:

| version | `<code>` spans | `<h1>` |
| --- | --- | --- |
| broken (on `rebuild/main` now) | **0** | no |
| this PR | **14** | yes |

No literal ``` leaks into the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
