### PR TITLE
APPS: rescan when a source device publishes, not only on SELECT

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1309,8 +1309,33 @@ void menuDeferredUpdate(void *data)
         // If other modes have been updated, then the apps list should be updated too.
         // Exclude FAV: a FAV rebuild marking apps dirty would re-trigger the FAV resync below
         // (an apps refresh calls loadFavourites), looping forever once favNeedsUpdate fires.
-        if (mod->support->mode != APP_MODE && mod->support->mode != FAV_MODE)
+        if (mod->support->mode != APP_MODE && mod->support->mode != FAV_MODE) {
             shouldAppsUpdate = 1;
+
+            // ...and SCHEDULE the pass that consumes that flag. Raising it is not enough: APPS has
+            // updateDelay > 0, so the only thing that ever queued an APP_MODE deferred update in the
+            // background was menuUpdateHook's `gAutoRefresh && longIdle` branch -- and automatic
+            // refresh is OFF by default. With it off the flag simply sat set until the user pressed
+            // SELECT.
+            //
+            // That is the reported bug (eliminator1403): USB and APPS both on Auto, and the APPS tab
+            // comes up EMPTY every boot. bdmEnumerateDevices() is asynchronous -- it only queues
+            // bdmLoadBlockDeviceModules -- so the per-slot bdmPrefix is still empty when the boot's
+            // one APP_MODE update runs, and oplScanApps skips every device-less prefix (#253). The
+            // stick then attaches, BDM publishes its list, this line raises shouldAppsUpdate... and
+            // nothing ever asked APPS to look at it. Pressing SELECT was the only consumer.
+            //
+            // Queue it here instead, exactly the way loadFavourites() below schedules FAV's rebuild.
+            // Bounded, not a storm: itemNeedsUpdate returns 1 only on a REAL source change (a
+            // never-connected BDM slot returns 0 early), and duplicates self-coalesce because
+            // oplShouldAppsUpdate() clears the flag on the first pass, so any extra queued pass
+            // rebuilds nothing. Enqueueing from this IO worker is the established pattern here
+            // (bdmNeedsUpdate and loadFavourites both do it): ioPutRequest takes only gEndSemaId,
+            // which the worker does not hold while a handler runs.
+            opl_io_module_t *appMod = &list_support[APP_MODE];
+            if (appMod->support != NULL && appMod->support->enabled)
+                ioPutRequest(IO_MENU_UPDATE_DEFFERED, &appMod->support->mode);
+        }
 
         // A source-list refresh may expose newly-loaded items to validate favourites
         // against. Re-sync the FAV tab (cheap/idempotent; skipped when FAV is disabled).


### PR DESCRIPTION
## The report

From eliminator1403 (Discord): with **USB and APPS both on Auto**, the APPS tab comes up **empty every boot** and only fills after pressing SELECT. The ask arrived as "please enable automatic refresh by default", but that would only have papered over the real gap — and at the cost of the refresh spam we deliberately avoid.

## Root cause: a latch with no consumer

1. `bdmEnumerateDevices()` is asynchronous — it only queues `bdmLoadBlockDeviceModules` onto the IO worker.
2. So when the boot's single `APP_MODE` deferred update runs, **no BDM slot has published a `bdmPrefix` yet**, and `oplScanApps` skips every device-less prefix (the #253 guard). Nothing on USB is found → empty APPS list.
3. The stick then attaches, BDM publishes its list, and `menuDeferredUpdate` raises `shouldAppsUpdate = 1` exactly as designed…
4. …but **nothing ever asked APPS to look at that flag**. APPS has `updateDelay = 240` (> 0), so the only thing that queues a background `APP_MODE` update is `menuUpdateHook`'s `gAutoRefresh && longIdle` branch — and Automatic Refresh is **off by default**.

`SELECT` (`itemExecRefresh`) was therefore the *sole* consumer of the flag. That is exactly why the manual refresh always worked, and why enabling auto-refresh would also have "fixed" it.

## The fix

Queue the `APP_MODE` update alongside raising the flag — the same way `loadFavourites()` already schedules FAV's rebuild two lines below:

```c
if (mod->support->mode != APP_MODE && mod->support->mode != FAV_MODE) {
    shouldAppsUpdate = 1;
    opl_io_module_t *appMod = &list_support[APP_MODE];
    if (appMod->support != NULL && appMod->support->enabled)
        ioPutRequest(IO_MENU_UPDATE_DEFFERED, &appMod->support->mode);
}
```

**Bounded, not a storm** — each gate checked:

- `itemNeedsUpdate` returns 1 only on a **real** source change. A never-connected BDM slot returns 0 early; both `bdmNeedsUpdate` and `mmceNeedsUpdate` quiesce once scanned (device-tick / size gates).
- Duplicates self-coalesce: `oplShouldAppsUpdate()` clears the flag on the first pass, so any extra queued pass rebuilds nothing.
- Enqueueing from the IO worker is the established pattern here — `bdmNeedsUpdate` and `loadFavourites` both do it, and `ioPutRequest` takes only `gEndSemaId`, which the worker does not hold while a handler runs.
- The `enabled` guard keeps a MANUAL APPS tab untouched; its flag still waits for the user's first visit, as before.

**Side benefit:** hotplug now populates APPS on the same event that populates the game list, instead of leaving it stale until the next SELECT.

**Automatic Refresh keeps its existing default (off).** The starved latch was the bug, not the setting.

## Verification

- Clean container build (`make clean` → `make languages` → `make opl.elf`), `MAKE_EXIT=0`, no new warnings on `opl.c`.
- `clang-format` 12 (`xianpengshen/clang-tools:12`) clean.
- ⚠️ **Not hardware-tested.** Worth a confirmation from eliminator1403 on his USB rig: USB + APPS both Auto, cold boot, APPS should fill without touching SELECT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Apps now automatically rescan after device changes when viewing eligible source lists, without requiring the user to press Select.
  - Improved Apps refresh behavior while the Apps module is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->