### PR TITLE
RA: ship a PACKED loader in the RA package, and assert it stays packed

### DIFF
--- a/.github/scripts/build_rolling_extras.sh
+++ b/.github/scripts/build_rolling_extras.sh
@@ -67,11 +67,19 @@ mkdir -p rolling/ra
 # 8 MB, so mc?:/ could not hold the RA build at all. So take $(EE_BIN_PACKED) (RIPTOPL.ELF) rather
 # than $(EE_BIN) (opl.elf). rolling-release.yml asserts the size of what lands here.
 for ra_pad in PADEMU=0 PADEMU=1; do
-  make clean >/dev/null 2>&1 || true
-  # `make clean` is best-effort (|| true), and RIPTOPL.ELF is also what the job's own main and DS5
-  # builds leave in this directory -- so without this the [ -f ] test below could pass on somebody
-  # else's loader and ship a NON-RA build inside the RA package. Same reason rolling-release.yml
-  # does `rm -f RIPTOPL-*.ELF` before each DS5 build; that glob does not match this name.
+  # A failed clean is FATAL to this variant, not something to build through. PADEMU changes between
+  # the two iterations and the Makefile does not rebuild objects when a flag changes, so leftover
+  # objects would silently produce a mixed-configuration loader -- and this one goes into a package
+  # people install, where a wrong binary is worse than an absent one. The other two loops in this
+  # file keep `|| true`; their payload is diagnostic.
+  if ! make clean >/dev/null 2>&1; then
+    echo "WARN: could not clean before RA build '$ra_pad'${SDK_SUFFIX}; skipping it" >&2
+    continue
+  fi
+  # RIPTOPL.ELF is also what the job's own main and DS5 builds leave in this directory, so without
+  # this the [ -f ] test below could pass on somebody else's loader and ship a NON-RA build inside
+  # the RA package. Same reason rolling-release.yml does `rm -f RIPTOPL-*.ELF` before each DS5
+  # build; that glob does not match this name.
   rm -f RIPTOPL.ELF
   if make --trace RETROACHIEVEMENTS=1 $ra_pad $BRAND_ARG && [ -f RIPTOPL.ELF ]; then
     mv RIPTOPL.ELF "rolling/ra/RIPTOPL-ra-pademu${ra_pad#PADEMU=}${SDK_SUFFIX}.ELF"

--- a/.github/scripts/build_rolling_extras.sh
+++ b/.github/scripts/build_rolling_extras.sh
@@ -59,10 +59,22 @@ done
 # instead (see "Pack the RIPTOPL RA package zip" in rolling-release.yml).
 echo "== Building RIPTOPL RetroAchievements flavour (suffix='${SDK_SUFFIX}') =="
 mkdir -p rolling/ra
+# PACKED, unlike the variants and debug loops above and below. Those two ship raw opl.elf on
+# purpose -- they are diagnostic bundles, and a debug build wants its symbols. The RA zip is not
+# one: it is an installable package a user chooses instead of the main archive, so its loader has
+# to be the same shape as the main one. NOT_PACKED=1 skips the strip + ps2-packer step, which made
+# the RA loader 12.2 MB against the main package's 1.46 MB -- and a standard PS2 memory card is
+# 8 MB, so mc?:/ could not hold the RA build at all. So take $(EE_BIN_PACKED) (RIPTOPL.ELF) rather
+# than $(EE_BIN) (opl.elf). rolling-release.yml asserts the size of what lands here.
 for ra_pad in PADEMU=0 PADEMU=1; do
   make clean >/dev/null 2>&1 || true
-  if make --trace RETROACHIEVEMENTS=1 $ra_pad NOT_PACKED=1 $BRAND_ARG && [ -f opl.elf ]; then
-    mv opl.elf "rolling/ra/RIPTOPL-ra-pademu${ra_pad#PADEMU=}${SDK_SUFFIX}.ELF"
+  # `make clean` is best-effort (|| true), and RIPTOPL.ELF is also what the job's own main and DS5
+  # builds leave in this directory -- so without this the [ -f ] test below could pass on somebody
+  # else's loader and ship a NON-RA build inside the RA package. Same reason rolling-release.yml
+  # does `rm -f RIPTOPL-*.ELF` before each DS5 build; that glob does not match this name.
+  rm -f RIPTOPL.ELF
+  if make --trace RETROACHIEVEMENTS=1 $ra_pad $BRAND_ARG && [ -f RIPTOPL.ELF ]; then
+    mv RIPTOPL.ELF "rolling/ra/RIPTOPL-ra-pademu${ra_pad#PADEMU=}${SDK_SUFFIX}.ELF"
   else
     echo "WARN: RA build '$ra_pad'${SDK_SUFFIX} failed to build; skipping it"
   fi

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -844,6 +844,19 @@ jobs:
               for pad in 1 0; do
                 SRC="rolling/ra/RIPTOPL-ra-pademu${pad}-${sdk}.ELF"
                 [ -f "$SRC" ] || continue
+                # The RA loader must be PACKED, like the one in the main package. It shipped raw for
+                # a while because build_rolling_extras.sh passed NOT_PACKED=1 to this flavour along
+                # with the diagnostic ones: 12.2 MB against the main package's 1.46 MB, which does
+                # not fit on an 8 MB memory card at all -- and nothing complained, because an
+                # oversized ELF is still a valid ELF. Assert the size instead of trusting the flag.
+                # The packed loader is ~1.5 MB, so 6 MB leaves room to grow and still catches a raw
+                # opl.elf by a wide margin.
+                RA_BYTES="$(wc -c < "$SRC")"
+                if [ "$RA_BYTES" -gt 6291456 ]; then
+                  echo "ERROR: RA loader $SRC is ${RA_BYTES} bytes -- that is an UNPACKED build." >&2
+                  echo "       It would not fit a memory card. Check NOT_PACKED in build_rolling_extras.sh." >&2
+                  exit 1
+                fi
                 if [ "$pad" = "1" ]; then DEST="$PKG/APP_RIPTOPL-RA-${sdk}"; else DEST="$PKG/APP_RIPTOPL-RA-${sdk}-nopademu"; fi
                 mkdir -p "$DEST"
                 cp -f "$SRC" "$DEST/RIPTOPL.ELF"


### PR DESCRIPTION
The RA zip shipped a **12.2 MB** loader where the main package ships **1.46 MB**. A standard PS2 memory card is 8 MB, so `mc?:/` could not hold the RA build at all — and nothing complained, because an oversized ELF is still a valid ELF and every job stayed green.

Found while verifying the post-merge rolling run for #634. **Pre-existing**, not caused by that PR — the run before it shows the same 12,203,876-byte RA loader.

## Cause

[build_rolling_extras.sh](.github/scripts/build_rolling_extras.sh) passed `NOT_PACKED=1` to the RA loop along with the variants and debug loops, and staged `$(EE_BIN)` — `opl.elf`, the unstripped and uncompressed binary.

That is correct for the other two. They are diagnostic bundles, `rolling-release.yml` deliberately excludes them from the permanent MEGA archive as *"not installable payload"*, and a debug build wants its symbols. **The RA zip is the opposite:** it exists to be an installable package a user picks *instead of* the main archive, built to the same shape, and it **is** archived. Its loader has to be the same shape as the main one too.

So drop `NOT_PACKED=1` there and take `$(EE_BIN_PACKED)` (`RIPTOPL.ELF`) — the stripped + `ps2-packer` output.

## Measured

`ps2dev:latest`, `RETROACHIEVEMENTS=1 PADEMU=1`, from clean:

| artifact | bytes | |
|---|---|---|
| `opl.elf` | 12,200,752 | what shipped |
| `opl_stripped.elf` | 3,951,284 | intermediate |
| `RIPTOPL.ELF` | **1,475,556** | what ships now |

1.48 MB against the main package's 1.46 MB — the ~17 KB is RA plus the two vendored IRX from #634.

## Two guards, because this was invisible for days

- **`rolling-release.yml` now refuses to stage an RA loader over 6 MB**, naming the flag to check. The packed loader is ~1.5 MB, so that leaves room to grow and still catches a raw `opl.elf` by a wide margin. A hard failure matches how the POPS files and the Ember licence are already handled.
- **`rm -f RIPTOPL.ELF` before each RA build.** `make clean` there is best-effort (`|| true`), and `RIPTOPL.ELF` is also what the job's own main and DS5 builds leave in that directory — so the `[ -f ]` test could otherwise pass on somebody else's loader and put a **non-RA build inside the RA package**. The existing `rm -f RIPTOPL-*.ELF` guards the same hazard elsewhere; that glob does not match this name.

VARIANTS and DEBUG are deliberately left unpacked.

## Testing

⚠️ **PR CI cannot exercise this.** The extras script only runs in the post-merge rolling job, so the sizes above come from a local build of the exact command the script now runs. YAML and shell syntax validated; the guard was checked against the real 1,475,556-byte artifact (accepts) and the old 12,199,712-byte one (rejects).

Watch the rolling run after merge and confirm the RA loader lands at ~1.5 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rolling-release packages now use the correct packed RA artifact.
  * Added a size check to prevent oversized RA loader files from being published.
  * Stale packed artifacts are cleared before builds to help ensure packages contain current files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->