### PR TITLE
fix: keep CR out of shared-config VMC paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,8 +759,7 @@ With special and sincere thanks to:
 - **Berion** — for the artwork and theme design that has shaped how OPL *looks* for years.
   The visual language this fork builds on owes a great deal to that craft.
 - **AdityaKumar7209** — whose [**Modulo-R1**](https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2)
-  project inspired this fork's **folder browsing** in the game list. We didn't use their code, but the
-  idea of navigating game subfolders came from seeing it there — thank you for the spark.
+  project inspired this fork's **folder browsing** in the game list.
 - **Irfanlesnar** — creator of [**PS2-Launcher**](https://github.com/Irfanlesnar/PS2-Launcher),
   for UI, feature ideas, and contributions across the OPL fork ecosystem.
 - **Ifcaro** and **jimmikaelkael** — the original Open PS2 Loader authors — and every

--- a/README.md
+++ b/README.md
@@ -787,6 +787,9 @@ work it is built on:
 
 ### Real-hardware testing (this fork)
 
+- **Aerosol** — isolated a UDPFS connection setup issue and confirmed that CRLF config output
+  could leave a carriage return in a VMC filename; converting the config to LF restored VMC loading.
+
 Enormous thanks to the testers who run rolling builds on real consoles and file the
 reports that shape the fixes — **eliminator1403, lucaslmgv, AndrewBento, AcidReach, bodvenomz,
 nuno6573, zackcage6 and Blade1984**.

--- a/src/config.c
+++ b/src/config.c
@@ -88,7 +88,7 @@ int isWS(char c)
 // wrong -- app title.cfg uses bare lowercase `title`/`boot`/`argv1` (appsupport.h), exactly like wOPL,
 // and conf_apps.cfg uses the user's own app title as the key. Instead, note that the two WRITERS are
 // fully characterised and cannot overlap:
-//   ours (configWrite below): "%s=%s\r\n"  -- NEVER a space before '=', NEVER a trailing ';'
+//   ours (configWrite below): "%s=%s\n"  -- NEVER a space before '=', NEVER a trailing ';'
 //   theirs (libconfig):       "key = val;" -- ALWAYS " = ", ALWAYS a trailing ';'
 // Requiring BOTH, plus a legal libconfig identifier, makes misclassification impossible for anything
 // either writer can emit.
@@ -1341,14 +1341,15 @@ int configWrite(config_set_t *configSet)
             // FORMAT INHERITANCE: emit whatever syntax this file arrived in. A file that was libconfig
             // when we read it is written back as libconfig; a legacy file stays legacy. We never
             // convert a user's file in either direction -- that is the whole point. Before this, a
-            // libconfig file hit the "%s=%s\r\n" loop below and was DESTROYED on the first save.
+            // libconfig file hit the legacy key=value loop below and was DESTROYED on the first save.
             if (configSet->format == CFG_FMT_LIBCONFIG) {
                 cfgWriteLibconfig(fileBuffer, configSet);
             } else {
                 struct config_value_t *cur = configSet->head;
                 while (cur) {
                     if ((cur->key[0] != '\0') && (cur->key[0] != '#')) {
-                        snprintf(line, sizeof(line), "%s=%s\r\n", cur->key, cur->val); // add windows CR+LF (0x0D 0x0A)
+                        // Shared configs also have readers that split on LF without stripping CR.
+                        snprintf(line, sizeof(line), "%s=%s\n", cur->key, cur->val);
                         writeFileBuffer(fileBuffer, line, strlen(line));
                     }
 


### PR DESCRIPTION
RiptOPL writes legacy shared configs with CRLF. Aerosol reported a VMC request for `VMC/SLUS_201.74_0\r.bin` and confirmed that converting the config to LF restored loading, until RiptOPL saved it again.

Write LF line endings for legacy key=value configs. RiptOPL already reads LF and CRLF; libconfig output already uses LF. Preserve values, format detection, and save verification. Credit Aerosol for the report and controlled hardware test.

Validation: compiled the actual buffered reader and assignment parser, together with the production writer statement, in a host harness. CRLF, LF, mixed endings, no final newline, and preserved value whitespace pass. A consumer splitting saved values on LF produces the correct VMC path after the fix; the old CRLF writer fails that check. git diff --check passed. This establishes the writer-side interoperability fix; the exact downstream parser that retained CR has not been identified, and the patched ELF still needs console validation.
