### PR TITLE
usbd: correct the comment that still called the swap RA-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -711,7 +711,9 @@ modules/isofs/isofs.irx: modules/isofs
 $(EE_ASM_DIR)isofs.c: modules/isofs/isofs.irx | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ $(*F)_irx
 
-# FORK-BUILT usbd_mini (modules/usb/usbd-ra) -- currently RA-only, see USBD_MINI_IRX above.
+# FORK-BUILT usbd_mini (modules/usb/usbd-ra) -- used by EVERY flavour, see USBD_MINI_IRX above.
+# The "-ra" in the directory name is historical: it is what upstream called it, kept so this
+# tree still diffs against theirs. It is NOT a statement about gating.
 #
 # ps2sdk rewrote its USB host driver on 2024-09-04 ("USBD feature update", b1f7ff96: 28 files,
 # +4446/-3336, with driver.c/hcd.h/hub.h deleted and device.c/endpoint.c/hub_resets.c added).
@@ -721,8 +723,10 @@ $(EE_ASM_DIR)isofs.c: modules/isofs/isofs.irx | $(EE_ASM_DIR)
 #
 # usbd_mini.irx is NOT a separate ps2sdk source tree: iop/usb/usbd_mini/Makefile just points
 # IOP_SRC_DIR at iop/usb/usbd/src and adds -DMINI_DRIVER, so that rewrite lands squarely on the
-# module we embed. We take the prebuilt straight out of the container, so every flavour we ship
-# carries the post-rewrite driver.
+# module we embed. Taking the prebuilt straight out of the build container is what gave every
+# flavour the post-rewrite driver; building it here is what stops that.
+#
+# Hardware-checked by Zack, 2026-09-10: no noticeable USB regressions on the promoted build.
 #
 # The source here is ps2sdk iop/usb/usbd as of 314d87e7 (2024-04-01), the last state before the
 # rewrite -- verified byte-identical to that tree, every file, with ONLY the Makefile ours

--- a/docs/RETROACHIEVEMENTS.md
+++ b/docs/RETROACHIEVEMENTS.md
@@ -223,6 +223,12 @@ It is therefore **not** gated: `USBD_MINI_IRX` sits outside the `RETROACHIEVEMEN
 every flavour gets the pre-rewrite driver. It is listed here only because this is where the module
 came from; it is not a RetroAchievements feature and does not depend on the flag.
 
+Hardware-checked by **Zack on 2026-09-10** before that promotion landed: no noticeable USB
+regressions on the promoted build. That is the check the promotion was waiting on — it is a
+no-regression result, not a confirmation that the Dynasty Warriors 2 case is cured here; that
+remains hacan359's finding on his own hardware. `backup/pre-usbd-forkwide-58fe5529` is the tree
+immediately before the swap, kept as a restore point.
+
 ## Before this is called finished
 
 Nothing below has been done. The feature is written end to end and builds clean; it has not run on a


### PR DESCRIPTION
Follow-up to #636. Comments and docs only — **no build change**.

Promoting `USBD_MINI_IRX` out of the `RETROACHIEVEMENTS` conditional left the comment block above the build rule describing the old state. Two of its sentences are now false, sitting directly over the rule they describe:

- *"currently RA-only"* — it is every flavour now.
- *"We take the prebuilt straight out of the container, so every flavour we ship carries the post-rewrite driver."* — that **was** the defect; building the module here is what stops it.

Also states plainly that the `-ra` in `modules/usb/usbd-ra` is historical — it is upstream's directory name, kept so the tree still diffs cleanly against theirs — and is **not** a statement about gating. The path is the first thing a reader meets and it implies a flag that no longer applies.

## Hardware result recorded

Zack, 2026-09-10: **no noticeable USB regressions** on the promoted build. Written down in both the Makefile and `docs/RETROACHIEVEMENTS.md`, along with what it does and does not cover — it is a no-regression pass, not a confirmation that the Dynasty Warriors 2 case is cured on our hardware. That remains hacan359's finding on his.

`backup/pre-usbd-forkwide-58fe5529` is named in the docs as the restore point: `rebuild/main` at its last pre-swap commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that all build variants use the locally built USB host module.
  - Documented hardware validation indicating no noticeable USB regressions.
  - Noted that validation does not confirm resolution of the Dynasty Warriors 2 issue.
  - Added information about retaining a pre-change restore point for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->