### PR TITLE
fix(udpfs): preflight Neutrino before pushing the MMCE GameID

### DIFF
--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -446,18 +446,28 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     // -dvd target (the udpfs: filesystem game file); a follow-up stage finalizes the exact -dvd/-bsd argv.
     sbCreatePath(game, partname, udpfsPrefix, "/", 0);
 
-    // MMCE cross-device game-id (#261): push the disc id to a present MMCE card before teardown frees
-    // `game`. Neutrino path forwarded so a Neutrino launch protects the MMCE hand-off timing.
-    mmceSendGameID(game->startup, neutrinoPath,
-                   (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
-
     // Neutrino keep-IOP handoff (sysLoadELFKeepIOP): Neutrino reads the game through OUR udpfs
     // filesystem and its config/modules from the neutrino.elf device (-cwd) before its own IOP
     // reset -- keep BOTH mounted across the teardown. Mirrors bdmsupport's Neutrino deinit contract.
     // D6: pre-teardown validation -- for UDPFS this is where the bsd toml ip= sync now happens
     // (was post-deinit inside sysLaunchNeutrino); a failure toasts and stays in the menu.
+    //
+    // ORDER (matches bdmsupport/hddsupport): the preflight runs BEFORE the GameID push, never after.
+    // The 0x8 devctl below physically re-mounts the MMCE card, and on Gen2 the busy bit it waits on
+    // can clear before the FILESYSTEM surface is back (see mmceSettleAfterSwitch). On a
+    // "Neutrino Device = MMCE" install the preflight's config/bsd-udpfs.toml open lands on mmceN:,
+    // so running it after the push aimed that open straight into the re-mount window and failed the
+    // launch with _STR_NEUTRINO_TOML_SYNC_FAILED on a toml that reads fine a moment earlier or
+    // later. Preflighting first also means an abort leaves the card UNSWITCHED instead of dropping
+    // the user back into the menu sitting on the per-game card.
     if (sysNeutrinoPreflight("udpfs", neutrinoPath) < 0)
         return;
+
+    // MMCE cross-device game-id (#261): push the disc id to a present MMCE card before teardown frees
+    // `game`. Neutrino path forwarded so a Neutrino launch protects the MMCE hand-off timing.
+    mmceSendGameID(game->startup, neutrinoPath,
+                   (neutrinoVmc.arg[0][0] ? 1 : 0) | (neutrinoVmc.arg[1][0] ? 2 : 0)); // Δ3: -mc-covered slots keep their card
+
     int neutrinoDevMode = oplPath2Mode(neutrinoPath);
     char gameStartup[GAME_STARTUP_MAX + 1];
     snprintf(gameStartup, sizeof(gameStartup), "%s", game->startup);


### PR DESCRIPTION
## What

The UDPFS launch leg sent the MMCE GameID and *then* ran `sysNeutrinoPreflight()`. Every other leg does it the other way round:

| leg | order |
|---|---|
| BDM `bdmsupport.c:1932` | preflight → send |
| HDD `hddsupport.c:1919` | preflight → send |
| MMCE `mmcesupport.c:1161` | send → `mmceSettleAfterSwitch()` → preflight |
| **UDPFS (before this PR)** | **send → preflight, no settle** |

This moves the preflight above the push. Reorder only.

## Why

The `0x8` GameID devctl physically re-mounts the MMCE card, and on Gen2 hardware the busy bit `mmceSendGameID()` waits on can clear before the filesystem surface is back — already documented on `mmceSettleAfterSwitch()` (`src/mmcesupport.c:268`).

With **Neutrino Device = MMCE**, `sbResolveNeutrinoPath()` returns `mmceN:/neutrino/neutrino.elf`, so the preflight's `sysSyncNeutrinoUdpfsToml()` opens `mmceN:/neutrino/config/bsd-udpfs.toml`. Running that after the push aimed the open straight into the re-mount window; a failed `open()` returns `-1` and aborts the launch with `_STR_NEUTRINO_TOML_SYNC_FAILED`.

The preflight is unconditional, so with the GameID feature **off** `mmceSendGameID()` returns at its `!gMMCEEnableGameID` guard, no devctl fires, and the identical open on the identical path succeeds. The card switch was the only variable between working and failing.

Secondary benefit: a preflight abort now leaves the card **unswitched**, rather than dropping the user back into a live menu already sitting on the game's per-game card.

## What this does *not* do

It does not close the re-mount window for the `neutrino.elf` load `sysLaunchNeutrino()` performs after `deinitEx`. Reusing `mmceSettleAfterSwitch()` there is not a drop-in: it derives its target from `mmceGetDeviceRoot()` (`mmcePrefix` / `gMMCESlot`), which on a UDPFS launch can be empty — with the slot on Auto it returns early and no-ops, exactly on the cross-device config it would be for. It would need re-pointing at `mmceGameIdTarget` the way `mmceGameIdSettle()` already does. Deliberately left alone: that edits a helper the working MMCE-hosted launch path depends on, and there is no hardware report behind it.

## Validation

- `make -j8 opl.elf` in `ps2dev/ps2dev:latest` → `MAKE_EXIT=0`
- `clang-format` 12 (`xianpengshen/clang-tools:12`, matches CI) → clean
- Not hardware-tested. The originating Discord report turned out to be user error, so this is a code-consistency fix, not a confirmed field repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game launch sequencing to prevent configuration access during device remounting.
  * Ensured aborted launches leave the memory card in its original state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->