### PR TITLE
fix: bring RA sender to xeRAbora alpha.8 parity

### DIFF
--- a/.github/scripts/test_ra_sender.py
+++ b/.github/scripts/test_ra_sender.py
@@ -1,0 +1,182 @@
+"""Exercise production RA sender functions with simulated IOP/DMA events.
+
+Host tests cover sequencing, packet data and polling, not real SMAP timing.
+"""
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+root = Path(__file__).resolve().parents[2]
+source = (root / 'modules/network/raudp/raudp.c').read_text()
+
+
+def function(name):
+    start = re.search(r'^static [^\n]+\b' + name + r'\([^\n]*\)\n\{', source, re.M).start()
+    end = source.index('\n}', start) + 2
+    return source[start:end]
+
+
+constants = '\n'.join(line for line in source.splitlines()
+                      if re.match(r'#define RA_(POLL_US|IDLE_TICKS|KEEPALIVE_TICKS|HEARTBEAT_TICKS|QUIET_US)\b', line))
+fields = source[source.index('struct ra_field\n'):source.index('/* ---- Formatting helpers')]
+prefix = r'''
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+#include "modules/network/common/ra_snap.h"
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef unsigned iop_sys_clock_t;
+#define USE_SMAP_REGS
+#define SMAP_REG8(x) 0
+#define RA_PAYLOAD 1472
+#define RA_HDR_LEN 42
+#define RA_FRAME_LEN (RA_HDR_LEN + RA_PAYLOAD)
+#define RA_OFF(id) (ra_fields[id].off)
+static u8 ra_frame[RA_FRAME_LEN], *ra_payload = ra_frame + RA_HDR_LEN;
+static u8 ra_stage[RA_SNAP_MAX_BYTES] __attribute__((aligned(4)));
+static u8 storage[RA_SNAP_TOTAL] __attribute__((aligned(4)));
+static volatile struct ra_snap *ra_snap = (void *)storage;
+static char ra_game_id[16] = "SLUS_210.65";
+static u32 ra_seq, ra_fail, ra_us, ra_us_max, ra_rxq, ra_skip, ra_snap_bad, ra_sent_sq;
+static int ra_err, ra_sent_any, ra_rx_in_game = 1;
+static u32 ra_disc_us;
+static unsigned packets, failed_packet, advance_packet, busy, drains, polls, heartbeats;
+static unsigned tick, limit, produce, quiet;
+static jmp_buf finished;
+static void ra_fmt(u8 *, u32, int);
+static void ra_fmt_err(u8 *, int);
+static void snapshot(u32 seq, u32 bytes) {
+    memset(storage, 0, sizeof(storage));
+    ra_snap = (void *)storage;
+    ra_snap->magic = RA_SNAP_MAGIC;
+    ra_snap->seq = seq;
+    ra_snap->bytes = bytes;
+    ra_snap->count = bytes;
+    memcpy((void *)ra_snap->game_id, ra_game_id, 16);
+    memset(storage + RA_SNAP_HDR, (u8)(seq % 1000000), bytes);
+    *(u32 *)(storage + RA_SNAP_TRAILER_OFF(bytes)) = seq;
+}
+static int ra_tx_busy(void) { return busy; }
+static void GetSystemTime(iop_sys_clock_t *t) { *t = 0; }
+static u32 ra_usec_delta(iop_sys_clock_t *a, iop_sys_clock_t *b) { (void)a; (void)b; return 1; }
+static int SMAPSendPacket(const void *, unsigned);
+static int ra_discover(void) { return 1; }
+static void ra_frame_init(void);
+static void ra_drain_rx(void) { drains++; }
+static void ra_poll_pc(void) { polls++; }
+static void ra_heartbeat(void) { heartbeats++; }
+static void DelayThread(unsigned);
+'''
+stubs = r'''
+static unsigned field(int id) {
+    unsigned n = 0;
+    for (int i = 0; i < ra_fields[id].width; i++)
+        n = n * 10 + ra_payload[RA_OFF(id) + i] - '0';
+    return n;
+}
+static int SMAPSendPacket(const void *p, unsigned len) {
+    assert(p == ra_frame && len == RA_FRAME_LEN);
+    unsigned sq = field(RA_F_SQ), nb = field(RA_F_VB);
+    for (unsigned i = 0; i < nb; i++)
+        assert(ra_payload[ra_head_len + i] == (u8)sq);
+    packets++;
+    if (packets == advance_packet) snapshot(sq + 1, ra_snap->bytes);
+    return packets == failed_packet ? -1 : 1;
+}
+static void ra_frame_init(void) { ra_head_build(); }
+static void DelayThread(unsigned us) {
+    if (us != RA_POLL_US) {
+        assert(us == RA_QUIET_US - ra_disc_us);
+        quiet++;
+        return;
+    }
+    if (++tick == limit) longjmp(finished, 1);
+    if (produce && tick % 4 == 0) snapshot(ra_snap->seq + 1, 8);
+}
+static void reset(void) {
+    ra_seq = ra_fail = ra_us = ra_us_max = ra_rxq = ra_skip = ra_snap_bad = ra_sent_sq = 0;
+    ra_err = ra_sent_any = 0;
+    packets = failed_packet = advance_packet = busy = drains = polls = heartbeats = 0;
+    tick = limit = produce = quiet = 0;
+    ra_disc_us = RA_QUIET_US;
+    ra_rx_in_game = 1;
+    snapshot(1, 8);
+    ra_head_build();
+}
+static void loop(unsigned count) {
+    limit = count;
+    if (!setjmp(finished)) ra_thread(NULL);
+}
+int main(void) {
+    /* Every source/destination alignment, boundary length and untouched byte. */
+    u8 src[RA_SNAP_MAX_BYTES + 8], dst[RA_SNAP_MAX_BYTES + 8];
+    for (unsigned i = 0; i < sizeof(src); i++) src[i] = (u8)(i * 17);
+    for (unsigned a = 0; a < 4; a++) for (unsigned b = 0; b < 4; b++)
+        for (unsigned n = 0; n <= RA_SNAP_MAX_BYTES; n++) {
+            memset(dst, 0xCC, sizeof(dst));
+            ra_copy(dst + b, src + a, n);
+            assert(!memcmp(dst + b, src + a, n));
+            for (unsigned i = 0; i < b; i++) assert(dst[i] == 0xCC);
+            for (unsigned i = b + n; i < sizeof(dst); i++) assert(dst[i] == 0xCC);
+        }
+    puts("PASS: aligned/unaligned copies and write boundaries");
+    reset();
+    busy = 1;
+    ra_send_one();
+    assert(!packets && !ra_seq && ra_snap_pending() == 1 && ra_skip == 1);
+    busy = 0;
+    *(u32 *)(storage + RA_SNAP_TRAILER_OFF(8)) = 0;
+    ra_send_one();
+    assert(!packets && !ra_seq && ra_snap_pending() == 1 && ra_snap_bad == 1);
+    *(u32 *)(storage + RA_SNAP_TRAILER_OFF(8)) = 1;
+    ra_send_one();
+    assert(packets == 1 && ra_sent_sq == 1 && ra_snap_pending() == 0);
+    puts("PASS: busy and torn snapshots remain pending, then send successfully");
+    for (unsigned fail = 1; fail <= RA_SNAP_PARTS; fail++) {
+        reset(); snapshot(41, RA_SNAP_MAX_BYTES); failed_packet = fail;
+        ra_send_one();
+        assert(ra_fail == 1 && !ra_sent_any && ra_snap_pending() == 1);
+        failed_packet = 0;
+        ra_send_one();
+        assert(packets == 2 * RA_SNAP_PARTS && ra_sent_sq == 41 && ra_snap_pending() == 0);
+    }
+    puts("PASS: failure of any multipart packet leaves the snapshot retryable");
+    reset(); snapshot(41, RA_SNAP_MAX_BYTES); advance_packet = 1;
+    ra_send_one();
+    assert(ra_sent_sq == 41 && ra_snap->seq == 42 && ra_snap_pending() == 1);
+    ra_send_one();
+    assert(ra_sent_sq == 42 && ra_snap_pending() == 0);
+    snapshot(UINT32_MAX, 8); ra_send_one(); snapshot(0, 8);
+    assert(ra_snap_pending() == 1);
+    ra_send_one(); assert(ra_snap_pending() == 0);
+    puts("PASS: DMA advancement during multipart send and sequence wraparound");
+    reset(); produce = 1; loop(2500);
+    assert(packets == 625 && drains == 625 && polls == 625 && heartbeats == 1);
+    reset(); ra_disc_us = 0; ra_rx_in_game = 0; loop(501);
+    assert(packets == 3 && !drains && !polls && quiet == 1);
+    reset(); ra_snap = NULL; loop(16);
+    assert(packets == 4 && !ra_sent_any);
+    reset(); busy = 1; loop(20);
+    assert(!packets && ra_skip == 20);
+    puts("PASS: new-only sending, idle keepalive, RX guard, quiet period and header-only cadence");
+}
+'''
+program = (prefix + constants + '\n' + fields + '\n' +
+           '\n'.join(function(n) for n in ('ra_fmt', 'ra_fmt_err', 'ra_copy',
+                                         'ra_send_one', 'ra_snap_pending', 'ra_thread')) + stubs)
+with tempfile.TemporaryDirectory(prefix='ra-sender-') as work:
+    path = Path(work) / 'sender.c'
+    exe = Path(work) / 'sender'
+    path.write_text(program)
+    # IOP pointers are 32-bit; on a 64-bit host the copy helper only examines
+    # their low alignment bits. Suppress that one target-size warning.
+    subprocess.run(['gcc', '-std=gnu99', '-O2', '-fno-strict-aliasing', '-Wall', '-Wextra',
+                    '-Werror', '-Wno-pointer-to-int-cast', '-I', str(root),
+                    str(path), '-o', str(exe)], check=True)
+    subprocess.run([str(exe)], check=True)

--- a/.github/workflows/flavours.yml
+++ b/.github/workflows/flavours.yml
@@ -55,6 +55,8 @@ jobs:
           persist-credentials: false
       - name: Check disc hashing, reset image and launch gates
         run: python3 .github/scripts/test_ra_disc.py
+      - name: Check RA snapshot scheduling and transmission retries
+        run: python3 .github/scripts/test_ra_sender.py
 
   build-flavour:
     strategy:

--- a/docs/RETROACHIEVEMENTS.md
+++ b/docs/RETROACHIEVEMENTS.md
@@ -134,6 +134,15 @@ game runs normally but nothing reaches the PC.
 The PC client is found automatically: the console broadcasts a query on UDP port 18194 and the client
 answers. Nothing is stored between runs.
 
+The sender follows xeRAbora alpha.8's console changes (`9bacfe59` and `9531fd9c`): it polls
+every 4 ms, sends each new snapshot once, and retries a busy transmitter or torn copy on the
+next poll. An unchanged snapshot is repeated only after about a second without a new one.
+RiptOPL additionally records the sequence of the staged payload, rather than rereading the live
+DMA buffer after sending, and leaves a snapshot pending if any packet fails to send. These
+contracts have host regression tests; snapshot loss and gameplay timing still need PS2 validation.
+Use the current upstream xeRAbora PC client. This sender update does not establish that the
+SMB/HTTP gameplay limitation above is fixed.
+
 ---
 
 ## Files on the card

--- a/modules/network/raudp/raudp.c
+++ b/modules/network/raudp/raudp.c
@@ -19,8 +19,8 @@
   still transmitting the previous frame, holding the mutex the whole
   time. Waiting there starves the stack thread and the game (audio,
   loading). So before sending we look at the transmitter's busy bit and
-  skip our frame when it is set. The game has priority; skipped frames
-  are counted and reported in the packet header.
+  defer our snapshot when it is set and retry on the next poll. The game
+  has priority; deferrals are counted and reported in the packet header.
 
   Finding the PC. Bypassing the stack also means no ARP, so the
   destination MAC must come from somewhere. Once, at start-up, this
@@ -77,8 +77,13 @@ static u8 ra_dst_mac[6];
 /* Hold-off after start so the game can finish loading. */
 #define RA_QUIET_US (30 * 1000 * 1000)
 
-/* One snapshot per game frame at 60 Hz. */
-#define RA_PERIOD_US 16666
+/* The EE lands a snapshot every frame, 16.7 ms. Polling four times a
+   frame and sending only a new seq catches each one; sleeping a whole
+   frame plus the work per pass missed one in twelve (lab/skips, 08.09). */
+#define RA_POLL_US         4000
+#define RA_IDLE_TICKS      4    /* no snapshot: one header-only packet per frame */
+#define RA_KEEPALIVE_TICKS 250  /* a second without a new snapshot: repeat the last */
+#define RA_HEARTBEAT_TICKS 2500 /* every ten seconds */
 
 /* ---- Frame layout ----------------------------------------------------
    One static Ethernet + IPv4 + UDP frame. Headers are filled once; each
@@ -116,8 +121,10 @@ static int ra_err = 0;      /* last error code */
 static u32 ra_us = 0;       /* time spent sending the last snapshot */
 static u32 ra_us_max = 0;   /* worst case */
 static u32 ra_rxq = 0;      /* controller receive FIFO depth at send time */
-static u32 ra_skip = 0;     /* frames skipped because the transmitter was busy */
-static u32 ra_snap_bad = 0; /* torn snapshots detected */
+static u32 ra_skip = 0;     /* sends deferred because the transmitter was busy */
+static u32 ra_snap_bad = 0; /* torn copies detected (retried on the next poll) */
+static u32 ra_sent_sq = 0;  /* seq of the last snapshot sent */
+static int ra_sent_any = 0;
 
 /* Snapshot buffer, owned by this module, written by the EE over SIF DMA.
    The address arrives as a load argument. */
@@ -164,12 +171,12 @@ static int ra_sock = -1;
 
    seq  packet counter            sq   snapshot number from the EE
    sz   payload size              ds   frames the EE skipped (DMA busy)
-   us   last send time, us        bad  torn snapshots seen here
+   us   last send time, us        bad  torn copies here, retried
    mx   worst send time, us       n    entries in the watch list
    rxq  receive FIFO depth        vb   value bytes in this packet
    fail send errors               pt   part index, from 0
    err  last error code           np   number of parts
-   sk   frames skipped, tx busy   id   game serial, padded with '~'
+   sk   sends deferred, tx busy   id   game serial, padded with '~'
    lk   link mode: speed (100/010/999) and duplex (F/H)
 
    "id" must stay last: the PC client finds the binary tail as the
@@ -559,24 +566,48 @@ static void ra_ctl_send(const char *msg, int len)
    Otherwise the EE could land the next frame between two sends and the
    parts would describe different moments; a condition such as
    "A == 1 and B == 2 in the same frame" would fire on a mix. */
-static u8 ra_stage[RA_SNAP_MAX_BYTES];
+static u8 ra_stage[RA_SNAP_MAX_BYTES] __attribute__((aligned(4)));
+
+/* Byte loops took the IOP most of a millisecond per snapshot; words when
+   both sides share alignment, halfwords when they share parity. */
+static void ra_copy(u8 *d, const u8 *src, u32 n)
+{
+    u32 i = 0;
+
+    if ((((u32)d ^ (u32)src) & 3) == 0) {
+        while (i < n && ((u32)(d + i) & 3) != 0) {
+            d[i] = src[i];
+            i++;
+        }
+        for (; i + 4 <= n; i += 4)
+            *(u32 *)(d + i) = *(const u32 *)(src + i);
+    } else if ((((u32)d ^ (u32)src) & 1) == 0) {
+        if (i < n && ((u32)(d + i) & 1) != 0) {
+            d[i] = src[i];
+            i++;
+        }
+        for (; i + 2 <= n; i += 2)
+            *(u16 *)(d + i) = *(const u16 *)(src + i);
+    }
+    for (; i < n; i++)
+        d[i] = src[i];
+}
 
 static void ra_send_one(void)
 {
     USE_SMAP_REGS;
     iop_sys_clock_t t0, t1;
-    u32 nb = 0, parts = 1, part;
-    int ret;
+    u32 nb = 0, parts = 1, part, staged_sq = 0;
+    int ret, sent = 1;
 
     ra_rxq = SMAP_REG8(SMAP_R_RXFIFO_FRAME_CNT);
 
     /* Checked once per snapshot, not per part: dropping the last part
        of three would waste the two already sent. Busy means the whole
-       snapshot is skipped. Pushing into a busy controller produced
-       duplicate frames on the wire. */
+       snapshot waits for the next poll. Pushing into a busy controller
+       produced duplicate frames on the wire. */
     if (ra_tx_busy()) {
         ra_skip++;
-        ra_seq++; /* the number is consumed so the PC sees the gap */
         return;
     }
 
@@ -591,27 +622,27 @@ static void ra_send_one(void)
        taken from the header before the copy; the trailer word after the
        values is the last to arrive. A trailer or header that no longer
        matches after the copy means a newer snapshot overwrote part of
-       what was copied: the snapshot is torn and dropped. */
+       what was copied: retry the snapshot on the next poll. */
     if (ra_snap != NULL) {
         u32 sq = ra_snap->seq;
 
         if (ra_snap->magic == RA_SNAP_MAGIC) {
             const u8 *src = (const u8 *)ra_snap + RA_SNAP_HDR;
-            u32 i, tail;
+            u32 tail;
 
             nb = ra_snap->bytes;
             if (nb > RA_SNAP_MAX_BYTES)
                 nb = RA_SNAP_MAX_BYTES;
 
-            for (i = 0; i < nb; i++)
-                ra_stage[i] = src[i];
+            ra_copy(ra_stage, src, nb);
 
             tail = *(volatile u32 *)((const u8 *)ra_snap + RA_SNAP_TRAILER_OFF(nb));
 
             if (tail != sq || ra_snap->seq != sq) {
                 ra_snap_bad++;
-                nb = 0;
+                return; /* the next poll copies it whole */
             } else {
+                staged_sq = sq;
                 ra_fmt(&ra_payload[RA_OFF(RA_F_SQ)], sq, 6);
                 ra_fmt(&ra_payload[RA_OFF(RA_F_DS)], ra_snap->dma_skip, 6);
                 ra_fmt(&ra_payload[RA_OFF(RA_F_N)], ra_snap->count, 4);
@@ -636,7 +667,6 @@ static void ra_send_one(void)
     for (part = 0; part < parts; part++) {
         u32 off = part * ra_chunk;
         u32 len = nb > off ? nb - off : 0;
-        u32 i;
 
         if (len > ra_chunk)
             len = ra_chunk;
@@ -646,14 +676,14 @@ static void ra_send_one(void)
         ra_fmt(&ra_payload[RA_OFF(RA_F_PT)], part, 1);
         ra_fmt(&ra_payload[RA_OFF(RA_F_NP)], parts, 1);
 
-        for (i = 0; i < len; i++)
-            ra_payload[ra_head_len + i] = ra_stage[off + i];
+        ra_copy(&ra_payload[ra_head_len], &ra_stage[off], len);
 
         ret = SMAPSendPacket(ra_frame, RA_FRAME_LEN);
 
         if (ret < 0) {
             ra_fail++;
             ra_err = ret;
+            sent = 0;
         }
 
         ra_seq++;
@@ -664,6 +694,22 @@ static void ra_send_one(void)
     ra_us = ra_usec_delta(&t0, &t1);
     if (ra_us > ra_us_max)
         ra_us_max = ra_us;
+
+    /* Commit only the staged sequence, after every part was accepted.
+       The EE may already have DMAed the next snapshot while we sent this
+       one. A failed part leaves this sequence pending for the next poll. */
+    if (nb > 0 && sent) {
+        ra_sent_sq = staged_sq;
+        ra_sent_any = 1;
+    }
+}
+
+/* -1: no snapshot to speak of; 1: one the PC has not seen; 0: sent already. */
+static int ra_snap_pending(void)
+{
+    if (ra_snap == NULL || ra_snap->magic != RA_SNAP_MAGIC)
+        return -1;
+    return (!ra_sent_any || ra_snap->seq != ra_sent_sq) ? 1 : 0;
 }
 
 /* ---- Discovery --------------------------------------------------------- */
@@ -1049,6 +1095,7 @@ static void ra_heartbeat(void)
 static void ra_thread(void *arg)
 {
     u32 iter = 0;
+    u32 idle = 0; /* polls since the last new snapshot */
 
     (void)arg;
 
@@ -1061,14 +1108,25 @@ static void ra_thread(void *arg)
         DelayThread(RA_QUIET_US - ra_disc_us);
 
     for (;;) {
-        ra_send_one();
-        if (ra_rx_in_game) {
+        int pending = ra_snap_pending();
+
+        if (pending > 0) {
+            ra_send_one();
+            idle = 0;
+        } else if (pending < 0) {
+            if (iter % RA_IDLE_TICKS == 0)
+                ra_send_one();
+        } else if (++idle >= RA_KEEPALIVE_TICKS) {
+            ra_send_one();
+            idle = 0;
+        }
+        if (ra_rx_in_game && iter % RA_IDLE_TICKS == 0) {
             ra_drain_rx();
             ra_poll_pc();
         }
-        if (++iter % 600 == 0)
+        if (++iter % RA_HEARTBEAT_TICKS == 0)
             ra_heartbeat();
-        DelayThread(RA_PERIOD_US);
+        DelayThread(RA_POLL_US);
     }
 }
 


### PR DESCRIPTION
The RA sender sleeps a full frame after doing its work, allowing the EE to overwrite snapshots before the IOP sends them. Port hacan359's alpha.8 console changes (9bacfe59 and 9531fd9c): poll every 4 ms, send each new snapshot once, retry busy/torn copies, use alignment-aware copies, and repeat an unchanged snapshot only after about a second without a new one.

Correct two upstream bookkeeping cases: record the staged sequence rather than the live DMA sequence after transmission, and advance sent state only if every multipart packet succeeds. Preserve RiptOPL's SMB/HTTP receive and discovery guards. The wire format and watch-list format are unchanged.

Validation:
- Production-function host tests pass for copy bounds/alignment, busy/torn retry, failure of each multipart packet, DMA advancement during send, sequence wraparound, keepalive scheduling, RX gating and the startup quiet period.
- Mutation checks confirm the suite rejects both upstream sent-state defects. Existing disc regression tests, clang-format 12 and git diff --check pass. The sender suite is wired into build-flavours CI.
- Clean local NOT_PACKED=1 builds pass for RETROACHIEVEMENTS=1 with PADEMU=0 and PADEMU=1, and for RETROACHIEVEMENTS=0, using ps2dev/ps2dev@sha256:8fba50ecc2229acd7f8da63d34302f12939b7d4fa6848dda1e6a0ce083321a11.
- Verified the built raudp.c matches the committed source after line-ending normalization; both RA ELFs embed the identical new raudp IRX and the default ELF does not contain it. Local artifacts use a disposable build-copy version, not a CI release identity.
- GitHub build-flavours run 34292362670 passed for head 25538250a1b6227946d6c2c0e4c343e5f9048db5, including the host tests and all six build configurations. Both CI-format-check runs passed.

PS2 hardware timing/gameplay remains unvalidated. This does not claim to fix the existing SMB/HTTP RA gameplay limitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Telemetry updates are now checked more frequently, with new snapshots sent promptly.
  - Unchanged snapshots are periodically repeated to maintain connectivity, with regular heartbeat messages.

- **Bug Fixes**
  - Busy transmitters and inconsistent snapshot reads are retried instead of being skipped.
  - Multipart transmission failures remain pending for retry, reducing the chance of lost telemetry.

- **Documentation**
  - Updated networking documentation explains telemetry timing, retries, keepalives, and current platform limitations.

- **Tests**
  - Added automated coverage for snapshot scheduling, retries, sequence handling, and transmission edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->