### PR TITLE
fix: share settings-home recovery with argv autolaunch (#545)

### DIFF
--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -43,6 +43,17 @@ the current values and reconnects immediately; Select / Refresh retries a failed
 `<version>` is the `ps2dev:latest` build's `git describe` (e.g. `v1.2.0-Beta-2562-c553567`); each
 flavour carries the same version with its flavour suffix (`-PS2DEVPINNED`, `-OFFICIALPINNED`, `-PS2DEVROLLING`, `-OFFICIALROLLING`).
 
+## Auto Loading global settings (#545; pending hardware validation)
+
+Auto Loading now uses the GUI's existing settings-home recovery, including
+same-device legacy folders and Custom Settings Path, so the launch path can read
+`conf_game.cfg` when the launcher's directory is not the settings home. The change
+preserves the first-run defaults gate. Diagnostic builds show the config home,
+read masks and global-config population before launch, with an eight-second hold
+that is absent from normal builds. Source review supports the fix; the original
+hardware report remains unconfirmed locally. See the
+[validation matrix and diagnostic limits](docs/AUTOLAUNCH-GLOBAL-SETTINGS.md).
+
 ## Which build should I use?
 
 All loaders contain **the same RiptOPL code** — they differ only by the SDK toolchain that built them.

--- a/ROLLING_RELEASE.md
+++ b/ROLLING_RELEASE.md
@@ -48,7 +48,11 @@ flavour carries the same version with its flavour suffix (`-PS2DEVPINNED`, `-OFF
 Auto Loading now uses the GUI's existing settings-home recovery, including
 same-device legacy folders and Custom Settings Path, so the launch path can read
 `conf_game.cfg` when the launcher's directory is not the settings home. The change
-preserves the first-run defaults gate. Diagnostic builds show the config home,
+does not scan merely because global settings are absent. For an APA/PFS ELF
+launching a BDM/ATA game, explicit settings redirects take precedence, followed
+by the ATA filesystem root and then the PFS home; an unrelated PFS master no
+longer hides the ATA-root settings bundle. GUI/HDL settings ownership is unchanged.
+Diagnostic builds show the config home,
 read masks and global-config population before launch, with an eight-second hold
 that is absent from normal builds. Source review supports the fix; the original
 hardware report remains unconfirmed locally. See the

--- a/docs/AUTOLAUNCH-GLOBAL-SETTINGS.md
+++ b/docs/AUTOLAUNCH-GLOBAL-SETTINGS.md
@@ -2,33 +2,60 @@
 
 Issue [#545](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/545) tracks
 [CosmicScale's upstream report](https://github.com/ps2homebrew/Open-PS2-Loader/issues/1768)
-on an SCPH-50001 with APA HDD games. Nathan has not reproduced it locally.
-The settings-home explanation is supported by source review, not yet by a PS2 trace.
+on an SCPH-50001. The reporter supplied an APA/PFS ELF path with BDM game arguments:
+
+```text
+path = hdd0:__system:pfs:/launcher/OPNPS2LD.ELF
+arg = Fantavision.iso
+arg = SCUS_971.05
+arg = DVD
+arg = bdm
+```
+
+The settings are reported at the ATA root. The reply repeats `conf_opl.cfg`;
+for this investigation the intended second filename is assumed to be
+`conf_game.cfg`, consistent with the original report. This is sufficient to
+review the mixed layout without requiring more work from the reporter.
+Nathan has not reproduced it locally. The root cause of the upstream behavior
+is still unconfirmed: upstream revision `3e3f34e9` already calls
+`checkLoadConfigBDM(CONFIG_ALL)` after an initial master-config miss, and that
+helper attempts to read globals as well as the master config.
 
 ## Change and scope
 
 `miniInit()` now resolves its boot/settings home for every launch mode and uses
-`tryAlternateDevice(CONFIG_ALL)` when the first read misses `CONFIG_OPL`, matching
+`tryAlternateDevice(CONFIG_ALL, mode)` when the first read misses `CONFIG_OPL`, using
 the GUI's recovery entry point. The three mode-specific `checkLoadConfig*` calls
 are removed. Its existing BDM semaphore initialization also runs for every mode:
 an APA game can have a BDM-hosted launcher or custom settings home, and the reused
 transport helpers acquire that semaphore.
 
+An APA/PFS boot with BDM argv is the deliberate exception to the initial-read
+gate: the ELF's PFS data home can contain a different master config from the
+game's ATA filesystem. For that combination, `tryAlternateDevice` first tries
+the existing explicit `config.path` redirect, then the first ATA-backed `massN:`
+root, then the existing PFS fallback. The ATA root is selected by driver identity,
+not by taking the first readable USB slot. It uses the existing bounded HDD
+readiness helper, and accepts a settings bundle only when its master config loads.
+GUI and HDL launches pass no BDM autolaunch mode and retain their existing policy.
+
 The shared GSM, cheats, PADEMU, pad-macro and OSD-language application code and
 the on-disk meaning of Global are unchanged. Per-game CFG files still come from
-the game device. An absent `conf_game.cfg` does **not** trigger recovery when the
-master config loaded successfully.
+the game device. An absent `conf_game.cfg` by itself does **not** trigger recovery.
+The mixed-layout exception is based on the launch mode and boot device, not on
+whether global settings exist. No new loading helper or filesystem writes are added.
 
 ## Source review (not runtime tests)
 
 | Layout/state | Path through the existing helpers |
 | --- | --- |
+| APA/PFS ELF, BDM/ATA game, settings at ATA root | Explicit redirect first, then ATA-identified `massN:/`, then PFS. Also applies if the initial PFS home contains another master config. |
 | Launcher `mc0:/APPS`, settings `mc0:/OPL` | Initial read misses; same-card recovery reads `/OPL`, including `CONFIG_GAME`. MC1 uses the same slot-preserving rule. |
 | BDM launcher directory differs from `<device>:/OPL` | Resolve the boot transport, then probe that device's `/OPL` and root. No other-device hunt on a known BDM boot. |
-| Custom Settings Path | On an initial master-config miss, read the boot home's `config.path`, prepare the target transport, and read all config sets from that target. A stale redirect falls back to the existing recovery policy. |
-| APA boot | Classify APA before recovery and resolve the existing PFS data home. Recovery retains the existing HDD ownership chain. |
+| Custom Settings Path | On ordinary initial-master misses, or the mixed APA/BDM path, read the boot home's `config.path`, prepare its transport, and read all config sets from the target. A stale redirect falls back to discovery. |
+| APA boot with GUI/HDL launch | Classify APA before recovery and resolve the existing PFS data home. Recovery retains the existing HDD ownership chain. |
 | Settings beside launcher, including globals | The first read succeeds; no recovery. |
-| Master exists but `conf_game.cfg` is absent | Keep defaults; no extra recovery scan. This also means an existing master beside the launcher still wins over a different `config.path` target, matching the GUI's existing gate. |
+| Master exists but `conf_game.cfg` is absent | Keep global defaults. Ordinary launches do not recover; mixed APA/BDM launches use their normal redirect/ATA/PFS selection regardless of whether the globals file exists. |
 | No configs on a known local boot | Same-device probes or the APA chain only. |
 | Unknown/deferred boot, master missing | Existing broad recovery can load USB with a 1500 ms mount budget, then probe MMCE. Hardware timing remains unmeasured. |
 
@@ -76,13 +103,15 @@ the argv autolaunch handoff, and compare actual behavior:
 | PADEMU enabled | USB | Pending hardware |
 | OSD language override | USB | Pending hardware |
 | Global option with Custom Settings Path | HDD/USB | Pending hardware |
+| APA/PFS ELF with `bdm`, ATA-root settings, with and without a different PFS master | ATA | Pending hardware |
 | Same options set to Per Game | HDD/USB | Pending hardware |
 | No `conf_game.cfg` anywhere; defaults and launch timing | HDD/USB | Pending hardware |
 
-Cover a launcher outside the settings home, settings on the game device, and APA
-boot. Include an HDD game with a BDM-hosted custom home to exercise semaphore
+Cover a launcher outside the settings home, settings on the game device, and both
+APA/HDL and mixed APA/BDM boot. Include an HDD game with a BDM-hosted custom home to exercise semaphore
 initialization, and measure unknown-boot recovery separately. No broad-scan flag
-has been introduced without timing evidence.
+has been introduced without timing evidence. Measure the mixed-layout ATA wait
+on hardware too; it reuses the former BDM fallback's 5000 ms readiness budget.
 
 Docker compilation and a PCSX2 GUI smoke test do not validate the real argv
 handoff, GSM output, cheats or controller behavior. No unit-test scaffolding is

--- a/docs/AUTOLAUNCH-GLOBAL-SETTINGS.md
+++ b/docs/AUTOLAUNCH-GLOBAL-SETTINGS.md
@@ -1,0 +1,89 @@
+# Auto Loading global settings (#545)
+
+Issue [#545](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/545) tracks
+[CosmicScale's upstream report](https://github.com/ps2homebrew/Open-PS2-Loader/issues/1768)
+on an SCPH-50001 with APA HDD games. Nathan has not reproduced it locally.
+The settings-home explanation is supported by source review, not yet by a PS2 trace.
+
+## Change and scope
+
+`miniInit()` now resolves its boot/settings home for every launch mode and uses
+`tryAlternateDevice(CONFIG_ALL)` when the first read misses `CONFIG_OPL`, matching
+the GUI's recovery entry point. The three mode-specific `checkLoadConfig*` calls
+are removed. Its existing BDM semaphore initialization also runs for every mode:
+an APA game can have a BDM-hosted launcher or custom settings home, and the reused
+transport helpers acquire that semaphore.
+
+The shared GSM, cheats, PADEMU, pad-macro and OSD-language application code and
+the on-disk meaning of Global are unchanged. Per-game CFG files still come from
+the game device. An absent `conf_game.cfg` does **not** trigger recovery when the
+master config loaded successfully.
+
+## Source review (not runtime tests)
+
+| Layout/state | Path through the existing helpers |
+| --- | --- |
+| Launcher `mc0:/APPS`, settings `mc0:/OPL` | Initial read misses; same-card recovery reads `/OPL`, including `CONFIG_GAME`. MC1 uses the same slot-preserving rule. |
+| BDM launcher directory differs from `<device>:/OPL` | Resolve the boot transport, then probe that device's `/OPL` and root. No other-device hunt on a known BDM boot. |
+| Custom Settings Path | On an initial master-config miss, read the boot home's `config.path`, prepare the target transport, and read all config sets from that target. A stale redirect falls back to the existing recovery policy. |
+| APA boot | Classify APA before recovery and resolve the existing PFS data home. Recovery retains the existing HDD ownership chain. |
+| Settings beside launcher, including globals | The first read succeeds; no recovery. |
+| Master exists but `conf_game.cfg` is absent | Keep defaults; no extra recovery scan. This also means an existing master beside the launcher still wins over a different `config.path` target, matching the GUI's existing gate. |
+| No configs on a known local boot | Same-device probes or the APA chain only. |
+| Unknown/deferred boot, master missing | Existing broad recovery can load USB with a 1500 ms mount budget, then probe MMCE. Hardware timing remains unmeasured. |
+
+`restoreRecoverySaveHome()` calls `configSetMove()` and may probe MC directories;
+neither it nor `configSetMove()` writes settings. For non-MC recovery, the final
+save home can be moved back to the boot directory after the config was read.
+Consequently, the final home alone does not prove which directory supplied the
+loaded values. A populated `CONFIG_GAME` alone also does not prove that those
+values are the intended ones.
+
+## Diagnostic build
+
+Build `make clean` followed by `make OPLDIAG=1 release`. `__DEBUG` is unnecessary.
+At the end of `miniInit`, the diagnostic displays:
+
+- resolved `gBootDir`, home before the first read, and final `configGetHomePath()`;
+- initial and final read masks (`CONFIG_OPL=0x01`, `CONFIG_GAME=0x10`);
+- whether `configGetByType(CONFIG_GAME)->head` is non-null;
+- elapsed configuration-read/recovery time, excluding the display itself and the
+  earlier module loading/boot-directory resolution.
+
+The diagnostic initializes only the renderer and built-in font, holds the screen
+for eight seconds, and releases both before launch. Normal builds contain neither
+the display nor the hold. Use normal pinned builds for launch timing and gameplay
+comparisons: the diagnostic itself changes timing and initializes the GS.
+
+The diagnostic-only baseline is commit `3e90d18f`; its functional config loading is
+unchanged from base `ae1f26c5`. Compare it with the fixed revision on the same setup.
+If the baseline already loads the intended globals, investigate `sbPrepare` and
+the individual apply paths instead of declaring settings-home recovery causal.
+
+## Hardware gate
+
+Use **run-pinned nightly.link** downloads and check each archive's
+`BUILD-MANIFEST.txt` against the intended source revision. Use PS2DEVPINNED for
+behavior/timing and PS2DEVPINNED-DIAG for the diagnostic screen.
+
+For each row, save the option as Global, launch the same game through the GUI and
+the argv autolaunch handoff, and compare actual behavior:
+
+| Check | Device | Status |
+| --- | --- | --- |
+| GSM enabled with a non-NTSC mode | APA HDD | Pending hardware |
+| Cheats enabled | APA HDD | Pending hardware |
+| PADEMU enabled | USB | Pending hardware |
+| OSD language override | USB | Pending hardware |
+| Global option with Custom Settings Path | HDD/USB | Pending hardware |
+| Same options set to Per Game | HDD/USB | Pending hardware |
+| No `conf_game.cfg` anywhere; defaults and launch timing | HDD/USB | Pending hardware |
+
+Cover a launcher outside the settings home, settings on the game device, and APA
+boot. Include an HDD game with a BDM-hosted custom home to exercise semaphore
+initialization, and measure unknown-boot recovery separately. No broad-scan flag
+has been introduced without timing evidence.
+
+Docker compilation and a PCSX2 GUI smoke test do not validate the real argv
+handoff, GSM output, cheats or controller behavior. No unit-test scaffolding is
+part of this change.

--- a/src/opl.c
+++ b/src/opl.c
@@ -2399,7 +2399,7 @@ static int tryMissingConfigPathRecovery(int types)
 }
 
 
-static int tryAlternateDevice(int types)
+static int tryAlternateDevice(int types, int autoLaunchMode)
 {
     char redirectPath[64];
     int value;
@@ -2438,7 +2438,20 @@ static int tryAlternateDevice(int types)
         }
     }
 
-    // APA/PFS boot identity is authoritative. After an explicit redirect misses, ONLY the
+    // A BDM argv launch can keep its ELF on APA/PFS while its ISO and settings live at the ATA
+    // filesystem root (#545). Prefer that settings bundle over the unrelated PFS data home, but
+    // only after an explicit config.path redirect. Match the ATA driver, not whichever USB slot
+    // happened to enumerate first. The same bounded HDD readiness helper served the old BDM fallback.
+    if (autoLaunchMode == BDM_MODE && gBootHomeApa) {
+        char home[BDM_DEVICE_ROOT_MAX];
+        if (bdmHDDIsPresent(5000) && bdmGetDeviceRootByType(BDM_TYPE_ATA, home, sizeof(home))) {
+            value = tryReadRecoveryConfigHome(types, home);
+            if (value & CONFIG_OPL)
+                return value;
+        }
+    }
+
+    // For GUI/HDL launches, APA/PFS boot identity is authoritative. After an explicit redirect misses, ONLY the
     // deterministic existing-PFS ownership chain is eligible: __common/OPL/conf_hdd.cfg's valid
     // existing target, otherwise __common/OPL. Never import an unrelated MC/USB master config into
     // an FHDB/APA session; that can resurrect stale Custom Settings Path state and makes the next
@@ -2769,7 +2782,7 @@ static void _loadConfig()
 
     if (lscstatus & CONFIG_OPL) {
         if (!(result & CONFIG_OPL)) {
-            result = tryAlternateDevice(lscstatus);
+            result = tryAlternateDevice(lscstatus, IO_MODE_SELECTED_NONE);
         }
 
         if (result & CONFIG_OPL) {
@@ -3074,7 +3087,7 @@ static void _loadConfig()
 
     if (lscstatus & CONFIG_NETWORK) {
         if (!(result & CONFIG_NETWORK)) {
-            result = tryAlternateDevice(lscstatus);
+            result = tryAlternateDevice(lscstatus, IO_MODE_SELECTED_NONE);
         }
 
         if (result & CONFIG_NETWORK) {
@@ -4836,8 +4849,11 @@ static void miniInit(int mode)
     initialRet = ret;
 #endif
     if (CONFIG_ALL & CONFIG_OPL) {
-        if (!(ret & CONFIG_OPL)) {
-            ret = tryAlternateDevice(CONFIG_ALL);
+        // A mixed APA-boot/BDM-game launch has a distinct settings owner. Resolve its redirect or
+        // ATA root even if the initial PFS home contained a different master config. A missing
+        // CONFIG_GAME alone still never triggers discovery on any launch path.
+        if (!(ret & CONFIG_OPL) || (mode == BDM_MODE && gBootHomeApa)) {
+            ret = tryAlternateDevice(CONFIG_ALL, mode);
         }
 
         if (ret & CONFIG_OPL) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -22,6 +22,7 @@
 #include "include/debug.h"
 #ifdef __OPLDIAG
 #include "include/fntsys.h"
+#include <delaythread.h>
 #endif
 #include "include/config.h"
 #include "include/util.h"

--- a/src/opl.c
+++ b/src/opl.c
@@ -20,6 +20,9 @@
 #include "include/menusys.h"
 #include "include/system.h"
 #include "include/debug.h"
+#ifdef __OPLDIAG
+#include "include/fntsys.h"
+#endif
 #include "include/config.h"
 #include "include/util.h"
 #include "include/compatupd.h"
@@ -4783,6 +4786,11 @@ static void deferredAudioInit(void)
 static void miniInit(int mode)
 {
     int ret;
+#ifdef __OPLDIAG
+    int initialRet;
+    char initialHome[256];
+    clock_t configStart;
+#endif
 
     setDefaults();
     configInit(gBootDir[0] ? gBootDir : NULL); // settings live in the boot dir (cwd)
@@ -4819,7 +4827,14 @@ static void miniInit(int mode)
 
     InitConsoleRegionData();
 
+#ifdef __OPLDIAG
+    configStart = clock();
+    snprintf(initialHome, sizeof(initialHome), "%s", configGetHomePath());
+#endif
     ret = configReadMulti(CONFIG_ALL);
+#ifdef __OPLDIAG
+    initialRet = ret;
+#endif
     if (CONFIG_ALL & CONFIG_OPL) {
         if (!(ret & CONFIG_OPL)) {
             if (mode == BDM_MODE)
@@ -4848,6 +4863,36 @@ static void miniInit(int mode)
                 configGetInt(configOPL, CONFIG_OPL_HDD_CACHE, &hddCacheSize);
         }
     }
+#ifdef __OPLDIAG
+    // Autolaunch never initializes the GUI or a release TTY. Display the captured config state
+    // using only the renderer and built-in font, then release them before the game handoff.
+    // Capture timing before the diagnostic display; its eight-second hold is DIAG-only.
+    config_set_t *globalGame = configGetByType(CONFIG_GAME);
+    char diagnostic[1536];
+    snprintf(diagnostic, sizeof(diagnostic),
+             "Auto Loading config diagnostic (#545)\n"
+             "mode=%d  config=%ld ms\n"
+             "boot: %s\ninitial home: %s\nfinal home: %s\n"
+             "read=0x%02x  final=0x%02x  GAME bit=0x%02x\n"
+             "CONFIG_GAME populated=%d\n"
+             "Game continues after 8 seconds.",
+             mode, (long)((clock() - configStart) / (CLOCKS_PER_SEC / 1000)),
+             gBootDir, initialHome, configGetHomePath(), initialRet, ret, CONFIG_GAME,
+             globalGame != NULL && globalGame->head != NULL);
+    printf("%s\n", diagnostic);
+    rmInit();
+    fntInit();
+    for (int frame = 0; frame < 2; frame++) {
+        rmStartFrame();
+        rmDrawRect(0, 0, 640, 480, GS_SETREG_RGBAQ(0, 0, 0, 0x80, 0));
+        fntRenderString(FNT_DEFAULT, 24, 32, 0, 592, 416, diagnostic,
+                        GS_SETREG_RGBAQ(0xff, 0xff, 0xff, 0x80, 0));
+        rmEndFrame();
+    }
+    DelayThread(8000000);
+    fntEnd();
+    rmEnd();
+#endif
 }
 
 void miniDeinit(config_set_t *configSet)

--- a/src/opl.c
+++ b/src/opl.c
@@ -4799,9 +4799,10 @@ static void miniInit(int mode)
     ioInit();
     LOG_ENABLE();
 
-    if (mode == BDM_MODE) {
-        bdmInitSemaphore();
+    // Settings discovery can need a BDM transport even when the game itself is on APA HDD.
+    bdmInitSemaphore();
 
+    if (mode == BDM_MODE) {
         // Force load all BDM modules.. we aren't using the gui so this is fine.
         // gEnableUSB belongs in this list and was the one missing from it. Unlike the others it is a
         // FORK INVENTION -- upstream loads USBMASS_BD unconditionally and has no such flag -- so the
@@ -4814,11 +4815,6 @@ static void miniInit(int mode)
         gEnableMX4SIO = 1;
         gEnableBdmHDD = 1;
         bdmLoadModules();
-
-        // Autolaunch reads its per-game config from the boot dir too -- resolve a launch-identity or
-        // not-yet-mounted massN: boot dir before the configReadMulti below, same as the full boot path.
-        resolveBootDirToMass();
-
     } else if (mode == HDD_MODE) {
         hddLoadModules();
         hddLoadSupportModules();
@@ -4826,6 +4822,9 @@ static void miniInit(int mode)
         mmceLoadModules();
     }
 
+    // Resolve the settings home and its recovery policy for every launch mode, as _loadConfig does.
+    // The launcher directory can differ from the game's device and from the saved settings home.
+    resolveBootDirToMass();
     InitConsoleRegionData();
 
 #ifdef __OPLDIAG
@@ -4838,12 +4837,7 @@ static void miniInit(int mode)
 #endif
     if (CONFIG_ALL & CONFIG_OPL) {
         if (!(ret & CONFIG_OPL)) {
-            if (mode == BDM_MODE)
-                ret = checkLoadConfigBDM(CONFIG_ALL);
-            else if (mode == HDD_MODE)
-                ret = checkLoadConfigHDD(CONFIG_ALL);
-            else if (mode == MMCE_MODE)
-                ret = checkLoadConfigMMCE(CONFIG_ALL);
+            ret = tryAlternateDevice(CONFIG_ALL);
         }
 
         if (ret & CONFIG_OPL) {


### PR DESCRIPTION
> **New evidence: the original reported layout is not covered by the current fix. Do not merge as a resolution of #545.**
>
> CosmicScale's reply specifies `hdd0:__system:pfs:/launcher/OPNPS2LD.ELF` with `Fantavision.iso`, `SCUS_971.05`, `DVD`, `bdm`, and configs at the ATA root. This selects BDM autolaunch despite the APA/PFS ELF location. See https://github.com/ps2homebrew/Open-PS2-Loader/issues/1768#issuecomment-5641416286.
>
> In this PR, `resolveBootDirToMass` classifies an HDD/PFS boot as APA. Without a usable explicit redirect, `tryAlternateDevice` then returns from the APA-only recovery branch and does not discover an ATA-backed mass root. Replacing the former `checkLoadConfigBDM` fallback can therefore remove recovery of an ATA-root RiptOPL config for this mixed layout. Build success does not address that regression risk.
>
> The reported upstream revision `3e3f34e9` already invokes `checkLoadConfigBDM(CONFIG_ALL)` after an initial master-config miss. That helper discovers `conf_opl.cfg` and reads all config sets, including `conf_game.cfg`. The earlier missed-home explanation is not established for this report. The duplicated filename, Custom Settings Path, and competing master configs remain to be clarified. No code was changed for this follow-up; the current head remains available for analysis, not as a validated fix for CosmicScale's setup.

Auto Loading previously searched for global game settings through a single game-device fallback. A launcher outside the settings home, or a boot home with a Custom Settings Path redirect, could therefore load per-game CFG options while missing conf_game.cfg.

miniInit now resolves the boot home in every mode and replaces its three checkLoadConfig calls with tryAlternateDevice(CONFIG_ALL). Its existing BDM semaphore is initialized before either mode can enter a BDM settings transport. The CONFIG_OPL gate and shared per-game/global apply logic remain unchanged. No new config-loading helper or unit-test scaffolding was added.

The separate diagnostic commits add an OPLDIAG-only config-state screen and eight-second hold; the normal build has no display or hold. Documentation records source-review cases and the pending hardware matrix.

Validation:
- Clean local pinned Docker make release builds passed with OPLDIAG=0 and OPLDIAG=1; container exited 0. No DEBUG=1.
- All six build flavours passed in run 34635400285, along with the existing ra-host-tests job and both format checks. Pinned clang-format 12 and git diff --check also passed locally.
- CodeRabbit skipped review because this PR is draft; that is not a completed code review.
- PCSX2 v2.7.525 was attempted with an isolated data directory and no user HDD/memory cards. Both launches stopped before guest boot and exposed no render window. GUI smoke validation remains unverified.
- No hardware result. The original report, Global/Per Game parity and unknown-boot recovery latency remain real-hardware gates. CosmicScale was asked for the original layout: https://github.com/ps2homebrew/Open-PS2-Loader/issues/1768#issuecomment-5639236432.

Verified run-pinned artifacts:
- Diagnostic-only baseline, commit 3e90d18f8eb13dde638eb94fd3f94959fbc23cd5: https://nightly.link/NathanNeurotic/Open-PS2-Loader/actions/runs/34635231868/OPL-PS2DEVPINNED-DIAG.zip
- Fixed normal build: https://nightly.link/NathanNeurotic/Open-PS2-Loader/actions/runs/34635400285/OPL-PS2DEVPINNED.zip
- Fixed diagnostic build: https://nightly.link/NathanNeurotic/Open-PS2-Loader/actions/runs/34635400285/OPL-PS2DEVPINNED-DIAG.zip

The fixed manifests identify synthetic merge 5ce8f827c2013188fab1134ca3ac21ebb0cb1a11. Its parents are base ae1f26c5 and PR head 34e27b3e; its tree a40aeb6a31bb4160140af88268e8612683e41f68 exactly matches the PR head. Both downloaded fixed manifests and the baseline diagnostic manifest were inspected.

Refs #545 and ps2homebrew/Open-PS2-Loader#1768. Keep draft pending runtime validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic loading of global settings when launching BDM/ATA games through APA or PFS ELF paths.
  * Settings can now be recovered from the appropriate device or configured custom settings location when the launcher starts outside the settings home.
  * Unrelated PFS data no longer prevents settings stored at the ATA root from being loaded.
  * Existing GUI and HDL settings behavior remains unchanged.

* **Documentation**
  * Added configuration details, validation guidance, and diagnostic-build information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->