### PR TITLE
coverflow: center covers vertically on mixed shelves (Favorites)

### DIFF
--- a/docs/THEME_ENGINE.md
+++ b/docs/THEME_ENGINE.md
@@ -417,7 +417,7 @@ SIO2 bus quiet — those covers still load on selection, as before.
 | `default` | Fallback cover (e.g. `cover`, or `coverapp` for the apps list). |
 | `overlay` + `overlay_*` corners | The case art drawn around each cover (e.g. `case` / `apps_case`). The corners place the cover **inside** the case frame; the engine auto-centers the visible frame and keeps it aspect-correct in both 4:3 and widescreen. |
 | `reflection` | `1` to draw the mirrored reflection below each cover (alpha-faded). |
-| `x`, `y`, `width`, `height` | Position and per-cover size. `width`/`height` should match your case art's pixel size so the overlay corners line up. |
+| `x`, `y`, `width`, `height` | Position and per-cover size. `width`/`height` should match your case art's pixel size so the overlay corners line up. `y` is the **vertical centerline** of the carousel: every cover is centered on it, whatever its shape, so a mixed shelf (Favorites *All*, a Mixed device page) keeps one horizontal center across portrait and square covers instead of aligning their top edges. |
 
 A minimal example (this fork's `<Coverflow>` theme uses values like these):
 
@@ -426,7 +426,7 @@ main2:
 	type=Coverflow
 	default=cover
 	reflection=1
-	y=197
+	y=233
 	width=184
 	height=256
 	overlay=case

--- a/misc/theme_coverflow.cfg
+++ b/misc/theme_coverflow.cfg
@@ -25,7 +25,7 @@ main2:
 	default=cover
 	reflection=1
 	reflection_offset=0
-	y=197
+	y=233
 	width=184
 	height=256
 	overlay=case

--- a/src/themes.c
+++ b/src/themes.c
@@ -1583,12 +1583,10 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         }
 
         int posX = basePosX + (i - COVERFLOW_PAD) * coverDistance + animOffset + recenterX * drawW / csw;
-        // Covers draw ALIGN_CENTER at elem->posY, so a tall (portrait) cover's TOP overshoots a square
-        // cover's top by (drawH-drawW)/2 and touches the background frame. Shift portrait covers DOWN by
-        // that excess so every cover TOP-aligns at the square baseline -- square covers (Apps, square
-        // VCD art) get 0 and are unchanged, and a mixed tab (Favourites) keeps a consistent cover top.
-        int topAlign = (drawH > drawW) ? (drawH - drawW) / 2 : 0;
-        int posY = elem->posY + recenterY * drawH / csh + topAlign;
+        // Every cover is vertically CENTERED on the page element's posY, whatever its shape: a
+        // mixed shelf (Favourites "All", Mixed device pages) shares one centerline across portrait
+        // and square covers instead of top-aligning them (#623).
+        int posY = elem->posY + recenterY * drawH / csh;
 
         u64 coverColor = (gCoverflowDimCovers && i != centerIdx) ? GS_SETREG_RGBA(0x80, 0x80, 0x80, 0x40) : gDefaultCol;
 


### PR DESCRIPTION
## Problem

On the Favorites **All** shelf (and Mixed device pages) with a Coverflow theme, covers line up by their **top edges** instead of sharing a vertical center — portrait PS2 covers sit lower than square PS1/app covers, producing the ragged staircase in [this video](https://github.com/NathanNeurotic/Open-PS2-Loader/issues/623#issuecomment-5639621612).

## Root cause

`drawCoverFlow()` applied a deliberate `topAlign = (drawH > drawW) ? (drawH - drawW) / 2 : 0` shift so every cover's top edge matched the square-cover baseline (originally to keep portrait tops off the background frame art). Since the per-row media-kind redirect (`thmGetElemForItem`) landed for #623, each row's height follows its own shape — so on a **mixed** shelf the shift differs per row and the top-alignment becomes visible. On homogeneous pages it is a uniform constant and invisible.

## Fix

- **`src/themes.c`** — removed `topAlign`; every cover is drawn `ALIGN_CENTER` on the page element's `y`, whatever its shape, so mixed shelves share one vertical centerline. Bonus: the center-cover zoom now grows symmetrically instead of pushing the bottom edge down.
- **`misc/theme_coverflow.cfg`** — `main2` `y=197 → 233` so pure-PS2 pages keep their exact current on-screen position (a portrait cover's center previously landed at 197 + (256−184)/2 = 233). Square `appsMain2`/`vcdMain2` had no shift and stay at 239.
- **`docs/THEME_ENGINE.md`** — §8 now documents `y` as the carousel's vertical centerline.

## Verification

- Built clean with the pinned CI toolchain (`ps2dev/ps2dev@sha256:8fba50…`); regenerated embedded theme confirmed to contain `y=233`.
- **Not yet hardware-verified**: worth a look on hardware/PCSX2 at the Favorites All shelf (PS2 + PS1 + app covers should share one centerline) and a pure-PS2 coverflow page (should look unchanged).

## Note for theme authors

Coverflow themes tuned with the old top-alignment will see portrait covers rise by `(drawH − drawW)/2` (~36 px at stock sizes) unless their `y` is re-tuned; list-mode `ItemCover` is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Coverflow covers are now vertically centered on the configured position, providing consistent alignment across portrait and square artwork.

- **Bug Fixes**
  - Updated the portrait Coverflow layout position to maintain the intended visual placement.

- **Documentation**
  - Clarified Coverflow’s vertical-centering behavior and updated the portrait layout example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->