### PR TITLE
neutrino: resolve the core from the APA HDD's OPL partition

### DIFF
--- a/docs/NEUTRINO.md
+++ b/docs/NEUTRINO.md
@@ -44,7 +44,8 @@ order is:
 | 1 | The device chosen in **Game Launching → Neutrino Defaults → Default Device** (see below) |
 | 2 | The custom **Neutrino ELF Path** (`neutrino_path`) |
 | 3 | The active game's own device — `<games prefix>/neutrino/`, then `<device root>/neutrino/` |
-| 4 | `mc0:` / `mc1:` — `NEUTRINO/neutrino.elf` and its lowercase / `NEUTRINO.ELF` variants |
+| 4 | The internal **APA HDD**'s OPL data partition — `hdd0:/+OPL/neutrino/` or `hdd0:/__common/OPL/neutrino/` (only while the HDD is started) |
+| 5 | `mc0:` / `mc1:` — `NEUTRINO/neutrino.elf` and its lowercase / `NEUTRINO.ELF` variants |
 
 If no complete install is found when you launch a game set to the Neutrino core, OPL shows a
 warning and falls back to the `<OPL>` core for that launch.
@@ -54,6 +55,23 @@ warning and falls back to the `<OPL>` core for that launch.
 HDD (APA) / **Game's Device** / iLink. A miss on the device you picked is not a dead end: OPL falls
 through to the AUTO tiers above. The exception is **Game's Device**, which only ever looks on
 the game's own device and reports "not found" instead of falling back.
+
+**HDD (APA)** is the one entry that is not a plain device root, because a raw APA partition cannot be
+opened directly — only a mounted one can. OPL therefore uses the **OPL data partition it has already
+mounted**, which is the same partition NHDDL resolves for its own
+`hdd0:/<OPL partition>/neutrino/neutrino.elf` rule (`hdd0:__common/OPL/conf_hdd.cfg`, else `+OPL`,
+else `__common/OPL`). In practice that means both of these work, with no extra setting to fill in:
+
+| Your OPL data home | Put Neutrino at |
+|---|---|
+| `+OPL` (the preferred default when the partition exists) | `hdd0:/+OPL/neutrino/` |
+| `__common` | `hdd0:/__common/OPL/neutrino/` |
+
+The APA HDD must be **started** for this to resolve — nothing is mounted to read otherwise — but the
+game itself may live anywhere: a USB or MMCE game can boot from an APA-hosted Neutrino, and OPL keeps
+that partition mounted across the handoff so the ELF is still readable when it is loaded. A Neutrino
+install on a partition that is *not* the OPL data home is not reachable; move it, or use one of the
+other devices.
 
 You can also point OPL at a **custom location** via the **Neutrino ELF Path** (`neutrino_path` key
 in `settings_riptopl.cfg`). When that field is set and the file exists it takes **priority** over the

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -87,6 +87,11 @@ int sbFileExists(const char *path);
 // ignores activePrefix. Pass NULL when no game device applies.
 const char *sbResolveNeutrinoPath(const char *activePrefix);
 
+// Deinit exception mask for the device holding a resolved neutrino.elf. UNMOUNT_EXCEPTION for every
+// device; APA (pfs) additionally needs KEEPIOP_EXCEPTION, because hddCleanUp's PDIOC_CLOSEALL would
+// drop the pfs descriptors before the keep-IOP handoff opens the ELF. Pass the resolved path.
+int sbNeutrinoDeinitException(const char *neutrinoPath);
+
 // Structured view of the USER-settable Neutrino launch flags (the catch-all "Launch Args" box).
 typedef struct
 {

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -1952,7 +1952,7 @@ static int bdmTryNeutrinoLaunch(item_list_t *itemList, base_game_info_t *game, b
         // Keep-IOP handoff: keep BOTH the game device and the neutrino.elf device mounted
         // (Neutrino reads its -cwd config/modules and the ISO through our mounts pre-reset).
         int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-        deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp frees bdmGames/game
+        deinitEx(sbNeutrinoDeinitException(neutrinoPath), itemList->mode, neutrinoDevMode); // CAREFUL: itemCleanUp frees bdmGames/game
     } else {
         miniDeinit(configSet);
         free(gAutoLaunchBDMGame);

--- a/src/gui.c
+++ b/src/gui.c
@@ -1969,7 +1969,8 @@ static int guiNeutrinoDefaultsUpdater(int modified)
 void guiShowNeutrinoDefaults(void)
 {
     // Neutrino lives at <root>:/neutrino/neutrino.elf on ANY device -- offer the common roots.
-    // MUST stay in sync with the roots[] table in sbResolveNeutrinoPath() (supportbase.c).
+    // MUST stay in sync with the NEUTRINO_DEV_* switch in sbResolveNeutrinoPath() (supportbase.c),
+    // where HDD (APA) resolves to the mounted OPL data partition rather than to a bare device root.
     const char *neutrinoDevStrs[] = {_l(_STR_AUTO), "Memory Card", "USB", "MX4SIO", "MMCE", "HDD (exFAT)", "HDD (APA)", _l(_STR_GAMES_DEVICE), "iLink", NULL}; // device TYPE holding /neutrino/neutrino.elf (NEUTRINO_DEV_*); iLink is appended after Game's Device to preserve every saved value
     diaSetEnum(diaNeutrinoDefaults, CFG_NEUTRINO_DEVICE, neutrinoDevStrs);
     diaSetInt(diaNeutrinoDefaults, CFG_NEUTRINO_DEVICE, gNeutrinoDevice);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1892,7 +1892,11 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
         return 0;
     }
 
-    const char *neutrinoPath = sbResolveNeutrinoPath(NULL); // #300: HDD keeps custom-path + mc0/mc1 + Device-picker resolution (raw APA isn't POSIX-reachable; pfs0 probe = shared-slot risk)
+    // NULL activePrefix: an HDL game has no POSIX prefix of its own (it is a raw APA partition), so
+    // there is no "co-located next to the games" install to probe for. The resolver still covers the
+    // internal HDD -- through the OPL data partition mounted on pfs0:, which it probes both for an
+    // explicit "HDD (APA)" pick and in AUTO -- alongside the custom path and mc0/mc1.
+    const char *neutrinoPath = sbResolveNeutrinoPath(NULL);
     if (neutrinoPath == NULL) {
         guiWarning(_l(_STR_NEUTRINO_NOT_FOUND), 6);
         return 0;
@@ -1952,13 +1956,20 @@ static int hddTryNeutrinoLaunch(hdl_game_info_t *game, config_set_t *configSet)
         // Keep-IOP handoff: keep the HDD stack up (NHDDL hands off with its full ATA stack
         // resident) AND the neutrino.elf device (-cwd config/module reads).
         int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-        deinitEx(UNMOUNT_EXCEPTION, HDD_MODE, neutrinoDevMode); // CAREFUL: itemCleanUp frees hddGames/game
+        deinitEx(sbNeutrinoDeinitException(neutrinoPath), HDD_MODE, neutrinoDevMode); // CAREFUL: itemCleanUp frees hddGames/game
     } else {
         miniDeinit(configSet);
         free(gAutoLaunchGame);
         gAutoLaunchGame = NULL;
-        fileXioUmount("pfs0:");
-        fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
+        // The game itself is read raw (-bsd=ata -bsdfs=hdl), so this teardown normally drops pfs0:
+        // outright. It must NOT when neutrino.elf lives on the OPL data partition: the keep-IOP
+        // handoff opens that ELF after this runs, and both the unmount and PDIOC_CLOSEALL would
+        // pull it out from under the load. Neutrino resets the IOP itself moments later, which
+        // reclaims the mount and the descriptors we leave behind here.
+        if ((sbNeutrinoDeinitException(neutrinoPath) & KEEPIOP_EXCEPTION) == 0) {
+            fileXioUmount("pfs0:");
+            fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
+        }
     }
 
     LOG("[NEUTRINO] apa partition_name=[%s]\n", apaPart);

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -1178,7 +1178,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         if (sysNeutrinoPreflight("mmce", neutrinoPath) < 0) // D6 pre-teardown validation
             return;
         int neutrinoDevMode = oplPath2Mode(neutrinoPath);
-        deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode);
+        deinitEx(sbNeutrinoDeinitException(neutrinoPath), itemList->mode, neutrinoDevMode);
         sysLaunchNeutrino("mmce", mmcePartname, mmceStartup, compatmask, EnablePS2Logo, neutrinoPath, neutrinoExtraArgs, neutrinoVideo, neutrinoGsmComp, 0 /* #11: mmce is fileid, no fs layer */, &neutrinoVmc);
         return;
     }

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1411,6 +1411,8 @@ static const char *sbNeutrinoProbeGameDevice(const char *activePrefix)
     for (int b = 0; b < 2; b++) {
         if (bases[b] == NULL || bases[b][0] == '\0')
             continue;
+        if (b == 1 && !strcmp(bases[1], bases[0]))
+            continue; // a prefix that IS the bare root (e.g. "pfs0:") -- do not probe it twice
         for (int i = 0; i < (int)(sizeof(forms) / sizeof(forms[0])); i++) {
             snprintf(probe, sizeof(probe), forms[i], bases[b]);
             // Δ1: a stale elf-only folder on the game device must NOT count as a valid install.
@@ -1419,6 +1421,54 @@ static const char *sbNeutrinoProbeGameDevice(const char *activePrefix)
         }
     }
     return NULL;
+}
+
+// Probe the internal APA HDD for a Neutrino install. Raw APA is not POSIX-open()-able, so the only
+// reachable install there is the OPL data partition OPL has ALREADY mounted on pfs0:. That is the
+// same partition NHDDL resolves for its own hdd0:/<OPL partition>/neutrino/neutrino.elf rule
+// (hdd0:__common/OPL/conf_hdd.cfg, else +OPL, else __common/OPL) -- OPL did that resolution at
+// startup and gHDDPrefix names the result: "pfs0:" for a +OPL home, "pfs0:OPL/" for the __common
+// one. Probing the data home AND the partition root therefore covers hdd0:/+OPL/neutrino/ and
+// hdd0:/__common/OPL/neutrino/ alike. NULL when the HDD stack is not up: nothing is mounted on
+// pfs0: to read, and a path that only open()s while the menu is alive is worse than no path at all.
+static const char *sbNeutrinoProbeApaHome(void)
+{
+    if (gHDDPrefix == NULL || gHDDPrefix[0] == '\0')
+        return NULL;
+
+    // (A) the data home, (B) the bare pfs0: root -- both with the folder/extension case variants.
+    const char *hit = sbNeutrinoProbeGameDevice(gHDDPrefix);
+    if (hit != NULL)
+        return hit;
+
+    // Leading-slash spellings of the partition root. PFS accepts pfs0:DIR and pfs0:/DIR alike and
+    // users copy whichever form they were shown, so both are tried rather than assumed equivalent.
+    static const char *rootForms[] = {
+        "pfs0:/neutrino/neutrino.elf",
+        "pfs0:/NEUTRINO/neutrino.elf",
+        "pfs0:/neutrino/NEUTRINO.ELF",
+        "pfs0:/NEUTRINO/NEUTRINO.ELF",
+    };
+    for (int i = 0; i < (int)(sizeof(rootForms) / sizeof(rootForms[0])); i++) {
+        if (sbFileExists(rootForms[i]) && sbNeutrinoInstallComplete(rootForms[i]))
+            return sbNeutrinoResolved(rootForms[i]);
+    }
+    return NULL;
+}
+
+// The deinit exception mask a Neutrino handoff needs for the device holding neutrino.elf. Every leg
+// hands off through sysLoadELFKeepIOP, which does NOT reset the IOP, and the ELF is opened AFTER the
+// teardown out of whatever is left behind. UNMOUNT_EXCEPTION spares the mount, which is all any
+// other device needs. On APA it is not enough: hddCleanUp also issues PDIOC_CLOSEALL and drops every
+// pfs descriptor in the IOP -- free before an IOP reset, fatal before a handoff that does not reset.
+// That is the exact trap the Ember APA launch hit; see KEEPIOP_EXCEPTION in include/iosupport.h.
+// The extra bit is added ONLY for a pfs-hosted neutrino.elf so every other leg keeps the teardown it
+// already has (per the rebuild rule: change behaviour only where there is a reason to).
+int sbNeutrinoDeinitException(const char *neutrinoPath)
+{
+    if (neutrinoPath != NULL && !strncmp(neutrinoPath, "pfs", 3))
+        return UNMOUNT_EXCEPTION | KEEPIOP_EXCEPTION;
+    return UNMOUNT_EXCEPTION;
 }
 
 // ---- Neutrino launch-args parse / assemble (the "Launch Args" picker) ----------------
@@ -1467,6 +1517,17 @@ const char *sbResolveNeutrinoPath(const char *activePrefix)
     if (gNeutrinoDevice == NEUTRINO_DEV_GAME)
         return sbNeutrinoProbeGameDevice(activePrefix);
 
+    // HDD (APA) is not a device ROOT like the others: OPL's data home is a partition mounted on
+    // pfs0:, and where inside it Neutrino sits depends on which partition that is ("pfs0:" for
+    // +OPL, "pfs0:OPL/" for __common/OPL). The helper knows both, so this pick never reaches the
+    // bare-root forms[] loop below. A miss still falls through to the AUTO tiers, same as any other
+    // picked-device miss.
+    if (gNeutrinoDevice == NEUTRINO_DEV_APA_HDD) {
+        const char *apaHit = sbNeutrinoProbeApaHome();
+        if (apaHit != NULL)
+            return apaHit;
+    }
+
     char cand[2][BDM_DEVICE_ROOT_MAX];
     int nCand = 0;
     switch (gNeutrinoDevice) {
@@ -1498,8 +1559,7 @@ const char *sbResolveNeutrinoPath(const char *activePrefix)
             }
             break;
         }
-        case NEUTRINO_DEV_APA_HDD:
-            snprintf(cand[nCand++], BDM_DEVICE_ROOT_MAX, "pfs0"); // the already-mounted OPL data partition
+        case NEUTRINO_DEV_APA_HDD: // handled above by sbNeutrinoProbeApaHome (the data home, not a bare root)
             break;
         default: // AUTO -- no explicit device root
             break;
@@ -1543,6 +1603,19 @@ const char *sbResolveNeutrinoPath(const char *activePrefix)
         const char *gameHit = sbNeutrinoProbeGameDevice(activePrefix);
         if (gameHit != NULL)
             return gameHit;
+    }
+
+    // Then the internal APA HDD's OPL data home, the way NHDDL's own discovery includes
+    // hdd0:/<OPL partition>/neutrino/. Only ever a candidate while the HDD stack is up (the helper
+    // returns NULL otherwise), so this costs a pointer test on consoles with no APA drive. It sits
+    // AFTER the game's own device -- a co-located install still wins for the device being played --
+    // and BEFORE mc0/mc1, because an APA install is the one a memory-card-starved user has
+    // deliberately placed, while an mc: copy is the historical default. An explicit HDD (APA) pick
+    // already ran this probe at the top and missed, so it is not repeated here.
+    if (gNeutrinoDevice != NEUTRINO_DEV_APA_HDD) {
+        const char *apaHit = sbNeutrinoProbeApaHome();
+        if (apaHit != NULL)
+            return apaHit;
     }
 
     static const char *candidates[] = {

--- a/src/udpfssupport.c
+++ b/src/udpfssupport.c
@@ -471,7 +471,7 @@ static void udpfsLaunchGame(item_list_t *itemList, int id, config_set_t *configS
     int neutrinoDevMode = oplPath2Mode(neutrinoPath);
     char gameStartup[GAME_STARTUP_MAX + 1];
     snprintf(gameStartup, sizeof(gameStartup), "%s", game->startup);
-    deinitEx(UNMOUNT_EXCEPTION, itemList->mode, neutrinoDevMode); // itemCleanUp frees udpfsGames/game
+    deinitEx(sbNeutrinoDeinitException(neutrinoPath), itemList->mode, neutrinoDevMode); // itemCleanUp frees udpfsGames/game
 
     // Hand off to Neutrino with the udpfs driver token. `partname` and `gameStartup` survive the deinit;
     // `game` does not and is not dereferenced past this point.


### PR DESCRIPTION
Requested by **eliminator1403**: an additional Neutrino core path at `hdd0:/+OPL/neutrino/`, so a
user short on memory-card space can keep one Neutrino install where NHDDL already looks for it.

NHDDL's rule is `hdd0:/<OPL partition>/neutrino/neutrino.elf`, with the partition read from
`hdd0:__common/OPL/conf_hdd.cfg` and `+OPL` / `__common/OPL` as fallbacks. **OPL already does that
exact resolution at startup and mounts the winner on `pfs0:`** — so this needs no new partition
setting to fill in, which is the good news given how much of a nightmare naming partitions by hand
would have been. `gHDDPrefix` *is* the answer: `pfs0:` for a `+OPL` home, `pfs0:OPL/` for `__common`.

## What was actually broken

The `HDD (APA)` entry in **Game Launching → Neutrino Defaults → Default Device** has existed for a
while, but it only ever probed the bare `pfs0:` **root**. That resolved a `+OPL` install by luck and
could never find a `__common/OPL` one. AUTO never looked at APA at all.

And a `pfs0:`-hosted ELF would not have survived the handoff regardless: all four Neutrino legs hand
off through `sysLoadELFKeepIOP` (no IOP reset) and open the ELF **after** the teardown, but passed
bare `UNMOUNT_EXCEPTION` — so `hddCleanUp`'s `PDIOC_CLOSEALL` still dropped every pfs descriptor
first, and the HDD autolaunch branch unmounted `pfs0:` outright. That is the same trap the Ember APA
launch hit and the reason `KEEPIOP_EXCEPTION` exists.

## Changes

- **`sbNeutrinoProbeApaHome()`** (supportbase.c) probes the OPL data home *and* the partition root,
  with the usual folder-case / `.ELF` / leading-slash variants. `hdd0:/+OPL/neutrino/` and
  `hdd0:/__common/OPL/neutrino/` both resolve. Returns NULL while the HDD stack is down — nothing is
  mounted to read, and a path that only `open()`s in a live menu is worse than no path.
- The **`HDD (APA)` pick** routes through it instead of the bare-root `forms[]` loop; a miss still
  falls through to the AUTO tiers like any other picked-device miss.
- **AUTO gained the APA tier**, after the game's own device (a co-located install still wins for the
  device being played) and before `mc0:`/`mc1:`.
- **`sbNeutrinoDeinitException()`** returns `UNMOUNT_EXCEPTION | KEEPIOP_EXCEPTION` for a pfs-hosted
  `neutrino.elf` and plain `UNMOUNT_EXCEPTION` otherwise. Wired into all four legs (bdm / hdd / mmce
  / udpfs) plus the HDD autolaunch branch's explicit unmount. **Every non-APA launch keeps the exact
  teardown it has today.**
- `sbNeutrinoProbeGameDevice` no longer probes the device root twice when the prefix already is the
  root (`pfs0:`).
- `docs/NEUTRINO.md`: the two working layouts, the new AUTO tier, and the started-HDD requirement.

## What this does not do

A Neutrino install on a partition that is **not** the OPL data home (say `hdd0:+NEUTRINO`) is still
unreachable — raw APA is not POSIX-open()-able, and `pfs0:` is owned by the data home. Borrowing that
slot mid-launch is the HDD-freeze hazard, so it is deliberately out of scope. **Game's Device** also
still reports "not found" for an HDL game, which has no POSIX prefix of its own; the APA home is
reached through AUTO or the explicit pick instead.

## Testing

Clean `make` in `ps2dev/ps2dev:latest` is green; `clang-format` 12 clean. **No hardware testing** —
the whole point of the change is a device that cannot be exercised in an emulator. Worth checking on
hardware, in rough order of risk:

1. `+OPL` home, `neutrino/` at the partition root, Neutrino Device = `HDD (APA)`, launch an HDL game.
2. Same with a `__common` home (`hdd0:/__common/OPL/neutrino/`) — the leg that could never work.
3. AUTO with no memory-card install and no co-located copy: should find the APA one.
4. A **USB** game with the Neutrino install only on the APA HDD — proves the mount survives a
   cross-device teardown.
5. Regression: a normal mc0:-hosted Neutrino launch on USB / MMCE / iLink, which must be byte-for-byte
   the teardown it was before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Neutrino installations can now be discovered from the mounted OPL data partition on APA HDDs.
  - HDD-based installations support both `+OPL` and `__common` directory layouts.
  - Installation lookup now prioritizes the APA HDD data partition before memory cards.
  - Launch handling preserves required storage access based on the location of `neutrino.elf`, improving compatibility across supported devices.

- **Documentation**
  - Added guidance explaining HDD (APA) device resolution and installation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->