### PR TITLE
release: publish one stable-named RIPTOPL.ELF for updating an install

### DIFF
--- a/.github/scripts/normalize_release_notes.py
+++ b/.github/scripts/normalize_release_notes.py
@@ -36,15 +36,36 @@ body = re.sub(r'\nSHA256 \(also published as SHA256SUMS\.txt\):\n```.*?```\n', '
 body = hero_re.sub('', body)
 body = body.lstrip()
 
-downloads = '''## Release downloads
+# `RIPTOPL.ELF` is published as a loose asset only when its (best-effort) flavour built this run,
+# so the workflow passes its presence in rather than letting these notes promise a download that
+# is not there. Absent argument => treat it as missing, which is the safe direction to be wrong in.
+oneclick = len(sys.argv) > 2 and sys.argv[2] == 'yes'
+oneclick_line = (
+    '- **RIPTOPL.ELF:** the loader on its own, for **updating an existing install** — download it and'
+    ' overwrite the `RIPTOPL.ELF` you already have. The filename never changes, so the link above is'
+    ' permanent. Use the unified package for a first install: the bare ELF does not bring `POPS/`,'
+    ' `EMBER/`, `neutrino/` or the language files.\n'
+) if oneclick else ''
+# The closing sentence has to track the line above it: saying "no bare ELF files are published"
+# while one sits in the asset list is exactly the kind of quiet contradiction people stop reading
+# release notes over.
+closing = (
+    'Apart from `RIPTOPL.ELF` above, no bare ELF files or SDK/IRX manifests are published as release'
+    ' assets; they are kept inside the appropriate archives where needed.'
+    if oneclick else
+    'No bare ELF files or SDK/IRX manifests are published as release assets; they are kept inside'
+    ' the appropriate archives where needed.'
+)
+
+downloads = f'''## Release downloads
 
 - **Unified package:** the normal installable RiptOPL package containing the standard loaders, PS1/POPSTARTER files, bundled Neutrino and the five companion-tool shortcuts.
-- **Variants:** alternate build configurations, including the DualSense (DS5) loaders.
+{oneclick_line}- **Variants:** alternate build configurations, including the DualSense (DS5) loaders.
 - **Debug:** diagnostic builds for troubleshooting, when produced.
 - **Languages:** additional UI language files and fonts, when produced.
 - **Source:** the exact source snapshot used to produce the release.
 
-No bare ELF files or SDK/IRX manifests are published as release assets; they are kept inside the appropriate archives where needed.'''
+{closing}'''
 
 # Hero FIRST, AI-disclosure banner LAST -- the two images do different jobs. The hero is the
 # project's identity and belongs where a reader lands. The disclosure badge is a footnote about how

--- a/.github/workflows/release-normalize.yml
+++ b/.github/workflows/release-normalize.yml
@@ -137,9 +137,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # RIPTOPL.ELF is the ONE deliberate exception. Every other loose ELF here is a
+          # version-and-flavour-stamped build that belongs inside an archive; RIPTOPL.ELF exists
+          # precisely so an existing install can be updated by replacing one file, from a link that
+          # never changes. Sweeping it up with the rest would delete the asset the rolling release
+          # advertises in its own "Get started" section.
           for f in release-work/*.ELF release-work/*MANIFEST*.txt release-work/SHA256SUMS.txt release-work/DETAILED_CHANGELOG; do
             [[ -f "$f" ]] || continue
             asset="$(basename "$f")"
+            if [[ "$asset" == "RIPTOPL.ELF" ]]; then
+              echo "Keeping one-click loader asset: $asset"
+              continue
+            fi
             echo "Removing floating release asset: $asset"
             gh release delete-asset "$TAG" "$asset" --repo "$GITHUB_REPOSITORY" --yes || true
           done
@@ -151,7 +160,11 @@ jobs:
           BODY="release-work/original-notes.md"
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '.body' > "$BODY"
 
-          python3 .github/scripts/normalize_release_notes.py "$BODY" > release-work/notes.md
+          # Tell the notes generator whether the one-click loader actually shipped this run, so the
+          # "Release downloads" list never advertises an asset the release does not carry.
+          ONECLICK=no
+          [[ -f release-work/RIPTOPL.ELF ]] && ONECLICK=yes
+          python3 .github/scripts/normalize_release_notes.py "$BODY" "$ONECLICK" > release-work/notes.md
 
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file release-work/notes.md
 
@@ -159,11 +172,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          ASSETS="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' | sort)"
           echo 'Final release assets:'
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' | sort
+          printf '%s\n' "$ASSETS"
           echo 'Invariant checks:'
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' | grep -E '\.ELF$|MANIFEST|SHA256SUMS|DETAILED_CHANGELOG'; then
+          # RIPTOPL.ELF is the one sanctioned loose loader (the one-click update download); every
+          # other match is a floating build artefact that should have stayed inside an archive.
+          if printf '%s\n' "$ASSETS" | grep -vFx 'RIPTOPL.ELF' | grep -E '\.ELF$|MANIFEST|SHA256SUMS|DETAILED_CHANGELOG'; then
             echo 'ERROR: floating ELF/manifest asset remains.' >&2
             exit 1
           fi
-          echo 'OK: no floating ELF or manifest assets.'
+          echo 'OK: no floating ELF or manifest assets beyond RIPTOPL.ELF.'
+          if printf '%s\n' "$ASSETS" | grep -qFx 'RIPTOPL.ELF'; then
+            echo 'OK: one-click RIPTOPL.ELF is published.'
+          else
+            # Not fatal: it comes from a best-effort flavour, so a build hiccup means the release
+            # ships without it rather than shipping a stale one under a stable name.
+            echo 'NOTE: no RIPTOPL.ELF this run -- its flavour did not build.'
+          fi

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -561,9 +561,13 @@ jobs:
           # is permanent and can be linked or bookmarked.
           #
           # ONLY ONE of the four flavours can hold that name; publishing four would recreate the
-          # "which do I pick" problem the single file exists to remove. The choice is Nathan's
-          # (2026-09-10) and lives here as one variable -- change this line to move the one-click
-          # download to another flavour, nothing else.
+          # "which do I pick" problem the single file exists to remove.
+          #
+          # SETTLED: OFFICIALROLLING, chosen by Nathan 2026-09-10 and reaffirmed the same day after
+          # the objection was put to him -- that it is flavour #4, a MOVING tag which can build
+          # green and not boot (issue #102), while every doc ranks PS2DEVPINNED first. It is his
+          # call, it is documented honestly wherever the asset is described, and it is not to be
+          # "corrected" to a pinned flavour. Moving it is this one line, nothing else.
           ONECLICK_FLAVOUR=OFFICIALROLLING
           SRC="rolling/${VERSIONED_BASE}-${ONECLICK_FLAVOUR}.ELF"
           # Landmine: build-rolling-ps2dev-latest stages its output as rolling/RIPTOPL.ELF and the

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -550,6 +550,41 @@ jobs:
           echo "Renamed assets:"
           ls -la rolling
 
+      - name: Stage the one-click RIPTOPL.ELF
+        run: |
+          set -eu
+          # ONE stable, version-agnostic loader asset, so somebody who already has RiptOPL installed
+          # can replace just the ELF without downloading and unpacking the whole package (requested
+          # by eliminator1403, 2026-09-10). The name is deliberately RIPTOPL.ELF -- exactly the
+          # filename it has to have on the card -- and it never changes, so the download URL
+          #   .../releases/download/rolling/RIPTOPL.ELF
+          # is permanent and can be linked or bookmarked.
+          #
+          # ONLY ONE of the four flavours can hold that name; publishing four would recreate the
+          # "which do I pick" problem the single file exists to remove. The choice is Nathan's
+          # (2026-09-10) and lives here as one variable -- change this line to move the one-click
+          # download to another flavour, nothing else.
+          ONECLICK_FLAVOUR=OFFICIALROLLING
+          SRC="rolling/${VERSIONED_BASE}-${ONECLICK_FLAVOUR}.ELF"
+          # Landmine: build-rolling-ps2dev-latest stages its output as rolling/RIPTOPL.ELF and the
+          # step above renames it to ...-PS2DEVROLLING.ELF. If that rename is ever moved or removed,
+          # a PS2DEVROLLING binary would silently inherit the one-click name. Fail instead.
+          if [ -f rolling/RIPTOPL.ELF ]; then
+            echo "ERROR: rolling/RIPTOPL.ELF already exists before this step -- the PS2DEVROLLING" >&2
+            echo "       rename must run first, or the one-click asset would be the wrong flavour." >&2
+            exit 1
+          fi
+          if [ -f "$SRC" ]; then
+            cp -f "$SRC" rolling/RIPTOPL.ELF
+            echo "One-click loader: RIPTOPL.ELF == ${ONECLICK_FLAVOUR}"
+          else
+            # Best-effort, like the flavour it comes from. The publish step deletes every existing
+            # asset before uploading, so a missing file this run simply means the release carries no
+            # one-click ELF, rather than last run's binary lingering under a stable name.
+            echo "WARN: ${ONECLICK_FLAVOUR} ELF missing this run; release ships without RIPTOPL.ELF" >&2
+          fi
+          echo "ONECLICK_FLAVOUR=${ONECLICK_FLAVOUR}" >> "$GITHUB_ENV"
+
       - name: Archive source snapshot
         run: |
           set -eu
@@ -866,6 +901,9 @@ jobs:
       - name: Build release notes
         run: |
           set -eu
+          # Same tag the Publish step below resolves, needed here to print a working download URL
+          # for the one-click ELF. Keep the two in step if either is ever changed.
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then REL_TAG="${GITHUB_REF_NAME}"; else REL_TAG="rolling"; fi
           HAS_PS2DEVPINNED=no
           [ -f "rolling/${VERSIONED_BASE}-PS2DEVPINNED.ELF" ] && HAS_PS2DEVPINNED=yes
           HAS_OFFICIALROLLING=no
@@ -893,6 +931,15 @@ jobs:
             printf 'the SDK toolchain each was built with -- the RiptOPL code in every one is identical. Pick a folder\n'
             printf 'and copy its RIPTOPL.ELF to your launch method.\n'
             printf '\n'
+            if [ -f rolling/RIPTOPL.ELF ]; then
+              printf '**Already running RiptOPL?** Grab the single **RIPTOPL.ELF** asset below and overwrite the\n'
+              printf 'one you already have -- no zip, no unpacking, nothing else to copy. It is the %s\n' "${ONECLICK_FLAVOUR:-OFFICIALROLLING}"
+              printf 'flavour, and the link never changes:\n'
+              printf '  %s/%s/releases/download/%s/RIPTOPL.ELF\n' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$REL_TAG"
+              printf 'Use the full package for a FIRST install -- the ELF alone does not bring POPS/, EMBER/,\n'
+              printf 'neutrino/ or the language files, and PS1 and Neutrino launches need those.\n'
+              printf '\n'
+            fi
             printf '**Prefer a PINNED flavour.** Pinned builds are digest-locked and reproducible, so a report\n'
             printf 'against one can be rebuilt and compared later. When you report, **name the flavour you are\n'
             printf 'running -- Settings -> About shows it** in the version string. That one line is what makes\n'
@@ -1000,6 +1047,9 @@ jobs:
             fi
             if [ -f "rolling/RIPTOPL-DEBUG-${OPL_VERSION:-rolling}.zip" ]; then
               printf -- '- RIPTOPL-DEBUG-*.zip: debug builds for the two ps2dev flavours (iopcore/ingame/eesio/ppctty/DTL_T10000)\n'
+            fi
+            if [ -f rolling/RIPTOPL.ELF ]; then
+              printf -- '- RIPTOPL.ELF: the one-click loader for updating an existing install -- %s flavour, stable filename, permanent link\n' "${ONECLICK_FLAVOUR:-OFFICIALROLLING}"
             fi
             if [ "$HAS_PS2DEVPINNED" = yes ]; then
               printf -- '- %s-PS2DEVPINNED.ELF: bare loader, digest-pinned ps2dev snapshot %s (SAFE FALLBACK -- pinned, boots reliably)\n' "$VERSIONED_BASE" "$SDK_VER"
@@ -1211,6 +1261,11 @@ jobs:
             case "$b" in
               RIPTOPL-VARIANTS-*.zip|RIPTOPL-DEBUG-*.zip)
                 echo "MEGA archive: excluding diagnostic bundle $b" ;;
+              RIPTOPL.ELF)
+                # Byte-identical to the versioned <base>-<flavour>.ELF already in this archive --
+                # it exists only to give the GitHub release a stable filename. The permanent copy
+                # keeps the versioned name, which is the one a restorer can identify.
+                echo "MEGA archive: excluding $b (duplicate of the versioned flavour ELF)" ;;
               *)
                 MEGA_FILES="$MEGA_FILES $b" ;;
             esac

--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ Download the **normal installable package**, `RIPTOPL-<rel>-<sha>.zip`. Separate
 different purposes: `RA` for the experimental RetroAchievements loader, `VARIANTS` for alternate
 configurations including DualSense, `DEBUG` for diagnostics, `LANGS` for translations, and `src`
 for the exact source snapshot. Optional archives or SDK flavours can be omitted; read the release notes.
-GitHub does not publish bare loader ELFs or separate checksum/SDK manifests in the normalized asset set.
+
+**Already have RiptOPL installed?** The rolling release carries one loose loader asset,
+`RIPTOPL.ELF`, for exactly that case: download it and overwrite the `RIPTOPL.ELF` you already have. Its name never changes, so
+<https://github.com/NathanNeurotic/Open-PS2-Loader/releases/download/rolling/RIPTOPL.ELF> is a
+permanent link. It is the `-OFFICIALROLLING` flavour, and it is not a first install — the bare loader
+does not bring `POPS/`, `EMBER/`, `neutrino/` or the language files. Apart from that one file, GitHub
+does not publish bare loader ELFs or separate checksum/SDK manifests in the normalized asset set.
 The workflow can also publish `v*` tags, but no such stable release is currently offered here.
 
 

--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -68,8 +68,11 @@ flavour suffix tells you. Those details greatly help pin down any issues between
 pulled by URL and dropped straight over your existing copy:
 
 ```sh
-curl -L -o RIPTOPL.ELF \
-  https://github.com/NathanNeurotic/Open-PS2-Loader/releases/download/rolling/RIPTOPL.ELF
+# --fail matters: the asset is best-effort, and a plain `curl -L -o` writes the
+# HTTP error page into the file and still exits 0 -- overwriting a loader that works.
+curl --fail --location --show-error --output RIPTOPL.ELF.tmp \
+  https://github.com/NathanNeurotic/Open-PS2-Loader/releases/download/rolling/RIPTOPL.ELF \
+  && mv RIPTOPL.ELF.tmp RIPTOPL.ELF
 ```
 
 Every other filename changes each build, so pull those by the `rolling` tag rather than a fixed

--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -17,16 +17,19 @@ archives by purpose (RA, DEBUG and language packs are listed when produced):
 | Asset | What it is |
 |---|---|
 | `RIPTOPL-<rel>-<sha>.zip` | **The installable package.** Normally contains four loader folders that differ ONLY by the SDK toolchain they were built with (the RiptOPL code in each is identical), each explicitly labeled: `APP_RIPTOPL-PS2DEVPINNED/RIPTOPL.ELF` (#1, recommended pinned ps2dev), `APP_RIPTOPL-OFFICIALPINNED/RIPTOPL.ELF` (#2, recommended pinned ps2homebrew), `APP_RIPTOPL-PS2DEVROLLING/RIPTOPL.ELF` (#3, rolling canary), and `APP_RIPTOPL-OFFICIALROLLING/RIPTOPL.ELF` (#4, rolling canary). A best-effort flavour can be absent when its build fails, and the release notes identify it. Also includes a `POPS/` folder for PS1 support via POPSTARTER (including all loose BDMA pairs—none are embedded in the loader—the new `usbd.irx.ilink` + `usbhdfsd.irx.ilink` pair for iLink VCD launches, and `POPS/POPSTARTER VERSIONS/`, the alternate POPSTARTER builds) and an `EMBER/` folder for PS1 support via **[Ember](https://github.com/Gageformer/Ember)** by **[Gageformer](https://github.com/Gageformer)**, the second PS1 core; the normally bundled **[Neutrino](https://github.com/rickgaiser/neutrino)** core by **[rickgaiser](https://github.com/rickgaiser)** as a ready-to-use `neutrino/` folder (drag-and-drop to `mc?:/`), plus `PS2-Servers.url`, `udpfs-server.url`, `OrbitPS2-Manager.url`, `OPL-PS1-AIO-Converter-GUI.url`, and `PS2RD-CHT-Manager.url`. Extract it, pick a folder and copy its `RIPTOPL.ELF` — see [Which build should I use?](#which-build-should-i-use) below. |
+| `RIPTOPL.ELF` | **The loader on its own, for updating an install you already have.** Download it and overwrite your existing `RIPTOPL.ELF` — no archive to unpack, nothing else to copy. Alone among the release assets its name never changes, so <https://github.com/NathanNeurotic/Open-PS2-Loader/releases/download/rolling/RIPTOPL.ELF> is a permanent link. It is the **`-OFFICIALROLLING`** flavour; there is only one of these because four would put the "which do I pick?" question back in front of the people this file exists for. It is not a first install: the bare loader does not bring `POPS/`, `EMBER/`, `neutrino/` or the language files, so PS1 and Neutrino launches need the package above. If you want a reproducible build to quote in a bug report, take a pinned folder from the package instead — see [Which build should I use?](#which-build-should-i-use). Best-effort, like the flavour it is copied from: if that build fails the release simply ships without it. |
 | `RIPTOPL-<version>-src.zip` | Source snapshot to rebuild this exact commit. |
 | `RIPTOPL-LANGS-*.zip` | Extra UI language files (`.lng` + non-Latin fonts) — copy into your OPL folder. |
 | `RIPTOPL-VARIANTS-*.zip` | Alternate build configs across the moving and pinned ps2dev flavours; the normalizer also adds one ready-made DualSense (`DUALSENSE=1`) loader for each available official flavour. |
 | `RIPTOPL-RA-*.zip` | The **RetroAchievements** loader as a complete, installable package — same shape as the main archive (`POPS/`, `EMBER/`, `neutrino/`, the PC-tool shortcuts), with `APP_RIPTOPL-RA-*` loader folders in place of the standard ones, plus `xeRAbora.url` for the PC client the feature needs. Its own archive rather than an entry in VARIANTS so it can be picked deliberately, and because VARIANTS is excluded from the permanent MEGA archive as a diagnostic bundle. **A development build, not a finished feature**: both halves are written, none of it has been tested on hardware. See [docs/RETROACHIEVEMENTS.md](docs/RETROACHIEVEMENTS.md). |
 | `RIPTOPL-DEBUG-*.zip` | Diagnostic builds across the moving and pinned ps2dev flavours, when produced. |
 
-The final GitHub release intentionally has no floating `.ELF`, `SHA256SUMS.txt`, detailed changelog,
-or SDK/IRX manifest assets. Standard loaders live in the unified package, DualSense loaders live in
-VARIANTS, and build checksums remain in the workflow log/immutable MEGA archive rather than beside the
-public archives.
+Apart from the single stable-named `RIPTOPL.ELF` above, the final GitHub release intentionally has
+no floating `.ELF`, `SHA256SUMS.txt`, detailed changelog, or SDK/IRX manifest assets. The other
+standard loaders live in the unified package, DualSense loaders live in VARIANTS, and build
+checksums remain in the workflow log/immutable MEGA archive rather than beside the public archives.
+The permanent MEGA archive keeps the versioned `…-OFFICIALROLLING.ELF` rather than the stable copy,
+since the two are byte-identical and only the versioned name identifies what it is.
 
 The current UI presents the same **PS2/PS1 Game Display** setting on Interface and PS Emulation:
 **Both (L3)** switches separate device libraries; **Mixed** combines them and L3 cycles
@@ -52,12 +55,24 @@ Start with a pinned SDK for reproducible comparisons:
 3. **`APP_RIPTOPL-PS2DEVROLLING/` (`-PS2DEVROLLING`) — bleeding-edge canary.** Tracks `ps2dev/ps2dev:latest`.
 4. **`APP_RIPTOPL-OFFICIALROLLING/` (`-OFFICIALROLLING`) — bleeding-edge official canary.** Tracks `ps2homebrew:main`.
 
+The loose `RIPTOPL.ELF` asset is **#4**, `-OFFICIALROLLING`. It is there to make *updating* a working
+install a one-file job, not to recommend that flavour: if you are chasing a bug, or want a build a
+report can be reproduced against later, take #1 or #2 out of the package.
+
 When something misbehaves on hardware, please say **which flavour you ran** — the in-app version string's
 flavour suffix tells you. Those details greatly help pin down any issues between application code and toolchain updates.
 
 ## Pull the latest build
 
-Because the filenames change each build, pull by the `rolling` tag rather than a fixed
+**Just updating the loader?** `RIPTOPL.ELF` is the one asset whose name is fixed, so it can be
+pulled by URL and dropped straight over your existing copy:
+
+```sh
+curl -L -o RIPTOPL.ELF \
+  https://github.com/NathanNeurotic/Open-PS2-Loader/releases/download/rolling/RIPTOPL.ELF
+```
+
+Every other filename changes each build, so pull those by the `rolling` tag rather than a fixed
 filename — the `gh` CLI grabs whatever is currently published:
 
 ```sh


### PR DESCRIPTION
Requested in Discord by **eliminator1403**: *"add RiptOPL.ELF in the downloads section so it becomes easy to download and replace the older version without having to use the zip file."* Four ELFs (one per SDK) was raised and rejected as not noob-friendly, so this ships exactly one.

## What lands

The rolling release gains a single loose **`RIPTOPL.ELF`** beside the archives, at a permanent URL:

```
https://github.com/NathanNeurotic/Open-PS2-Loader/releases/download/rolling/RIPTOPL.ELF
```

It is already named what it has to be called on the card, so updating an install is: download, overwrite, done.

**Flavour: `OFFICIALROLLING`**, per Nathan's call. Worth stating plainly, because it is a deliberate deviation — every other doc ranks that flavour **#4**, a moving `ps2homebrew:main` canary that can build green and not boot (#102). It is the one-click *update* path, not a recommendation, and the docs say so: bug reports should still quote a pinned build. Moving it is a one-line change to `ONECLICK_FLAVOUR=` in the staging step.

## How it holds together

- **Staging runs after the version rename.** `build-rolling-ps2dev-latest` stages its own output as `rolling/RIPTOPL.ELF`, which the rename step turns into `…-PS2DEVROLLING.ELF`. A guard fails the build if that file still exists, so a PS2DEVROLLING binary can never inherit the one-click name if the steps are ever reordered.
- **Best-effort, like its flavour.** A failed OFFICIALROLLING build means the release ships without the ELF — not that last run's binary lingers under a stable name, since the publish step clears every asset before uploading.
- **`release-normalize.yml` was the real blocker.** It exists to strip floating ELFs and *hard-fails* if one survives. Both the delete loop and the invariant grep now carve out this one asset by exact name; everything else is still swept up as before.
- **`normalize_release_notes.py` takes the asset's presence as an argument**, so the public download list never advertises an ELF that run did not produce — and its closing "no bare ELF files are published" sentence no longer contradicts the list directly above it.
- **MEGA keeps the versioned copy**, not this one: they are byte-identical and only the versioned name identifies what it is.

## Docs

README, plus `ROLLING_RELEASE.md`'s asset table, normalizer paragraph, "Which build should I use?" and a `curl` one-liner under "Pull the latest build". The gh-pages site copy is staged separately and should go out **after** the first rolling run that actually carries the asset, so the site never links a download that is not there yet.

## Testing

⚠️ **This cannot be exercised by this PR.** `publish-rolling` is gated to `rebuild/main` and `v*` tags — a PR runs the build jobs and withholds the publish, by design — and `release-normalize.yml` only fires on a completed Rolling Release run. The new staging step, the notes text and the normalizer carve-out therefore all execute for the first time **on merge**.

What was verified locally instead:

- Both workflows parse as YAML; the notes script compiles and was run with and without the flag.
- The staging step's shell logic simulated across four scenarios: all four flavours present, OFFICIALROLLING failed, every best-effort flavour failed, and the stale-file guard tripping.
- No C sources touched, so `check-format` does not trigger and `flavours.yml` builds the same source as before.

**After merge:** watch the rolling run and confirm the asset survives normalize — its verify step now prints either `OK: one-click RIPTOPL.ELF is published` or `NOTE: no RIPTOPL.ELF this run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rolling releases now provide a stable, standalone `RIPTOPL.ELF` download for updating existing installations without downloading the full package.
  * Release notes and asset listings identify the standalone loader and provide its permanent download URL.
  * Release archives continue to include the versioned loader while avoiding duplicate standalone assets.

* **Documentation**
  * Added guidance distinguishing first-time installation packages from loader-only updates, including a direct download command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->