### PR TITLE
ioman: drop the dead request cap, and write down why there isn't one

### DIFF
--- a/src/ioman.c
+++ b/src/ioman.c
@@ -10,7 +10,30 @@
 #include <sio.h>
 #endif
 
-#define MAX_IO_REQUESTS 64
+/*
+  There is deliberately NO cap on the number of queued requests.
+
+  A MAX_IO_REQUESTS 64 constant used to sit here, enforced nowhere -- the dead half of the pair whose
+  live half (MAX_IO_HANDLERS, below) IS enforced in ioRegisterHandler. Removed rather than wired up,
+  because enforcing it would be wrong in both directions:
+
+  Nothing to protect. A request node is a type plus two pointers. Sixty-four of them is about a
+  kilobyte on a 32 MB console, and the worker drains the queue to empty before it sleeps
+  (ioWorkerThread), so depth is set by the event rate, not by any cap.
+
+  Backpressure already exists, at the PRODUCERS, which is the only place it can be lossless. The
+  background rescans refuse to enqueue at all while anything is pending (menuUpdateHook's
+  `if (ioHasPendingRequests()) return;`), and art has its own gArtQueuedCount gate -- lock-free
+  precisely because the obvious queue-side counter, ioGetPendingRequestCount(), takes gProcSemaId,
+  which the worker holds across the WHOLE drain, so calling it from the GUI thread froze the menu for
+  as long as any art was in flight (see texcache.c). Those gates also close the one case a cap might
+  seem to answer: a wedged handler stops the drain, but it stops the enqueues with it.
+
+  And rejecting here would LOSE work rather than defer it. Most call sites ignore the return value, so
+  a refused IO_MENU_UPDATE_DEFFERED is a list that never refreshes and a refused art load is a cover
+  that parks forever -- the exact failure classes this fork keeps having to fix. IO_ERR_TOO_MANY_REQUESTS
+  stays: ioPutRequest still returns it when the node allocation itself fails.
+*/
 #define MAX_IO_HANDLERS 64
 
 extern void *_gp;


### PR DESCRIPTION
Follow-up to #616, where CodeRabbit read `MAX_IO_REQUESTS` as an unbounded-growth risk. The finding's conclusion was declined there, but one sub-claim was correct and worth acting on.

## What was wrong

`#define MAX_IO_REQUESTS 64` sat at the top of `src/ioman.c` and was enforced **nowhere** — `grep -rn` over live source returns only the define itself. Its sibling `MAX_IO_HANDLERS` *is* enforced, in `ioRegisterHandler`. That is the fork's familiar defect shape from the pre-v1.0 audit: one half of a feature ported (the constant, plus the `IO_ERR_TOO_MANY_REQUESTS` code), the enforcement half missing, and no `-Wall` diagnostic to catch it.

## Why it's removed rather than wired up

**Nothing to protect.** A request node is a `type` plus two pointers. Sixty-four of them is ~1KB on a 32MB console, and `ioWorkerThread` drains the queue to empty before it sleeps — depth is set by the event rate, not by any cap.

**Backpressure already exists, at the producers** — the only place it can be lossless:
- `menuUpdateHook` refuses to enqueue background rescans at all while anything is pending (`if (ioHasPendingRequests()) return;`).
- Art has its own `gArtQueuedCount` gate, lock-free *precisely because* the obvious queue-side counter `ioGetPendingRequestCount()` takes `gProcSemaId` — which the worker holds across the **whole** drain — so calling it from the GUI thread froze the menu for as long as any art was in flight (the "everything turns to chit" / black-screen-after-save reports; see the comment in `texcache.c`).

Those gates also close the one case a cap might seem to answer: a wedged handler stops the drain, but it stops the enqueues with it.

**Rejecting in `ioPutRequest` would lose work rather than defer it.** Most call sites ignore the return value, so a refused `IO_MENU_UPDATE_DEFFERED` is a list that never refreshes, and a refused art load is a cover that parks forever — the exact failure classes this fork keeps having to fix, including the one #616 just fixed.

`IO_ERR_TOO_MANY_REQUESTS` stays: `ioPutRequest` still returns it when the node allocation itself fails.

## Scope

**No behaviour change** — the constant had no readers. The comment replacing it records load-bearing architecture that was previously only discoverable by reading three files, and stops this finding being re-filed on every future PR that touches `ioman.c`.

## Verification

- Container build `MAKE_EXIT=0`, no new warnings.
- `clang-format` 12 (`xianpengshen/clang-tools:12`) clean.
- No hardware testing needed or possible: zero generated-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
