### PR TITLE
fix(ra): build the RA flavour like the main loader, not like a variant

### DIFF
--- a/docs/RETROACHIEVEMENTS.md
+++ b/docs/RETROACHIEVEMENTS.md
@@ -173,6 +173,13 @@ Hand testers a **run-pinned nightly.link build**, never a bare artifact link.
 * **Deleting `obj/` is mandatory** after any change to `EECoreConfig_t`, `OPL_MODULE_ID` or the
   submenu structs. This Makefile does not track header dependencies, so an incremental build can
   pass locally while CI's `make clean` fails.
+* **`ee_core` has about 3 KB of headroom, and RA spends it.** ram84 is 77312 bytes
+  (`ee_core/linkfile`). Without RA, an `EXTRA_FEATURES=1` ee_core comes to 74215; with RA and
+  without extras, 74067. Either fits; both together overflow by roughly 6.5 KB and `ld` refuses
+  with `.bss is not within region ram84`. That is why the release builds RA at the default
+  `EXTRA_FEATURES=0`, which is also what the main loader ships as — so the RA archive is the
+  shipping loader plus achievements, not a variant. `ra_snap_buf` and `ra_watch` are most of RA's
+  share; shrink them before trying to add anything else to that build.
 * **Do not build a PC client.** hacan359 provides and maintains xeRAbora. Do not commit `pc/RA/`.
 * **Disc mode is deferred**, deliberately, as a separate game source. It is not a missing piece of
   this work.


### PR DESCRIPTION
**The RetroAchievements builds have been failing in the release pipeline since the feature merged, and failing quietly.** `build_rolling_extras.sh` logs a WARN and skips, `rolling/ra/` comes out empty, the packaging step reports "No RA builds present" and skips the zip — and the workflow goes green and publishes a release with no `RIPTOPL-RA-*.zip` in it.

Nothing in PR CI could have caught it: those jobs build the **default** flavour, so nothing ever built RA until the post-merge rolling job did. Found by reading that job's log rather than trusting its green tick.

## The failure

```
ld: address 0x9896c of ee_core.elf section `.bss' is not within region `ram84'
```

`ram84` is 77,312 bytes (`ee_core/linkfile`). Measured in the same container CI uses:

| config | ee_core total | fits? |
| --- | --- | --- |
| `EXTRA_FEATURES=1`, no RA | 74,215 | yes, 3,097 spare |
| `EXTRA_FEATURES=0`, **+RA** | 74,067 | yes, 3,245 spare |
| `EXTRA_FEATURES=1`, **+RA** | ~80,700 | **no — over by ~6.5 KB** |

GSM_1080P + IGS cost ee_core about 6.2 KB of text; RA costs about 6.0 KB of bss. There is room for one of them, not both.

## The fix, and why it isn't a concession

Stop passing `EXTRA_FEATURES=1`.

`EXTRA_FEATURES ?= 0`, and **the main release loader is built with that default** — the flag is only used by the variants matrix. I had borrowed it from that matrix on the reasoning that an opt-in build may as well carry everything. That was wrong on its own terms: it made the RA loader differ from the one it is supposed to be a copy of. Dropping it makes `RIPTOPL-RA-*.zip` what it claims to be — the shipping loader plus achievements.

So the RA build loses nothing it was ever meant to have.

## Guardrail

The constraint is recorded in both the script and `docs/RETROACHIEVEMENTS.md`, because "add `EXTRA_FEATURES=1`, it's only a flag" is an obvious-looking change that fails 6.5 KB later, in a linker message that never mentions RA.

## Validation

- Both builds the script actually performs (`PADEMU=0` and `PADEMU=1`) link cleanly at the default, in `ps2dev/ps2dev:latest`.
- The failure reproduces exactly with `EXTRA_FEATURES=1`.
- Still not hardware-tested — like the rest of the RA feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added build notes describing memory considerations for AI-related features.
  * Documented the recommended configuration for release builds to remain within available memory limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->