### PR TITLE
fix(ra): bound the ISO9660 walk by the directory, not just the buffer

### DIFF
--- a/src/rahash.c
+++ b/src/rahash.c
@@ -107,11 +107,22 @@ static int find_entry(int fd, unsigned int dir_lba, unsigned int dir_size,
     while (done < dir_size) {
         int got = read_at(fd, (long long)(dir_lba)*ISO_SECTOR + done, g_chunk, ISO_SECTOR);
         int p = 0;
+        /* Parse only as far as the DIRECTORY runs, which is not always as far as the sector we
+           just read. A well-formed ISO9660 sizes every directory extent in whole 2048-byte
+           blocks, so on a good image this is always ISO_SECTOR -- but a damaged or hand-built
+           image can end its extent mid-sector, and the bytes after it belong to whatever file
+           follows. Parsing those would let adjacent image data pose as a directory record,
+           match the name we are looking for, and hand back its LBA: raHashIsoDirect then hashes
+           the wrong file and reports a confident, wrong game id. The read stays a full sector
+           on purpose -- clamping it too would turn a truncated image into a hard failure that
+           did not happen before, and bounding the PARSE is what actually fixes this. */
+        unsigned int left = dir_size - done;
+        int limit = (left < (unsigned int)ISO_SECTOR) ? (int)left : ISO_SECTOR;
 
         if (got != ISO_SECTOR)
             return -1;
 
-        while (p < ISO_SECTOR) {
+        while (p < limit) {
             unsigned char *rec = (unsigned char *)&g_chunk[p];
             int len = rec[0];
             int namelen;
@@ -123,8 +134,10 @@ static int find_entry(int fd, unsigned int dir_lba, unsigned int dir_size,
                walk trusts len blindly: rec[32] and the name bytes at rec[33 + i] read up to
                ~287 bytes past p, and since only the first ISO_SECTOR of g_chunk was filled
                that is leftover data from an earlier 64 KB read -- so a truncated image can
-               match a name that is not there and hand back a bogus LBA. */
-            if (len < 33 || p + len > ISO_SECTOR)
+               match a name that is not there and hand back a bogus LBA. Bounded by `limit`,
+               not ISO_SECTOR: a record must fit inside the directory, not merely inside the
+               buffer the directory was read into. */
+            if (len < 33 || p + len > limit)
                 break;
 
             namelen = rec[32];


### PR DESCRIPTION
Follow-up to a CodeRabbit finding on [#607](https://github.com/NathanNeurotic/Open-PS2-Loader/pull/607), which landed before the review arrived. **The finding is correct** — it's a gap in the hardening that PR added.

## What was wrong

`find_entry` reads a full 2048-byte sector and parsed **all** of it, regardless of how much of the directory extent was actually left. The check added in #607 stopped a record claiming more than the *sector* held; it never stopped one claiming more than the *directory* held.

A well-formed ISO9660 sizes every directory extent in whole 2048-byte blocks, so on a good image the two limits are identical and this never fires. On a damaged or hand-built image whose extent ends mid-sector, the bytes after it belong to whatever file follows — and parsing those lets adjacent image data pose as a directory record, match the filename being searched for, and return its LBA. `raHashIsoDirect` then hashes the wrong file and reports a **confident, wrong game id**, which is worse than failing to find one.

Robustness against malformed images was the whole point of the original change, so this belongs to it.

## The fix

Parse to `min(ISO_SECTOR, dir_size - done)`, and require each record to fit inside *that* rather than inside the buffer.

**One deviation from the review's suggestion:** it proposed clamping the *read* as well. I kept the read at a full sector on purpose — clamping it would turn a truncated image into a hard read failure (`got != ISO_SECTOR` → `-1`) that didn't happen before, which is a new failure mode for no benefit. Bounding the **parse** is what actually fixes the defect.

## Not done

The review also asked for a regression image whose directory ends mid-sector with a matching record in the following bytes. That's a fair ask, but this repo has no ISO fixture harness to hang it on, and inventing one for a single case is a larger piece of work than the fix. Noting it rather than silently skipping it.

## Validation

- RA flavour builds clean in `ps2dev/ps2dev:latest`.
- `clang-format` 12 clean.
- Not hardware-tested — like the rest of the RA feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)