### PR TITLE
RA: no PC reads from the network while a game runs from a share

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ contains and how to pull it.
 ### Known limitations
 
 - **HTTP:** implemented and host-tested, but not yet tested on PS2 hardware. ISO only; no VMC, Neutrino or PS1. DVD9 probing is implemented but unproven. [HTTP guide](docs/HTTP.md).
-- **RetroAchievements:** a separate development package; the console integration has not been hardware-tested. It requires xeRAbora on a PC and OPL-core launching. [RA guide](docs/RETROACHIEVEMENTS.md).
+- **RetroAchievements:** a separate development package; the console integration has not been hardware-tested. It requires xeRAbora on a PC and OPL-core launching. Keep games you play with achievements on a local device — upstream reports on hardware that a game with an achievement set stops loading about a minute in from a network share. [RA guide](docs/RETROACHIEVEMENTS.md).
 - **iLink:** revision 2692 passed Ember on the tested SCPH-39001 but failed native OPL, Neutrino and POPSTARTER handoffs. The Neutrino `-qb` correction is implemented; a passing retest is still needed.
 - **Core switching is source-dependent:** SMB and HTTP use OPL; UDPFS/UDPBD use Neutrino. See the [source table](#introduction).
 

--- a/docs/RETROACHIEVEMENTS.md
+++ b/docs/RETROACHIEVEMENTS.md
@@ -61,16 +61,30 @@ Telemetry lives inside OPL's own loader core, which only exists for launches OPL
 | Launch path | Supported |
 | --- | --- |
 | BDM — USB, iLink, MX4SIO, ATA/exFAT | yes |
-| ETH / SMB | yes |
+| ETH / SMB | wired, but **known bad upstream** — see below |
 | HDD (APA) | yes — but see the note below |
 | MMCE | yes |
-| HTTP | local watch-list loading is wired into OPL-core launch; combined HTTP/RA operation is not hardware-validated |
+| HTTP | local watch-list loading is wired into OPL-core launch; combined HTTP/RA operation is not hardware-validated, and it shares the ETH/SMB risk below |
 | Neutrino core (`$CoreLoader`) | **no** |
 | UDPFS | **no** |
 | PS1 / VCD (POPSTARTER, Ember) | **no** |
 
 Neutrino, UDPFS and PS1 hand the console over to an external ELF and never load OPL's core, so there is
 nothing to take a snapshot from. This is structural, not an oversight.
+
+### Do not expect a game with achievements to run from a network share
+
+A game that streams its own disc over the NIC is competing with telemetry for that NIC. This build no
+longer *reads* from the network in play on such a launch — `raudp` stops walking the SMAP receive ring
+and stops polling the stack, because the game's disc stream arrives through both — but **hacan359
+reports on hardware (2026-09-05) that this is not enough: a game with an achievement set still stops
+loading about a minute in from a share, so the send path disturbs the stream on its own.** xeRAbora's
+own documentation says the same, and names the USB stick and the original disc as the only tested ways
+to play.
+
+That defect is upstream's and ours alike; we have not reproduced or ruled it out on our own hardware,
+because none of this has been hardware-tested here yet. Until it is, **keep the images you play with
+achievements on a local device.** The same reasoning applies to HTTP, which streams down the same path.
 
 HDD (APA) games are stored in HDLoader format and have no image file to hash, so while a watch list
 placed by hand still loads and streams, the console cannot work out the hash for them itself.

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -231,10 +231,11 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
 
         if (snap != NULL) {
             /* argv[1]: the IOP snapshot, EE event and EE badge buffer
-               addresses, eight hex digits each, comma-separated.
+               addresses, eight hex digits each; then whether raudp may read
+               from the network in play, then the game's serial.
                argv[2]: SMAP's ipconfig strings -- raudp finds the PC itself. */
-            char args[27 + IPCONFIG_MAX_LEN];
-            int k;
+            char args[45 + IPCONFIG_MAX_LEN];
+            int k, n;
 
             ra_snap_iop = (unsigned int)snap;
             RA_Hex32(ra_snap_iop, &args[0]);
@@ -242,12 +243,30 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
             RA_Hex32((unsigned int)RA_OverlayEventBuffer(), &args[9]);
             args[17] = ',';
             RA_Hex32((unsigned int)RA_OverlayBadgeBuffer(), &args[18]);
-            args[26] = '\0';
+
+            /* Both roads raudp takes to the PC cost the game something when it
+               streams its own disc over this NIC: the raw one frees the SMAP
+               receive descriptors that stream arrives in, the lwIP one queues
+               on the mailbox the SMB or HTTP client waits on. A game from a
+               share loads for ever with either, so tell raudp to stop looking.
+               Sending is unaffected and stays on. HTTP_MODE is ours -- upstream
+               has no HTTP protocol -- but it streams down the same path and
+               carries the same defect. */
+            args[26] = ',';
+            args[27] = (config->GameMode == ETH_MODE || config->GameMode == HTTP_MODE) ? '0' : '1';
+
+            /* The serial seeds the packet header, so the PC has it before the
+               first snapshot is written. */
+            args[28] = ',';
+            for (n = 0; n < 15 && config->GameID[n] != '\0'; n++)
+                args[29 + n] = config->GameID[n];
+            args[29 + n] = '\0';
+            n += 30;
 
             for (k = 0; k < g_ipconfig_len && k < IPCONFIG_MAX_LEN; k++)
-                args[27 + k] = g_ipconfig[k];
+                args[n + k] = g_ipconfig[k];
 
-            LoadOPLModule(OPL_MODULE_ID_RAUDP, 0, 27 + k, args);
+            LoadOPLModule(OPL_MODULE_ID_RAUDP, 0, n + k, args);
         } else {
             /* No buffer, so nothing can be sent. Leaving ra_snap_iop at zero
                makes ra.c's per-frame path a no-op, and there is no reason to

--- a/modules/network/raudp/raudp.c
+++ b/modules/network/raudp/raudp.c
@@ -752,6 +752,21 @@ static int ra_discover(void)
 
         tries++;
         if (tries >= RA_DISC_FAST) {
+            /* The endless slow re-query exists so the PC client may start
+               after the game. On a share it must not: every poll posts to the
+               stack mailbox the SMB or HTTP client is waiting on, and there
+               that is the road the game's own disc arrives by -- the same
+               reason ra_rx_in_game shuts the in-play reads down. Discovery
+               runs before that gate is reached, so bound it here instead:
+               the fast phase gets ten seconds, inside the start-up hold-off,
+               and then the stack is left alone for the rest of the session.
+               Nothing that worked is lost -- with no PC there is no address
+               to send telemetry to either. */
+            if (!ra_rx_in_game) {
+                lwip_close(s);
+                return 0;
+            }
+
             DelayThread(RA_DISC_SLOW_US);
             if (ra_disc_us < 0xF0000000)
                 ra_disc_us += RA_DISC_SLOW_US;

--- a/modules/network/raudp/raudp.c
+++ b/modules/network/raudp/raudp.c
@@ -94,6 +94,21 @@ static u8 ra_dst_mac[6];
 static u8 ra_frame[RA_FRAME_LEN] __attribute__((aligned(16)));
 static u8 *ra_payload = &ra_frame[RA_HDR_LEN];
 
+/* May this module look for the PC while a game runs? Off when the game
+   streams its own disc over the same NIC -- a share (ETH_MODE) or an HTTP
+   host. Both roads to the PC take something the game needs: the raw one
+   frees every SMAP receive descriptor it walks, and the disc stream arrives
+   through that ring; the lwIP one posts to the stack mailbox the SMB or HTTP
+   client is waiting on. Either way the game reaches its first menu and loads
+   for ever. ee_core decides and says so in a load argument. Sending is
+   unaffected and stays on. */
+static int ra_rx_in_game = 1;
+
+/* The game's serial, from the same argument, so the very first packets carry
+   it instead of fifteen zeroes -- the snapshot has it too, but not before the
+   EE has written one. */
+static char ra_game_id[16] = {0};
+
 /* Counters reported in every packet. */
 static u32 ra_seq = 0;      /* packets sent or skipped */
 static u32 ra_fail = 0;     /* SMAPSendPacket() errors */
@@ -216,6 +231,20 @@ static int ra_head_len = 0;
    header change can never silently truncate the tail. */
 static u32 ra_chunk = RA_SNAP_CHUNK_BYTES;
 
+/* Serial as-is, padded with '~'. Not '_': serials contain underscores
+   (SLUS_210.65). Only valid once ra_head_build has set the field offsets. */
+static void ra_id_put(const char *src)
+{
+    int i;
+
+    for (i = 0; i < 15; i++) {
+        char c = src[i];
+
+        ra_payload[RA_OFF(RA_F_ID) + i] =
+            (c >= 0x20 && c < 0x7F) ? (u8)c : (u8)'~';
+    }
+}
+
 static void ra_head_build(void)
 {
     static const char tag[] = "RA15";
@@ -245,6 +274,8 @@ static void ra_head_build(void)
     ra_chunk = (u32)(RA_PAYLOAD - ra_head_len);
     if (ra_chunk > RA_SNAP_CHUNK_BYTES)
         ra_chunk = RA_SNAP_CHUNK_BYTES;
+
+    ra_id_put(ra_game_id);
 }
 
 /* ---- Formatting helpers (no libc in this module) ---------------------- */
@@ -585,14 +616,7 @@ static void ra_send_one(void)
                 ra_fmt(&ra_payload[RA_OFF(RA_F_DS)], ra_snap->dma_skip, 6);
                 ra_fmt(&ra_payload[RA_OFF(RA_F_N)], ra_snap->count, 4);
 
-                /* Serial as-is, padded with '~'. Not '_': serials
-                   contain underscores (SLUS_210.65). */
-                for (i = 0; i < 15; i++) {
-                    char c = ra_snap->game_id[i];
-
-                    ra_payload[RA_OFF(RA_F_ID) + i] =
-                        (c >= 0x20 && c < 0x7F) ? (u8)c : (u8)'~';
-                }
+                ra_id_put((const char *)ra_snap->game_id);
             }
         } else {
             ra_snap_bad++;
@@ -1023,8 +1047,10 @@ static void ra_thread(void *arg)
 
     for (;;) {
         ra_send_one();
-        ra_drain_rx();
-        ra_poll_pc();
+        if (ra_rx_in_game) {
+            ra_drain_rx();
+            ra_poll_pc();
+        }
         if (++iter % 600 == 0)
             ra_heartbeat();
         DelayThread(RA_PERIOD_US);
@@ -1036,13 +1062,16 @@ int _shutdown(void)
     return 0;
 }
 
-/* Arguments, built by ee_core (iopmgr.c):
-     argv[1]  snapshot buffer address in IOP RAM, eight hex digits; then
-              optionally a comma and the event buffer address in EE RAM,
-              eight hex digits more
-     argv[2]  own IP in dotted form (followed by netmask and gateway,
-              which this module does not need)
-   argv[0] is the module name, inserted by the IOP loader. */
+/* Arguments, built by ee_core (iopmgr.c). argv[1] is a comma-separated list,
+   each field optional from the left:
+     snapshot buffer address in IOP RAM, eight hex digits
+     event buffer address in EE RAM, eight hex digits
+     badge buffer address in EE RAM, eight hex digits
+     '1' or '0': may this module read from the network while a game runs
+     the game's serial, up to fifteen characters
+   argv[2] is the own IP in dotted form (followed by netmask and gateway,
+   which this module does not need). argv[0] is the module name, inserted by
+   the IOP loader. */
 int _start(int argc, char *argv[])
 {
     iop_thread_t thread;
@@ -1051,7 +1080,7 @@ int _start(int argc, char *argv[])
     if (argc >= 2 && argv[1] != NULL) {
         int len;
 
-        for (len = 0; len < 27 && argv[1][len] != '\0'; len++)
+        for (len = 0; len < 44 && argv[1][len] != '\0'; len++)
             ;
 
         if (len >= 8)
@@ -1060,6 +1089,15 @@ int _start(int argc, char *argv[])
             ra_ee_event = ra_hex_at(argv[1], 9, 8);
         if (len >= 26 && argv[1][17] == ',')
             ra_ee_badge = ra_hex_at(argv[1], 18, 8);
+        if (len >= 28 && argv[1][26] == ',')
+            ra_rx_in_game = argv[1][27] != '0';
+        if (len >= 29 && argv[1][28] == ',') {
+            int i;
+
+            for (i = 0; i < 15 && argv[1][29 + i] != '\0'; i++)
+                ra_game_id[i] = argv[1][29 + i];
+            ra_game_id[i] = '\0';
+        }
     }
 
     if (argc >= 3 && argv[2] != NULL)


### PR DESCRIPTION
Ports hacan359's [`efbd175b`](https://github.com/hacan359/Open-PS2-Loader/commit/efbd175b), the console-side half of xeRAbora `v0.1.0-alpha.6`.

## Why

`ra_drain_rx()` walks the SMAP receive BD ring and its own comment says it "must be the ring's only consumer while a game runs" — but on a share the game's disc stream arrives through that same ring, so telemetry eats disc frames. The lwIP road (`ra_poll_pc`) queues on the stack mailbox the SMB client is waiting on. Either way the game reaches its first menu and loads for ever.

ee_core now tells `raudp` whether it may read from the network in play, and passes the game's serial along. **Sending is untouched.**

## Deviation from upstream

`HTTP_MODE` is gated alongside `ETH_MODE`. Upstream has no HTTP protocol; ours streams down the same SMAP/SMSTCPIP path and carries the identical defect. UDPBD needs no gate — `bdmsupport.c` has no UDPBD branch into `sysLaunchLoaderElf` (it is Neutrino-locked), so ee_core never runs there.

## Not ported

Upstream's companion commit `0364f1c3` ("no watch list, no telemetry at all"). **We already have it**, arrived at independently as `RA_TelemetryWanted()` in `ee_core/src/iopmgr.c`, which is stricter — it also requires `raSnapBytes > 0` and skips `raudp` entirely on snapshot-alloc failure where upstream still loads it argless. Its DISC_MODE half is moot here; disc mode was deferred.

## The limitation this does NOT fix

From upstream's own commit message, after hardware testing on 2026-09-05:

> "Hardware 05.09: not enough. A game with achievements still stops about a minute in from a share, so the send path disturbs the stream on its own."

xeRAbora's alpha.6 notes say the same and name the USB stick and the original disc as the only tested ways to play. `docs/RETROACHIEVEMENTS.md` and the README RA line now say so. Kept anyway because it costs nothing and rules the receive side out.

## Wire protocol

Unchanged. `hacan359/xerabora`'s `protocol/` has not been touched since `2d7b4364` (2026-09-02); `PROTOCOL.md`, `ra_watch.h` and `ra_snap.h` are sha256-identical to our vendored copies. alpha.5/6/7 talk to this ELF exactly as alpha.4 did.

## Verification

⚠ **PR CI does not build this code.** `flavours.yml` runs `make clean release` with no `RETROACHIEVEMENTS=1`; the RA flavour is built only by `build_rolling_extras.sh`, post-merge from `rolling-release.yml` — and that loop logs `WARN … skipping it` on failure and stays green. So this was verified locally in `ps2dev/ps2dev:latest`:

| check | result |
| --- | --- |
| `RETROACHIEVEMENTS=1` build | clean; `ee_core.elf` 74148 B, **3164 under the 77312 `ram84` ceiling** |
| default build | clean |
| acceptance gate | default `ee_core.elf` **byte-identical** with and without this change (sha256 `73bd3818…`) |
| clang-format 12 | clean on both changed `.c` files |

**Still zero hardware testing**, as with all of RA here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RetroAchievements network-play behavior for ETH and HTTP launches by preventing in-game network reads that can interfere with gameplay streams.
  * RetroAchievements telemetry now includes the game serial for improved identification.

* **Documentation**
  * Updated launch-path support information for ETH/SMB and HTTP.
  * Added guidance to store games with achievements on a local device, as network-share playback may still stop loading during play.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->