### PR TITLE
usbd: use the pre-rewrite driver in EVERY build, not just RA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,12 +259,11 @@ endif
 # for the full account of each). Both defaults below are the stock ps2sdk prebuilt, and the RA
 # branch swaps in ours.
 #
-# ⚠ THE USBD SWAP IS NOT AN RA FEATURE. It fixes a bug that is present in every build this fork
-# ships -- and in official OPL too -- and it is held behind the RA switch only because it replaces
-# the USB host driver for every user and has not been validated on OUR hardware yet. Promoting it
-# is deliberately a one-line change: move USBD_MINI_IRX out of the conditional. Do that only with
-# a hardware pass behind it.
-USBD_MINI_IRX = $(PS2SDK)/iop/irx/usbd_mini.irx
+# THE USBD SWAP IS FORK-WIDE, ON PURPOSE. It fixes a bug present in every build this fork ships
+# -- and in official OPL too -- so it is deliberately NOT gated: a CD-era game run off a USB
+# stick loses its pad AND its sound at the game's first IOP reboot with ps2sdk's post-2024-09-04
+# driver, whatever flavour you built. See the rule further down for the whole account.
+USBD_MINI_IRX = modules/usb/usbd-ra/usbd_mini.irx
 SMBMAN_IRX    = $(PS2SDK)/iop/irx/smbman.irx
 
 # RetroAchievements flavour. Everything the feature adds hangs off this one switch, on BOTH sides
@@ -274,8 +273,7 @@ SMBMAN_IRX    = $(PS2SDK)/iop/irx/smbman.irx
 ifeq ($(RETROACHIEVEMENTS),1)
   EE_CFLAGS += -DRETROACHIEVEMENTS
   EECORE_EXTRA_FLAGS += RETROACHIEVEMENTS=1
-  USBD_MINI_IRX = modules/usb/usbd-ra/usbd_mini.irx
-  SMBMAN_IRX    = modules/network/smbman-ra/smbman.irx
+  SMBMAN_IRX = modules/network/smbman-ra/smbman.irx
   # md5 (vendored, zlib licence): the game hash the PC client keys achievements on.
   # rawatch: the watch list the menu hands to ee_core, loaded from <device>RA/.
   # rahash:  the image hash RetroAchievements keys a game on, taken by walking

--- a/docs/RETROACHIEVEMENTS.md
+++ b/docs/RETROACHIEVEMENTS.md
@@ -219,10 +219,9 @@ fork**. Swapping only that one module fixes it. `usbd_mini.irx` is not a separat
 `iop/usb/usbd_mini/Makefile` points `IOP_SRC_DIR` at `iop/usb/usbd/src` and adds `-DMINI_DRIVER`, so
 the rewrite lands squarely on the module every RiptOPL flavour embeds straight from its container.
 
-It is behind the RA switch **only** because promoting it changes the USB host driver for every user
-on the strength of someone else's hardware test, and this is not something an emulator can answer.
-Moving `USBD_MINI_IRX` out of the conditional is the whole change; do it with a hardware pass behind
-it, not before.
+It is therefore **not** gated: `USBD_MINI_IRX` sits outside the `RETROACHIEVEMENTS` conditional and
+every flavour gets the pre-rewrite driver. It is listed here only because this is where the module
+came from; it is not a RetroAchievements feature and does not depend on the flag.
 
 ## Before this is called finished
 


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE WITHOUT A HARDWARE PASS.** This PR exists so its CI artifacts can be tested on a real console *before* the change reaches every user. Stacked on #634 — merge that first; GitHub will retarget this to `rebuild/main` automatically.

## What this is

#634 vendors ps2sdk's April-2024 `usbd` and wires it behind `RETROACHIEVEMENTS`. **That gating is the only artificial thing about it.** The bug it fixes is in the loader everyone runs:

- ps2sdk rewrote its USB host driver on **2024-09-04** (`b1f7ff96`: 28 files, +4446/−3336).
- Since then a **CD-era game run off a USB stick loses its controller and its sound** at the game's first IOP reboot — Dynasty Warriors 2 on real hardware (hacan359, 2026-09-10).
- It reproduces **with official OPL as much as with this fork**, and swapping only that module fixes it.
- `usbd_mini.irx` is built from `iop/usb/usbd/src` (`usbd_mini/Makefile` just adds `-DMINI_DRIVER`), and every RiptOPL flavour embeds the container's prebuilt — so **all four flavours carry the post-rewrite driver today**.

The whole diff is moving `USBD_MINI_IRX` out of the `RETROACHIEVEMENTS` conditional, plus the doc paragraph that described it as gated. **`smbman` stays RA-gated** — that one really is an RA fix.

## How to test the artifacts

Every `build-flavour` job on this PR uploads its ELF (`OPL-<FLAVOUR>`), and those builds now contain the older driver. Grab the flavour you normally run — `OPL-PS2DEVPINNED` is the recommended one — and check:

1. **The regression itself:** a CD-era game (Dynasty Warriors 2 is the known case) from a USB stick. Pad and sound should survive the game's first IOP reboot.
2. **No new regressions on USB generally:** normal DVD-era games off USB, your usual sticks/adapters, hot-plug, and MX4SIO if you use it — this is the host driver, so anything on the USB bus is in scope.
3. Ideally compare against the same flavour from the current `rolling`, which has the newer driver.

## Verified here

A **default** build (no `RETROACHIEVEMENTS`) from clean in `ps2dev/ps2dev:latest` builds `modules/usb/usbd-ra` and links — so the promotion takes effect outside the RA flavour and the tree still builds without the flag.

What that **cannot** tell us is how the older driver behaves across the USB devices people actually use. An emulator cannot answer it and neither can CI. That is the entire reason this is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
